### PR TITLE
Add BinaryRefResourceLoader

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HTML.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HTML.java
@@ -32,7 +32,9 @@ import org.eclipse.scout.rt.platform.html.internal.HtmlTableDataBuilder;
 import org.eclipse.scout.rt.platform.html.internal.HtmlTableHeadBuilder;
 import org.eclipse.scout.rt.platform.html.internal.HtmlTableRowBuilder;
 import org.eclipse.scout.rt.platform.html.internal.StyleElementBuilder;
+import org.eclipse.scout.rt.platform.resource.BinaryRefs;
 import org.eclipse.scout.rt.platform.resource.BinaryResourceUtility;
+import org.eclipse.scout.rt.platform.util.StringUtility;
 
 /**
  * Convenience for building a HTML document or parts of it with encoded text.
@@ -263,6 +265,22 @@ public final class HTML {
    */
   public static IHtmlElement imgByBinaryResource(CharSequence binaryResource) {
     return new HtmlImageBuilder(BinaryResourceUtility.createUrl(binaryResource.toString()));
+  }
+
+  /**
+   * Creates a <code>&lt;img src="binref:..."&gt</code> element.
+   * <p>
+   * <i>Example:</i><br>
+   * <code>String encodedHtml = HTML.imgByBinaryRef("/crm/customer/image/1234").toHtml();</code>
+   *
+   * @param binaryRef
+   *          base path plus id
+   */
+  public static IHtmlElement imgByBinaryRef(CharSequence binaryRef) {
+    if (binaryRef != null && StringUtility.startsWith(binaryRef.toString(), BinaryRefs.URI_SCHEME + ":")) {
+      return new HtmlImageBuilder(binaryRef);
+    }
+    return new HtmlImageBuilder(BinaryRefs.URI_SCHEME + ":" + binaryRef);
   }
 
   /**

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/res/BinaryResourceUrlUtilityTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/res/BinaryResourceUrlUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -100,6 +100,13 @@ public class BinaryResourceUrlUtilityTest {
   public void testGetFilenameWithFingerprint_WithoutContent_NonAsciiFilename() {
     BinaryResource binaryResource = new BinaryResource("fäé.txt", null);
     assertEquals("fäé.txt", BinaryResourceUrlUtility.getFilenameWithFingerprint(binaryResource));
+  }
+
+  @Test
+  public void testReplaceBinaryRefHandlerWithUrl() {
+    assertEquals("\"binref/test/some/123\"", BinaryResourceUrlUtility.replaceBinaryRefHandlerWithUrl("\"binref:/test/some/123\""));
+    assertEquals("\"binref/test/some/123\"", BinaryResourceUrlUtility.replaceBinaryRefHandlerWithUrl("\"binref:test/some/123\""));
+    assertEquals("\"binref/test/f%C3%A4%C3%A9/123\"", BinaryResourceUrlUtility.replaceBinaryRefHandlerWithUrl("\"binref:/test/fäé/123\""));
   }
 
   protected IJsonAdapter<Long> createJsonAdapterMock(String adapterId, String uiSessionId) {

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/BinaryRefResourceInfo.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/BinaryRefResourceInfo.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.ui.html.res.loader;
+
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.scout.rt.platform.resource.BinaryRefs;
+import org.eclipse.scout.rt.platform.util.IOUtility;
+
+public class BinaryRefResourceInfo {
+
+  /**
+   * Pattern to determine if the provided url path is a binaryRef resource path. Allow an additional / at the start.
+   */
+  public static final Pattern PATTERN_BINARY_REF_RESOURCE_PATH = Pattern.compile("^/?" + BinaryRefs.URI_SCHEME + "/([^/]*/.*)$");
+
+  private final String m_binaryRef;
+
+  public BinaryRefResourceInfo(String binaryRef) {
+    m_binaryRef = binaryRef;
+  }
+
+  public String toPath() {
+    String binaryRef = IOUtility.urlEncode(getBinaryRef());
+    // / was encoded by %2F, revert this encoding
+    binaryRef = binaryRef.replace("%2F", "/");
+    return BinaryRefs.URI_SCHEME + (binaryRef.startsWith("/") ? "" : "/") + binaryRef;
+  }
+
+  public URI toBinaryRefUri() {
+    return URI.create(BinaryRefs.URI_SCHEME + ":" + (getBinaryRef().startsWith("/") ? "" : "/") + getBinaryRef());
+  }
+
+  public String getBinaryRef() {
+    return m_binaryRef;
+  }
+
+  /**
+   * @param path
+   *          decoded path (non url-encoded)
+   */
+  public static BinaryRefResourceInfo fromPath(String path) {
+    BinaryRefResourcePathComponents parts = BinaryRefResourcePathComponents.fromPath(path);
+    if (parts == null) {
+      return null;
+    }
+    return new BinaryRefResourceInfo(parts.getBinaryRef());
+  }
+
+  protected static class BinaryRefResourcePathComponents {
+    String m_binaryRef;
+
+    BinaryRefResourcePathComponents(String binaryRef) {
+      m_binaryRef = binaryRef;
+    }
+
+    public String getBinaryRef() {
+      return m_binaryRef;
+    }
+
+    /**
+     * @param path
+     *          decoded path (non url-encoded)
+     * @see BinaryRefResourceInfo#fromPath(String)
+     */
+    public static BinaryRefResourcePathComponents fromPath(String path) {
+      if (path == null) {
+        return null;
+      }
+
+      Matcher m = PATTERN_BINARY_REF_RESOURCE_PATH.matcher(path);
+      if (!m.matches()) {
+        return null;
+      }
+
+      String binaryRef = m.group(1);
+      return new BinaryRefResourcePathComponents(binaryRef);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/BinaryRefResourceLoader.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/BinaryRefResourceLoader.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.ui.html.res.loader;
+
+import java.net.URI;
+import java.util.Map.Entry;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.eclipse.scout.rt.client.IClientSession;
+import org.eclipse.scout.rt.client.context.ClientRunContexts;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.resource.BinaryRefs;
+import org.eclipse.scout.rt.platform.resource.BinaryResource;
+import org.eclipse.scout.rt.platform.util.collection.TTLCache;
+import org.eclipse.scout.rt.server.commons.servlet.cache.HttpCacheKey;
+import org.eclipse.scout.rt.server.commons.servlet.cache.HttpCacheObject;
+import org.eclipse.scout.rt.server.commons.servlet.cache.IHttpResourceCache;
+import org.eclipse.scout.rt.ui.html.HttpSessionHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class loads binaryRef resources.
+ * <p>
+ * The pathInfo is expected to have the following form: <code>/binref/[path]/[id]</code>
+ */
+public class BinaryRefResourceLoader extends AbstractResourceLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BinaryRefResourceLoader.class);
+
+  private static final String BINARY_REF_CACHE = "binaryRef.cache";
+
+  private final HttpServletRequest m_req;
+
+  public BinaryRefResourceLoader(HttpServletRequest req) {
+    super(null /* no instance required as getCache() is overridden */);
+    m_req = req;
+  }
+
+  public HttpServletRequest getRequest() {
+    return m_req;
+  }
+
+  @Override
+  public IHttpResourceCache getCache(HttpCacheKey cacheKey) {
+    HttpSession httpSession = getRequest().getSession();
+    if (httpSession == null) {
+      return null;
+    }
+
+    Object o = httpSession.getAttribute(BINARY_REF_CACHE);
+    if (o instanceof IHttpResourceCache) {
+      return (IHttpResourceCache) o;
+    }
+
+    IHttpResourceCache cache = createCache();
+    httpSession.setAttribute(BINARY_REF_CACHE, cache);
+    return cache;
+  }
+
+  protected IHttpResourceCache createCache() {
+    return new IHttpResourceCache() {
+      private final TTLCache<HttpCacheKey, HttpCacheObject> m_cache = new TTLCache<>(300000); // 5 minutes (5 * 60 * 1000)
+
+      @Override
+      public boolean put(HttpCacheObject obj) {
+        if (obj == null) {
+          return false;
+        }
+        if (obj.getResource() != null && obj.getResource().isCachingAllowed()) {
+          // this will be cached by the browser, so there is no need to cache it here
+          return false;
+        }
+        m_cache.put(obj.getCacheKey(), obj);
+        return true;
+      }
+
+      @Override
+      public HttpCacheObject get(HttpCacheKey cacheKey) {
+        return m_cache.get(cacheKey);
+      }
+
+      @Override
+      public HttpCacheObject remove(HttpCacheKey cacheKey) {
+        return m_cache.remove(cacheKey);
+      }
+
+      @Override
+      public void clear() {
+        m_cache.clear();
+      }
+    };
+  }
+
+  @Override
+  public BinaryResource loadResource(String pathInfo) {
+    HttpSession httpSession = getRequest().getSession();
+    if (httpSession == null) {
+      return null;
+    }
+
+    BinaryRefResourceInfo info = createBinaryRefResourceInfo(pathInfo);
+    if (info == null) {
+      return null;
+    }
+
+    URI uri = info.toBinaryRefUri();
+
+    // binaryRefs must be independent of the IClientSession, therefore take any
+    IClientSession clientSession = BEANS.get(HttpSessionHelper.class)
+        .getSessionStore(httpSession)
+        .getClientSessionMap().entrySet().stream()
+        .findAny()
+        .map(Entry::getValue)
+        .orElse(null);
+
+    if (clientSession == null) {
+      return null;
+    }
+
+    try {
+      return ClientRunContexts.copyCurrent()
+          .withSession(clientSession, true)
+          .call(() -> BinaryRefs.loadBinaryResource(uri));
+    }
+    catch (Exception e) {
+      LOG.warn("Unable to load binary resource for URI {}", uri);
+    }
+    return null;
+  }
+
+  protected BinaryRefResourceInfo createBinaryRefResourceInfo(HttpCacheKey cacheKey) {
+    return createBinaryRefResourceInfo(cacheKey.getResourcePath());
+  }
+
+  protected BinaryRefResourceInfo createBinaryRefResourceInfo(String pathInfo) {
+    return BinaryRefResourceInfo.fromPath(pathInfo);
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/ResourceLoaders.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/ResourceLoaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import org.eclipse.scout.rt.ui.html.UiThemeHelper;
 public class ResourceLoaders {
 
   protected static final Pattern ICON_PATTERN = Pattern.compile("^/icon/(.*)");
+  protected static final Pattern BINARY_REF_PATTERN = Pattern.compile("^/binref/(.*)");
   protected static final Pattern DYNAMIC_RESOURCES_PATTERN = Pattern.compile("^/" + DynamicResourceInfo.PATH_PREFIX + "/.*");
   protected static final Pattern DEFAULT_VALUES_PATTERN = Pattern.compile("^/defaultValues$");
 
@@ -32,6 +33,9 @@ public class ResourceLoaders {
 
     if (ICON_PATTERN.matcher(resourcePath).matches()) {
       return new IconLoader();
+    }
+    if (BINARY_REF_PATTERN.matcher(resourcePath).matches()) {
+      return new BinaryRefResourceLoader(req);
     }
     if (DYNAMIC_RESOURCES_PATTERN.matcher(resourcePath).matches()) {
       return new DynamicResourceLoader(req);


### PR DESCRIPTION
Add a loader for binaryRefs that resolves the corresponding resource via
the IBinaryRefHandlers. For this purpose any IClientSession of the user
is used so the resources to be loaded must not be dependent on the
session. Resources for which no caching is possible in the browser are
cached on the HttpSession.