### PR TITLE
Do nothing when _acceptInput is called on SmartField while removing

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.js
@@ -293,15 +293,22 @@ export default class SmartField extends ValueField {
    */
   _acceptInput(sync, searchText, searchTextEmpty, searchTextChanged, selectedLookupRow) {
 
-    // Do nothing when search text is equals to the text of the current lookup row
-    if (!selectedLookupRow && this.lookupRow) {
+    let unchanged = false;
+    if (this.removing) {
+      // Rare case: _acceptInput may be called when the field is being removed. In that case
+      // we do nothing and leave the lookupRow unchanged.
+      unchanged = true;
+    } else if (!selectedLookupRow && this.lookupRow) {
+      // Do nothing when search text is equals to the text of the current lookup row
       let lookupRowText = strings.nvl(this.lookupRow.text);
-      if (lookupRowText === searchText) {
-        $.log.isDebugEnabled() && $.log.debug('(SmartField#_acceptInput) unchanged: text is equals. Close popup');
-        this._clearLookupStatus();
-        this._inputAccepted(false);
-        return;
-      }
+      unchanged = lookupRowText === searchText;
+    }
+
+    if (unchanged) {
+      $.log.isDebugEnabled() && $.log.debug('(SmartField#_acceptInput) unchanged: widget is removing or searchText is equals. Close popup');
+      this._clearLookupStatus();
+      this._inputAccepted(false);
+      return;
     }
 
     // Don't show the not-unique error when the search-text becomes empty while typing (see ticket #229775)


### PR DESCRIPTION
This issue was noticed because a propertyChange:lookupRow event handler
has been attached to a SmartField. This handler called the insertField()
function on the same group-box which contained the SmartField. This
causes the group-box to remove/render the SmartField. When remove() has
been called, the SmartField couldn't deal with that unexpected state,
which caused wrong property change events for the lookupRow property.

300953