### PR TITLE
BrushUp: add scroll shadow

### DIFF
--- a/eclipse-scout-core/src/calendar/YearPanel.less
+++ b/eclipse-scout-core/src/calendar/YearPanel.less
@@ -13,6 +13,7 @@
   vertical-align: top;
   width: 0;
   overflow: hidden;
+  position: relative;
 }
 
 .year-panel-title {

--- a/eclipse-scout-core/src/desktop/bench/DesktopBench.less
+++ b/eclipse-scout-core/src/desktop/bench/DesktopBench.less
@@ -142,6 +142,10 @@
       #scout.scrollbar-x-padding(4px, 2px);
     }
 
+    & + .scroll-shadow {
+      .scroll-shadow.large();
+    }
+
     & > .table-row,
     & > .table-aggregate-row {
       /* Desktop table has a 2px border. Top and bottom border are added to the table cell. */

--- a/eclipse-scout-core/src/form/fields/FormField.js
+++ b/eclipse-scout-core/src/form/fields/FormField.js
@@ -1201,7 +1201,7 @@ export default class FormField extends Widget {
   }
 
   /**
-   * @return {FormFieldLayout} the default layout FormFieldLayout. Override this function if your field needs another layout.
+   * @return {FormFieldLayout|AbstractLayout} the default layout FormFieldLayout. Override this function if your field needs another layout.
    */
   _createLayout() {
     return new FormFieldLayout(this);

--- a/eclipse-scout-core/src/form/fields/groupbox/GroupBox.less
+++ b/eclipse-scout-core/src/form/fields/groupbox/GroupBox.less
@@ -39,6 +39,20 @@
   &.collapsed > .menubar {
     display: none;
   }
+
+  &.has-scroll-shadow-top:not(.menubar-position-top) > .group-box-header {
+    width: 100%;
+    margin-left: 0;
+    padding-left: @mandatory-indicator-width;
+  }
+
+  &.has-scroll-shadow-top.menubar-position-top,
+  &.has-scroll-shadow-bottom.menubar-position-bottom {
+    & > .menubar {
+      margin-left: 0;
+      padding-left: @mandatory-indicator-width;
+    }
+  }
 }
 
 .root-group-box,

--- a/eclipse-scout-core/src/form/fields/tabbox/TabBox.less
+++ b/eclipse-scout-core/src/form/fields/tabbox/TabBox.less
@@ -16,6 +16,11 @@
   position: relative;
   margin-bottom: @tab-area-border-width;
 
+  .tab-box.has-scroll-shadow-top > & {
+    margin-left: 0;
+    padding-left: @mandatory-indicator-width;
+  }
+
   & > .bottom-border {
     position: absolute;
     left: 0;

--- a/eclipse-scout-core/src/form/fields/tabbox/TabBoxHeaderLayout.js
+++ b/eclipse-scout-core/src/form/fields/tabbox/TabBoxHeaderLayout.js
@@ -47,9 +47,7 @@ export default class TabBoxHeaderLayout extends AbstractLayout {
       insets = htmlContainer.insets(),
       containerSize = htmlContainer.availableSize({
         exact: true
-      }).subtract(htmlContainer.insets()),
-      clientArea = new Rectangle(insets.left, insets.top, containerSize.width, containerSize.height),
-      left = clientArea.x;
+      }).subtract(htmlContainer.insets());
 
     menuBarMinumumSize = menuBar.htmlComp.prefSize({
       widthHint: 0
@@ -61,35 +59,32 @@ export default class TabBoxHeaderLayout extends AbstractLayout {
     }
 
     tabAreaPrefSize = tabArea.htmlComp.prefSize({
-      widthHint: clientArea.width - menuBarMinumumSize.width - menuBarMargins.horizontal() - statusSizeLarge.width,
+      widthHint: containerSize.width - menuBarMinumumSize.width - menuBarMargins.horizontal() - statusSizeLarge.width,
       exact: false
     });
 
-    // layout tabItemsBar
-    tabArea.htmlComp.setBounds(new Rectangle(
-      clientArea.x + tabAreaMargins.left,
-      insets.top + tabAreaMargins.top,
+    // layout tabArea
+    tabArea.htmlComp.setSize(new Dimension(
       tabAreaPrefSize.width,
-      clientArea.height - tabAreaMargins.vertical()
+      containerSize.height - tabAreaMargins.vertical()
     ));
 
     menuBar.htmlComp.layout.collapsed = tabArea.htmlComp.layout.overflowTabs.length > 0;
     // layout menuBar
     menuBar.htmlComp.setBounds(new Rectangle(
-      left + tabAreaPrefSize.width + tabAreaMargins.horizontal() + menuBarMargins.left,
-      insets.top + menuBarMargins.top,
-      clientArea.width - tabAreaPrefSize.width - tabAreaMargins.horizontal() - menuBarMargins.horizontal() - statusSizeLarge.width,
-      clientArea.height - menuBarMargins.vertical()
+      insets.left + tabAreaPrefSize.width + tabAreaMargins.horizontal(),
+      insets.top,
+      containerSize.width - tabAreaPrefSize.width - tabAreaMargins.horizontal() - menuBarMargins.horizontal() - statusSizeLarge.width,
+      containerSize.height - menuBarMargins.vertical()
     ));
 
     // layout status
     if (this.tabBoxHeader.tabBox.statusPosition === FormField.StatusPosition.TOP && $status && $status.isVisible()) {
       $status.cssWidth(this.fieldStatusWidth)
-        .cssRight(insets.left)
-        .cssHeight(clientArea.height - graphics.margins($status).vertical())
-        .cssLineHeight(clientArea.height - graphics.margins($status).vertical());
+        .cssRight(insets.right)
+        .cssHeight(containerSize.height - graphics.margins($status).vertical())
+        .cssLineHeight(containerSize.height - graphics.margins($status).vertical());
     }
-
   }
 
   preferredLayoutSize($container, options) {

--- a/eclipse-scout-core/src/form/fields/wizard/WizardProgressField.js
+++ b/eclipse-scout-core/src/form/fields/wizard/WizardProgressField.js
@@ -49,7 +49,8 @@ export default class WizardProgressField extends FormField {
     this.$wizardStepsBody = this.$field.appendDiv('wizard-steps-body');
 
     this._installScrollbars({
-      axis: 'x'
+      axis: 'x',
+      scrollShadow: 'none'
     });
 
     // If this field is the first field in a form's main box, mark the form as "wizard-container-form"

--- a/eclipse-scout-core/src/menu/ContextMenuPopup.js
+++ b/eclipse-scout-core/src/menu/ContextMenuPopup.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {Action, arrays, ContextMenuPopupLayout, HtmlComponent, MenuDestinations, menuNavigationKeyStrokes, Popup, RowLayout, Rectangle, graphics} from '../index';
+import {Action, arrays, ContextMenuPopupLayout, graphics, HtmlComponent, MenuDestinations, menuNavigationKeyStrokes, Popup, Rectangle, RowLayout} from '../index';
 import $ from 'jquery';
 
 export default class ContextMenuPopup extends Popup {
@@ -80,7 +80,8 @@ export default class ContextMenuPopup extends Popup {
 
   _installScrollbars(options) {
     super._installScrollbars({
-      axis: 'y'
+      axis: 'y',
+      scrollShadow: 'none'
     });
   }
 

--- a/eclipse-scout-core/src/scrollbar/Scrollbar.js
+++ b/eclipse-scout-core/src/scrollbar/Scrollbar.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -75,6 +75,9 @@ export default class Scrollbar extends Widget {
     this._dir = this.axis === 'x' ? 'left' : 'top';
     this._dirReverse = this.axis === 'x' ? 'right' : 'bottom';
     this._scrollDir = this.axis === 'x' ? 'scrollLeft' : 'scrollTop';
+
+    // this.$parent.appendDiv('invisible scroll-shadow ' + this._dir);
+    // this.$parent.appendDiv('invisible scroll-shadow ' + this._dirReverse);
 
     // Install listeners
     let scrollbars = this.$parent.data('scrollbars');

--- a/eclipse-scout-core/src/scrollbar/Scrollbar.less
+++ b/eclipse-scout-core/src/scrollbar/Scrollbar.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -127,4 +127,100 @@
 
 .hybrid-scrollable {
   #scout.hide-scrollbars();
+}
+
+.scroll-shadow {
+  transition: box-shadow 250ms;
+  position: absolute;
+  pointer-events: none;
+
+  #scout.scroll-shadow();
+
+  &.gradient {
+    --scroll-shadow-color: @scroll-shadow-gradient-color;
+    --scroll-shadow-size: 20px;
+    --scroll-shadow-blur: 15px;
+    --scroll-shadow-spread: 15px;
+  }
+
+  &.large {
+    --scroll-shadow-size: @scroll-shadow-size-large;
+    --scroll-shadow-blur: @scroll-shadow-size-large;
+    --scroll-shadow-spread: @scroll-shadow-size-large;
+  }
+}
+
+#scout {
+  .scroll-shadow() {
+    --scroll-shadow-color: @scroll-shadow-color;
+    --scroll-shadow-size: @scroll-shadow-size;
+    --scroll-shadow-blur: @scroll-shadow-blur;
+    --scroll-shadow-spread: @scroll-shadow-spread;
+    @scroll-shadow-blur-spread-color: var(--scroll-shadow-blur) calc(-1 * var(--scroll-shadow-spread)) var(--scroll-shadow-color);
+    @scroll-shadow-top: inset 0 var(--scroll-shadow-size) @scroll-shadow-blur-spread-color;
+    @scroll-shadow-bottom: inset 0 calc(-1 * var(--scroll-shadow-size)) @scroll-shadow-blur-spread-color;
+    @scroll-shadow-left: inset var(--scroll-shadow-size) 0 @scroll-shadow-blur-spread-color;
+    @scroll-shadow-right: inset calc(-1 * var(--scroll-shadow-size)) 0 @scroll-shadow-blur-spread-color;
+    @scroll-shadow-none: inset 0 0 0 0 transparent;
+
+    &.top {
+      box-shadow: @scroll-shadow-top, @scroll-shadow-none, @scroll-shadow-none, @scroll-shadow-none;
+
+      &.bottom {
+        box-shadow: @scroll-shadow-top, @scroll-shadow-none, @scroll-shadow-bottom, @scroll-shadow-none;
+
+        &.left {
+          box-shadow: @scroll-shadow-top, @scroll-shadow-none, @scroll-shadow-bottom, @scroll-shadow-left;
+        }
+
+        &.right {
+          box-shadow: @scroll-shadow-top, @scroll-shadow-right, @scroll-shadow-bottom, @scroll-shadow-none;
+
+          &.left {
+            box-shadow: @scroll-shadow-top, @scroll-shadow-right, @scroll-shadow-bottom, @scroll-shadow-left;
+          }
+        }
+      }
+
+      &.left {
+        box-shadow: @scroll-shadow-top, @scroll-shadow-none, @scroll-shadow-none, @scroll-shadow-left;
+
+        &.right {
+          box-shadow: @scroll-shadow-top, @scroll-shadow-right, @scroll-shadow-none, @scroll-shadow-left;
+        }
+      }
+
+      &.right {
+        box-shadow: @scroll-shadow-top, @scroll-shadow-right, @scroll-shadow-none, @scroll-shadow-none;
+      }
+    }
+
+    &.bottom {
+      box-shadow: @scroll-shadow-none, @scroll-shadow-none, @scroll-shadow-bottom, @scroll-shadow-none;
+
+      &.right {
+        box-shadow: @scroll-shadow-none, @scroll-shadow-right, @scroll-shadow-bottom, @scroll-shadow-none;
+      }
+    }
+
+    &.left {
+      box-shadow: @scroll-shadow-none, @scroll-shadow-none, @scroll-shadow-none, @scroll-shadow-left;
+
+      &.right {
+        box-shadow: @scroll-shadow-none, @scroll-shadow-right, @scroll-shadow-none, @scroll-shadow-left;
+      }
+
+      &.bottom {
+        box-shadow: @scroll-shadow-none, @scroll-shadow-none, @scroll-shadow-bottom, @scroll-shadow-left;
+
+        &.right {
+          box-shadow: @scroll-shadow-none, @scroll-shadow-right, @scroll-shadow-bottom, @scroll-shadow-left;
+        }
+      }
+    }
+
+    &.right {
+      box-shadow: @scroll-shadow-none, @scroll-shadow-right, @scroll-shadow-none, @scroll-shadow-none;
+    }
+  }
 }

--- a/eclipse-scout-core/src/style/colors-dark.less
+++ b/eclipse-scout-core/src/style/colors-dark.less
@@ -180,6 +180,7 @@
 @scrollbar-thumb-inverted-hover-color: fade(@scrollbar-thumb-inverted-main-color, 45%);
 @scrollbar-thumb-inverted-small-color: fade(@scrollbar-thumb-inverted-main-color, 15%);
 @scrollbar-thumb-inverted-small-hover-color: fade(@scrollbar-thumb-inverted-main-color, 15%);
+@scroll-shadow-alpha: 70%;
 @search-outline-field-focus-glow-color: @focus-glow-color;
 @slider-thumb-color: @palette-gray-2;
 @slider-thumb-border-color: @palette-gray-2-1;

--- a/eclipse-scout-core/src/style/colors.less
+++ b/eclipse-scout-core/src/style/colors.less
@@ -340,6 +340,9 @@
 @scrollbar-thumb-inverted-hover-color: fade(@scrollbar-thumb-inverted-main-color, 40%);
 @scrollbar-thumb-inverted-small-color: fade(@scrollbar-thumb-inverted-main-color, 15%);
 @scrollbar-thumb-inverted-small-hover-color: fade(@scrollbar-thumb-inverted-main-color, 15%);
+@scroll-shadow-alpha: 30%;
+@scroll-shadow-color: rgba(0, 0, 0, @scroll-shadow-alpha);
+@scroll-shadow-gradient-color: @background-color;
 @status-menu-color: @palette-gray-7;
 @status-menu-hover-color: @hover-color;
 @status-ok-color: @ok-color;

--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -236,6 +236,10 @@
 @scrollbar-size: 14px;
 @scrollbar-thumb-size: 4px;
 @scrollbar-thumb-hover-size: 8px;
+@scroll-shadow-size-large: 10px;
+@scroll-shadow-size: 5px;
+@scroll-shadow-blur: @scroll-shadow-size;
+@scroll-shadow-spread: @scroll-shadow-size + 1; // +1 to ensure firefox does not draw a light shadow on the side of the scrollable
 @search-outline-panel-padding-bottom: 14px;
 @split-box-splitter-line-size: 3px;
 @split-box-x-splitter-padding: 19px;
@@ -257,9 +261,9 @@
 @table-cell-padding-right: @table-cell-padding-left;
 @table-cell-padding-right-last: @scrollbar-size;
 @table-control-content-padding: 10px;
-@table-control-container-height: 360px;
+@table-control-container-height: 364px;
 @table-control-container-height-dense: 320px;
-@table-control-resize-border-width: 3px;
+@table-control-resize-border-width: 2px;
 @table-control-size: 40px;
 @table-footer-height: @main-menubar-height;
 @table-footer-text-filter-height: 32px;

--- a/eclipse-scout-core/src/table/TableHeaderMenu.js
+++ b/eclipse-scout-core/src/table/TableHeaderMenu.js
@@ -134,7 +134,8 @@ export default class TableHeaderMenu extends Popup {
     this.$body = this.$container.appendDiv('table-header-menu-body');
     HtmlComponent.install(this.$body, this.session);
     this._installScrollbars({
-      axis: 'y'
+      axis: 'y',
+      scrollShadow: 'none'
     });
     this.$columnActions = this.$body.appendDiv('table-header-menu-actions');
 

--- a/eclipse-scout-core/src/table/TableHeaderMenu.less
+++ b/eclipse-scout-core/src/table/TableHeaderMenu.less
@@ -14,6 +14,7 @@
   #scout.drop-shadow-large();
   white-space: nowrap;
   margin: @widget-popup-margin;
+  overflow: hidden;
 
   &.animate-open {
     .popup-animate-open();

--- a/eclipse-scout-core/src/widget/Widget.js
+++ b/eclipse-scout-core/src/widget/Widget.js
@@ -22,9 +22,6 @@ import {
   graphics,
   icons,
   inspector,
-  KeyStrokeContext,
-  LoadingSupport,
-  LogicalGrid,
   objects,
   scout,
   scrollbars,
@@ -2166,8 +2163,8 @@ export default class Widget {
 
   _onScroll() {
     let $scrollable = this.get$Scrollable();
-    this.scrollTop = $scrollable[0].scrollTop;
-    this.scrollLeft = $scrollable[0].scrollLeft;
+    this._setProperty('scrollTop', $scrollable[0].scrollTop);
+    this._setProperty('scrollLeft', $scrollable[0].scrollLeft);
   }
 
   setScrollTop(scrollTop) {
@@ -2175,13 +2172,7 @@ export default class Widget {
       this.getDelegateScrollable().setScrollTop(scrollTop);
       return;
     }
-    if (this.scrollTop === scrollTop) {
-      return;
-    }
-    this.scrollTop = scrollTop;
-    if (this.rendered) {
-      this._renderScrollTop();
-    }
+    this.setProperty('scrollTop', scrollTop);
   }
 
   _renderScrollTop() {
@@ -2204,13 +2195,7 @@ export default class Widget {
       this.getDelegateScrollable().setScrollLeft(scrollLeft);
       return;
     }
-    if (this.scrollLeft === scrollLeft) {
-      return;
-    }
-    this.scrollLeft = scrollLeft;
-    if (this.rendered) {
-      this._renderScrollLeft();
-    }
+    this.setProperty('scrollLeft', scrollLeft);
   }
 
   _renderScrollLeft() {
@@ -2236,6 +2221,10 @@ export default class Widget {
    */
   get$Scrollable() {
     return this.$container;
+  }
+
+  hasScrollShadow(position) {
+    return scrollbars.hasScrollShadow(this.get$Scrollable(), position);
   }
 
   /**

--- a/eclipse-scout-core/src/widget/widgets.js
+++ b/eclipse-scout-core/src/widget/widgets.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, Widget} from '../index';
+import {arrays} from '../index';
 import $ from 'jquery';
 
 let uniqueIdSeqNo = 0;
@@ -67,10 +67,26 @@ export function findFirstFocusableWidget(widgets, container, checkTabbable) {
   return arrays.find(widgets, widget => widget.isFocusable(checkTabbable));
 }
 
+export function preserveAndSetProperty(setter, getter, preserver, preserverName) {
+  if (preserver[preserverName] === null) {
+    preserver[preserverName] = getter();
+  }
+  setter();
+}
+
+export function resetProperty(setter, preserver, preserverName) {
+  if (preserver[preserverName] != null) {
+    setter(preserver[preserverName]);
+    preserver[preserverName] = null;
+  }
+}
+
 export default {
   createUniqueId,
   findFirstFocusableWidget,
   get,
   uniqueIdSeqNo,
-  updateFirstLastMarker
+  updateFirstLastMarker,
+  preserveAndSetProperty,
+  resetProperty
 };


### PR DESCRIPTION
The scroll shadow visualizes whether there is scrollable content.
It is installed automatically when scrollbars are installed.
The shadow is a div that is placed after the scrollable.
The div has 4 box shadows, one for each side. Since it is placed
after the scrollable, it has to track the style, visibility and position
of the scrollable and adjust itself accordingly. The size and position
are mainly updated by the already existing scrollbars.update calls by
the layouts. Additionally, dom mutation and intersection observers are
used to track dom movements and visibility changes.

Some alternative solutions that did not work well:
- Using a box shadow inside the scrollable container: The box shadow
  lays under the elements, so if they have a background color the shadow
  won't be visible completely.
- Using position sticky: only works with relative positioning and does
  not work well for horizontal scrolling
- Using position absolute and update position while scrolling as done
  for the scrollbars itself: does not work well with native scrolling
  because scroll events are not fired immediately -> shadow jumps
  around.

292522