### PR TITLE
Table: don't show broken font icon in tooltip

### DIFF
--- a/eclipse-scout-core/src/encoder/PlainTextEncoder.js
+++ b/eclipse-scout-core/src/encoder/PlainTextEncoder.js
@@ -36,6 +36,10 @@ export default class PlainTextEncoder {
     // Separate td with ' '
     text = text.replace(/<\/td>/gi, ' ');
 
+    if (options.removeFontIcons) {
+      text = text.replace(/<span\s+class="[^"]*font-icon[^"]*">[^<]*<\/span>/gmi, '');
+    }
+
     // Replace remaining tags
     text = text.replace(/<[^>]+>/gi, '');
 

--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -853,13 +853,16 @@ export default class Table extends Widget {
 
     if (tooltipText) {
       return tooltipText;
-    } else if ($row.data('aggregateRow') && $cell.text().trim() && ($cell.isContentTruncated() || ($cell.children('.table-cell-icon').length && !$cell.children('.table-cell-icon').isVisible()))) {
+    }
+    if ($row.data('aggregateRow') && $cell.text().trim() && ($cell.isContentTruncated() || ($cell.children('.table-cell-icon').length && !$cell.children('.table-cell-icon').isVisible()))) {
       $cell = $cell.clone();
       $cell.children('.table-cell-icon').setVisible(true);
       return $cell.html();
-    } else if (this._isTruncatedCellTooltipEnabled(column) && $cell.isContentTruncated()) {
+    }
+    if (this._isTruncatedCellTooltipEnabled(column) && $cell.isContentTruncated()) {
       return strings.plainText($cell.html(), {
-        trim: true
+        trim: true,
+        removeFontIcons: true
       });
     }
   }

--- a/eclipse-scout-core/src/table/TableHeader.js
+++ b/eclipse-scout-core/src/table/TableHeader.js
@@ -278,7 +278,7 @@ export default class TableHeader extends Widget {
     }
     let $text = $col.children('.table-header-item-text');
     if ($text.isContentTruncated() || ($col.width() + $col.position().left) > $col.parent().width()) {
-      let text = strings.plainText($col.html(), {
+      let text = strings.plainText($text.html(), {
         trim: true
       });
       if (strings.hasText(text)) {

--- a/eclipse-scout-core/src/util/strings.js
+++ b/eclipse-scout-core/src/util/strings.js
@@ -155,9 +155,10 @@ export function encode(text) {
  * Tries to preserve the new lines. Since it does not consider the style, it won't be right in any cases.
  * A div for example always generates a new line, even if display style is not set to block.
  *
- * Options:
- * - compact: Multiple consecutive empty lines are reduced to a single empty line
- * - trim: Calls string.trim(). White space at the beginning and the end of the text gets removed.
+ * @param {object} [options]
+ * @param {boolean} [options.compact] Multiple consecutive empty lines are reduced to a single empty line. Default is false.
+ * @param {boolean}[options.trim] Calls string.trim(). White space at the beginning and the end of the text gets removed.. Default is false.
+ * @param {boolean} [options.removeFontIcons] Removes font icons. Default is false.
  */
 export function plainText(text, options) {
   if (!plainTextEncoder) { // lazy instantiation to avoid cyclic dependency errors during webpack bootstrap

--- a/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.js
+++ b/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.js
@@ -98,4 +98,14 @@ describe('PlainTextEncoder', () => {
     expect(encoder.encode(htmlText, {compact: true})).toBe('Hello!\n\nI like coding!');
   });
 
+  it('removes font icons if configured', () => {
+    let htmlText = '<span class="table-cell-icon font-icon"></span><span class="text">Text</span>';
+    expect(encoder.encode(htmlText)).toBe('Text');
+    expect(encoder.encode(htmlText, {removeFontIcons: true})).toBe('Text');
+
+    htmlText = '<span\nclass="font-icon xy-icon"></span>\n<span class="text">Text</span>';
+    expect(encoder.encode(htmlText)).toBe('\nText');
+    expect(encoder.encode(htmlText, {removeFontIcons: true})).toBe('\nText');
+  });
+
 });


### PR DESCRIPTION
Tooltip does not know how to display a font icon -> don't include
it when generating the plain text.

302034