### PR TITLE
Data object: add exist check for convenience methods

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoCollectionTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoCollectionTest.java
@@ -321,6 +321,79 @@ public class DoCollectionTest {
     assertCollectionEquals(Arrays.asList("foo", "bar", "baz"), actual);
   }
 
+  /**
+   * Methods from {@link DoCollection} must not create the node if it's not necessary.
+   */
+  @Test
+  public void testIdempotentMethodCalls() {
+    DoCollection<String> collection = new DoCollection<>(null, m_lazyCreate);
+    assertFalse(collection.exists());
+
+    assertFalse(collection.contains("value"));
+    assertFalse(collection.exists());
+
+    // add method has a side effect
+
+    collection.addAll((Collection<String>) null);
+    assertFalse(collection.exists());
+
+    collection.addAll((String[]) null);
+    assertFalse(collection.exists());
+
+    assertFalse(collection.remove("value"));
+    assertFalse(collection.exists());
+
+    assertFalse(collection.removeAll(Collections.singletonList("value")));
+    assertFalse(collection.exists());
+
+    assertFalse(collection.removeAll("value"));
+    assertFalse(collection.exists());
+
+    collection.updateAll((Collection<String>) null);
+    assertFalse(collection.exists());
+
+    collection.updateAll((String[]) null);
+    assertFalse(collection.exists());
+
+    collection.clear();
+    assertFalse(collection.exists());
+
+    assertEquals(0, collection.size());
+    assertFalse(collection.exists());
+
+    assertTrue(collection.isEmpty());
+    assertFalse(collection.exists());
+
+    assertEquals(0, collection.stream().count());
+    assertFalse(collection.exists());
+
+    assertFalse(collection.exists());
+    assertFalse(collection.exists());
+
+    assertEquals(0, collection.parallelStream().count());
+    assertFalse(collection.exists());
+
+    assertFalse(collection.iterator().hasNext());
+    assertFalse(collection.exists());
+
+    // findFirst(Function,VALUE) calls findFirst(Predicate)
+    assertNull(collection.findFirst(x -> true));
+    assertFalse(collection.exists());
+
+    // find(Function,VALUE) calls find(Predicate)
+    assertTrue(collection.find(x -> true).isEmpty());
+    assertFalse(collection.exists());
+
+    collection.valueHashCode();
+    assertFalse(collection.exists());
+
+    DoCollection<String> otherCollection = new DoCollection<>(null, m_lazyCreate);
+    assertFalse(otherCollection.exists());
+    assertTrue(collection.valueEquals(otherCollection));
+    assertFalse(collection.exists());
+    assertFalse(otherCollection.exists());
+  }
+
   @Test
   public void testStream() {
     assertCollectionEquals(Arrays.asList("foo", "bar", "baz"), m_testDoCollection.stream().collect(Collectors.toSet()));

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoListTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoListTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -399,14 +400,14 @@ public class DoListTest {
 
   @Test
   public void testSort() {
-    m_testDoList.sort((left, right) -> left.compareTo(right));
+    m_testDoList.sort(Comparator.naturalOrder());
     assertEquals(Arrays.asList("bar", "baz", "foo"), m_testDoList.get());
 
-    m_testDoList.sort((left, right) -> right.compareTo(left));
+    m_testDoList.sort(Comparator.reverseOrder());
     assertEquals(Arrays.asList("foo", "baz", "bar"), m_testDoList.get());
   }
 
-  protected Function<String, DoValue<String>> listValueAccessor = new Function<String, DoValue<String>>() {
+  protected Function<String, DoValue<String>> listValueAccessor = new Function<>() {
     @Override
     public DoValue<String> apply(String input) {
       for (String item : m_testDoList.get()) {
@@ -438,6 +439,36 @@ public class DoListTest {
   public void testFind() {
     assertEquals(Arrays.asList("bar"), m_testDoList.find("bar"::equals));
     assertEquals(Arrays.asList("bar", "baz"), m_testDoList.find((input) -> "bar".equals(input) || "baz".equals(input)));
+  }
+
+  /**
+   * Methods from {@link DoList} must not create the node if it's not necessary.
+   */
+  @Test
+  public void testIdempotentMethodCalls() {
+    DoList<String> list = new DoList<>(null, m_lazyCreate);
+    assertFalse(list.exists());
+
+    assertThrows(IndexOutOfBoundsException.class, () -> list.get(0));
+    assertFalse(list.exists());
+
+    assertThrows(IndexOutOfBoundsException.class, () -> list.remove(0));
+    assertFalse(list.exists());
+
+    assertNull(list.first());
+    assertFalse(list.exists());
+
+    assertNull(list.last());
+    assertFalse(list.exists());
+
+    assertFalse(list.listIterator().hasNext());
+    assertFalse(list.exists());
+
+    list.sort(Comparator.naturalOrder());
+    assertFalse(list.exists());
+
+    assertNotNull(list.toString());
+    assertFalse(list.exists());
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoSetTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoSetTest.java
@@ -329,6 +329,18 @@ public class DoSetTest {
     assertEquals(CollectionUtility.hashSet("foo", "bar", "baz"), m_testDoSet.parallelStream().collect(Collectors.toSet()));
   }
 
+  /**
+   * Methods from {@link DoSet} must not create the node if it's not necessary.
+   */
+  @Test
+  public void testIdempotentMethodCalls() {
+    DoSet<String> set = new DoSet<>(null, m_lazyCreate);
+    assertFalse(set.exists());
+
+    assertNotNull(set.toString());
+    assertFalse(set.exists());
+  }
+
   @Test
   public void testAttributeName() {
     assertNull(new DoSet<>().getAttributeName());

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractDoCollection.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractDoCollection.java
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.dataobject;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
@@ -38,6 +39,9 @@ public abstract class AbstractDoCollection<V, COLLECTION extends Collection<V>> 
 
   @Override
   public boolean contains(V item) {
+    if (!exists()) {
+      return false;
+    }
     return get().contains(item);
   }
 
@@ -63,11 +67,17 @@ public abstract class AbstractDoCollection<V, COLLECTION extends Collection<V>> 
 
   @Override
   public boolean remove(V item) {
+    if (!exists()) {
+      return false;
+    }
     return get().remove(item);
   }
 
   @Override
   public boolean removeAll(Collection<? extends V> items) {
+    if (!exists()) {
+      return false;
+    }
     if (items != null) {
       return get().removeAll(items);
     }
@@ -77,6 +87,9 @@ public abstract class AbstractDoCollection<V, COLLECTION extends Collection<V>> 
   @Override
   @SafeVarargs
   public final boolean removeAll(@SuppressWarnings("unchecked") V... items) {
+    if (!exists()) {
+      return false;
+    }
     if (items != null) {
       return removeAll(Arrays.asList(items));
     }
@@ -98,31 +111,49 @@ public abstract class AbstractDoCollection<V, COLLECTION extends Collection<V>> 
 
   @Override
   public void clear() {
+    if (!exists()) {
+      return;
+    }
     get().clear();
   }
 
   @Override
   public int size() {
+    if (!exists()) {
+      return 0;
+    }
     return get().size();
   }
 
   @Override
   public boolean isEmpty() {
+    if (!exists()) {
+      return true;
+    }
     return get().isEmpty();
   }
 
   @Override
   public Stream<V> stream() {
+    if (!exists()) {
+      return Stream.empty();
+    }
     return get().stream();
   }
 
   @Override
   public Stream<V> parallelStream() {
+    if (!exists()) {
+      return Stream.empty();
+    }
     return get().parallelStream();
   }
 
   @Override
   public Iterator<V> iterator() {
+    if (!exists()) {
+      return Collections.emptyIterator();
+    }
     return get().iterator();
   }
 

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoCollection.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoCollection.java
@@ -58,17 +58,23 @@ public final class DoCollection<V> extends AbstractDoCollection<V, Collection<V>
 
   @Override
   protected int valueHashCode() {
+    if (!exists()) {
+      return 0;
+    }
     return CollectionUtility.hashCodeCollection(get(), false);
   }
 
   @Override
   protected boolean valueEquals(DoNode other) {
+    if (!exists() && !other.exists()) {
+      return true;
+    }
     //noinspection unchecked
     return CollectionUtility.equalsCollection(get(), (Collection<V>) other.get(), false);
   }
 
   @Override
   public String toString() {
-    return "DoCollection [m_collection=" + get() + " exists=" + exists() + "]";
+    return "DoCollection [m_collection=" + (exists() ? get() : "[]") + " exists=" + exists() + "]";
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoList.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoList.java
@@ -11,6 +11,7 @@
 package org.eclipse.scout.rt.dataobject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ListIterator;
@@ -53,6 +54,9 @@ public final class DoList<V> extends AbstractDoCollection<V, List<V>> implements
    * Returns the element at the specified position in this list.
    */
   public V get(int index) {
+    if (!exists()) {
+      throw new IndexOutOfBoundsException("Node doesn't exist");
+    }
     return get().get(index);
   }
 
@@ -62,6 +66,9 @@ public final class DoList<V> extends AbstractDoCollection<V, List<V>> implements
    * @return the element previously at the specified position
    */
   public V remove(int index) {
+    if (!exists()) {
+      throw new IndexOutOfBoundsException("Node doesn't exist");
+    }
     return get().remove(index);
   }
 
@@ -69,36 +76,41 @@ public final class DoList<V> extends AbstractDoCollection<V, List<V>> implements
    * Returns first element of this list or {@code null} if list is empty.
    */
   public V first() {
-    return get().size() == 0 ? null : get(0);
+    return size() == 0 ? null : get(0);
   }
 
   /**
    * Returns last element of this list or {@code null} if list is empty.
    */
   public V last() {
-    return get().size() == 0 ? null : get(get().size() - 1);
+    return size() == 0 ? null : get(get().size() - 1);
   }
 
   /**
    * @return an {@code ListIterator} over the elements in this list.
    */
   public ListIterator<V> listIterator() {
+    if (!exists()) {
+      return Collections.emptyListIterator();
+    }
     return get().listIterator();
   }
 
   /**
-   * Sorts the internal list using {@code comparator} and returns the list.
+   * Sorts the internal list using {@code comparator}.
    */
-  public List<V> sort(Comparator<V> comparator) {
+  public void sort(Comparator<V> comparator) {
+    if (!exists()) {
+      return;
+    }
     List<V> list = get();
     list.sort(comparator);
-    return list;
   }
 
   // ArrayList already implemented hashCode/equals with considering element position, thus no need to override valueHashCode/valueEquals.
 
   @Override
   public String toString() {
-    return "DoList [m_list=" + get() + " exists=" + exists() + "]";
+    return "DoList [m_list=" + (exists() ? get() : "[]") + " exists=" + exists() + "]";
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoSet.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoSet.java
@@ -56,6 +56,6 @@ public final class DoSet<V> extends AbstractDoCollection<V, Set<V>> {
 
   @Override
   public String toString() {
-    return "DoSet [m_set=" + get() + " exists=" + exists() + "]";
+    return "DoSet [m_set=" + (exists() ? get() : "[]") + " exists=" + exists() + "]";
   }
 }


### PR DESCRIPTION
By using an exist check before, the node/collection is not created when these methods are used instead the ones on the collection itself.