### PR TITLE
BrushUp: improve message box style

### DIFF
--- a/eclipse-scout-core/src/messagebox/MessageBox.js
+++ b/eclipse-scout-core/src/messagebox/MessageBox.js
@@ -137,7 +137,8 @@ export default class MessageBox extends Widget {
     this.$buttons.on('copy', this._onCopy.bind(this));
 
     this._installScrollbars({
-      axis: 'y'
+      axis: 'y',
+      scrollShadow: 'none'
     });
 
     // Render properties
@@ -200,6 +201,7 @@ export default class MessageBox extends Widget {
   _renderHeader() {
     this.$header.html(strings.nl2br(this.header));
     this.$header.setVisible(this.header || this.iconId);
+    this.$header.toggleClass('has-text', strings.hasText(this.header));
   }
 
   _renderBody() {

--- a/eclipse-scout-core/src/messagebox/MessageBox.less
+++ b/eclipse-scout-core/src/messagebox/MessageBox.less
@@ -17,12 +17,16 @@
   #scout.drop-shadow-large();
   background-color: @messagebox-background-color;
   border-radius: @border-radius-medium;
+  overflow: hidden;
   margin: 10px /* minimum padding to desktop */ 10px 15px;
 
-  .severity-button(@color) {
+  &.full-height.full-width {
+    border-radius: 0;
+  }
+
+  .severity-button(@color, @hover-color: darken(@color, 6%), @active-color: darken(@color, 13%), @focus-color: @focus-box-shadow-color) {
     & > .box-buttons > .box-button {
       border-color: @color;
-      font-weight: @font-weight-bold;
       color: @color;
 
       &:focus {
@@ -30,29 +34,36 @@
       }
 
       &.keyboard-navigation {
-        box-shadow: 0 0 0 @focus-box-shadow-size fade(@color, 50%);
+        #scout.button-focus(@box-shadow-color: @focus-color, @border-color: mix(@color, @focus-color, 25%));
       }
 
       &.disabled {
-        cursor: default;
-        color: @disabled-color;
-        border-color: @disabled-color;
+        color: @button-disabled-color;
+        border-color: @button-disabled-border-color;
       }
 
       &.default {
-        color: @button-selected-color;
-
-        &:hover {
-          background-color: darken(@color, 5%);
-        }
-
+        color: @default-button-color;
         background-color: @color;
 
+        &:hover {
+          background-color: @hover-color;
+          border-color: @hover-color;
+        }
+
+        &.active, &:active {
+          background-color: @active-color;
+          border-color: @active-color;
+        }
+
+        &.keyboard-navigation {
+          #scout.button-focus(@box-shadow-color: @focus-color, @border-color: mix(@color, @focus-color, 25%));
+        }
+
         &.disabled {
-          cursor: default;
-          color: @disabled-color;
-          border-color: @disabled-color;
-          background-color: @palette-white;
+          color: @button-disabled-color;
+          border-color: @button-disabled-border-color;
+          background-color: @button-disabled-background-color;
         }
       }
     }
@@ -63,11 +74,11 @@
       color: @info-color;
 
       & > .font-icon.messagebox-icon {
-        .notification-font-icon-style(@info-color, @font-size-smaller);
+        .notification-font-icon-style(@info-color, 14px);
       }
     }
 
-    .severity-button(@info-color);
+    .severity-button(@info-color, @default-button-hover-background-color, @default-button-active-background-color);
   }
 
   &.error {
@@ -75,11 +86,11 @@
       color: @error-color;
 
       & > .font-icon.messagebox-icon {
-        .notification-font-icon-style(@error-color, @font-size-smaller);
+        .notification-font-icon-style(@error-color, 14px);
       }
     }
 
-    .severity-button(@error-color);
+    .severity-button(@error-color, @focus-color: @error-box-shadow-focus-color);
   }
 
   &.warning {
@@ -87,11 +98,11 @@
       color: @warning-color;
 
       & > .font-icon.messagebox-icon {
-        .notification-font-icon-style(@warning-color, @font-size-smaller);
+        .notification-font-icon-style(@warning-color, 14px);
       }
     }
 
-    .severity-button(@warning-color);
+    .severity-button(@warning-color, @focus-color: @warning-box-shadow-focus-color);
   }
 
   &.ok {
@@ -99,11 +110,11 @@
       color: @ok-color;
 
       & > .font-icon.messagebox-icon {
-        .notification-font-icon-style(@ok-color, @font-size-smaller);
+        .notification-font-icon-style(@ok-color, 14px);
       }
     }
 
-    .severity-button(@ok-color);
+    .severity-button(@ok-color, @focus-color: @ok-box-shadow-focus-color);
   }
 
   &.animate-open {
@@ -119,8 +130,7 @@
 .messagebox-content {
   min-height: 30px;
   background-color: @messagebox-background-color;
-  padding: @messagebox-label-padding 26px 21px 26px;
-  border-radius: @border-radius-medium;
+  padding: @messagebox-label-padding 26px 17px 26px;
 
   /* add a bit of extra space to the scrollbar on the right */
 
@@ -137,7 +147,6 @@
   font-size: @font-size-smaller;
   justify-content: center;
   flex-shrink: 0;
-  margin-right: 12px;
 }
 
 .messagebox-label {
@@ -164,7 +173,11 @@
 .messagebox-header {
   font-size: @font-size-large;
   font-weight: @font-weight-bold;
-  padding-bottom: 20px;
+  padding-bottom: 16px;
+
+  &.has-text > .messagebox-icon {
+    margin-right: 12px;
+  }
 }
 
 .messagebox-body {
@@ -174,7 +187,7 @@
 .messagebox-buttons {
   display: flex;
   justify-content: center;
-  padding: 0 26px 25px 26px;
+  padding: 4px 26px 25px 26px;
 }
 
 @media (max-width: @messagebox-max-width) {
@@ -184,19 +197,18 @@
     /* no need to have a margin on small screens */
     margin: 0;
 
-    & > .box-buttons {
+    & > .messagebox-buttons {
+      padding-left: 10px;
+      padding-right: 10px;
+
       & > .box-button {
         min-width: 70px; /* less min width for buttons on small screens */
-        margin-right: 4px;
-      }
+        margin-right: 8px;
 
-      & > .messagebox-buttons {
-        padding: 0 10px 20px 10px;
+        &:last-child {
+          margin-right: 0;
+        }
       }
-    }
-
-    & > .messagebox-content {
-      padding: 10px; /* loose less space on small screens */
     }
   }
 }

--- a/eclipse-scout-core/src/messagebox/MessageBoxLayout.js
+++ b/eclipse-scout-core/src/messagebox/MessageBoxLayout.js
@@ -25,6 +25,12 @@ export default class MessageBoxLayout extends AbstractLayout {
       messageBoxMargins = htmlComp.margins();
 
     messageBoxSize = DialogLayout.fitContainerInWindow(windowSize, currentBounds.point(), messageBoxSize, messageBoxMargins);
+
+    // Add markers to be able to style the msg box in a different way when it uses the full width or height
+    $container
+      .toggleClass('full-width', (currentBounds.x === 0 && messageBoxMargins.horizontal() === 0 && windowSize.width === messageBoxSize.width))
+      .toggleClass('full-height', (currentBounds.y === 0 && messageBoxMargins.vertical() === 0 && windowSize.height === messageBoxSize.height));
+
     graphics.setSize($container, messageBoxSize);
 
     let buttonsSize = graphics.size(this.messageBox.$buttons, {

--- a/eclipse-scout-core/src/notification/Notification.less
+++ b/eclipse-scout-core/src/notification/Notification.less
@@ -21,9 +21,9 @@
   height: calc(~'100% - '(7px * 2));
 }
 
-.notification-font-icon-style(@color, @font-size: 16px) {
-  color: @background-color;
-  background-color: @color;
+.notification-font-icon-style(@background-color, @font-size: 16px) {
+  color: @notification-font-icon-color;
+  background-color: @background-color;
   font-size: @font-size;
   border-radius: 50%;
 }

--- a/eclipse-scout-core/src/style/colors-dark.less
+++ b/eclipse-scout-core/src/style/colors-dark.less
@@ -76,10 +76,12 @@
 @info-color: @palette-blue-1-1;
 @ok-color: @palette-green-3;
 @error-background-color: @background-color;
+@error-box-shadow-focus-color: mix(@error-color, @palette-black, 50%);
+@warning-box-shadow-focus-color: mix(@warning-color, @palette-black, 50%);
+@ok-box-shadow-focus-color: mix(@ok-color, @palette-black, 50%);
 @focus-border-color: @focus-color;
 @focus-color: @palette-blue-1-1;
-@focus-box-shadow-color: @focus-color;
-@focus-box-shadow-size: 2px;
+@focus-box-shadow-color: darken(@focus-color, 30%);
 @hover-background-color: fade(@palette-white, 15%);
 @highlight-inverted-background-color: @palette-orange-5;
 @hover-color: @active-color;
@@ -93,6 +95,8 @@
 @label-color: @palette-gray-5-1;
 @panel-background-color: @palette-gray-8;
 @popup-background-color: #283438;
+@selected-background-color: @palette-blue-1-1;
+@selected-hover-background-color: darken(@selected-background-color, 10%);
 @text-color-dark: @palette-black;
 @text-color: @palette-gray-1;
 @text-disabled-color: @disabled-color;
@@ -113,7 +117,6 @@
 @button-border-color: @palette-blue-4;
 @button-color: @palette-blue-1-1;
 @button-disabled-border-color: @disabled-color;
-@button-selected-color: @palette-black;
 @calendar-component-intro-color: @palette-gray-2;
 @calendar-day-color: @text-color;
 @calendar-mode-selected-background-color: @border-color;
@@ -145,6 +148,7 @@
 @dashboard-tile-menu-hover-color: @hover-color;
 @dashboard-tile-menu-active-color: @hover-color;
 @default-button-background-color: @selected-background-color;
+@default-button-color: @palette-black;
 @desktop-header-background-color: @palette-gray-4;
 @desktop-header-border-color: @palette-gray-8;
 @desktop-notification-background-color: @palette-gray-4;

--- a/eclipse-scout-core/src/style/colors.less
+++ b/eclipse-scout-core/src/style/colors.less
@@ -102,6 +102,9 @@
 @error-background-color: @palette-red-0;
 @error-border-color: @error-color;
 @error-glow-color: @error-color;
+@error-box-shadow-focus-color: fade(@error-color, 40%);
+@warning-box-shadow-focus-color: fade(@warning-color, 40%);
+@ok-box-shadow-focus-color: fade(@ok-color, 40%);
 @focus-border-color: @palette-blue-6;
 @focus-box-shadow-color: darken(@palette-blue-1, 10%);
 @focus-color: @palette-blue-6;
@@ -164,7 +167,6 @@
 @button-disabled-border-color: @border-color;
 @button-disabled-color: @disabled-color;
 @button-hover-color: @button-color;
-@button-selected-color: @palette-white;
 @busyindicator-active-color: @palette-blue-6;
 @calendar-component-color: @palette-black;
 @calendar-component-intro-color: @palette-gray-5-1;
@@ -293,6 +295,7 @@
 @desktop-navigation-background-color: @desktop-header-background-color;
 @desktop-navigation-body-background-color: @palette-white;
 @desktop-navigation-color: @palette-gray-10;
+@notification-font-icon-color: @default-button-color;
 @notification-ok-background-color: @ok-color;
 @notification-ok-border-color: @ok-color;
 @notification-info-background-color: @info-color;

--- a/eclipse-scout-core/src/style/mixins.less
+++ b/eclipse-scout-core/src/style/mixins.less
@@ -396,14 +396,14 @@
     white-space: nowrap;
   }
 
-  .button-focus() {
-    #scout.box-shadow-focus();
-    border-color: mix(@button-border-color, @focus-box-shadow-color, 25%);
+  .button-focus(@box-shadow-size: @focus-box-shadow-size, @box-shadow-color: @focus-box-shadow-color, @border-color: mix(@button-border-color, @focus-box-shadow-color, 25%)) {
+    #scout.box-shadow-focus(@box-shadow-size: @box-shadow-size, @box-shadow-color: @box-shadow-color);
+    border-color: @border-color;
   }
 
-  .box-shadow-focus() {
+  .box-shadow-focus(@box-shadow-size: @focus-box-shadow-size, @box-shadow-color: @focus-box-shadow-color) {
     outline: none;
-    box-shadow: 0 0 0 @focus-box-shadow-size @focus-box-shadow-color;
+    box-shadow: 0 0 0 @box-shadow-size @box-shadow-color;
   }
 
   .box-shadow-focus-inset() {


### PR DESCRIPTION
- Use same focus colors as for regular buttons
- Add pressed style for buttons
- Reduced header padding a little
- Don't remove padding on small screens, it looks better with large
 padding
- Don't add margin to icon if there is no text
- Increase icon font-size, it was very hard to see what it is
- Use darker color for icon in dark theme to improve contrast
- Slightly adjust focus and hover colors
- Fix broken messagebox-buttons rule for small screens