### PR TITLE
Data object contributions: lazy init of internal representation

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectContributionTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectContributionTest.java
@@ -25,6 +25,14 @@ import org.junit.runner.RunWith;
 public class DataObjectContributionTest {
 
   @Test
+  public void testHasContributions() {
+    SimpleFixtureDo doEntity = BEANS.get(SimpleFixtureDo.class);
+    assertFalse(doEntity.hasContributions());
+    doEntity.putContribution(BEANS.get(FirstSimpleContributionFixtureDo.class));
+    assertTrue(doEntity.hasContributions());
+  }
+
+  @Test
   public void testHasGetContribution() {
     SimpleFixtureDo doEntity = BEANS.get(SimpleFixtureDo.class);
     assertTrue(doEntity.getContributions().isEmpty());
@@ -103,5 +111,17 @@ public class DataObjectContributionTest {
 
     // Order of contributions must not be relevant for comparison
     assertEquals(doEntity1, doEntity2);
+    assertEquals(doEntity1.hashCode(), doEntity2.hashCode());
+  }
+
+  @Test
+  public void testEqualityHashCodeWithLazyInit() {
+    SimpleFixtureDo doEntity1 = BEANS.get(SimpleFixtureDo.class);
+    SimpleFixtureDo doEntity2 = BEANS.get(SimpleFixtureDo.class);
+    doEntity2.getContributions(); // internal contribution list is created
+
+    // Existence of internal contribution list must not be relevant for comparison
+    assertEquals(doEntity1, doEntity2);
+    assertEquals(doEntity1.hashCode(), doEntity2.hashCode());
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/IDoEntity.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/IDoEntity.java
@@ -328,6 +328,15 @@ public interface IDoEntity extends IDataObject {
   }
 
   /**
+   * @return <code>true</code> if contributions are available, <code>false</code> otherwise.
+   */
+  boolean hasContributions();
+
+  /**
+   * For read-only calls it's recommended to call {@link #hasContributions()} before calling this method because this
+   * method might create an internal representation to store contributions which is usually not necessary if used
+   * read-only.
+   *
    * @return An mutable collection of DO entity contributions (never <code>null</code>).
    */
   Collection<IDoEntityContribution> getContributions();
@@ -351,6 +360,9 @@ public interface IDoEntity extends IDataObject {
    */
   default <CONTRIBUTION extends IDoEntityContribution> CONTRIBUTION getContribution(Class<CONTRIBUTION> contributionClass) {
     assertNotNull(contributionClass, "contributionClass is required");
+    if (!hasContributions()) {
+      return null;
+    }
     return getContributions().stream()
         .filter(contribution -> contributionClass.equals(contribution.getClass()))
         .findFirst()
@@ -382,6 +394,9 @@ public interface IDoEntity extends IDataObject {
    * @return <code>true</code> if the DO entity contribution was available and removed, <code>false</code> otherwise.
    */
   default boolean removeContribution(Class<? extends IDoEntityContribution> contributionClass) {
+    if (!hasContributions()) {
+      return false;
+    }
     return getContributions().removeIf(contribution -> contributionClass.equals(contribution.getClass()));
   }
 }

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestCustomImplementedEntityDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestCustomImplementedEntityDo.java
@@ -44,7 +44,7 @@ import org.eclipse.scout.rt.platform.util.CollectionUtility;
 public class TestCustomImplementedEntityDo implements IDoEntity {
 
   private final Map<String, DoNode<?>> m_attributes = new LinkedHashMap<>();
-  private final List<IDoEntityContribution> m_contributions = new ArrayList<>();
+  private List<IDoEntityContribution> m_contributions;
 
   // attributes
   private static final String DATE_ATTRIBUTE = "dateAttribute";
@@ -123,7 +123,15 @@ public class TestCustomImplementedEntityDo implements IDoEntity {
   }
 
   @Override
+  public boolean hasContributions() {
+    return !CollectionUtility.isEmpty(m_contributions);
+  }
+
+  @Override
   public Collection<IDoEntityContribution> getContributions() {
+    if (m_contributions == null) {
+      m_contributions = new ArrayList<>();
+    }
     return m_contributions;
   }
 

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DefaultDoEntityDeserializerTypeStrategy.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DefaultDoEntityDeserializerTypeStrategy.java
@@ -18,6 +18,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.IDoEntityContribution;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.LazyValue;
 
 import com.fasterxml.jackson.databind.JavaType;
@@ -48,7 +49,9 @@ public class DefaultDoEntityDeserializerTypeStrategy implements IDoEntityDeseria
   @Override
   public void putContributions(IDoEntity doEntity, String attributeName, Collection<?> contributions) {
     // add contributions to corresponding list in do entity
-    //noinspection unchecked
-    doEntity.getContributions().addAll((Collection<? extends IDoEntityContribution>) contributions);
+    if (!CollectionUtility.isEmpty(contributions)) {
+      //noinspection unchecked
+      doEntity.getContributions().addAll((Collection<? extends IDoEntityContribution>) contributions);
+    }
   }
 }

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
@@ -92,8 +92,8 @@ public class DoEntitySerializer extends StdSerializer<IDoEntity> {
   }
 
   protected void serializeContributions(JsonGenerator gen, IDoEntity entity, SerializerProvider provider) throws IOException {
-    Collection<IDoEntityContribution> contributions = entity.getContributions();
-    if (!contributions.isEmpty()) {
+    if (entity.hasContributions()) {
+      Collection<IDoEntityContribution> contributions = entity.getContributions();
       validateContributions(entity, contributions);
       serializeCollection(m_context.getContributionsAttributeName(), contributions, gen, provider);
     }

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/RawDoEntityDeserializerTypeStrategy.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/RawDoEntityDeserializerTypeStrategy.java
@@ -39,6 +39,8 @@ public class RawDoEntityDeserializerTypeStrategy implements IDoEntityDeserialize
 
   @Override
   public void putContributions(IDoEntity doEntity, String attributeName, Collection<?> contributions) {
-    doEntity.putList(attributeName, CollectionUtility.arrayList(contributions)); // for raw do entity, handle contributions as regular node (DoList)
+    if (!CollectionUtility.isEmpty(contributions)) {
+      doEntity.putList(attributeName, CollectionUtility.arrayList(contributions)); // for raw do entity, handle contributions as regular node (DoList)
+    }
   }
 }


### PR DESCRIPTION
Most data objects won't have contributions. Always initializing m_contributions with an empty list isn't necessary therefore. m_contributions is now initialized on first access via IDoEntity#getContributions.

Providing an additional IDoEntity#hasContributions method that will not create the internal representation. IDoEntity#getContributions must always the create internal representation because a mutable list is returned.