### PR TITLE
Simplify usage of DragAndDropHandler.js

### DIFF
--- a/eclipse-scout-core/src/filechooser/FileChooser.js
+++ b/eclipse-scout-core/src/filechooser/FileChooser.js
@@ -173,7 +173,7 @@ export default class FileChooser extends Widget {
 
   _remove() {
     this._glassPaneRenderer.removeGlassPanes();
-    this._uninstallDragAndDropHandler();
+    dragAndDrop.uninstallDragAndDropHandler(this);
     this._uninstallFocusContext();
     super._remove();
   }
@@ -184,44 +184,6 @@ export default class FileChooser extends Widget {
 
   _uninstallFocusContext() {
     this.session.focusManager.uninstallFocusContext(this.$container);
-  }
-
-  _createDragAndDropHandler() {
-    return dragAndDrop.handler(this, {
-      supportedScoutTypes: dragAndDrop.SCOUT_TYPES.FILE_TRANSFER,
-      validateFiles: () => {
-      },
-      onDrop: event => this.addFiles(event.files),
-      dropType: () => dragAndDrop.SCOUT_TYPES.FILE_TRANSFER,
-      dropMaximumSize: () => this.maximumUploadSize
-    });
-  }
-
-  _installOrUninstallDragAndDropHandler() {
-    if (this.enabledComputed) {
-      this._installDragAndDropHandler();
-    } else {
-      this._uninstallDragAndDropHandler();
-    }
-  }
-
-  _installDragAndDropHandler() {
-    if (this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler = this._createDragAndDropHandler();
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.install(this.$container);
-  }
-
-  _uninstallDragAndDropHandler() {
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.uninstall();
-    this.dragAndDropHandler = null;
   }
 
   /**
@@ -288,6 +250,18 @@ export default class FileChooser extends Widget {
       this.displayParent.fileChooserController.unregisterAndRemove(this);
     }
     this.destroy();
+  }
+
+  _installOrUninstallDragAndDropHandler() {
+    dragAndDrop.installOrUninstallDragAndDropHandler(
+      {
+        target: this,
+        onDrop: event => this.addFiles(event.files),
+        dropMaximumSize: () => this.maximumUploadSize,
+        // disable file validation
+        validateFiles: (files, defaultValidator) => {
+        }
+      });
   }
 
   browse() {

--- a/eclipse-scout-core/src/filechooser/FileInput.js
+++ b/eclipse-scout-core/src/filechooser/FileInput.js
@@ -152,50 +152,24 @@ export default class FileInput extends Widget {
   }
 
   _remove() {
-    this._uninstallDragAndDropHandler();
+    dragAndDrop.uninstallDragAndDropHandler(this);
     super._remove();
   }
 
-  _createDragAndDropHandler() {
-    return dragAndDrop.handler(this, {
-      supportedScoutTypes: dragAndDrop.SCOUT_TYPES.FILE_TRANSFER,
-      validateFiles: () => {
-      },
-      onDrop: event => {
-        if (event.files.length >= 1) {
-          this._setFiles(event.files);
-        }
-      },
-      dropType: () => dragAndDrop.SCOUT_TYPES.FILE_TRANSFER,
-      dropMaximumSize: () => this.maximumUploadSize
-    });
-  }
-
   _installOrUninstallDragAndDropHandler() {
-    if (this.enabledComputed) {
-      this._installDragAndDropHandler();
-    } else {
-      this._uninstallDragAndDropHandler();
-    }
-  }
-
-  _installDragAndDropHandler() {
-    if (this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler = this._createDragAndDropHandler();
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.install(this.$container);
-  }
-
-  _uninstallDragAndDropHandler() {
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.uninstall();
-    this.dragAndDropHandler = null;
+    dragAndDrop.installOrUninstallDragAndDropHandler(
+      {
+        target: this,
+        onDrop: event => {
+          if (event.files.length >= 1) {
+            this._setFiles(event.files);
+          }
+        },
+        dropMaximumSize: () => this.maximumUploadSize,
+        // disable file validation
+        validateFiles: (files, defaultValidator) => {
+        }
+      });
   }
 
   clear() {

--- a/eclipse-scout-core/src/form/fields/FormField.js
+++ b/eclipse-scout-core/src/form/fields/FormField.js
@@ -268,7 +268,7 @@ export default class FormField extends Widget {
     this._removeIcon();
     this.removeMandatoryIndicator();
     this._removeDisabledCopyOverlay();
-    this._uninstallDragAndDropHandler();
+    dragAndDrop.uninstallDragAndDropHandler(this);
   }
 
   setFieldStyle(fieldStyle) {
@@ -1306,40 +1306,23 @@ export default class FormField extends Widget {
     this.setProperty('dropMaximumSize', dropMaximumSize);
   }
 
-  _createDragAndDropHandler() {
-    return dragAndDrop.handler(this, {
-      supportedScoutTypes: dragAndDrop.SCOUT_TYPES.FILE_TRANSFER,
-      onDrop: event => this.trigger('drop', event),
-      dropType: () => this.dropType,
-      dropMaximumSize: () => this.dropMaximumSize
-    });
-  }
-
   _installOrUninstallDragAndDropHandler() {
-    if (this.dropType && this.enabledComputed) {
-      this._installDragAndDropHandler();
-    } else {
-      this._uninstallDragAndDropHandler();
-    }
+    dragAndDrop.installOrUninstallDragAndDropHandler(this._getDragAndDropHandlerOptions());
   }
 
-  _installDragAndDropHandler() {
-    if (this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler = this._createDragAndDropHandler();
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.install(this.$field || this.$container);
-  }
-
-  _uninstallDragAndDropHandler() {
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.uninstall();
-    this.dragAndDropHandler = null;
+  /**
+   *
+   * @return {DragAndDropOptions}
+   * @private
+   */
+  _getDragAndDropHandlerOptions() {
+    return {
+      target: this,
+      doInstall: () => this.dropType && this.enabledComputed,
+      container: () => this.$field || this.$container,
+      dropType: () => this.dropType,
+      onDrop: event => this.trigger('drop', event)
+    };
   }
 
   _updateDisabledCopyOverlay() {

--- a/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.js
+++ b/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, Device, dragAndDrop, InputFieldKeyStrokeContext, keys, mimeTypes, scout, Session, strings, ValueField} from '../../../index';
+import {arrays, Device, InputFieldKeyStrokeContext, keys, mimeTypes, scout, Session, strings, ValueField} from '../../../index';
 import $ from 'jquery';
 
 export default class ClipboardField extends ValueField {
@@ -84,19 +84,12 @@ export default class ClipboardField extends ValueField {
       .on('cut', this._onCopy.bind(this));
   }
 
-  _renderProperties() {
-    super._renderProperties();
-    this._renderDropType();
-  }
-
-  _createDragAndDropHandler() {
-    return dragAndDrop.handler(this, {
-      supportedScoutTypes: dragAndDrop.SCOUT_TYPES.FILE_TRANSFER,
-      onDrop: event => this.trigger('drop', event),
-      dropType: () => this.dropType,
-      dropMaximumSize: () => this.maximumSize,
-      allowedTypes: () => this.allowedMimeTypes
-    });
+  _getDragAndDropHandlerOptions() {
+    let options = super._getDragAndDropHandlerOptions();
+    options.allowedTypes = () => this.allowedMimeTypes;
+    // use the smaller property (this.maximumSize for backwards compatibility) but ignore null values which would result in a maximum size of zero.
+    options.dropMaximumSize = () => Math.min(scout.nvl(this.dropMaximumSize, this.maximumSize), scout.nvl(this.maximumSize, this.dropMaximumSize));
+    return options;
   }
 
   _renderDisplayText() {

--- a/eclipse-scout-core/src/form/fields/imagefield/ImageField.js
+++ b/eclipse-scout-core/src/form/fields/imagefield/ImageField.js
@@ -70,13 +70,10 @@ export default class ImageField extends FormField {
     }
   }
 
-  _installDragAndDropHandler() {
-    if (this.dragAndDropHandler) {
-      return;
-    }
-    // add drag and drop event listeners to field container, img field might be hidden (e.g. if no image has been set)
-    this.dragAndDropHandler = this._createDragAndDropHandler();
-    this.dragAndDropHandler.install(this.$fieldContainer);
+  _getDragAndDropHandlerOptions() {
+    let options = super._getDragAndDropHandlerOptions();
+    options.container = () => this.$fieldContainer;
+    return options;
   }
 
   setImageUrl(imageUrl) {

--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -537,7 +537,7 @@ export default class Table extends Widget {
   _remove() {
     this.session.desktop.off('propertyChange', this._desktopPropertyChangeHandler);
     this.session.desktop.off('popupOpen', this._popupOpenHandler);
-    this._uninstallDragAndDropHandler();
+    dragAndDrop.uninstallDragAndDropHandler(this);
     // TODO [7.0] cgu do not delete header, implement according to footer
     this.header = null;
     if (this.$data) {
@@ -4725,51 +4725,26 @@ export default class Table extends Widget {
     this.setProperty('dropMaximumSize', dropMaximumSize);
   }
 
-  _createDragAndDropHandler() {
-    return dragAndDrop.handler(this, {
-      supportedScoutTypes: dragAndDrop.SCOUT_TYPES.FILE_TRANSFER,
-      onDrop: event => this.trigger('drop', event),
-      dropType: () => this.dropType,
-      dropMaximumSize: () => this.dropMaximumSize,
-      additionalDropProperties: event => {
-        let $target = $(event.currentTarget);
-        let properties = {
-          rowId: ''
-        };
-        if ($target.hasClass('table-row')) {
-          let row = $target.data('row');
-          properties.rowId = row.id;
-        }
-        return properties;
-      }
-    });
-  }
-
   _installOrUninstallDragAndDropHandler() {
-    if (this.dropType && this.enabledComputed) {
-      this._installDragAndDropHandler();
-    } else {
-      this._uninstallDragAndDropHandler();
-    }
-  }
-
-  _installDragAndDropHandler() {
-    if (this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler = this._createDragAndDropHandler();
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.install(this.$container, '.table-data,.table-row');
-  }
-
-  _uninstallDragAndDropHandler() {
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.uninstall();
-    this.dragAndDropHandler = null;
+    dragAndDrop.installOrUninstallDragAndDropHandler(
+      {
+        target: this,
+        doInstall: () => this.dropType && this.enabledComputed,
+        selector: '.table-data,.table-row',
+        onDrop: event => this.trigger('drop', event),
+        dropType: () => this.dropType,
+        additionalDropProperties: event => {
+          let $target = $(event.currentTarget);
+          let properties = {
+            rowId: ''
+          };
+          if ($target.hasClass('table-row')) {
+            let row = $target.data('row');
+            properties.rowId = row.id;
+          }
+          return properties;
+        }
+      });
   }
 
   /**

--- a/eclipse-scout-core/src/tree/Tree.js
+++ b/eclipse-scout-core/src/tree/Tree.js
@@ -398,7 +398,7 @@ export default class Tree extends Widget {
     // Detach nodes from jQuery objects (because those will be removed)
     this.visitNodes(this._resetTreeNode.bind(this));
 
-    this._uninstallDragAndDropHandler();
+    dragAndDrop.uninstallDragAndDropHandler(this);
     this._uninstallNodeTooltipSupport();
     this.$fillBefore = null;
     this.$fillAfter = null;
@@ -1177,51 +1177,26 @@ export default class Tree extends Widget {
     this.setProperty('dropMaximumSize', dropMaximumSize);
   }
 
-  _createDragAndDropHandler() {
-    return dragAndDrop.handler(this, {
-      supportedScoutTypes: dragAndDrop.SCOUT_TYPES.FILE_TRANSFER,
-      onDrop: event => this.trigger('drop', event),
-      dropType: () => this.dropType,
-      dropMaximumSize: () => this.dropMaximumSize,
-      additionalDropProperties: event => {
-        let $target = $(event.currentTarget);
-        let properties = {
-          nodeId: ''
-        };
-        if ($target.hasClass('tree-node')) {
-          let node = $target.data('node');
-          properties.nodeId = node.id;
-        }
-        return properties;
-      }
-    });
-  }
-
   _installOrUninstallDragAndDropHandler() {
-    if (this.dropType && this.enabledComputed) {
-      this._installDragAndDropHandler();
-    } else {
-      this._uninstallDragAndDropHandler();
-    }
-  }
-
-  _installDragAndDropHandler() {
-    if (this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler = this._createDragAndDropHandler();
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.install(this.$container, '.tree-data,.tree-node');
-  }
-
-  _uninstallDragAndDropHandler() {
-    if (!this.dragAndDropHandler) {
-      return;
-    }
-    this.dragAndDropHandler.uninstall();
-    this.dragAndDropHandler = null;
+    dragAndDrop.installOrUninstallDragAndDropHandler(
+      {
+        target: this,
+        doInstall: () => this.dropType && this.enabledComputed,
+        selector: '.tree-data,.tree-node',
+        onDrop: event => this.trigger('drop', event),
+        dropType: () => this.dropType,
+        additionalDropProperties: event => {
+          let $target = $(event.currentTarget);
+          let properties = {
+            nodeId: ''
+          };
+          if ($target.hasClass('tree-node')) {
+            let node = $target.data('node');
+            properties.nodeId = node.id;
+          }
+          return properties;
+        }
+      });
   }
 
   _updateMarkChildrenChecked(node, init, checked, checkChildrenChecked) {

--- a/eclipse-scout-core/src/util/DragAndDropHandler.js
+++ b/eclipse-scout-core/src/util/DragAndDropHandler.js
@@ -20,6 +20,7 @@ export default class DragAndDropHandler {
     this.dropMaximumSize = null;
     this.target = null;
     this.onDrop = null;
+    this.validateFiles = null;
 
     $.extend(this, options);
     this.supportedScoutTypes = arrays.ensure(options.supportedScoutTypes);
@@ -75,22 +76,27 @@ export default class DragAndDropHandler {
         return;
       }
       try {
-        this.validateFiles(files);
+        this.validateFiles(files, this._validateFiles.bind(this));
       } catch (error) {
-        this._validationFailed(files, error);
+        this._validationFailed(error);
         return;
       }
       event.stopPropagation();
       event.preventDefault();
-      let formattedDropEvent = {
+      this.onDrop({
         originalEvent: event,
         files: files
-      };
-      this.onDrop(formattedDropEvent);
+      });
     }
   }
 
-  validateFiles(files) {
+  /**
+   *
+   * @param {File[]} files
+   * @private
+   * @throws {dropValidationErrorMessage} validationErrorMessage
+   */
+  _validateFiles(files) {
     if (!this.dropMaximumSize) {
       return;
     }
@@ -104,23 +110,27 @@ export default class DragAndDropHandler {
   }
 
   /**
-   * @param {object} error object containing message and optionally a title
+   * @param {dropValidationErrorMessage} error
    */
-  _validationFailed(files, error) {
+  _validationFailed(error) {
     $.log.isDebugEnabled() && $.log.debug('File validation failed', error);
     let title = '';
     let message = 'Invalid files';
-    if (typeof error === 'object') {
+    if (error) {
       title = error.title || title;
       message = error.message || message;
     }
-    MessageBoxes.createOk(this.target)
+    return MessageBoxes.createOk(this.target)
       .withSeverity(Status.Severity.ERROR)
       .withHeader(title)
       .withBody(message)
       .buildAndOpen();
   }
 
+  /**
+   *
+   * @param {File[]} files
+   */
   uploadFiles(files) {
     if (files.length >= 1) {
       this.target.session.uploadFiles(this.target, files,
@@ -129,4 +139,12 @@ export default class DragAndDropHandler {
         this.allowedTypes ? this.allowedTypes() : undefined);
     }
   }
+
+  // ----------------- TYPEDEF -----------------
+
+  /**
+   * @typedef dropValidationErrorMessage
+   * @param {string} title
+   * @param {string} message
+   */
 }


### PR DESCRIPTION
The current drag & drop handler needs too much boilerplate code to use
and is not well documented.
With this change the handler will now provide a simple install and
uninstall function where all parameters are documented and can be set
within an options object.