### PR TITLE
Improve MessageBoxes helper

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/messagebox/MessageBoxTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/messagebox/MessageBoxTest.java
@@ -193,8 +193,8 @@ public class MessageBoxTest {
    */
   @Test
   public void testShowDeleteConfirmationMessageBigArray() {
-    MessageBoxes.showDeleteConfirmationMessage(new String[]{"Alice", "Bob", "Cleo", "Dominic", "Emma", "Fiona", "George", "Heidi", "Ingrid", "James", "Kyla", "Louis"});
-    assertMessageBox(TEXTS.get("DeleteConfirmationText"), "- Alice\n- Bob\n- Cleo\n- Dominic\n- Emma\n- Fiona\n- George\n- Heidi\n- Ingrid\n- James\n  ...\n- Louis\n");
+    MessageBoxes.showDeleteConfirmationMessage(new String[]{"Alice", "Bob", "Cleo", "Dominic", "Emma", "Fiona", "George", "Heidi", "Ingrid", "James", "Kyla", "Louis", "Maria"});
+    assertMessageBox(TEXTS.get("DeleteConfirmationText"), "- Alice\n- Bob\n- Cleo\n- Dominic\n- Emma\n- Fiona\n- George\n- Heidi\n- Ingrid\n- James\n...\n3 more\n");
   }
 
   /**
@@ -203,8 +203,8 @@ public class MessageBoxTest {
    */
   @Test
   public void testShowDeleteConfirmationMessageBigList() {
-    MessageBoxes.showDeleteConfirmationMessage("Numbers", Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-    assertMessageBox(TEXTS.get("DeleteConfirmationTextX", "Numbers"), "- 1\n- 2\n- 3\n- 4\n- 5\n- 6\n- 7\n- 8\n- 9\n- 10\n");
+    MessageBoxes.showDeleteConfirmationMessage("Numbers", Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
+    assertMessageBox(TEXTS.get("DeleteConfirmationTextX", "Numbers"), "- 1\n- 2\n- 3\n- 4\n- 5\n- 6\n- 7\n- 8\n- 9\n- 10\n- 11\n- 12\n");
   }
 
   @Test

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/messagebox/MessageBoxes.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/messagebox/MessageBoxes.java
@@ -13,9 +13,11 @@ package org.eclipse.scout.rt.client.ui.messagebox;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.text.TEXTS;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 
 /**
@@ -131,37 +133,59 @@ public final class MessageBoxes {
    * @since Scout 4.0.1
    */
   public static boolean showDeleteConfirmationMessage(String itemType, Collection<?> items) {
-    StringBuilder t = new StringBuilder();
+    int result = createDeleteConfirmationMessage(itemType, items).show();
+    return result == IMessageBox.YES_OPTION;
+  }
 
-    int n = 0;
-    if (items != null) {
-      n = items.size();
-      int i = 0;
-      for (Object item : items) {
-        if (i < 10 || i == n - 1) {
-          t.append("- ");
-          t.append(StringUtility.emptyIfNull(item));
-          t.append("\n");
-        }
-        else if (i == 10) {
-          t.append("  ...\n");
-        }
-        i++;
-      }
-    }
-    //
+  /**
+   * Convenience function for simple delete confirmation message box
+   *
+   * @param items
+   *          a list of multiple items
+   * @return <code>IMessageBox</code>
+   * @since Scout 22.0
+   */
+  public static IMessageBox createDeleteConfirmationMessage(Collection<?> items) {
+    return createDeleteConfirmationMessage(null, items);
+  }
+
+  /**
+   * Convenience function for simple delete confirmation message box
+   *
+   * @param itemType
+   *          display text in plural such as "Persons", "Relations", "Tickets", ...
+   * @param items
+   *          a list of multiple items
+   * @return <code>IMessageBox</code>
+   * @since Scout 22.0
+   */
+  public static IMessageBox createDeleteConfirmationMessage(String itemType, Collection<?> items) {
+    final boolean hasItems = !CollectionUtility.isEmpty(items);
     String header = null;
-    String body = null;
     if (itemType != null) {
-      header = (n > 0 ? TEXTS.get("DeleteConfirmationTextX", itemType) : TEXTS.get("DeleteConfirmationTextNoItemListX", itemType));
-      body = (n > 0 ? t.toString() : null);
+      header = (hasItems ? TEXTS.get("DeleteConfirmationTextX", itemType) : TEXTS.get("DeleteConfirmationTextNoItemListX", itemType));
     }
     else {
-      header = (n > 0 ? TEXTS.get("DeleteConfirmationText") : TEXTS.get("DeleteConfirmationTextNoItemList"));
-      body = (n > 0 ? t.toString() : null);
+      header = (hasItems ? TEXTS.get("DeleteConfirmationText") : TEXTS.get("DeleteConfirmationTextNoItemList"));
     }
+    return createYesNo().withHeader(header).withBody(createDeleteConfirmationMessageBody(items));
+  }
 
-    int result = createYesNo().withHeader(header).withBody(body).show();
-    return result == IMessageBox.YES_OPTION;
+  private static String createDeleteConfirmationMessageBody(Collection<?> items) {
+    if (CollectionUtility.isEmpty(items)) {
+      return null;
+    }
+    final int maxVisibleItemsCount = 10;
+    final int excessItemsMessageLines = 2;
+    final int hiddenItemsCount = items.size() - maxVisibleItemsCount;
+    final boolean showExcessItemsEntry = hiddenItemsCount > excessItemsMessageLines;
+    String body = items.stream()
+        .limit(maxVisibleItemsCount + (showExcessItemsEntry ? 0 : excessItemsMessageLines))
+        .map(item -> "- " + StringUtility.emptyIfNull(item))
+        .collect(Collectors.joining("\n"));
+    if (showExcessItemsEntry) {
+      body += "\n...\n" + TEXTS.get("XAdditional", Integer.toString(hiddenItemsCount));
+    }
+    return body + "\n";
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/resources/org/eclipse/scout/rt/shared/texts/ScoutTexts.properties
+++ b/org.eclipse.scout.rt.shared/src/main/resources/org/eclipse/scout/rt/shared/texts/ScoutTexts.properties
@@ -341,6 +341,7 @@ WizardNextButton=Next
 WizardNextButtonTooltip=Proceed to next step
 WizardSuspendButton=Close
 WizardSuspendButtonTooltip=Closes this process and closes the wizard (can be resumed later on).
+XAdditional={0} more
 XMustBeGreaterThanOrEqualY='{0}' must be greater than or equal to '{1}'
 XMustBeLessThanOrEqualY='{0}' must be less than or equal to '{1}'
 YearToDate=Year-to-date

--- a/org.eclipse.scout.rt.shared/src/main/resources/org/eclipse/scout/rt/shared/texts/ScoutTexts_de.properties
+++ b/org.eclipse.scout.rt.shared/src/main/resources/org/eclipse/scout/rt/shared/texts/ScoutTexts_de.properties
@@ -341,6 +341,7 @@ WizardNextButton=Weiter
 WizardNextButtonTooltip=Weiter zum n\u00E4chsten Schritt
 WizardSuspendButton=Unterbrechen
 WizardSuspendButtonTooltip=Unterbricht den Prozess und schlie\u00DFt den Wizard (kann sp\u00E4ter weitergef\u00FChrt werden).
+XAdditional={0} weitere
 XMustBeGreaterThanOrEqualY='{0}' muss gr\u00F6\u00DFer oder gleich '{1}' sein
 XMustBeLessThanOrEqualY='{0}' muss kleiner oder gleich '{1}' sein
 YearToDate=Seit Jahresbeginn


### PR DESCRIPTION
The helper to create delete confirmation messages only offers limited
functionality. For customized messages such as setting the error level
or tuning the header text, the helpers logic has to be duplicated.

To solve this, the creation of the messagebox is split into a separate
function.
The show function still exists to ensure backwards compatibility.
Also the item list has been tuned to show how many items are not shown
in the confirmation message.

288246