### PR TITLE
Mode selector: mode text is not centered in alternative mode

### DIFF
--- a/eclipse-scout-core/src/modeselector/Mode.less
+++ b/eclipse-scout-core/src/modeselector/Mode.less
@@ -61,30 +61,35 @@
 
   & > .icon {
     padding: 0; // remove padding from button
+
     &.with-label {
       margin-right: 8px;
     }
   }
 }
 
-.dense .mode {
-  padding: @mode-padding-dense;
-}
-
 .mode-selector.alternative {
+  border: @mode-alternative-border-width solid transparent;
+
   & > .mode {
     color: @mode-color;
-    border: @mode-alternative-border-width transparent solid;
+    border: none;
     background-color: transparent;
-    border-radius: @button-border-radius + @mode-alternative-border-width;
+    border-radius: @button-border-radius;
+
+    &:not(.last):not(.selected) {
+      padding-right: @mode-padding-x;
+    }
+
+    &.after-selected {
+      padding-left: @mode-padding-x;
+    }
 
     &:hover {
-      border-color: transparent;
       background-color: rgba(0, 0, 0, 0.05);
     }
 
     &:active {
-      border-color: transparent;
       background-color: rgba(0, 0, 0, 0.1);
     }
 
@@ -93,7 +98,6 @@
       transition: color 500ms ease;
 
       &:hover {
-        border: @mode-alternative-border-width transparent solid;
         background-color: transparent;
       }
     }
@@ -108,6 +112,31 @@
       color: @button-disabled-color;
       background-color: transparent;
       cursor: default;
+    }
+  }
+}
+
+.dense .mode-selector {
+
+  & > .mode {
+    padding: @mode-padding-dense;
+
+    &:not(.last):not(.selected) {
+      padding-right: @mode-padding-dense-x + @mode-border-width; /* account for the missing border, so that text does not jump */
+    }
+
+    &.after-selected {
+      padding-left: @mode-padding-dense-x + @mode-border-width; /* account for the missing border, so that text does not jump */
+    }
+  }
+
+  &.alternative > .mode {
+    &:not(.last):not(.selected) {
+      padding-right: @mode-padding-dense-x;
+    }
+
+    &.after-selected {
+      padding-left: @mode-padding-dense-x;
     }
   }
 }

--- a/eclipse-scout-core/src/modeselector/ModeSelector.js
+++ b/eclipse-scout-core/src/modeselector/ModeSelector.js
@@ -8,11 +8,9 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, events, HtmlComponent, ModeSelectorLayout, styles, Widget} from '../index';
+import {arrays, events, HtmlComponent, ModeSelectorLayout, Widget} from '../index';
 
 export default class ModeSelector extends Widget {
-
-  static SLIDER_PADDING = null; // Configured in sizes.css
 
   constructor() {
     super();
@@ -22,8 +20,6 @@ export default class ModeSelector extends Widget {
     this.modes = [];
     this.selectedMode = null;
     this.$slider = null;
-
-    ModeSelector.SLIDER_PADDING = $.pxToNumber(styles.get('mode-slider-padding', 'padding-left')['paddingLeft']);
 
     this._modePropertyChangeHandler = this._onModePropertyChange.bind(this);
   }
@@ -142,8 +138,8 @@ export default class ModeSelector extends Widget {
       return;
     }
 
-    let cssSliderWidth = '(100% - ' + 2 * ModeSelector.SLIDER_PADDING + 'px) / ' + visibleNodes.length;
-    let sliderPosX = ModeSelector.SLIDER_PADDING + 'px + ((' + cssSliderWidth + ') * ' + index + ')';
+    let cssSliderWidth = '100% / ' + visibleNodes.length;
+    let sliderPosX = cssSliderWidth + ' * ' + index;
     this.$slider.cssLeft('calc(' + sliderPosX + ')');
     this.$slider.cssWidth('calc(' + cssSliderWidth + ')');
   }
@@ -152,8 +148,8 @@ export default class ModeSelector extends Widget {
     let className = 'mode-selector-dragging';
     let onDown = /** @type {SwipeCallbackEvent} */e => this.selectedMode && this.selectedMode.$container === $mode;
     let onMove = /** @type {SwipeCallbackEvent} */e => {
-      let maxX = this.$container.width() - $mode.outerWidth() - ModeSelector.SLIDER_PADDING + 1;
-      let minX = ModeSelector.SLIDER_PADDING;
+      let maxX = this.$container.width() - $mode.outerWidth() + 1;
+      let minX = 0;
       let newModeLeft = Math.max(Math.min(e.newLeft, maxX), minX); // limit to the size of the ModeSelector
       this.$container.children().addClass(className);
       if (newModeLeft !== e.originalLeft) {

--- a/eclipse-scout-core/src/modeselector/ModeSelector.less
+++ b/eclipse-scout-core/src/modeselector/ModeSelector.less
@@ -26,8 +26,8 @@
     &:not(.disabled) > .mode-slider {
       display: block;
       position: absolute;
-      top: @mode-slider-padding;
-      height: calc(100% - (@mode-slider-padding * 2));
+      top: 0;
+      height: 100%;
       background-color: @mode-alternative-selected-background-color;
       border-radius: @button-border-radius;
       transition: left 500ms ease;
@@ -38,9 +38,4 @@
       }
     }
   }
-}
-
-// used to read the padding from ModeSelector.js (ModeSelector.SLIDER_PADDING)
-.mode-slider-padding {
-  padding-left: @mode-slider-padding;
 }

--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -198,10 +198,11 @@
 @mobile-popup-title-margin-top: 10px;
 @mode-padding-x: 12px;
 @mode-padding-y: 6px;
-@mode-padding-dense: 3px;
+@mode-padding-dense: @mode-padding-dense-y @mode-padding-dense-x;
+@mode-padding-dense-x: 5px;
+@mode-padding-dense-y: 3px;
 @mode-border-width: 1px;
-@mode-alternative-border-width: 2px;
-@mode-slider-padding: @mode-alternative-border-width;
+@mode-alternative-border-width: 3px;
 @notification-no-icon-padding-y: 13px;
 @outline-breadcrumb-node-padding-x: @outline-title-padding-left;
 @outline-breadcrumb-node-padding-y: 12px;


### PR DESCRIPTION
Use transparent border instead of a padding. This way no compensation
is necessary which makes it easier.
Also add padding to mode selector itself instead of using mode borders.
This makes the hover effect look better.