### PR TITLE
Fix tooltip-position if it overlaps the left edge

### DIFF
--- a/eclipse-scout-core/src/tooltip/Tooltip.js
+++ b/eclipse-scout-core/src/tooltip/Tooltip.js
@@ -281,6 +281,11 @@ export default class Tooltip extends Widget {
       left -= overlapX;
       arrowPosition = x - left;
     }
+    // Move tooltip to the right if it overlaps the left edge
+    if (left < this.windowPaddingX) {
+      left = this.windowPaddingX;
+      arrowPosition = x - this.windowPaddingX;
+    }
 
     // Move tooltip to the bottom, arrow on top
     this.$arrow.removeClass('arrow-top arrow-bottom');


### PR DESCRIPTION
Move tooltip to this.windowPaddingX if it overlaps the left edge.