### PR TITLE
ButtonTile: improve hover effect

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageTileGrid.js
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageTileGrid.js
@@ -131,7 +131,7 @@ export default class PageTileGrid extends TileGrid {
       outline: this.outline,
       page: page
     });
-    let tile = scout.create('FormFieldTile', {
+    let tile = scout.create('ButtonTile', {
       parent: this,
       cssClass: this.compact ? 'compact' : null,
       tileWidget: button

--- a/eclipse-scout-core/src/index.js
+++ b/eclipse-scout-core/src/index.js
@@ -600,6 +600,7 @@ export {default as WidgetTileAdapter} from './tile/WidgetTileAdapter';
 export {default as PlaceholderTile} from './tile/PlaceholderTile';
 export {default as FormFieldTile} from './tile/fields/FormFieldTile';
 export {default as FormFieldTileAdapter} from './tile/fields/FormFieldTileAdapter';
+export {default as ButtonTile} from './tile/fields/button/ButtonTile';
 export {default as TileButton} from './tile/fields/button/TileButton';
 export {default as TileTableField} from './tile/fields/tablefield/TileTableField';
 export {default as SimpleTab} from './tabbox/SimpleTab';

--- a/eclipse-scout-core/src/style/colors.less
+++ b/eclipse-scout-core/src/style/colors.less
@@ -431,8 +431,8 @@
 @tile-button-alternative-inverted-active-background-color: darken(@tile-alternative-inverted-background-color, 10);
 @tile-button-alternative-inverted-hover-background-color: darken(@tile-alternative-inverted-background-color, 5);
 @tile-button-alternative-inverted-color: @tile-button-default-inverted-color;
-@tile-button-default-active-background-color: @button-active-background-color;
-@tile-button-default-hover-background-color: @hover-background-color;
+@tile-button-default-active-background-color: fade(@palette-black, 5%);
+@tile-button-default-hover-background-color: fade(@palette-black, 2%);
 @tile-button-default-icon-color: @palette-gray-5-1;
 @tile-button-default-inverted-hover-background-color: @default-button-hover-background-color;
 @tile-button-default-inverted-active-background-color: @default-button-active-background-color;

--- a/eclipse-scout-core/src/tile/fields/button/ButtonTile.js
+++ b/eclipse-scout-core/src/tile/fields/button/ButtonTile.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {FormFieldTile} from '../../../index';
+
+export default class ButtonTile extends FormFieldTile {
+  _render() {
+    super._render();
+    this.$container.addClass('button-tile');
+  }
+}

--- a/eclipse-scout-core/src/tile/fields/button/TileButton.less
+++ b/eclipse-scout-core/src/tile/fields/button/TileButton.less
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-.tile.dashboard > .form-field.tile-button {
+.tile.dashboard > .tile-button {
   padding-top: 0;
   padding-bottom: 0;
   cursor: pointer;
@@ -59,7 +59,7 @@
   }
 }
 
-.tile.dashboard.compact > .form-field.tile-button {
+.tile.dashboard.compact > .tile-button {
   & > .field {
     padding-top: @tile-field-compact-padding-y;
     padding-bottom: @tile-field-compact-padding-y;
@@ -87,73 +87,87 @@
   }
 }
 
-.tile.dashboard {
-  & > .form-field.tile-button > .field > .label {
+.button-tile.dashboard {
+  & > .tile-button > .field > .label {
     color: @link-color;
   }
 
-  &:hover > .form-field.tile-button {
-    background-color: @tile-button-default-hover-background-color;
+  &:hover {
+
+    .dimmed-background & {
+      #scout.drop-shadow(); // More intense than regular dashboard shadow
+    }
+
+    & > .tile-button {
+      background-color: @tile-button-default-hover-background-color;
+    }
   }
 
-  &:active > .form-field.tile-button,
-  &.active > .form-field.tile-button {
+  &:active > .tile-button,
+  &.active > .tile-button {
     background-color: @tile-button-default-active-background-color;
   }
 
   &.inverted {
-    & > .form-field.tile-button > .field {
+    & > .tile-button > .field {
       & > .icon-container > .font-icon,
       & > .label {
         color: @tile-button-default-inverted-color;
       }
     }
 
-    &:hover > .form-field.tile-button {
+    &:hover > .tile-button {
       background-color: @tile-button-default-inverted-hover-background-color;
       border-color: @tile-button-default-inverted-hover-background-color;
     }
 
-    &:active > .form-field.tile-button,
-    &.active > .form-field.tile-button {
+    &:active > .tile-button,
+    &.active > .tile-button {
       background-color: @tile-button-default-inverted-active-background-color;
       border-color: @tile-button-default-inverted-active-background-color;
     }
   }
 
   &.color-alternative.inverted {
-    & > .form-field.tile-button > .field {
+    & > .tile-button > .field {
       & > .icon-container > .font-icon,
       & > .label {
         color: @tile-button-alternative-inverted-color;
       }
     }
 
-    &:hover > .form-field.tile-button {
+    &:hover > .tile-button {
       background-color: @tile-button-alternative-inverted-hover-background-color;
       border-color: @tile-button-alternative-inverted-hover-background-color;
     }
 
-    &:active > .form-field.tile-button,
-    &.active > .form-field.tile-button {
+    &:active > .tile-button,
+    &.active > .tile-button {
       background-color: @tile-button-alternative-inverted-active-background-color;
       border-color: @tile-button-alternative-inverted-active-background-color;
     }
   }
 
-  &.disabled > .form-field.tile-button {
-    &, .inverted&, .color-alternative.inverted& {
-      background-color: @tile-default-inner-border-color;
-      border-color: @button-disabled-border-color;
-      cursor: default;
+  &.disabled {
 
-      & > .field {
-        & > .icon-container > .font-icon {
-          color: @button-disabled-color;
-        }
+    .dimmed-background & {
+      #scout.drop-shadow(@alpha: @dashboard-tile-drop-shadow-light-alpha);
+    }
 
-        & > .label {
-          color: @button-disabled-color;
+    & > .tile-button {
+      &, .inverted&, .color-alternative.inverted& {
+        background-color: @tile-default-inner-border-color;
+        border-color: @button-disabled-border-color;
+        cursor: default;
+
+        & > .field {
+          & > .icon-container > .font-icon {
+            color: @button-disabled-color;
+          }
+
+          & > .label {
+            color: @button-disabled-color;
+          }
         }
       }
     }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/tile/fields/AbstractButtonTile.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/tile/fields/AbstractButtonTile.java
@@ -42,6 +42,11 @@ public abstract class AbstractButtonTile extends AbstractFormFieldTile<Button> {
     return null;
   }
 
+  @Override
+  protected String getConfiguredCssClass() {
+    return "button-tile";
+  }
+
   /**
    * If set, this value is applied to the tile field's "preventDoubleClick" property.
    */


### PR DESCRIPTION
A hovered button melts with the dimmed background.

Also simplify selectors: using .form-field is unnecessary because
TileButton.less comes after FormField.less.