### PR TITLE
Data objects migration: add support for external local context data

### DIFF
--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationContext.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationContext.java
@@ -13,9 +13,11 @@ package org.eclipse.scout.rt.dataobject.migration;
 import static org.eclipse.scout.rt.platform.util.Assertions.*;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.scout.rt.platform.BEANS;
@@ -61,6 +63,19 @@ public class DoStructureMigrationContext {
    */
   protected DoStructureMigrationContext copy() {
     return new DoStructureMigrationContext(this);
+  }
+
+  /**
+   * Clones the context via {@link #copy} and pushes the given initial local context datas to the local context data
+   * map. If no initial local context datas are provided behaves same as {@link #copy}.
+   */
+  protected DoStructureMigrationContext initializedCopy(IDoStructureMigrationLocalContextData... initialLocalContextDatas) {
+    DoStructureMigrationContext copy = copy();
+    if (initialLocalContextDatas != null) {
+      // Calling push without a remove is okay here because these provided locale contexts are valid for the whole data object
+      Arrays.stream(initialLocalContextDatas).filter(Objects::nonNull).forEach(copy::push);
+    }
+    return copy;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationCountingPassThroughLogger.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationCountingPassThroughLogger.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the BSI CRM Software License v1.0
+ * which accompanies this distribution as bsi-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import java.util.concurrent.atomic.LongAdder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Thread-safe implementation for a DO structure migration logger that additional counts the log items per log level.
+ */
+public class DoStructureMigrationCountingPassThroughLogger extends DoStructureMigrationPassThroughLogger {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DoStructureMigrationCountingPassThroughLogger.class);
+
+  protected final LongAdder m_traceCount = new LongAdder();
+  protected final LongAdder m_debugCount = new LongAdder();
+  protected final LongAdder m_infoCount = new LongAdder();
+  protected final LongAdder m_warnCount = new LongAdder();
+  protected final LongAdder m_errorCount = new LongAdder();
+
+  @Override
+  public void trace(String message, Object... args) {
+    super.trace(message, args);
+    m_traceCount.increment();
+  }
+
+  @Override
+  public void debug(String message, Object... args) {
+    super.debug(message, args);
+    m_debugCount.increment();
+  }
+
+  @Override
+  public void info(String message, Object... args) {
+    super.info(message, args);
+    m_infoCount.increment();
+  }
+
+  @Override
+  public void warn(String message, Object... args) {
+    super.warn(message, args);
+    m_warnCount.increment();
+  }
+
+  @Override
+  public void error(String message, Object... args) {
+    super.error(message, args);
+    m_errorCount.increment();
+  }
+
+  public long getTraceCount() {
+    return m_traceCount.sum();
+  }
+
+  public long getDebugCount() {
+    return m_debugCount.sum();
+  }
+
+  public long getInfoCount() {
+    return m_infoCount.sum();
+  }
+
+  public long getWarnCount() {
+    return m_warnCount.sum();
+  }
+
+  public long getErrorCount() {
+    return m_errorCount.sum();
+  }
+
+  public void printSummary() {
+    long total = m_traceCount.sum() + m_debugCount.sum() + m_infoCount.sum() + m_warnCount.sum() + m_errorCount.sum();
+    if (total == 0) {
+      LOG.info("No DO structure migration log entries were made");
+    }
+    else {
+      LOG.info("{} DO structure migration log entries were made: {} trace, {} debug, {} info, {} warn, {} error", total, m_traceCount.sum(), m_debugCount.sum(), m_infoCount.sum(), m_warnCount.sum(), m_errorCount.sum());
+    }
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationInventory.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationInventory.java
@@ -301,6 +301,13 @@ public class DoStructureMigrationInventory {
   }
 
   /**
+   * @return Unmodifiable list of ordered versions according to VersionedItemInventory.
+   */
+  public List<NamespaceVersion> getAllVersionsOrdered() {
+    return Collections.unmodifiableList(new ArrayList<>(m_orderedVersions));
+  }
+
+  /**
    * For each type name {@link #findNextMigrationHandlerVersion(String, NamespaceVersion)} is called. The lowest version
    * of all type names defines the starting point.
    *

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationStatsContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationStatsContextData.java
@@ -32,19 +32,54 @@ public class DoStructureMigrationStatsContextData implements IDoStructureMigrati
   protected final LongAdder m_dataObjectsChanged = new LongAdder();
   protected final LongAdder m_accumulatedMigrationDurationNano = new LongAdder(); // nanoseconds
 
+  /**
+   * Sets the initial migration start time, to be called before any migration related operation is executed (e.g. data
+   * objects are loaded, ...).
+   */
   public void start() {
     m_startNanos.compareAndSet(0, System.nanoTime());
   }
 
+  /**
+   * Increment the number of processed data objects. To be called for each processed data object.
+   */
   protected void incrementDataObjectsProcessed() {
     m_dataObjectsProcessed.increment();
   }
 
+  /**
+   * Difference in nanoseconds between calling {@link #start()} and this method.
+   *
+   * @return Duration in nanoseconds for the overall migration process.
+   */
+  public long getOverallMigrationDurationNano() {
+    return System.nanoTime() - m_startNanos.get();
+  }
+
+  /**
+   * @return The number of processed data objects.
+   */
+  public long getDataObjectsProcessedCount() {
+    return m_dataObjectsProcessed.sum();
+  }
+
+  /**
+   * Increment the number of changed data objects. To be called for each processed data object that has changed.
+   */
   protected void incrementDataObjectsChanged() {
     m_dataObjectsChanged.increment();
   }
 
   /**
+   * @return The number of changed data objects.
+   */
+  public long getDataObjectsChangedCount() {
+    return m_dataObjectsChanged.sum();
+  }
+
+  /**
+   * Accumulation of raw data object migration duration. To be called after migration of a single data object.
+   *
    * @param startNano
    *          {@link System#nanoTime()} when migration was started
    */
@@ -53,19 +88,26 @@ public class DoStructureMigrationStatsContextData implements IDoStructureMigrati
   }
 
   /**
+   * @return Duration in nanoseconds for the accumulated raw data object migration durations.
+   */
+  public long getAccumulatedMigrationDurationNano() {
+    return m_accumulatedMigrationDurationNano.sum();
+  }
+
+  /**
    * @param name
    *          Name to print for entities
    * @param entityCount
-   *          Number of entities processed (optional), can be different then the number of calls made to
+   *          Number of entities processed (optional), can be different than the number of calls made to
    *          {@link DoStructureMigrator#migrateDataObject(DoStructureMigrationContext, IDataObject)}.
    */
   public void printStats(String name, Integer entityCount) {
-    LOG.info("Migration of {}{} entities finished in {} ms (accumulated raw data object migration took {} ms). Changed {} of {} processed data objects.",
+    LOG.info("DO structure migration of {}{} entities finished in {} ms (accumulated raw data object migration took {} ms). Changed {} of {} processed data objects.",
         entityCount == null ? "" : entityCount + " ",
         name,
-        m_startNanos.get() == 0 ? "?" : StringUtility.formatNanos(System.nanoTime() - m_startNanos.get()),
-        StringUtility.formatNanos(m_accumulatedMigrationDurationNano.sum()),
-        m_dataObjectsChanged.sum(),
-        m_dataObjectsProcessed.sum());
+        m_startNanos.get() == 0 ? "?" : StringUtility.formatNanos(getOverallMigrationDurationNano()),
+        StringUtility.formatNanos(getAccumulatedMigrationDurationNano()),
+        getDataObjectsChangedCount(),
+        getDataObjectsProcessedCount());
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrator.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrator.java
@@ -78,15 +78,25 @@ public class DoStructureMigrator {
   /**
    * Migrates the raw data object.
    * <p>
-   * Uses latest version to migrate too.
+   * Uses latest version to migrate too. Uses no intial local context data.
    */
   public boolean migrateDataObject(DoStructureMigrationContext ctx, IDataObject dataObject) {
     return migrateDataObject(ctx, dataObject, (NamespaceVersion) null /* latest version */);
   }
 
   /**
-   * <b>ATTENTION:</b> use {@link #migrateDataObject(DoStructureMigrationContext, IDataObject)} instead. Only use this
-   * for tests and very special cases.
+   * Migrates the raw data object.
+   * <p>
+   * Uses latest version to migrate too. Uses given initial local context data during migration.
+   */
+  public boolean migrateDataObject(DoStructureMigrationContext ctx, IDataObject dataObject, IDoStructureMigrationLocalContextData... initialLocalContextData) {
+    return migrateDataObject(ctx, dataObject, null /* latest version */, initialLocalContextData);
+  }
+
+  /**
+   * <b>ATTENTION:</b> use {@link #migrateDataObject(DoStructureMigrationContext, IDataObject)} or
+   * {@link #migrateDataObject(DoStructureMigrationContext, IDataObject, IDoStructureMigrationLocalContextData...)}
+   * instead. Only use this for tests and very special cases.
    * <p>
    * Migrates the raw data object.
    *
@@ -95,12 +105,16 @@ public class DoStructureMigrator {
    *          data object parts are migrated.
    * @param toVersion
    *          Versions to migrate to, <code>null</code> if migrating to latest version.
+   * @param initialLocalContextData
+   *          Initial local context data to use.
    */
-  public boolean migrateDataObject(DoStructureMigrationContext ctx, IDataObject dataObject, NamespaceVersion toVersion) {
+  public boolean migrateDataObject(DoStructureMigrationContext ctx, IDataObject dataObject, NamespaceVersion toVersion, IDoStructureMigrationLocalContextData... initialLocalContextData) {
     assertNotNull(ctx, "ctx is required");
     assertNotNull(dataObject, "dataObject is required");
 
-    DoStructureMigrationContext ctxCopy = ctx.copy(); // copy context to work on own stack for local context data.
+    // copy context to work on own stack for local context data.
+    // Local context may be initialized via initialLocalContextData.
+    DoStructureMigrationContext ctxCopy = ctx.initializedCopy(initialLocalContextData);
     DoStructureMigrationStatsContextData stats = ctxCopy.getStats();
     IDoStructureMigrationLogger logger = ctxCopy.getLogger();
 


### PR DESCRIPTION
- Add getter for DoStructureMigrationStatsContextData to allow retrieving details and not summary only.
- Add optional counting logger to allow more detailed summary of a migration only