### PR TITLE
Limit text length on smart field and tag field

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
@@ -80,9 +80,6 @@ export default class ProposalField extends SmartField {
     if (this.trimText) {
       validValue = validValue.trim();
     }
-    if (validValue.length > this.maxLength) {
-      validValue = validValue.substring(0, this.maxLength);
-    }
     if (validValue === '') {
       validValue = null;
     }
@@ -205,10 +202,6 @@ export default class ProposalField extends SmartField {
 
   setTrimText(trimText) {
     this.setProperty('trimText', trimText);
-  }
-
-  setMaxLength(maxLength) {
-    this.setProperty('maxLength', maxLength);
   }
 
   /**

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.js
@@ -63,6 +63,8 @@ export default class SmartField extends ValueField {
     // only when the result is up-to-date, we can use the selected lookup row
     this.initActiveFilter = null;
     this.disabledCopyOverlay = true;
+    this.maxLength = 500;
+    this.maxLengthHandler = scout.create('MaxLengthHandler', {target: this});
 
     this._addCloneProperties(['lookupRow', 'codeType', 'lookupCall', 'activeFilter', 'activeFilterEnabled', 'activeFilterLabels',
       'browseHierarchy', 'browseMaxRowCount', 'browseAutoExpandAll', 'browseLoadIncremental', 'searchRequired', 'columnDescriptors',
@@ -150,6 +152,7 @@ export default class SmartField extends ValueField {
         .on('input', this._onFieldInput.bind(this));
     }
     this.addField($field);
+    this.maxLengthHandler.install($field);
 
     if (!this.embedded) {
       this.addMandatoryIndicator();
@@ -157,6 +160,11 @@ export default class SmartField extends ValueField {
     this.addIcon();
     this.$icon.addClass('needsclick');
     this.addStatus();
+  }
+
+  _renderProperties() {
+    super._renderProperties();
+    this._renderMaxLength();
   }
 
   _renderGridData() {
@@ -593,6 +601,14 @@ export default class SmartField extends ValueField {
   _renderEnabled() {
     super._renderEnabled();
     this.$field.setTabbable(this.enabledComputed);
+  }
+
+  setMaxLength(maxLength) {
+    this.setProperty('maxLength', maxLength);
+  }
+
+  _renderMaxLength() {
+    this.maxLengthHandler.render();
   }
 
   setLookupCall(lookupCall) {

--- a/eclipse-scout-core/src/form/fields/tagfield/TagField.js
+++ b/eclipse-scout-core/src/form/fields/tagfield/TagField.js
@@ -37,6 +37,8 @@ export default class TagField extends ValueField {
     this.lookupCall = null;
     this._currentLookupCall = null;
     this.tagBar = null;
+    this.maxLength = 500;
+    this.maxLengthHandler = scout.create('MaxLengthHandler', {target: this});
   }
 
   _init(model) {
@@ -85,12 +87,14 @@ export default class TagField extends ValueField {
       .on('input', this._onFieldInput.bind(this));
     this.addFieldContainer($fieldContainer);
     this.addField($field);
+    this.maxLengthHandler.install($field);
     this.addStatus();
   }
 
   _renderProperties() {
     super._renderProperties();
     this._renderValue();
+    this._renderMaxLength();
   }
 
   _renderValue() {
@@ -153,6 +157,14 @@ export default class TagField extends ValueField {
     if (this.rendered) {
       this.fieldHtmlComp.invalidateLayoutTree();
     }
+  }
+
+  setMaxLength(maxLength) {
+    this.setProperty('maxLength', maxLength);
+  }
+
+  _renderMaxLength() {
+    this.maxLengthHandler.render();
   }
 
   _updateInputVisible() {

--- a/eclipse-scout-core/src/index.js
+++ b/eclipse-scout-core/src/index.js
@@ -42,6 +42,7 @@ export {default as fonts} from './util/fonts';
 export {default as icons} from './util/icons';
 export {default as inspector} from './util/inspector';
 export {default as locales} from './util/locales';
+export {default as MaxLengthHandler} from './util/MaxLengthHandler';
 export {default as logging} from './logging/logging';
 export {default as NullLogger} from './logging/NullLogger';
 export {default as mimeTypes} from './util/mimeTypes';

--- a/eclipse-scout-core/src/util/MaxLengthHandler.js
+++ b/eclipse-scout-core/src/util/MaxLengthHandler.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {arrays, objects, scout, Status} from '../index';
+import $ from 'jquery';
+import {assertValue} from '../scout';
+
+export default class MaxLengthHandler {
+
+  constructor(options) {
+    options = options || {};
+    assertValue(options.target, 'target is mandatory');
+
+    this.$textInputField = null;
+    this.onInputFieldPaste = this._onInputFieldPaste.bind(this);
+    $.extend(this, options);
+  }
+
+  install($textInputField) {
+    this.uninstall();
+    if (!$textInputField || (!$textInputField.is('input:text') && !$textInputField.is('textarea'))) {
+      return;
+    }
+    if ($textInputField) {
+      this.$textInputField = $textInputField;
+      this.$textInputField.on('paste', this.onInputFieldPaste);
+    }
+  }
+
+  uninstall() {
+    if (this.$textInputField) {
+      this.$textInputField.off('paste', this.onInputFieldPaste);
+    }
+  }
+
+  render() {
+    if (!this.$textInputField || objects.isNullOrUndefined(this.target.maxLength)) {
+      return;
+    }
+    this.$textInputField.attr('maxlength', this.target.maxLength);
+
+    // Make sure current text does not exceed max length
+    let text = this.$textInputField.val();
+    if (text.length > this.target.maxLength) {
+      this.$textInputField.val(text.slice(0, this.target.maxLength));
+    }
+    if (!this.target.rendering) {
+      this.target.parseAndSetValue(this.target._readDisplayText());
+    }
+  }
+
+  _onInputFieldPaste(event) {
+    if (!this.$textInputField || objects.isNullOrUndefined(this.target.maxLength)) {
+      return;
+    }
+    // must read out the text and selection size now because when the callback is executed, the clipboard content has already been applied to the input field
+    let textSize = this.$textInputField.val().length - this._getSelectionSize();
+
+    this._getClipboardData(event, pastedText => {
+      if (!pastedText) {
+        return;
+      }
+      if ((textSize + pastedText.length) > this.target.maxLength) {
+        this._showNotification('ui.PastedTextTooLong');
+      }
+    });
+  }
+
+  _getSelectionSize() {
+    let start = scout.nvl(this.$textInputField[0].selectionStart, null);
+    let end = scout.nvl(this.$textInputField[0].selectionEnd, null);
+    if (start === null || end === null) {
+      return 0;
+    }
+    return end - start;
+  }
+
+  /**
+   * Get clipboard data, different strategies for browsers.
+   * Must use a callback because this is required by Chrome's clipboard API.
+   */
+  _getClipboardData(event, doneHandler) {
+    let data = event.originalEvent.clipboardData || this.target.$container.window(true).clipboardData;
+    if (data) {
+      // Chrome, Firefox
+      if (data.items && data.items.length) {
+        let item = arrays.find(data.items, item => {
+          return item.type === 'text/plain';
+        });
+        if (item) {
+          item.getAsString(doneHandler);
+        }
+        return;
+      }
+
+      // IE, Safari
+      if (data.getData) {
+        doneHandler(data.getData('Text'));
+      }
+    }
+
+    // Can't access clipboard -> don't call done handler
+  }
+
+  _showNotification(textKey) {
+    scout.create('DesktopNotification', {
+      parent: this.target,
+      severity: Status.Severity.WARNING,
+      message: this.target.session.text(textKey)
+    }).show();
+  }
+}

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/SmartFieldLookupTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/SmartFieldLookupTest.java
@@ -51,7 +51,7 @@ import org.mockito.ArgumentMatcher;
 public class SmartFieldLookupTest {
 
   @BeanMock
-  private ITestLookupService m_mock_service;
+  private ITestLookupService m_mockService;
 
   private ISmartField<Long> m_field;
 
@@ -60,7 +60,7 @@ public class SmartFieldLookupTest {
   @Before
   public void setup() {
     testMasterValue = 10;
-    m_field = new AbstractSmartField<Long>() {
+    m_field = new AbstractSmartField<>() {
     };
     List<ILookupRow<Long>> childRows = new ArrayList<>();
     childRows.add(new LookupRow<>(0L, "Alice"));
@@ -70,10 +70,10 @@ public class SmartFieldLookupTest {
     inactiveRows.add(new LookupRow<>(2L, "B"));
     inactiveRows.add(null);
 
-    when(m_mock_service.getDataByRec(argThat(hasRec(1L)))).thenReturn(childRows);
-    when(m_mock_service.getDataByRec(argThat(isInactive()))).thenReturn(inactiveRows);
-    when(m_mock_service.getDataByRec(argThat(hasMaxRowCount(2)))).thenReturn(inactiveRows);
-    when(m_mock_service.getDataByRec(argThat(hasMaster(testMasterValue)))).thenReturn(inactiveRows);
+    when(m_mockService.getDataByRec(argThat(hasRec(1L)))).thenReturn(childRows);
+    when(m_mockService.getDataByRec(argThat(isInactive()))).thenReturn(inactiveRows);
+    when(m_mockService.getDataByRec(argThat(hasMaxRowCount(2)))).thenReturn(inactiveRows);
+    when(m_mockService.getDataByRec(argThat(hasMaster(testMasterValue)))).thenReturn(inactiveRows);
   }
 
   /**
@@ -129,7 +129,7 @@ public class SmartFieldLookupTest {
 
   @Test
   public void testSubtreeLookup_WithMasterField() {
-    IValueField<Long> masterField = new AbstractValueField<Long>() {
+    IValueField<Long> masterField = new AbstractValueField<>() {
     };
     masterField.setValue(testMasterValue);
     m_field.setLookupCall(new TestLookupCall());
@@ -140,7 +140,7 @@ public class SmartFieldLookupTest {
 
   @Test
   public void testSubtreeLookup_InBackground() {
-    IValueField<Long> masterField = new AbstractValueField<Long>() {
+    IValueField<Long> masterField = new AbstractValueField<>() {
     };
     masterField.setValue(testMasterValue);
     m_field.setLookupCall(new TestLookupCall());
@@ -179,7 +179,7 @@ public class SmartFieldLookupTest {
   @Test(expected = PlatformException.class)
   public void testTextLookupWithExceptions() {
     m_field.setLookupCall(new TestLookupCall());
-    when(m_mock_service.getDataByText(any(ILookupCall.class))).thenThrow(new PlatformException("lookup error"));
+    when(m_mockService.getDataByText(any(ILookupCall.class))).thenThrow(new PlatformException("lookup error"));
     m_field.callTextLookup("test", 10);
   }
 
@@ -188,13 +188,13 @@ public class SmartFieldLookupTest {
   public void testSubtreeLookupExceptions_InBackground() {
     final IBlockingCondition bc = Jobs.newBlockingCondition(true);
     m_field.setLookupCall(new TestLookupCall());
-    when(m_mock_service.getDataByRec(any(ILookupCall.class))).thenThrow(new PlatformException("lookup error"));
+    when(m_mockService.getDataByRec(any(ILookupCall.class))).thenThrow(new PlatformException("lookup error"));
 
     IFuture<List<ILookupRow<Long>>> rows = m_field.callSubTreeLookupInBackground(1L, TriState.TRUE, false);
 
     rows.whenDone(event -> {
       assertTrue(event.getException() instanceof RuntimeException);
-      assertEquals("lookup error", event.getException().getMessage());
+      assertTrue(event.getException().getMessage().startsWith("lookup error"));
       bc.setBlocking(false);
     }, ClientRunContexts.copyCurrent());
     bc.waitFor();
@@ -205,7 +205,7 @@ public class SmartFieldLookupTest {
   public void testTextLookupExceptions_InBackground() {
     m_field.setLookupCall(new TestLookupCall());
     final String errorText = "lookup error";
-    when(m_mock_service.getDataByText(any(ILookupCall.class))).thenThrow(new PlatformException(errorText));
+    when(m_mockService.getDataByText(any(ILookupCall.class))).thenThrow(new PlatformException(errorText));
     final IBlockingCondition bc = Jobs.newBlockingCondition(true);
     ILookupRowFetchedCallback callback = new ILookupRowFetchedCallback<Long>() {
 
@@ -229,7 +229,7 @@ public class SmartFieldLookupTest {
 
   @Test
   public void testSubteeLookup_WithPrepare() {
-    ISmartField<Long> field = new AbstractSmartField<Long>() {
+    ISmartField<Long> field = new AbstractSmartField<>() {
 
       @Override
       protected void execPrepareLookup(ILookupCall<Long> call) {
@@ -243,7 +243,7 @@ public class SmartFieldLookupTest {
 
   @Test
   public void testSubteeLookup_WithPrepareRec() {
-    ISmartField<Long> field = new AbstractSmartField<Long>() {
+    ISmartField<Long> field = new AbstractSmartField<>() {
 
       @Override
       protected void execPrepareRecLookup(ILookupCall<Long> call, Long parentKey) {
@@ -258,7 +258,7 @@ public class SmartFieldLookupTest {
 
   @Test
   public void testSubtreeLookup_FilterResult() {
-    ISmartField<Long> field = new AbstractSmartField<Long>() {
+    ISmartField<Long> field = new AbstractSmartField<>() {
 
       @Override
       protected void execFilterRecLookupResult(ILookupCall<Long> call, List<ILookupRow<Long>> result) {
@@ -273,7 +273,7 @@ public class SmartFieldLookupTest {
 
   @SuppressWarnings("unchecked")
   private void throwOnRecLookup() {
-    when(m_mock_service.getDataByRec(any(ILookupCall.class))).thenThrow(new PlatformException("lookup error"));
+    when(m_mockService.getDataByRec(any(ILookupCall.class))).thenThrow(new PlatformException("lookup error"));
   }
 
   /**

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/AbstractProposalField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/AbstractProposalField.java
@@ -38,18 +38,10 @@ public abstract class AbstractProposalField<VALUE> extends AbstractSmartField<VA
   @Override
   protected void initConfig() {
     super.initConfig();
-    setMaxLength(getConfiguredMaxLength());
     setTrimText(getConfiguredTrimText());
   }
 
-  /**
-   * Configures the initial value of {@link AbstractProposalField#getMaxLength()
-   * <p>
-   * Subclasses can override this method
-   * <p>
-   * Default is 4000
-   */
-  @ConfigProperty(ConfigProperty.INTEGER)
+  @Override
   protected int getConfiguredMaxLength() {
     return 4000;
   }
@@ -77,19 +69,6 @@ public abstract class AbstractProposalField<VALUE> extends AbstractSmartField<VA
   @Override
   protected String formatValueInternal(VALUE value) {
     return value != null ? value.toString() : "";
-  }
-
-  @Override
-  public void setMaxLength(int maxLength) {
-    boolean changed = propertySupport.setPropertyInt(PROP_MAX_LENGTH, Math.max(0, maxLength));
-    if (changed && isInitConfigDone()) {
-      setValue(getValue());
-    }
-  }
-
-  @Override
-  public int getMaxLength() {
-    return propertySupport.getPropertyInt(PROP_MAX_LENGTH);
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/AbstractSmartField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/AbstractSmartField.java
@@ -258,6 +258,19 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
   }
 
   /**
+   * Configures the initial value of {@link AbstractSmartField#getMaxLength()
+   * <p>
+   * Subclasses can override this method
+   * <p>
+   * Default is 500
+   */
+  @ConfigProperty(ConfigProperty.INTEGER)
+  @Order(330)
+  protected int getConfiguredMaxLength() {
+    return 500;
+  }
+
+  /**
    * called before any lookup is performed (key, text, browse)
    */
   @ConfigOperation
@@ -390,6 +403,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
       setLookupCall(call);
     }
     setWildcard(getConfiguredWildcard());
+    setMaxLength(getConfiguredMaxLength());
   }
 
   private void initLookupRowFetcher() {
@@ -442,7 +456,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
 
   @Override
   public TriState getInitActiveFilter() {
-    return (TriState)  propertySupport.getProperty(PROP_INIT_ACTIVE_FILTER);
+    return (TriState) propertySupport.getProperty(PROP_INIT_ACTIVE_FILTER);
   }
 
   @Override
@@ -561,6 +575,19 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
   }
 
   @Override
+  public void setMaxLength(int maxLength) {
+    boolean changed = propertySupport.setPropertyInt(PROP_MAX_LENGTH, Math.max(0, maxLength));
+    if (changed && isInitConfigDone()) {
+      setValue(getValue());
+    }
+  }
+
+  @Override
+  public int getMaxLength() {
+    return propertySupport.getPropertyInt(PROP_MAX_LENGTH);
+  }
+
+  @Override
   public Class<? extends ICodeType<?, VALUE>> getCodeTypeClass() {
     return m_codeTypeClass;
   }
@@ -591,7 +618,8 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
   }
 
   /**
-   * @param wildcard Wildcard character used in lookup calls
+   * @param wildcard
+   *          Wildcard character used in lookup calls
    */
   @Override
   public void setWildcard(String wildcard) {
@@ -675,7 +703,8 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
   }
 
   /**
-   * @param lookupRow Lookup row used to resolve the value
+   * @param lookupRow
+   *          Lookup row used to resolve the value
    * @return a property from the lookup row which is used as value (usually this is the key of the lookup row)
    */
   protected VALUE getValueFromLookupRow(ILookupRow<VALUE> lookupRow) {
@@ -838,6 +867,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
   }
 
   protected void lookupByTextInternal(String text, boolean synchronous) {
+    text = StringUtility.substring(text, 0, getMaxLength());
     doSearch(QueryParam.createByText(text), synchronous);
   }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/IProposalField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/IProposalField.java
@@ -23,17 +23,10 @@ package org.eclipse.scout.rt.client.ui.form.fields.smartfield;
  * <p>
  * There's no validation logic that checks for duplicates between manually entered text and the proposal list.
  *
- * @param VALUE
+ * @param <VALUE>
  *          generic parameter type of lookup key
  */
 public interface IProposalField<VALUE> extends ISmartField<VALUE> {
-
-  /**
-   * {@link Integer}
-   *
-   * @since 6.1
-   */
-  String PROP_MAX_LENGTH = "maxLength";
 
   /**
    * {@link Boolean}
@@ -43,21 +36,7 @@ public interface IProposalField<VALUE> extends ISmartField<VALUE> {
   String PROP_TRIM_TEXT_ON_VALIDATE = "trimText";
 
   String getValueAsString();
-
   void setValueAsString(String value);
-
-  /**
-   * @param maxLength
-   *          of the text in this field. Negative values are automatically converted to 0.
-   * @since 6.1
-   */
-  void setMaxLength(int maxLength);
-
-  /**
-   * @return the maximum length of text, default is 4000
-   * @since 6.1
-   */
-  int getMaxLength();
 
   /**
    * @param b

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/ISmartField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/ISmartField.java
@@ -56,6 +56,7 @@ public interface ISmartField<VALUE> extends IValueField<VALUE> {
   String PROP_COLUMN_DESCRIPTORS = "columnDescriptors";
   String PROP_LOOKUP_ROW = "lookupRow";
   String PROP_LOAD_PARENT_NODES = "loadParentNodes";
+  String PROP_MAX_LENGTH = "maxLength";
 
   String DISPLAY_STYLE_DEFAULT = "default";
   String DISPLAY_STYLE_DROPDOWN = "dropdown";
@@ -141,6 +142,17 @@ public interface ISmartField<VALUE> extends IValueField<VALUE> {
   boolean isLoadParentNodes();
 
   void setLoadParentNodes(boolean loadParentNodes);
+
+  /**
+   * @param maxLength
+   *          of the text in this field. Negative values are automatically converted to 0.
+   */
+  void setMaxLength(int maxLength);
+
+  /**
+   * @return the maximum length of text
+   */
+  int getMaxLength();
 
   /**
    * Filter selection of hierarchy browse tree. The level reported here is different than the one used in {@link AbstractTree}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/tagfield/ITagField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/tagfield/ITagField.java
@@ -19,6 +19,7 @@ import org.eclipse.scout.rt.client.ui.form.fields.IValueField;
 public interface ITagField extends IValueField<Set<String>> {
 
   String PROP_RESULT = "result";
+  String PROP_MAX_LENGTH = "maxLength";
 
   void addTag(String tag);
 
@@ -28,10 +29,20 @@ public interface ITagField extends IValueField<Set<String>> {
 
   void removeAllTags();
 
+  /**
+   * @param maxLength
+   *          of the text in this field. Negative values are automatically converted to 0.
+   */
+  void setMaxLength(int maxLength);
+
+  /**
+   * @return the maximum length of text.
+   */
+  int getMaxLength();
+
   void lookupByText(String proposal);
 
   ITagFieldUIFacade getUIFacade();
 
   ILookupCallResult<String> getResult();
-
 }

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/lookup/CodeLookupCallTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/lookup/CodeLookupCallTest.java
@@ -71,7 +71,6 @@ public class CodeLookupCallTest {
   public void testGetDataByTextFiltered() {
     runGetDataByTextFiltered(null);
     runGetDataByTextFiltered("*or*");
-    runGetDataByTextFiltered("*or");
     runGetDataByTextFiltered("ip");
     runGetDataByTextFiltered("foo");
     runGetDataByTextFiltered("ipi");
@@ -80,7 +79,6 @@ public class CodeLookupCallTest {
   }
 
   private void runGetDataByTextFiltered(String text) {
-
     P_LegacyCodeLookupCall oldLc = new P_LegacyCodeLookupCall();
     oldLc.setText(text);
     List<ILookupRow<Integer>> oldRows = oldLc.getDataByText();
@@ -94,13 +92,13 @@ public class CodeLookupCallTest {
 
   @Test
   public void testGetDataByKey() {
-    runGetDataByKey(0, null);
-    runGetDataByKey(1, ROW10_KEY);
-    runGetDataByKey(1, ROW31_KEY);
-    runGetDataByKey(0, Integer.valueOf(0));
+    runGetDataByKey(null);
+    runGetDataByKey(ROW10_KEY);
+    runGetDataByKey(ROW31_KEY);
+    runGetDataByKey(Integer.valueOf(0));
   }
 
-  private void runGetDataByKey(int expectedLength, Integer key) {
+  private void runGetDataByKey(Integer key) {
 
     P_LegacyCodeLookupCall oldLc = new P_LegacyCodeLookupCall();
     oldLc.setKey(key);
@@ -115,15 +113,14 @@ public class CodeLookupCallTest {
 
   @Test
   public void testGetDataByRec() {
-    runGetDataByRec(3, null);
-    runGetDataByRec(2, ROW10_KEY);
-    runGetDataByRec(0, ROW20_KEY);
-    runGetDataByRec(1, ROW30_KEY);
-    runGetDataByRec(0, ROW11_KEY);
-
+    runGetDataByRec(null);
+    runGetDataByRec(ROW10_KEY);
+    runGetDataByRec(ROW20_KEY);
+    runGetDataByRec(ROW30_KEY);
+    runGetDataByRec(ROW11_KEY);
   }
 
-  private void runGetDataByRec(int expectedLength, Integer parent) {
+  private void runGetDataByRec(Integer parent) {
     P_LegacyCodeLookupCall oldLc = new P_LegacyCodeLookupCall();
     oldLc.setRec(parent);
     List<ILookupRow<Integer>> oldRows = oldLc.getDataByRec();
@@ -149,7 +146,6 @@ public class CodeLookupCallTest {
 
   @Test
   public void testGetFilteredData() {
-
     P_LegacyCodeLookupCall oldLc = new P_LegacyCodeLookupCall();
     oldLc.setFilter((call, code, treeLevel) -> true);
     List<ILookupRow<Integer>> oldRows = oldLc.getDataByAll();
@@ -167,9 +163,6 @@ public class CodeLookupCallTest {
     }
     if (rows1 == null || rows2 == null) {
       return false;
-    }
-    else {
-
     }
     if (rows1.size() != rows2.size()) {
       return false;

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/lookup/CodeLookupCall.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/lookup/CodeLookupCall.java
@@ -18,7 +18,6 @@ import java.util.regex.Pattern;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.classid.ClassId;
-import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.shared.services.common.code.ICode;
 import org.eclipse.scout.rt.shared.services.common.code.ICodeType;
 import org.eclipse.scout.rt.shared.services.common.code.ICodeVisitor;
@@ -156,21 +155,6 @@ public class CodeLookupCall<CODE_ID> extends LocalLookupCall<CODE_ID> {
         .withEnabled(c.isEnabled())
         .withParentKey(c.getParentCode() != null ? c.getParentCode().getId() : null)
         .withActive(c.isActive());
-  }
-
-  @Override
-  protected Pattern createSearchPattern(String s) {
-    if (s == null) {
-      s = "";
-    }
-    s = s.replace(getWildcard(), "@wildcard@");
-    s = s.toLowerCase();
-    s = StringUtility.escapeRegexMetachars(s);
-    s = s.replace("@wildcard@", ".*");
-    if (!s.endsWith(".*")) {
-      s = s + ".*";
-    }
-    return Pattern.compile(s, Pattern.DOTALL);
   }
 
   /**

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/smartfield/JsonProposalField.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/smartfield/JsonProposalField.java
@@ -34,12 +34,6 @@ public class JsonProposalField<VALUE, MODEL extends IProposalField<VALUE>> exten
   @Override
   protected void initJsonProperties(MODEL model) {
     super.initJsonProperties(model);
-    putJsonProperty(new JsonProperty<IProposalField<VALUE>>(IProposalField.PROP_MAX_LENGTH, model) {
-      @Override
-      protected Integer modelValue() {
-        return getModel().getMaxLength();
-      }
-    });
     putJsonProperty(new JsonProperty<IProposalField<VALUE>>(IProposalField.PROP_TRIM_TEXT_ON_VALIDATE, model) {
       @Override
       protected Boolean modelValue() {

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/smartfield/JsonSmartField.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/smartfield/JsonSmartField.java
@@ -159,6 +159,12 @@ public class JsonSmartField<VALUE, MODEL extends ISmartField<VALUE>> extends Jso
         return columnDescriptorsToJson((ColumnDescriptor[]) value);
       }
     });
+    putJsonProperty(new JsonProperty<ISmartField<VALUE>>(ISmartField.PROP_MAX_LENGTH, model) {
+      @Override
+      protected Integer modelValue() {
+        return getModel().getMaxLength();
+      }
+    });
   }
 
   @Override

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/tagfield/JsonTagField.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/tagfield/JsonTagField.java
@@ -67,6 +67,12 @@ public class JsonTagField extends JsonValueField<ITagField> {
         return JsonLookupCallResult.toJson((ILookupCallResult<String>) value);
       }
     });
+    putJsonProperty(new JsonProperty<ITagField>(ITagField.PROP_MAX_LENGTH, model) {
+      @Override
+      protected Integer modelValue() {
+        return getModel().getMaxLength();
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
Currently smart field and tag field allow an infinite text to be entered
by the user. this may cause two problems:
1. the website inside the browser may crash due to an out of memory
   exception.
2. the ui server thread handling the submitted text may crash due to an
   out of memory exception. This may also cause a security risk.

To solve this, the smart field and tag field will now have a max length
property and the ui server truncates all received text longer than the
max length value.
The .js fields will only allow to type as many characters as the max
length value, including text pasting.
The logic has been extracted from StringField.js and moved into a new
MaxLengthHandler.js which allows all fields to use the same logic.

In addition the code lookup call will also be resistent against regex
DoS.

295423

Signed-off-by: Cyrill Wyss <cyrill.wyss@bsi-software.com>