### PR TITLE
Add filter for fields to store in the xml export

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/form/StoreAndLoadXml4FormTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/form/StoreAndLoadXml4FormTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2015 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.client.ui.form;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.ui.form.StoreAndLoadXml4FormTest.TestForm.MainBox.GroupBox.ExcludedStringField;
+import org.eclipse.scout.rt.client.ui.form.StoreAndLoadXml4FormTest.TestForm.MainBox.GroupBox.IncludedStringField;
+import org.eclipse.scout.rt.client.ui.form.fields.button.AbstractCloseButton;
+import org.eclipse.scout.rt.client.ui.form.fields.groupbox.AbstractGroupBox;
+import org.eclipse.scout.rt.client.ui.form.fields.stringfield.AbstractStringField;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests exporting a form with a "store to xml field filter"
+ */
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(TestEnvironmentClientSession.class)
+public class StoreAndLoadXml4FormTest {
+
+  static final String TEST_DATA = "testdata";
+
+  @Test
+  public void test() {
+    TestForm f = new TestForm();
+    try {
+      f.startModify();
+      assertEquals(TEST_DATA, f.getIncludedStringField().getValue());
+      assertEquals(TEST_DATA, f.getExcludedStringField().getValue());
+
+      //store xml
+      String xml = f.storeToXmlString();
+      assertTrue(xml.contains("IncludedStringField"));
+      assertFalse(xml.contains("ExcludedStringField"));
+
+      // clear form
+      f.getExcludedStringField().setValue(null);
+      f.getIncludedStringField().setValue(null);
+      assertNull(f.getIncludedStringField().getValue());
+      assertNull(f.getExcludedStringField().getValue());
+
+      // load xml
+      f.loadFromXmlString(xml);
+      assertEquals(TEST_DATA, f.getIncludedStringField().getValue()); // restored from xml
+      assertNull(f.getExcludedStringField().getValue()); // still null, not included in the xml export
+    }
+    finally {
+      f.doClose();
+    }
+  }
+
+  public static class TestForm extends AbstractForm {
+
+    public TestForm() {
+      super();
+      // custom filter
+      setStoreToXmlFieldFilter(field -> !field.getClass().equals(ExcludedStringField.class));
+    }
+
+    @Override
+    protected String getConfiguredTitle() {
+      return "TestForm";
+    }
+
+    public void startModify() {
+      startInternal(new ModifyHandler());
+    }
+
+    public MainBox getMainBox() {
+      return getFieldByClass(MainBox.class);
+    }
+
+    public ExcludedStringField getExcludedStringField() {
+      return getFieldByClass(ExcludedStringField.class);
+    }
+
+    public IncludedStringField getIncludedStringField() {
+      return getFieldByClass(IncludedStringField.class);
+    }
+
+    @Order(10)
+    public class MainBox extends AbstractGroupBox {
+
+      @Order(10)
+      public class GroupBox extends AbstractGroupBox {
+
+        @Order(10)
+        public class IncludedStringField extends AbstractStringField {
+        }
+
+        @Order(20)
+        public class ExcludedStringField extends AbstractStringField {
+        }
+      }
+    }
+
+    @Order(20)
+    public class CloseButton extends AbstractCloseButton {
+    }
+
+    public class ModifyHandler extends AbstractFormHandler {
+      @Override
+      protected void execLoad() {
+        getIncludedStringField().setValue(TEST_DATA);
+        getExcludedStringField().setValue(TEST_DATA);
+      }
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/AbstractForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/AbstractForm.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.eclipse.scout.rt.client.ModelContextProxy;
 import org.eclipse.scout.rt.client.ModelContextProxy.ModelContext;
@@ -209,6 +210,9 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
   private Map<Class<?>, Class<? extends IFormField>> m_fieldReplacements;
   private IContributionOwner m_contributionHolder;
 
+  // filter for fields to store in xml export
+  private Predicate<IFormField> m_storeToXmlFieldFilter;
+
   public AbstractForm() {
     this(true);
   }
@@ -220,6 +224,7 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
     m_closeType = IButton.SYSTEM_TYPE_NONE;
     m_displayParent = new PreferredValue<>(null, false);
     m_eventHistory = createEventHistory();
+    m_storeToXmlFieldFilter = createDefaultStoreToXmlFieldFilter();
     setHandler(new NullFormHandler());
     setFormLoading(true);
     m_blockingCondition = Jobs.newBlockingCondition(false);
@@ -258,6 +263,18 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
   @Override
   public final <T> T optContribution(Class<T> contribution) {
     return m_contributionHolder.optContribution(contribution);
+  }
+
+  public Predicate<IFormField> getStoreToXmlFieldFilter() {
+    return m_storeToXmlFieldFilter;
+  }
+
+  public void setStoreToXmlFieldFilter(Predicate<IFormField> storeToXmlFieldFilter) {
+    m_storeToXmlFieldFilter = storeToXmlFieldFilter != null ? storeToXmlFieldFilter : createDefaultStoreToXmlFieldFilter();
+  }
+
+  protected Predicate<IFormField> createDefaultStoreToXmlFieldFilter() {
+    return field -> true;
   }
 
   @Override
@@ -2182,8 +2199,8 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
     final Element xFields = root.getOwnerDocument().createElement("fields");
     root.appendChild(xFields);
     Function<IFormField, TreeVisitResult> v = field -> {
-      if (field.getForm() != AbstractForm.this) {
-        // field is part of a wrapped form and is handled by the AbstractWrappedFormField
+      if (field.getForm() != AbstractForm.this || !getStoreToXmlFieldFilter().test(field)) {
+        // field is part of a wrapped form and is handled by the AbstractWrappedFormField or should not be included in the export
         return TreeVisitResult.CONTINUE;
       }
       Element xField = xFields.getOwnerDocument().createElement("field");


### PR DESCRIPTION
Before all fields of a form would be stored in the xml export. This
filter allows the form to customize which field end up in the xml
export.