### PR TITLE
Improve logging in case client notification messages are dropped

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/KeyCacheEntryFilter.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/KeyCacheEntryFilter.java
@@ -50,4 +50,9 @@ public final class KeyCacheEntryFilter<K, V> implements ICacheEntryFilter<K, V> 
     }
     return null;
   }
+
+  @Override
+  public String toString() {
+    return "KeyCacheEntryFilter [m_keys=" + m_keys + ']';
+  }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/clientnotification/IClientNotificationAddress.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/clientnotification/IClientNotificationAddress.java
@@ -12,6 +12,9 @@ package org.eclipse.scout.rt.shared.clientnotification;
 
 import java.io.Serializable;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
 /**
  * Address of a client notification that can be used for dispatching.
@@ -40,4 +43,19 @@ public interface IClientNotificationAddress extends Serializable {
    */
   boolean isNotifyAllNodes();
 
+  default String prettyPrint() {
+    if (isNotifyAllNodes()) {
+      return "all nodes";
+    }
+    if (isNotifyAllSessions()) {
+      return "all sessions";
+    }
+    if (CollectionUtility.hasElements(getUserIds())) {
+      return getUserIds().stream().sorted().collect(Collectors.joining(", ", "users [", "]"));
+    }
+    if (CollectionUtility.hasElements(getSessionIds())) {
+      return getSessionIds().stream().sorted().collect(Collectors.joining(", ", "sessions [", "]"));
+    }
+    return "unknown";
+  }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/CodeTypeCacheEntryFilter.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/CodeTypeCacheEntryFilter.java
@@ -55,4 +55,9 @@ public class CodeTypeCacheEntryFilter implements ICacheEntryFilter<CodeTypeCache
     }
     return null;
   }
+
+  @Override
+  public String toString() {
+    return "CodeTypeCacheEntryFilter [m_codeTypeClasses=" + m_codeTypeClasses + ']';
+  }
 }


### PR DESCRIPTION
The oldest client notification messages are removed when new messages
cannot be added due to capacity limitations.