### PR TITLE
 Remove java.net.URL hashCode and equals calls

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/UriUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/UriUtilityTest.java
@@ -89,4 +89,24 @@ public class UriUtilityTest {
     }
   }
 
+  @Test
+  public void testUrlEquals() throws Exception {
+    assertTrue(UriUtility.equals(null, null));
+    String s = "http://host/path/to?test=foo#anchor";
+    URL a = new URL(s);
+    URL b = new URL(s);
+    assertFalse(UriUtility.equals(a, null));
+    assertFalse(UriUtility.equals(null, b));
+    assertFalse(UriUtility.equals(a, new URL(s + "test")));
+    assertTrue(UriUtility.equals(a, b));
+  }
+
+  @Test
+  public void testUrlHashCode() throws Exception {
+    String s = "http://host/path/to?test=foo#anchor";
+    URL a = new URL(s);
+    URL b = new URL(s);
+    assertEquals(UriUtility.hashCode(a), UriUtility.hashCode(b));
+  }
+
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/UriUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/UriUtility.java
@@ -20,6 +20,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.slf4j.Logger;
@@ -264,4 +265,44 @@ public final class UriUtility {
     }
   }
 
+  /**
+   * Indicates whether the string representation of URL a is equal to the string representation of URL b.
+   * <p>
+   * <b>Warning: The returned value is not equal to the value of {@link URL#equals(Object)}.</b>
+   * <p>
+   * Compared to {@link URL#equals(Object)} this method does not do DNS lookups for hostnames and thus does not consider
+   * two URLs with hostnames resolving to the same IP address as equal. Compared to calling {@link URL#toURI()} and
+   * {@link URI#equals(Object)}, this method does no additional validation and is not case-insensitive with regard to
+   * hostnames.
+   *
+   * @see URL#equals(Object)
+   */
+  public static boolean equals(URL a, URL b) {
+    if (a == b) {
+      return true;
+    }
+    if (a == null) {
+      return false;
+    }
+    if (b == null) {
+      return false;
+    }
+    return ObjectUtility.equals(a.toString(), b.toString());
+  }
+
+  /**
+   * Generates a hash code based on the string representation of the URL.
+   * <p>
+   * <b>Warning: The returned value is not equal to the value of {@link URL#hashCode()}.</b>
+   * <p>
+   * Compared to {@link URL#hashCode()} this method does not do a DNS lookup for the hostname and thus does not generate
+   * the same hash code for two URLs with hostnames resolving to the same IP address. Compared to calling
+   * {@link URL#toURI()} and {@link URI#equals(Object)}, this method does no additional validation and is not
+   * case-insensitive with regard to hostnames.
+   *
+   * @see URL#hashCode()
+   */
+  public static int hashCode(URL a) {
+    return Objects.hashCode(a == null ? null : a.toString());
+  }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/UriUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/UriUtility.java
@@ -42,7 +42,7 @@ public final class UriUtility {
   /**
    * Parses the given URL's query string using encoding UTF_8 and extracts the query parameter.
    *
-   * @param uri
+   * @param url url
    * @return map with parsed query parameters. Never <code>null</code>.
    */
   public static Map<String, String> getQueryParameters(URL url) {
@@ -52,7 +52,7 @@ public final class UriUtility {
   /**
    * Parses the given URL's query string using the given encoding and extracts the query parameter.
    *
-   * @param uri
+   * @param url url
    * @param encoding
    *          encoding of the query parameter. If <code>null</code> UTF_8 is used.
    * @return map with parsed query parameters. Never <code>null</code>.
@@ -67,7 +67,7 @@ public final class UriUtility {
   /**
    * Parses the given URI's query string using encoding UTF_8 and extracts the query parameter.
    *
-   * @param uri
+   * @param uri uri
    * @return map with parsed query parameters. Never <code>null</code>.
    */
   public static Map<String, String> getQueryParameters(URI uri) {
@@ -77,7 +77,7 @@ public final class UriUtility {
   /**
    * Parses the given URI's query string using the given encoding and extracts the query parameter.
    *
-   * @param uri
+   * @param uri uri
    * @param encoding
    *          encoding of the query parameter. If <code>null</code> UTF-8 is used.
    * @return map with parsed query parameters. Never <code>null</code>.
@@ -127,7 +127,7 @@ public final class UriUtility {
   /**
    * Splits the path of the given {@link URI} in its elements.
    *
-   * @param uri
+   * @param uri uri
    * @return the path elements or an empty string array if the uri or its path is <code>null</code>.
    */
   public static String[] getPath(URI uri) {
@@ -144,7 +144,7 @@ public final class UriUtility {
   /**
    * Converts the given URL into an URI.
    *
-   * @param url
+   * @param url url
    * @return <code>null</code> if the given url is <code>null</code>.
    */
   public static URI urlToUri(URL url) {
@@ -162,7 +162,7 @@ public final class UriUtility {
   /**
    * Converts the given URI into an URL.
    *
-   * @param uri
+   * @param uri uri
    * @return <code>null</code> if the given uri is <code>null</code>.
    */
   public static URL uriToUrl(URI uri) {
@@ -180,7 +180,7 @@ public final class UriUtility {
   /**
    * Parses the given string into an {@link URI}.
    *
-   * @param uri
+   * @param uri uri
    * @return <code>null</code> if the given string is null or has no text or a parsed {@link URI} instance.
    */
   public static URI toUri(String uri) {
@@ -198,7 +198,7 @@ public final class UriUtility {
   /**
    * Parses the given string into an {@link URL}.
    *
-   * @param url
+   * @param url url
    * @return <code>null</code> if the given string is null or has no text or a parsed {@link URL} instance.
    */
   public static URL toUrl(String url) {
@@ -240,7 +240,7 @@ public final class UriUtility {
   }
 
   /**
-   * Delegates to {@link URLDecoder#encode(String, String)} using default encoding.
+   * Delegates to {@link URLEncoder#encode(String, String)} using default encoding.
    *
    * @return the newly encoded String
    */
@@ -249,7 +249,7 @@ public final class UriUtility {
   }
 
   /**
-   * Delegates to {@link URLDecoder#encode(String, String)} using the given encoding.
+   * Delegates to {@link URLEncoder#encode(String, String)} using the given encoding.
    *
    * @return the newly encoded String
    */

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/ui/webresource/WebResourceDescriptor.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/ui/webresource/WebResourceDescriptor.java
@@ -14,6 +14,7 @@ import java.net.URL;
 import java.util.Objects;
 
 import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.UriUtility;
 
 public class WebResourceDescriptor {
 
@@ -48,14 +49,14 @@ public class WebResourceDescriptor {
       return false;
     }
     WebResourceDescriptor that = (WebResourceDescriptor) o;
-    return Objects.equals(m_url, that.m_url) &&
+    return UriUtility.equals(m_url, that.m_url) &&
         Objects.equals(m_requestPath, that.m_requestPath) &&
         Objects.equals(m_resolvedPath, that.m_resolvedPath);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(m_url, m_requestPath, m_resolvedPath);
+    return Objects.hash(UriUtility.hashCode(m_url), m_requestPath, m_resolvedPath);
   }
 
   @Override


### PR DESCRIPTION
The URL hashCode and equals methods perform DNS lookups and should not be used. Add helper methods to UriUtility for direct comparison of URLs using their string representation, without converting to URIs. Note that implicit use of hashCode/equals (by maps/sets) must still be prevented, and URIs should be used instead whereever possible.

309389