### PR TITLE
Add utility function objects#isPromise that checks for thenables

### DIFF
--- a/eclipse-scout-core/src/util/objects.js
+++ b/eclipse-scout-core/src/util/objects.js
@@ -366,6 +366,19 @@ export function isArray(obj) {
 }
 
 /**
+ * Checks whether the provided value is a promise or not.
+ * @param {any} value The value to check.
+ * @return {boolean} Returns true, in case the provided value is a thenable, false otherwise.
+ *
+ * Note: This method checks whether the provided value is a "thenable" (see https://promisesaplus.com/#terminology).
+ *       Checking for promise would require to check the behavior which is not possible. So you could provide an object
+ *       with a "then" function that does not conform to the Promises/A+ spec but this method would still return true.
+ */
+export function isPromise(value) {
+  return !!value && typeof value === 'object' && typeof value.then === 'function';
+}
+
+/**
  * Returns values from the given (map) object. By default only values of 'own' properties are returned.
  *
  * @returns {Array} an Array with values
@@ -728,6 +741,7 @@ export default {
   isNumber,
   isPlainObject,
   isString,
+  isPromise,
   keyByValue,
   mandatoryFunction,
   optProperty,

--- a/eclipse-scout-core/test/util/objectsSpec.js
+++ b/eclipse-scout-core/test/util/objectsSpec.js
@@ -281,6 +281,26 @@ describe('scout.objects', () => {
     });
   });
 
+  describe('isPromise', () => {
+    it('returns false for "not a promise" inputs', () => {
+      expect(objects.isPromise()).toBeFalse();
+      expect(objects.isPromise(null)).toBeFalse();
+      expect(objects.isPromise('foo')).toBeFalse();
+      expect(objects.isPromise(5)).toBeFalse();
+      expect(objects.isPromise(['foo'])).toBeFalse();
+      expect(objects.isPromise({foo: 'bar'})).toBeFalse();
+    });
+
+    it('returns true for thenables', () => {
+      expect(objects.isPromise($.resolvedPromise())).toBeTrue();
+      expect(objects.isPromise($.Deferred().promise())).toBeTrue();
+      expect(objects.isPromise({
+        then() {
+        }
+      })).toBeTrue();
+    });
+  });
+
   describe('values', () => {
     it('returns object values', () => {
       let Class = function() {


### PR DESCRIPTION
This change adds a new function to the objects utility that checks a provided
value for being a thenable or not, according to the Promises/A+ spec as
mentioned here: https://promisesaplus.com/#terminology.