### PR TITLE
ModeSelector: fix mode width when computing the preferred size

### DIFF
--- a/eclipse-scout-core/src/modeselector/ModeSelectorLayout.js
+++ b/eclipse-scout-core/src/modeselector/ModeSelectorLayout.js
@@ -38,12 +38,17 @@ export default class ModeSelectorLayout extends AbstractLayout {
     });
 
     let maxWidth = 0;
-    this.modeSelector.modes.forEach(mode => {
-      let modeWidth = mode.htmlComp.prefSize().width;
-      if (modeWidth > maxWidth) {
-        maxWidth = modeWidth;
-      }
-    });
+    this.modeSelector.modes
+      .filter(mode => mode.rendered)
+      .forEach(mode => {
+        let oldModeStyle = mode.$container.attr('style');
+        mode.$container.css('flex', 'none');
+        let modeWidth = mode.htmlComp.prefSize().width;
+        if (modeWidth > maxWidth) {
+          maxWidth = modeWidth;
+        }
+        mode.$container.attrOrRemove('style', oldModeStyle);
+      });
 
     this.modeSelector.$container.attrOrRemove('style', oldStyle);
 


### PR DESCRIPTION
The mode selector uses flexbox. When computing the preferred size, the
preferred size of each mode is measured. The get the correct preferred
size of each mode, its "flexing" has to temporarily disabled.