### PR TITLE
Fixed isEditable and removable behavior of checkable columns

### DIFF
--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -2111,7 +2111,7 @@ export default class Table extends Widget {
       });
     }
 
-    if (column === this.checkableColumn) {
+    if (column === this.checkableColumn && column.guiOnly) {
       return scout.create('Cell', {
         value: row.checked,
         editable: true,

--- a/eclipse-scout-core/src/table/columns/BooleanColumn.js
+++ b/eclipse-scout-core/src/table/columns/BooleanColumn.js
@@ -58,6 +58,9 @@ export default class BooleanColumn extends Column {
     }
 
     enabled = enabled && cell.editable;
+    if (this.table.checkableColumn === this) {
+      enabled = enabled && this.table.checkable;
+    }
     cssClass = this._cellCssClass(cell, tableNodeColumn);
     style = this._cellStyle(cell, tableNodeColumn, rowPadding);
     if (!enabled) {
@@ -110,12 +113,13 @@ export default class BooleanColumn extends Column {
   onMouseUp(event, $row) {
     let row = $row.data('row'),
       cell = this.cell(row);
-    if (this.isCellEditable(row, cell, event)) {
-      if (this.table.checkableColumn === this) {
-        this.table.checkRow(row, !row.checked);
-      } else {
-        this._toggleCellValue(row, cell);
-      }
+    if (!this.isCellEditable(row, cell, event)) {
+      return;
+    }
+    if (this.table.checkable && this.table.checkableColumn === this) {
+      this.table.checkRow(row, !row.checked);
+    } else {
+      this._toggleCellValue(row, cell);
     }
   }
 

--- a/eclipse-scout-core/src/table/columns/BooleanColumn.js
+++ b/eclipse-scout-core/src/table/columns/BooleanColumn.js
@@ -110,10 +110,12 @@ export default class BooleanColumn extends Column {
   onMouseUp(event, $row) {
     let row = $row.data('row'),
       cell = this.cell(row);
-    if (this.table.checkableColumn === this) {
-      this.table.checkRow(row, !row.checked);
-    } else if (this.isCellEditable(row, cell, event)) {
-      this._toggleCellValue(row, cell);
+    if (this.isCellEditable(row, cell, event)) {
+      if (this.table.checkableColumn === this) {
+        this.table.checkRow(row, !row.checked);
+      } else {
+        this._toggleCellValue(row, cell);
+      }
     }
   }
 

--- a/eclipse-scout-core/src/table/keystrokes/TableToggleRowKeyStroke.js
+++ b/eclipse-scout-core/src/table/keystrokes/TableToggleRowKeyStroke.js
@@ -30,7 +30,9 @@ export default class TableToggleRowKeyStroke extends KeyStroke {
 
   handle(event) {
     let selectedRows = this.field.selectedRows.filter(row => {
-      return row.enabled;
+      return row.enabled &&
+        this.field.checkableColumn &&
+        this.field.checkableColumn.isCellEditable(row, this.field.checkableColumn.cell(row), event);
     });
     // Toggle checked state to 'true', except if every row is already checked
     let checked = selectedRows.some(row => {

--- a/eclipse-scout-core/src/table/keystrokes/TableToggleRowKeyStroke.js
+++ b/eclipse-scout-core/src/table/keystrokes/TableToggleRowKeyStroke.js
@@ -31,8 +31,8 @@ export default class TableToggleRowKeyStroke extends KeyStroke {
   handle(event) {
     let selectedRows = this.field.selectedRows.filter(row => {
       return row.enabled &&
-        this.field.checkableColumn &&
-        this.field.checkableColumn.isCellEditable(row, this.field.checkableColumn.cell(row), event);
+        (!this.field.checkableColumn ||
+          this.field.checkableColumn.isCellEditable(row, this.field.checkableColumn.cell(row), event));
     });
     // Toggle checked state to 'true', except if every row is already checked
     let checked = selectedRows.some(row => {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
@@ -539,7 +539,9 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
 
   /**
    * Configures the checkable column. The checkable column represents the check state of the row, i.e. if it is checked
-   * or not. If no checkable column is configured, only the row itself represents if the row was checked or not.
+   * or not. If no checkable column is configured, only the row itself represents if the row was checked or not. Note
+   * that {@link AbstractColumn#execCompleteEdit(ITableRow, IFormField)} as well as
+   * {@link AbstractColumn#execPrepareEdit(ITableRow)} are not supported for checkable columns.
    * <p>
    * Subclasses can override this method. Default is {@code null}.
    *
@@ -4388,7 +4390,7 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
     }
 
     IColumn<?> ctxCol = getContextColumn();
-    if (isCellEditable(row, ctxCol)) {
+    if (isCellEditable(row, ctxCol) && !ctxCol.equals(getCheckableColumn())) {
       //cell-level checkbox
       if (ctxCol instanceof IBooleanColumn) {
         //editable boolean columns consume this click

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableOrganizer.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableOrganizer.java
@@ -48,7 +48,8 @@ public class TableOrganizer implements ITableOrganizer {
   public boolean isColumnRemovable(IColumn column) {
     // We could write column.isVisible() || getCustomizer().isCustomizable(column) && hasRemovePermission()
     // here but the outcome would be the same as 'true', because the given column is always visible here.
-    return true;
+    // The only exception is the checkable column (if it is set), which cannot be removed even if it is visible.
+    return getTable().getCheckableColumn() == null || !getTable().getCheckableColumn().equals(column);
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractColumn.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractColumn.java
@@ -405,6 +405,10 @@ public abstract class AbstractColumn<VALUE> extends AbstractPropertyObserver imp
    * non-editable column is read-only.
    * <p>
    * Subclasses can override this method. Default is {@code false}.
+   * <p>
+   * Overriding this method does not have any effect on columns marked as
+   * {@link AbstractTable#getConfiguredCheckableColumn()}. Instead, checkable columns can be set to editable=false by
+   * overriding {@link AbstractColumn#execInitColumn()}.
    *
    * @return {@code true} if this column is editable, {@code false} otherwise.
    */


### PR DESCRIPTION
- Checkable columns can now be set to isEditable=false
- Checkable columns cannot be removed through the UI anymore