### PR TITLE
Table: hide filter field if cellEditorPopup is open

### DIFF
--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -3056,6 +3056,7 @@ export default class Table extends Widget {
     this.ensureRowRendered(row);
     let popup = column.startCellEdit(row, field);
     this.cellEditorPopup = popup;
+    this.$container.toggleClass('has-cell-editor-popup', !!popup);
     return popup;
   }
 
@@ -5384,6 +5385,9 @@ export default class Table extends Widget {
     let destroyEditor = () => {
       this.cellEditorPopup.destroy();
       this.cellEditorPopup = null;
+      if (this.$container) {
+        this.$container.removeClass('has-cell-editor-popup');
+      }
       if (callback) {
         callback();
       }

--- a/eclipse-scout-core/src/table/Table.less
+++ b/eclipse-scout-core/src/table/Table.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -134,6 +134,16 @@
       &:not(.focused).empty {
         --filter-field-max-bottom: calc(~'50% - ' (@filter-field-icon-size + var(--controls-height)) / 2);
       }
+    }
+
+    .has-cell-editor-popup& {
+      opacity: 0;
+      visibility: hidden;
+
+      // start the "fade out" transition right away
+      --filter-field-opacity-transition-delay: 0s;
+      // set visibility to hidden right after the "fade out" transition ends
+      --filter-field-visibility-transition-delay: calc(@filter-field-transition-duration + var(--filter-field-opacity-transition-delay));
     }
   }
 }

--- a/eclipse-scout-core/src/widget/FilterSupport.less
+++ b/eclipse-scout-core/src/widget/FilterSupport.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,13 @@
   #scout.drop-shadow();
   background-color: var(--filter-field-background-color);
   opacity: 1;
+  visibility: visible;
+
+  // delay the "fade in" transition
+  --filter-field-opacity-transition-delay: 100ms;
+  // the visibility transition is not a smooth transition but allows to set the value visibility delayed
+  // set visibility to visible right before the "fade in" transition starts
+  --filter-field-visibility-transition-delay: var(--filter-field-opacity-transition-delay);
 
   transition: bottom @filter-field-transition-duration ease-in-out,
   right @filter-field-transition-duration ease-in-out,
@@ -33,10 +40,17 @@
   min-width @filter-field-transition-duration ease-in-out,
   max-width @filter-field-transition-duration ease-in-out,
   box-shadow @filter-field-transition-duration ease-in-out,
-  opacity @filter-field-transition-duration ease-in-out;
+  opacity @filter-field-transition-duration ease-in-out var(--filter-field-opacity-transition-delay),
+  visibility 0s var(--filter-field-visibility-transition-delay);
 
   :not(:hover) > &:not(.focused):not(.focus-inside-widget).empty {
     opacity: 0;
+    visibility: hidden;
+
+    // start the "fade out" transition right away
+    --filter-field-opacity-transition-delay: 0s;
+    // set visibility to hidden right after the "fade out" transition ends
+    --filter-field-visibility-transition-delay: calc(@filter-field-transition-duration + var(--filter-field-opacity-transition-delay));
   }
 
   &::before {
@@ -143,6 +157,10 @@
 
   &:not(:hover) > .filter-field:not(.focused):not(.focus-inside-widget).empty {
     opacity: 1;
+    visibility: visible;
+
+    --filter-field-opacity-transition-delay: 100ms;
+    --filter-field-visibility-transition-delay: var(--filter-field-opacity-transition-delay);
   }
 
   & > .filter-field {
@@ -152,6 +170,10 @@
 
     :not(:hover) > &:not(.focused):not(.focus-inside-widget).empty {
       opacity: 0;
+      visibility: hidden;
+
+      --filter-field-opacity-transition-delay: 0s;
+      --filter-field-visibility-transition-delay: calc(@filter-field-transition-duration + var(--filter-field-opacity-transition-delay));
     }
 
     &:not(.focused).empty {


### PR DESCRIPTION
Hide the filter field on a table if the cellEditorPopup is open because
in some cases it lies above the clearIcon of the cellEditorPopup.

312429