### PR TITLE
FilterSupport: move icon slightly and add transparent background

### DIFF
--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,8 +26,8 @@
 @drop-shadow-blur: 13px;
 @drop-shadow-large-y: 8px;
 @drop-shadow-large-blur: 32px;
-@filter-field-bottom: 6px;
-@filter-field-right: 6px;
+@filter-field-bottom: 8px;
+@filter-field-right: 8px;
 @filter-field-height: @logical-grid-row-height;
 @filter-field-width: 190px;
 @filter-field-min-width: 75px;

--- a/eclipse-scout-core/src/widget/FilterSupport.js
+++ b/eclipse-scout-core/src/widget/FilterSupport.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -126,10 +126,12 @@ export default class FilterSupport extends WidgetSupport {
     this._filterField.$field.attr('tabIndex', -1);
 
     let color = styles.getFirstOpaqueBackgroundColor(this._filterField.$container),
-      transparentColorRgba = $.extend(true, {}, styles.rgb(color), {alpha: 0.5}),
-      transparentColor = 'rgba(' + transparentColorRgba.red + ', ' + transparentColorRgba.green + ', ' + transparentColorRgba.blue + ', ' + transparentColorRgba.alpha + ')';
+      colorRgba = $.extend(true, {red: 0, green: 0, blue: 0, alpha: 1}, styles.rgb(color)),
+      transparent50Color = 'rgba(' + colorRgba.red + ', ' + colorRgba.green + ', ' + colorRgba.blue + ', ' + 0.5 + ')',
+      transparent80Color = 'rgba(' + colorRgba.red + ', ' + colorRgba.green + ', ' + colorRgba.blue + ', ' + 0.8 + ')';
     this._filterField.$container.css('--filter-field-background-color', color);
-    this._filterField.$container.css('--filter-field-transparent-background-color', transparentColor);
+    this._filterField.$container.css('--filter-field-transparent-50-background-color', transparent50Color);
+    this._filterField.$container.css('--filter-field-transparent-80-background-color', transparent80Color);
 
     this._textFilter = this._createTextFilter();
     this._textFilter.synthetic = true;

--- a/eclipse-scout-core/src/widget/FilterSupport.less
+++ b/eclipse-scout-core/src/widget/FilterSupport.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -101,7 +101,7 @@
     min-width: @filter-field-icon-size;
     max-width: @filter-field-icon-size;
     box-shadow: none;
-    #scout.backdrop-filter(@background-color: var(--filter-field-transparent-background-color), @backdrop-filter: blur(2px), @fallback-background-color: var(--filter-field-background-color));
+    #scout.backdrop-filter(@background-color: var(--filter-field-transparent-50-background-color), @backdrop-filter: blur(2px), @fallback-background-color: var(--filter-field-transparent-80-background-color));
 
     &::before {
       bottom: 0;


### PR DESCRIPTION
Add a transparent background color for all browsers that do not support
blur (e.g. Firefox).

312135