### PR TITLE
Keep additional opts during updateChart debouncing.

### DIFF
--- a/eclipse-scout-chart/src/chart/Chart.js
+++ b/eclipse-scout-chart/src/chart/Chart.js
@@ -285,6 +285,8 @@ export default class Chart extends Widget {
       if (this._updateChartOpts) {
         // Inherit 'true' values from previously scheduled updates
         opts.requestAnimation = opts.requestAnimation || this._updateChartOpts.requestAnimation;
+        opts.onlyUpdateData = opts.onlyUpdateData || this._updateChartOpts.onlyUpdateData;
+        opts.onlyRefresh = opts.onlyRefresh || this._updateChartOpts.onlyRefresh;
       }
       this._updateChartTimeoutId = null;
       this._updateChartOpts = null;


### PR DESCRIPTION
If a debounced updateChart call with opts.onlyUpdateData = true is
replaced with a call where opts.onlyUpdateData = false, the necessary
data update of the chart will be skipped thus loosing this update.

By merging the current opts parameters this behavior changes such as
the data update will be made. The merge only makes sure that the
strongest function will be invoked with an order of:
1. updateData
2. refresh
3. remove & render

Signed-off-by: Cyrill Wyss <cyrill.wyss@bsi-software.com>