### PR TITLE
Chart: do not render chart if it is detached

### DIFF
--- a/eclipse-scout-chart/src/chart/AbstractChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/AbstractChartRenderer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -95,13 +95,6 @@ export default class AbstractChartRenderer {
 
   _render() {
     // Override in subclasses
-  }
-
-  checkCompletlyRendered() {
-    if (this.rendered || !this.chart.data) {
-      return;
-    }
-    this.render();
   }
 
   renderCheckedItems() {

--- a/eclipse-scout-chart/src/chart/Chart.js
+++ b/eclipse-scout-chart/src/chart/Chart.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,6 +45,7 @@ export default class Chart extends Widget {
 
     this._updateChartTimeoutId = null;
     this._updateChartOpts = null;
+    this._updateChartOptsWhileNotAttached = [];
     this.updatedOnce = false;
   }
 
@@ -101,6 +102,11 @@ export default class Chart extends Widget {
       requestAnimation: true,
       debounce: Chart.DEFAULT_DEBOUNCE_TIMEOUT
     });
+  }
+
+  _renderOnAttach() {
+    super._renderOnAttach();
+    this._updateChartOptsWhileNotAttached.splice(0).forEach(opts => this.updateChart($.extend(true, {}, opts, {debounce: true})));
   }
 
   _remove() {
@@ -256,6 +262,7 @@ export default class Chart extends Widget {
       if (this._updateChartOpts) {
         // Inherit 'true' values from previously scheduled updates
         opts.requestAnimation = opts.requestAnimation || this._updateChartOpts.requestAnimation;
+        opts.onlyUpdateData = opts.onlyUpdateData || this._updateChartOpts.onlyUpdateData;
       }
       this._updateChartTimeoutId = null;
       this._updateChartOpts = null;
@@ -279,6 +286,12 @@ export default class Chart extends Widget {
     function updateChartImpl() {
       this._updateChartTimeoutId = null;
       this._updateChartOpts = null;
+
+      if (!this.$container || !this.$container.isAttached()) {
+        this._updateChartOptsWhileNotAttached.push(opts);
+        return;
+      }
+
       if (opts.onlyUpdateData && this.chartRenderer && this.chartRenderer.isDataUpdatable()) {
         this.chartRenderer.updateData(opts.requestAnimation);
       } else if (this.chartRenderer) {

--- a/eclipse-scout-chart/src/chart/VennChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/VennChartRenderer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -110,14 +110,6 @@ export default class VennChartRenderer extends AbstractSvgChartRenderer {
           this._calc3(this.vennReal1, this.vennReal2, this.vennReal3, true, draw);
         }
       });
-    }
-  }
-
-  checkCompletlyRendered() {
-    if (this.readyToDraw) {
-      this._draw(false, true);
-    } else {
-      super.checkCompletlyRendered();
     }
   }
 

--- a/eclipse-scout-chart/src/form/fields/chartfield/ChartField.js
+++ b/eclipse-scout-chart/src/form/fields/chartfield/ChartField.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,12 +35,5 @@ export default class ChartField extends FormField {
   _removeChart() {
     this.chart.remove();
     this._removeField();
-  }
-
-  _renderOnAttach() {
-    super._renderOnAttach();
-    if (this.chart && this.chart.chartRenderer) {
-      this.chart.chartRenderer.checkCompletlyRendered();
-    }
   }
 }


### PR DESCRIPTION
Do not render a chart via its chartRenderer if the chart is detached,
otherwise the chartRenderers using css properties of chart.$container
will render incorrect charts. Therefore, render the chart when it is
attached for the first time.

307111