### PR TITLE
RestLookupCall: more specific error message defined

### DIFF
--- a/eclipse-scout-core/src/lookup/RestLookupCall.js
+++ b/eclipse-scout-core/src/lookup/RestLookupCall.js
@@ -170,12 +170,15 @@ export default class RestLookupCall extends LookupCall {
         });
       })
       .catch(ajaxError => {
+        const message = ajaxError.jqXHR && ajaxError.jqXHR.status === 403 ?
+          this.session.text('YouAreNotAllowedToReadThisData') :
+          this.session.text('ErrorWhileLoadingData');
         this._deferred.resolve({
           queryBy: this.queryBy,
           text: this.searchText,
           key: this.key,
           lookupRows: [],
-          exception: this.session.text('ErrorWhileLoadingData')
+          exception: message
         });
       });
 

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiTextContributor.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiTextContributor.java
@@ -195,6 +195,8 @@ public class UiTextContributor implements IUiTextContributor {
         "ui.Inactive",
         "ui.All",
         "ui.CloseAllTabs",
-        "ui.CloseOtherTabs"));
+        "ui.CloseOtherTabs",
+        // From org.eclipse.scout.rt.security
+        "YouAreNotAllowedToReadThisData"));
   }
 }


### PR DESCRIPTION
A generic error message ('Failed to load the data.') is returned if the
RestLookupCall runs into an error. The same message is displayed if the
user does not have sufficient permissions for the lookup call. To
distinguish this situation, a more specific message ('You are not
authorized to read this data.') is now returned.