### PR TITLE
Tree: improve performance and fix some bugs

### DIFF
--- a/eclipse-scout-core/src/tree/LazyNodeFilter.js
+++ b/eclipse-scout-core/src/tree/LazyNodeFilter.js
@@ -18,10 +18,9 @@ export default class LazyNodeFilter {
   accept(node) {
     if (node.expanded) {
       return true;
-    } else {
-      // not expanded: remove lazy expand marker (forget lazy expanded children)
-      node.childNodes.forEach(child => delete child._lazyNodeFilterAccepted);
     }
+    // not expanded: remove lazy expand marker (forget lazy expanded children)
+    node.childNodes.forEach(child => child._lazyNodeFilterAccepted = false);
 
     if (!node.parentNode || !node.parentNode.expandedLazy || !node.parentNode.lazyExpandingEnabled || !this.tree.lazyExpandingEnabled) {
       // no lazy expanding supported

--- a/eclipse-scout-core/test/tree/TreeSpec.js
+++ b/eclipse-scout-core/test/tree/TreeSpec.js
@@ -1331,6 +1331,30 @@ describe('Tree', () => {
       expect(secondExpanded.filterAccepted).toBe(false);  // no longer visible
     });
 
+    it('only shows selected in breadcrumb mode even if a child has filter accepted=true', () => {
+      let model = helper.createModelFixture(2, 2);
+      let tree = helper.createTree(model);
+      tree.render(session.$entryPoint);
+
+      // To reproduce manually in an outline tree, the node needs to be expanded, collapsed and expanded again.
+      tree.setNodeExpanded(tree.nodes[0], true);
+
+      let firstChild = tree.nodes[0].childNodes[0];
+      let secondChild = tree.nodes[0].childNodes[1];
+      tree.setNodeExpanded(firstChild, true);
+      tree.setNodeExpanded(firstChild, false); // Remove from visible list, filterAccepted is still true
+
+      tree.selectNode(secondChild);
+      expect(firstChild.filterAccepted).toBe(true);
+      expect(firstChild.childNodes[0].filterAccepted).toBe(true);
+      expect(secondChild.filterAccepted).toBe(true);
+
+      tree.setDisplayStyle(Tree.DisplayStyle.BREADCRUMB);
+      expect(firstChild.filterAccepted).toBe(false);
+      expect(firstChild.childNodes[0].filterAccepted).toBe(false);
+      expect(secondChild.filterAccepted).toBe(true);
+    });
+
     it('in breadcrumb mode renders children', () => {
       let model = helper.createModelFixture(10, 2);
       let tree = helper.createTree(model);


### PR DESCRIPTION
Improves
- Expanding all nodes (change in _applyFiltersForNodeRec)
- Lazy expanding a node (change in setNodeExpanded)
- Adding nodes (change in insertNodes and LazyNodeFilter)
  delete operation is very expensive
- Initializing (change in init)
- Simplified updateSelectionPath because after splitting it up,
  the selected node was always expanded after initializing

Fixes
- bread crumb showed too many nodes because filterVisibleNodes did
  not check children (see spec)
- adding a node to a lazy expanded parent (double click table row)
  created many animation-wrappers which stayed forever in the DOM
  without creating an animation.
- nodes were invisible after parent was expanded. Happened after
  collapsing the parent while nodes were hiding due to a filter.
- _nodesFiltered should always be executed, even if apply is false,
  to have a consistent model (not an actual bug)

312492