### PR TITLE
Disable ListenerListRegistry by default

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/events/ListenerListMonitorTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/events/ListenerListMonitorTest.java
@@ -10,8 +10,7 @@
  */
 package org.eclipse.scout.rt.platform.events;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -37,17 +36,17 @@ import org.junit.runner.RunWith;
 @RunWith(PlatformTestRunner.class)
 public class ListenerListMonitorTest {
 
-  private ListenerListRegistry m_originalListenerListRegistry;
+  private IListenerListProfiler m_originalListenerListProfiler;
 
   @Before
   public void runWithPrivateListenerListRegistry() {
-    m_originalListenerListRegistry = ListenerListRegistry.globalInstance();
-    ListenerListRegistry.setGlobalInstance(new ListenerListRegistry());
+    m_originalListenerListProfiler = ListenerListRegistry.globalInstance();
+    ListenerListRegistry.setGlobalInstance(new DefaultListenerListProfiler());
   }
 
   @After
   public void restoreOriginalListenerListRegistry() {
-    ListenerListRegistry.setGlobalInstance(m_originalListenerListRegistry);
+    ListenerListRegistry.setGlobalInstance(m_originalListenerListProfiler);
   }
 
   @Test

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/events/DefaultListenerListProfiler.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/events/DefaultListenerListProfiler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.platform.events;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * This class is Thread safe
+ */
+public class DefaultListenerListProfiler implements IListenerListProfiler {
+
+  private final Map<IListenerListWithManagement, Object> m_set = new WeakHashMap<>();
+
+  /**
+   * Add a weak reference to a event listener list
+   * <p>
+   * NOTE: This monitor does not add a reference to the argument. If the passed argument is not referenced by the source
+   * type, it is garbage collected almost immediately after the call to this method
+   */
+  @Override
+  public void registerAsWeakReference(IListenerListWithManagement eventListenerList) {
+    synchronized (m_set) {
+      m_set.put(eventListenerList, null);
+    }
+  }
+
+  @Override
+  public int getListenerListCount() {
+    synchronized (m_set) {
+      return m_set.size();
+    }
+  }
+
+  @Override
+  public ListenerListSnapshot createSnapshot() {
+    ListenerListSnapshot snapshot = new ListenerListSnapshot();
+    synchronized (m_set) {
+      for (IListenerListWithManagement list : m_set.keySet()) {
+        if (list != null) {
+          list.createSnapshot((context, listener) -> snapshot.add(list, context, listener));
+        }
+      }
+    }
+    return snapshot;
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/events/DisabledListenerListProfiler.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/events/DisabledListenerListProfiler.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.platform.events;
+
+public class DisabledListenerListProfiler implements IListenerListProfiler {
+
+  @Override
+  public ListenerListSnapshot createSnapshot() {
+    return new ListenerListSnapshot();
+  }
+
+  @Override
+  public void registerAsWeakReference(IListenerListWithManagement eventListenerList) {
+    // nop
+  }
+
+  @Override
+  public int getListenerListCount() {
+    return 0;
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/events/IListenerListProfiler.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/events/IListenerListProfiler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.platform.events;
+
+public interface IListenerListProfiler {
+
+  ListenerListSnapshot createSnapshot();
+
+  /**
+   * Add a weak reference to a event listener list
+   * <p>
+   * NOTE: This monitor does not add a reference to the argument. If the passed argument is not referenced by the source
+   * type, it is garbage collected almost immediately after the call to this method
+   */
+  void registerAsWeakReference(IListenerListWithManagement eventListenerList);
+
+  int getListenerListCount();
+}


### PR DESCRIPTION
Adds config property
org.eclipse.scout.rt.platform.management.EnableListenerListProfiler
which controls whether to monitor and expose all
IListenerListWithManagement classes.

314693