### PR TITLE
Table: read row of rowMouseUp event before calling the column onMouseUp

### DIFF
--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -633,11 +633,11 @@ export default class Table extends Widget {
       // Don't start cell editor or trigger click if row control was clicked (expansion itself is handled by the mouse down handler)
       return;
     }
+    let row = $row.data('row'); // read row before the $row potentially could be replaced by the column specific logic on mouse up
     if (mouseButton === 1) {
       column.onMouseUp(event, $row);
       $appLink = this._find$AppLink(event);
     }
-    let row = $row.data('row');
     if ($appLink) {
       this._triggerAppLinkAction(column, row, $appLink.data('ref'), $appLink);
     } else {

--- a/eclipse-scout-core/test/table/columns/BooleanColumSpec.js
+++ b/eclipse-scout-core/test/table/columns/BooleanColumSpec.js
@@ -95,6 +95,21 @@ describe('BooleanColumn', () => {
       expect($checkbox).not.toHaveClass('checked');
     });
 
+    it('triggers rowClick event correctly', () => {
+      let model = helper.createModelSingleColumnByValues([true, false], 'BooleanColumn');
+      let table = helper.createTable(model);
+      let column0 = table.columns[0];
+      column0.setEditable(true);
+      table.render();
+      table.on('rowClick', event => {
+        expect(event.row).toBeDefined();
+        expect(event.row).toBe(model.rows[1]);
+        expect(event.mouseButton).toBe(1);
+        expect(event.column).toBe(column0);
+      });
+      table.$cell(0, table.rows[1].$row).triggerClick();
+    });
+
     describe('setCellValue', () => {
       it('rebuilds the cell', () => {
         let model = helper.createModelSingleColumnByValues([true], 'BooleanColumn');


### PR DESCRIPTION
The row could be replaced by calling the column specific onMouseUp
handling, which leads to an undefined row later on.