### PR TITLE
Add basic classes to allow easy usage of bearer api authentication

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/TokenUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/TokenUtility.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.platform.util;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+
+public final class TokenUtility {
+
+  private TokenUtility() {
+  }
+
+  public static char[] toChars(byte[] bytes) {
+    CharBuffer charBuffer = StandardCharsets.UTF_8.decode(ByteBuffer.wrap(bytes));
+    char[] chars = new char[charBuffer.limit()];
+    charBuffer.get(chars, 0, chars.length);
+    return chars;
+  }
+
+  public static byte[] toBytes(char[] chars) {
+    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(chars));
+    byte[] bytes = new byte[byteBuffer.limit()];
+    byteBuffer.get(bytes, 0, bytes.length);
+    return bytes;
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/BearerAuthRequestFilter.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/BearerAuthRequestFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.rest.client;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.eclipse.scout.rt.platform.util.Base64Utility;
+import org.eclipse.scout.rt.platform.util.TokenUtility;
+
+public class BearerAuthRequestFilter implements ClientRequestFilter {
+
+  private final char[] m_token;
+
+  public BearerAuthRequestFilter(char[] token) {
+    m_token = token;
+  }
+
+  protected char[] getToken() {
+    return m_token;
+  }
+
+  @Override
+  public void filter(ClientRequestContext requestContext) throws IOException {
+    addTokenHeader(requestContext);
+  }
+
+  protected void addTokenHeader(ClientRequestContext requestContext) {
+    requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + Base64Utility.encode(TokenUtility.toBytes(getToken())));
+  }
+}

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/BearerAuthAccessController.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/BearerAuthAccessController.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.server.commons.authentication;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.Base64Utility;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.SleepUtil;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.server.commons.authentication.token.ITokenPrincipalProducer;
+import org.eclipse.scout.rt.server.commons.authentication.token.ITokenVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Authenticates a request using <a href="https://tools.ietf.org/html/rfc6750">Bearer Token Usage</a>.
+ */
+@Bean
+public class BearerAuthAccessController implements IAccessController {
+
+  public static final String HTTP_BEARER_AUTH_NAME = "Bearer";
+  private static final Logger LOG = LoggerFactory.getLogger(BearerAuthAccessController.class);
+
+  protected HttpBearerAuthConfig m_config;
+
+  public BearerAuthAccessController init(final HttpBearerAuthConfig config) {
+    m_config = config;
+    Assertions.assertNotNull(m_config.getTokenVerifier(), "TokenVerifier must not be null");
+    return this;
+  }
+
+  @Override
+  public boolean handle(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) throws IOException, ServletException {
+    if (!m_config.isEnabled()) {
+      return false;
+    }
+    return handleInternal(request, response, chain);
+  }
+
+  @Override
+  public void destroy() {
+    // NOOP
+  }
+
+  /**
+   * If <code>"Authorization"</code> header is not set, <code>"WWW-Authenticate: Bearer"</code> header is returned with
+   * status code 401 ({@link HttpServletResponse#SC_UNAUTHORIZED}).
+   * <p>
+   * Otherwise, the given token is checked using the configured token verifier. If the token is invalid, status code 403
+   * ({@link HttpServletResponse#SC_FORBIDDEN}) is returned. Otherwise, the filter chain continues. If a principal
+   * producer is configured, the chain continues on behalf of a subject.
+   */
+  protected boolean handleInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) throws IOException, ServletException {
+    // Never cache authentication requests.
+    response.setHeader("Cache-Control", "no-cache"); // HTTP 1.1
+    response.setHeader("Pragma", "no-cache"); // HTTP 1.0
+    response.setDateHeader("Expires", 0); // prevents caching at the proxy server
+
+    final List<byte[]> bearerTokenParts = readBearerToken(request);
+    if (CollectionUtility.isEmpty(bearerTokenParts)) {
+      handleForbidden(ITokenVerifier.AUTH_CREDENTIALS_REQUIRED, response);
+      return true;
+    }
+
+    final int status = m_config.getTokenVerifier().verify(bearerTokenParts);
+    if (status != ITokenVerifier.AUTH_OK) {
+      handleForbidden(status, response);
+      return true;
+    }
+
+    if (m_config.getPrincipalProducer() != null) {
+      final Principal principal = m_config.getPrincipalProducer().produce(bearerTokenParts);
+      BEANS.get(ServletFilterHelper.class).continueChainAsSubject(principal, request, response, chain);
+    }
+    else {
+      chain.doFilter(request, response);
+    }
+    return true;
+  }
+
+  /**
+   * Method invoked if the token could not be verified.
+   */
+  protected void handleForbidden(final int status, final HttpServletResponse resp) throws IOException {
+    if (status == ITokenVerifier.AUTH_CREDENTIALS_REQUIRED) {
+      resp.addHeader(ServletFilterHelper.HTTP_HEADER_WWW_AUTHENTICATE, HTTP_BEARER_AUTH_NAME);
+      resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+    else {
+      if (m_config.getStatus403WaitMillis() > 0L) {
+        SleepUtil.sleepSafe(m_config.getStatus403WaitMillis(), TimeUnit.MILLISECONDS);
+      }
+      resp.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+  }
+
+  /**
+   * Reads the bearer token from the request's {@link ServletFilterHelper#HTTP_HEADER_AUTHORIZATION} headers.
+   *
+   * @return The provided token. A bearer token is in most cases base64 encoded, but may contain character like "-",
+   *         ".", "_" or "~" which are not part of a base64 token and used to separate different token parts (see
+   *         https://datatracker.ietf.org/doc/html/rfc6750#section-2.1)
+   */
+  protected List<byte[]> readBearerToken(final HttpServletRequest req) {
+    final String bearerToken = parseBearerAuthRequest(req);
+    if (StringUtility.isNullOrEmpty(bearerToken)) {
+      return null;
+    }
+
+    String[] encodedBearerTokenParts = StringUtility.split(bearerToken, "[-._~]");
+
+    List<byte[]> tokenParts = new ArrayList<>();
+    for (int i = 0; i < encodedBearerTokenParts.length; i++) {
+      String encodedPart = encodedBearerTokenParts[i];
+      try {
+        tokenParts.add(Base64Utility.decode(encodedPart));
+      }
+      catch (IllegalArgumentException e) {
+        LOG.error("Token is not a valid base64 encoded value. Check part {} of the token", i);
+        throw new IllegalArgumentException("Token is not a valid base64 encoded value", e);
+      }
+    }
+
+    return tokenParts;
+  }
+
+  /**
+   * Parse request authorization header with bearer token and return it
+   *
+   * @param req
+   *          ServletRequest
+   * @return token
+   */
+  public String parseBearerAuthRequest(HttpServletRequest req) {
+    String h = req.getHeader(ServletFilterHelper.HTTP_HEADER_AUTHORIZATION);
+    if (h == null || !h.startsWith(HTTP_BEARER_AUTH_NAME + " ")) {
+      return null;
+    }
+    return h.substring(HTTP_BEARER_AUTH_NAME.length() + 1);
+  }
+
+  /**
+   * Configuration for {@link BearerAuthAccessController}.
+   */
+  public static class HttpBearerAuthConfig {
+
+    private boolean m_enabled = true;
+    private ITokenVerifier m_tokenVerifier;
+    private ITokenPrincipalProducer m_principalProducer = null;
+    private long m_status403WaitMillis = 500L;
+
+    public boolean isEnabled() {
+      return m_enabled;
+    }
+
+    public HttpBearerAuthConfig withEnabled(final boolean enabled) {
+      m_enabled = enabled;
+      return this;
+    }
+
+    public ITokenVerifier getTokenVerifier() {
+      return m_tokenVerifier;
+    }
+
+    /**
+     * Sets the {@link ITokenVerifier} to verify the token.
+     */
+    public HttpBearerAuthConfig withTokenVerifier(final ITokenVerifier tokenVerifier) {
+      m_tokenVerifier = tokenVerifier;
+      return this;
+    }
+
+    public ITokenPrincipalProducer getPrincipalProducer() {
+      return m_principalProducer;
+    }
+
+    /**
+     * Sets the {@link ITokenPrincipalProducer} to produce a {@link Principal} for authenticated tokens. By default, no
+     * principal is produced.
+     */
+    public HttpBearerAuthConfig withPrincipalProducer(final ITokenPrincipalProducer principalProducer) {
+      m_principalProducer = principalProducer;
+      return this;
+    }
+
+    public long getStatus403WaitMillis() {
+      return m_status403WaitMillis;
+    }
+
+    /**
+     * Sets the time to wait to respond with a 403 response code. That is a simple mechanism to address brute-force
+     * attacks, but may have a negative effect on DoS attacks. By default, this authenticator waits for 500ms.
+     */
+    public HttpBearerAuthConfig withStatus403WaitMillis(final long waitMillis) {
+      m_status403WaitMillis = waitMillis;
+      return this;
+    }
+  }
+}

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/ITokenPrincipalProducer.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/ITokenPrincipalProducer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.server.commons.authentication.token;
+
+import java.security.Principal;
+import java.util.List;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+/**
+ * Producer for {@link Principal} objects to represent authenticated users.
+ */
+@FunctionalInterface
+@ApplicationScoped
+public interface ITokenPrincipalProducer {
+
+  /**
+   * @param tokenParts
+   *          all parts of the token
+   * @return a principal based on the token parts
+   */
+  Principal produce(List<byte[]> tokenParts);
+}

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/ITokenVerifier.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/ITokenVerifier.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.server.commons.authentication.token;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+/**
+ * Verifies a token against a data source like database, config.properties or others.
+ */
+@FunctionalInterface
+@ApplicationScoped
+public interface ITokenVerifier {
+
+  /**
+   * Valid token provided.
+   */
+  int AUTH_OK = 1;
+
+  /**
+   * Invalid token provided.
+   */
+  int AUTH_FORBIDDEN = 1 << 1;
+
+  /**
+   * Failed to verify token.
+   */
+  int AUTH_FAILED = 1 << 2;
+
+  /**
+   * No token provided.
+   */
+  int AUTH_CREDENTIALS_REQUIRED = 1 << 3;
+
+  /**
+   * Attempts to verify the given token.
+   *
+   * @param tokenParts
+   *          The decoded tokens to verify. Multiple parts are split by "-" / "." / "_" / "~" (see
+   *          https://datatracker.ietf.org/doc/html/rfc6750#section-2.1)
+   * @return Result of the verification; one of {@link #AUTH_OK}, {@link #AUTH_FORBIDDEN},
+   *         {@link #AUTH_CREDENTIALS_REQUIRED}, {@link #AUTH_FAILED}
+   */
+  int verify(List<byte[]> tokenParts) throws IOException;
+}

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenPrincipalProducer.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenPrincipalProducer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.server.commons.authentication.token;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.scout.rt.platform.security.SimplePrincipal;
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.TokenUtility;
+
+public class SingleStringTokenPrincipalProducer implements ITokenPrincipalProducer {
+
+  protected Function<char[], String> m_tokenToPrincipalMapper;
+
+  public SingleStringTokenPrincipalProducer init(Function<char[], String> tokenToPrincipalMapper) {
+    Assertions.assertNotNull(tokenToPrincipalMapper, "Principal mapper must not be null");
+    m_tokenToPrincipalMapper = tokenToPrincipalMapper;
+    return this;
+  }
+
+  @Override
+  public Principal produce(List<byte[]> tokenParts) {
+    if (CollectionUtility.size(tokenParts) != 1) {
+      return null;
+    }
+
+    return new SimplePrincipal(m_tokenToPrincipalMapper.apply(TokenUtility.toChars(tokenParts.get(0))));
+  }
+}

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenVerifier.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenVerifier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.server.commons.authentication.token;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.TokenUtility;
+
+public class SingleStringTokenVerifier implements ITokenVerifier {
+
+  protected Predicate<char[]> m_verifier;
+
+  public SingleStringTokenVerifier init(Predicate<char[]> verifier) {
+    Assertions.assertNotNull(verifier, "Verifier must not be null");
+    m_verifier = verifier;
+    return this;
+  }
+
+  @Override
+  public int verify(List<byte[]> tokenParts) {
+    if (CollectionUtility.size(tokenParts) != 1) {
+      return ITokenVerifier.AUTH_FAILED;
+    }
+    return m_verifier.test(TokenUtility.toChars(tokenParts.get(0))) ? ITokenVerifier.AUTH_OK : ITokenVerifier.AUTH_FORBIDDEN;
+  }
+}


### PR DESCRIPTION
This change gives access to easily secure a rest api through OAuth2
token authentication (see https://tools.ietf.org/html/rfc6750).
It allows the usage of any token to be used as Bearer Token
but also implements a basic single string token implementation.
It also provides a client request filter to access a Bearer token secured api.

288192