### PR TITLE
Dark theme: improve login box and default severity button colors

### DIFF
--- a/eclipse-scout-core/src/box/Box.less
+++ b/eclipse-scout-core/src/box/Box.less
@@ -26,9 +26,9 @@
 }
 
 .box-content {
-  border: 1px solid @border-color;
+  border: @popup-border-width solid @popup-border-color;
   border-radius: @border-radius-large;
-  background-color: @background-color;
+  background-color: @popup-background-color;
   max-width: @box-width;
   margin: 0 auto;
   padding: 45px 95px 50px 95px;

--- a/eclipse-scout-core/src/login/LoginBox.less
+++ b/eclipse-scout-core/src/login/LoginBox.less
@@ -53,18 +53,20 @@
  */
 .login-button.default {
 
-  &.login-error {
-    border-color: @palette-red-4;
-    background-color: @palette-red-4;
+  &.login-error:not(.disabled) {
+    border-color: transparent;
+    background-color: @error-color;
 
     &:hover {
-      background-color: @palette-red-4;
-      border-color: @palette-red-4;
+      background-color: @error-default-button-background-hover-color;
     }
 
     &:active {
-      border-color: @palette-red-4;
-      background-color: darken(@palette-red-4, 5%);
+      background-color: @error-default-button-background-active-color;
+    }
+
+    &:focus {
+      #scout.focus-border(@box-shadow-color: @error-focus-box-shadow-color, @border-color: mix(@error-color, @error-focus-box-shadow-color, 25%));
     }
   }
 

--- a/eclipse-scout-core/src/messagebox/MessageBox.less
+++ b/eclipse-scout-core/src/messagebox/MessageBox.less
@@ -88,7 +88,7 @@
       }
     }
 
-    .severity-button(@error-color, @focus-color: @error-focus-box-shadow-color);
+    .severity-button(@error-color, @error-default-button-background-hover-color, @error-default-button-background-active-color, @error-focus-box-shadow-color);
   }
 
   &.warning {
@@ -100,7 +100,7 @@
       }
     }
 
-    .severity-button(@warning-color, @focus-color: @warning-focus-box-shadow-color);
+    .severity-button(@warning-color, @warning-default-button-background-hover-color, @warning-default-button-background-active-color, @warning-focus-box-shadow-color);
   }
 
   &.ok {
@@ -112,7 +112,7 @@
       }
     }
 
-    .severity-button(@ok-color, @focus-color: @ok-focus-box-shadow-color);
+    .severity-button(@ok-color, @ok-default-button-background-hover-color, @ok-default-button-background-active-color, @ok-focus-box-shadow-color);
   }
 
   &.animate-open {

--- a/eclipse-scout-core/src/style/colors-dark.less
+++ b/eclipse-scout-core/src/style/colors-dark.less
@@ -75,8 +75,14 @@
 @warning-color: @palette-orange-2;
 @ok-color: @palette-green-2;
 @error-background-color: @background-color;
+@error-default-button-background-hover-color: lighten(@error-color, 6%);
+@error-default-button-background-active-color: lighten(@error-color, 10%);
 @error-focus-box-shadow-color: mix(@error-color, @palette-black, 50%);
+@warning-default-button-background-hover-color: lighten(@warning-color, 8%);
+@warning-default-button-background-active-color: lighten(@warning-color, 12%);
 @warning-focus-box-shadow-color: mix(@warning-color, @palette-black, 50%);
+@ok-default-button-background-hover-color: lighten(@ok-color, 8%);
+@ok-default-button-background-active-color: lighten(@ok-color, 14%);
 @ok-focus-box-shadow-color: mix(@ok-color, @palette-black, 50%);
 @focus-border-color: @focus-color;
 @focus-box-shadow-color: darken(@focus-color, 30%);
@@ -102,7 +108,8 @@
 @popup-2-background-color: @palette-gray-6;
 @popup-2-backdrop-background-color: fade(@popup-2-background-color, 80%);
 @popup-2-backdrop-filter: blur(15px);
-@selected-hover-background-color: darken(@selected-background-color, 10%);
+@selected-hover-background-color: lighten(@selected-background-color, 8%);
+@selected-active-background-color: lighten(@selected-background-color, 12%);
 @selected-disabled-background-color: @palette-gray-5;
 @text-color: @palette-gray-2;
 @text-color-1: @palette-gray-3;

--- a/eclipse-scout-core/src/style/colors.less
+++ b/eclipse-scout-core/src/style/colors.less
@@ -101,8 +101,14 @@
 @ok-color: @palette-green-5;
 @error-background-color: @palette-red-0;
 @error-border-color: @error-color;
+@error-default-button-background-hover-color: darken(@error-color, 6%);
+@error-default-button-background-active-color: darken(@error-color, 13%);
 @error-focus-box-shadow-color: fade(@error-color, 40%);
+@warning-default-button-background-hover-color: darken(@warning-color, 6%);
+@warning-default-button-background-active-color: darken(@warning-color, 13%);
 @warning-focus-box-shadow-color: fade(@warning-color, 40%);
+@ok-default-button-background-hover-color: darken(@ok-color, 6%);
+@ok-default-button-background-active-color: darken(@ok-color, 13%);
 @ok-focus-box-shadow-color: fade(@ok-color, 40%);
 @focus-border-color: @accent-color-3;
 @focus-box-shadow-color: darken(@accent-color-1, 10%);


### PR DESCRIPTION
Login box:
The login box now uses the same colors as regular popups.
The login-error button now uses the same state colors as a
regular error button.

Severity buttons:
In dark theme, the hover and active background colors should get,
compared to the light theme where the colors get darker.

312897