### PR TITLE
Add Security and Code of Conduct files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Community Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as community members, contributors, committers, and project leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+With the support of the Eclipse Foundation staff (the “Staff”), project committers and leaders are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project committers and leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the Eclipse Foundation project or its community in public spaces. Examples of representing a project or community include posting via an official social media account, or acting as a project representative at an online or offline event. Representation of a project may be further defined and clarified by project committers, leaders, or the EMO.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Staff at codeofconduct@eclipse.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The Staff is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project committers or leaders who do not follow the Code of Conduct in good faith may face temporary or permanent repercussions as determined by the Staff.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ To learn more about Scout and how to use it, you should have a look at our [docu
 
 We welcome any kind of contributions (bug report, documentation improvement, code contribution...). Just open a GitHub issue and / or create a Pull Request.
 
-However, in order to create a valid Pull Request, you need an Eclipse account and a signed Eclipse Contributor Agreement (ECA). Please consult the [contribution guide](https://www.eclipse.org/projects/handbook/#contributing-contributors) of
-Eclipse for details.
+However, in order to create a valid Pull Request, you need an Eclipse account and a signed Eclipse Contributor Agreement ([ECA](https://www.eclipse.org/legal/ECA.php)).
+Please consult the [Eclipse Contribution Guide](https://www.eclipse.org/projects/handbook/#contributing-contributors) for details.
 
 Many thanks to all the people who have already contributed to Scout!
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+_ISO 27005 defines vulnerability as:
+"A weakness of an asset or group of assets that can be exploited by one or more threats."_
+
+## The Eclipse Security Team
+
+The Eclipse Security Team provides help and advice to Eclipse projects
+on vulnerability issues and is the first point of contact
+for handling security vulnerabilities.
+Members of the Security Team are committers on Eclipse Projects
+and members of the Eclipse Architecture Council.
+
+Contact the [Eclipse Security Team](mailto:security@eclipse.org).
+
+**Note that, as a matter of policy, the security team does not open attachments.**
+
+## Reporting a Security Vulnerability
+
+Vulnerabilities should be reported via email to the Eclipse Security Team.
+
+The general security mailing list address is security@eclipse.org.
+Members of the Eclipse Security Team will receive messages sent to this address.
+This address should be used only for reporting undisclosed vulnerabilities;
+regular issue reports and questions unrelated to vulnerabilities in Eclipse software
+will be ignored.
+Note that this email address is not encrypted.
+
+## Disclosure
+
+Disclosure is initially limited to the reporter and all Eclipse Committers,
+but is expanded to include other individuals, and the general public.
+The timing and manner of disclosure is governed by the
+[Eclipse Security Policy](https://www.eclipse.org/security/policy.php).
+
+Publicly disclosed issues are listed on the
+[Disclosed Vulnerabilities Page](https://www.eclipse.org/security/known.php).


### PR DESCRIPTION
Also add link to ECA in README.md.

The content has been copied and slightly adapted from
https://github.com/eclipse-ee4j/.github.