### PR TITLE
Mobile: increase size of ellipsis menu in desktop tool box a little

### DIFF
--- a/eclipse-scout-core/src/desktop/navigation/DesktopNavigation.less
+++ b/eclipse-scout-core/src/desktop/navigation/DesktopNavigation.less
@@ -47,5 +47,9 @@
     & > .font-icon {
       font-size: @view-tab-icon-font-size;
     }
+
+    &.ellipsis > .font-icon {
+      font-size: @view-tab-icon-font-size + 2px;
+    }
   }
 }


### PR DESCRIPTION
The icon looks a little too small compared to other icons.

311795