### PR TITLE
REST client: Add support for ConfigurableProxySelector

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.client/pom.xml
+++ b/org.eclipse.scout.rt.rest.jersey.client/pom.xml
@@ -28,9 +28,16 @@
       <groupId>org.eclipse.scout.rt</groupId>
       <artifactId>org.eclipse.scout.rt.rest</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
+    </dependency>
+
+    <!-- required for ConfigurableProxySelector -->
+    <dependency>
+      <groupId>org.eclipse.scout.rt</groupId>
+      <artifactId>org.eclipse.scout.rt.shared</artifactId>
     </dependency>
 
     <!-- JAX-RS Jersey Client Apache Connector -->

--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/glassfish/jersey/apache/connector/ConfigurableProxySelectorApacheHttpClientBuilderConfigurator.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/glassfish/jersey/apache/connector/ConfigurableProxySelectorApacheHttpClientBuilderConfigurator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.glassfish.jersey.apache.connector;
+
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.shared.http.proxy.ConfigurableProxySelector;
+
+/**
+ * Apache http client builder interceptor registering Scout {@link ConfigurableProxySelector}.
+ */
+@Bean
+public class ConfigurableProxySelectorApacheHttpClientBuilderConfigurator implements ApacheHttpClientBuilderConfigurator {
+
+  @Override
+  public HttpClientBuilder configure(HttpClientBuilder httpClientBuilder) {
+    return httpClientBuilder.setRoutePlanner(new SystemDefaultRoutePlanner(BEANS.get(ConfigurableProxySelector.class)));
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/glassfish/jersey/apache/connector/ScoutConfigurableProxySelectorConfigurator.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/glassfish/jersey/apache/connector/ScoutConfigurableProxySelectorConfigurator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010-2018 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.glassfish.jersey.apache.connector;
+
+import javax.ws.rs.client.ClientBuilder;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.rest.client.IGlobalRestClientConfigurator;
+
+public class ScoutConfigurableProxySelectorConfigurator implements IGlobalRestClientConfigurator {
+
+  @Override
+  public void configure(ClientBuilder clientBuilder) {
+    clientBuilder.register(BEANS.get(ConfigurableProxySelectorApacheHttpClientBuilderConfigurator.class));
+  }
+}


### PR DESCRIPTION
Added support for Scout ConfigurableProxySelector within Apache HTTP
client used in Jersey client of AbstractRestClientHelper

237883

Signed-off-by: Paolo Bazzi <paolo.bazzi@bsi-software.com>