### PR TITLE
Fix reloading from root

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
@@ -1969,7 +1969,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
 
   @Override
   public void reloadPageFromRoot(IPage<?> page) {
-    Bookmark bm = createBookmark(page);
+    Bookmark bm = createBookmark();
     page.setChildrenDirty(true);
     //activate bookmark without activating the outline, since this would hide active tabs.
     activateBookmark(bm, false);


### PR DESCRIPTION
When reloading a page from root, reload active page instead of page
that triggered the reload. Because intermediate pages may need to reload
as well if a child node changes, reloading the triggering page causes
jumping around in outline.