### PR TITLE
TableHeader: autoOptimizeWidth column may show ... after filter reset

### DIFF
--- a/eclipse-scout-core/src/table/TableHeader.js
+++ b/eclipse-scout-core/src/table/TableHeader.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, Column, ColumnUserFilter, Device, graphics, GroupBoxMenuItemsOrder, inspector, MenuBar, MenuDestinations, scout, scrollbars, strings, styles, Table, tooltips, Widget} from '../index';
+import {arrays, Column, ColumnUserFilter, Device, graphics, GroupBoxMenuItemsOrder, inspector, MenuBar, MenuDestinations, objects, scout, scrollbars, strings, styles, Table, tooltips, Widget} from '../index';
 import $ from 'jquery';
 
 export default class TableHeader extends Widget {
@@ -459,21 +459,23 @@ export default class TableHeader extends Widget {
     let filtered = this.table.getFilter(column.id);
     if (column.sortActive || column.grouped || filtered) {
       if (column.minWidth < Column.DEFAULT_MIN_WIDTH) {
-        column.prefMinWidth = column.minWidth;
+        column.__minWidthWithoutState = column.minWidth;
+        column.__widthWithoutState = column.width;
         column.minWidth = Column.DEFAULT_MIN_WIDTH;
       }
       if (column.width < column.minWidth) {
         this.table.resizeColumn(column, column.minWidth);
       }
     } else {
-      // Reset to preferred min width if no state is visible
-      if (column.prefMinWidth !== null) {
-        column.minWidth = column.prefMinWidth;
-        column.prefMinWidth = null;
-        // Resize to old min width, assuming user has not manually changed the size because column is still as width as default_min_width
+      // Reset to previous min width if no state is visible
+      if (!objects.isNullOrUndefined(column.__minWidthWithoutState)) {
+        column.minWidth = column.__minWidthWithoutState;
+        // Resize to previous min width, assuming user has not manually changed the size because column is still as width as default_min_width
         if (column.width === Column.DEFAULT_MIN_WIDTH) {
-          this.table.resizeColumn(column, column.minWidth);
+          this.table.resizeColumn(column, column.__widthWithoutState);
         }
+        column.__minWidthWithoutState = null;
+        column.__widthWithoutState = null;
       }
     }
   }

--- a/eclipse-scout-core/src/table/columns/Column.js
+++ b/eclipse-scout-core/src/table/columns/Column.js
@@ -43,7 +43,6 @@ export default class Column {
     this.type = 'text';
     this.width = 60;
     this.initialWidth = undefined; // the width the column initially has
-    this.prefMinWidth = null;
     this.minWidth = Column.DEFAULT_MIN_WIDTH; // the minimal width the column can have
     this.showSeparator = true;
     this.table = null;


### PR DESCRIPTION
Use case:
A column has minWidth < 60 and autoOptimizeWidth = true.
The calculated content width of the column is between minWidth and 60.
If a column filter is added, the column width will be increased to
show the filter icon -> ok.
If the filter is removed, the column width will be reset to the previous
minWidth instead of the previous width -> nok, because the cell
may now show ... instead of the full content.

The same happens for the other states like grouping and filtering.

316566