### PR TITLE
Widget: don't animate removal if parent is being removed

### DIFF
--- a/eclipse-scout-core/src/widget/Widget.js
+++ b/eclipse-scout-core/src/widget/Widget.js
@@ -524,7 +524,7 @@ export default class Widget {
    * After the animation is executed, the element gets removed using this._removeInternal.
    */
   _removeAnimated() {
-    if (!Device.get().supportsCssAnimation() || !this.$container || this.$container.isDisplayNone()) {
+    if (this.parent.removing || !Device.get().supportsCssAnimation() || !this.$container || this.$container.isDisplayNone()) {
       // Cannot remove animated, remove regularly
       this._removeInternal();
       return;


### PR DESCRIPTION
Use case:
A notification has animateRemoval set to true and is shown in a
tab item. Switching the tab will remove the tab content but the
remove of the notification will never be executed because animationEnd
will never fire due to the removed parent. Switching back will fail
with an already rendered exception.

311487