### PR TITLE
Popup: allow remove animation while removing parent for certain popups

### DIFF
--- a/eclipse-scout-core/src/popup/Popup.js
+++ b/eclipse-scout-core/src/popup/Popup.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {CloseKeyStroke, DialogLayout, Dimension, Event, FocusRule, GlassPaneRenderer, graphics, HtmlComponent, Insets, KeyStrokeContext, Point, PopupLayout, Rectangle, scout, scrollbars, strings, Widget} from '../index';
+import {CloseKeyStroke, DialogLayout, Dimension, Event, FocusRule, GlassPaneRenderer, graphics, HtmlComponent, Insets, KeyStrokeContext, Point, PopupLayout, Rectangle, scout, scrollbars, strings, Widget, widgets} from '../index';
 import $ from 'jquery';
 
 export default class Popup extends Widget {
@@ -440,6 +440,15 @@ export default class Popup extends Widget {
         break;
     }
     return cssClass;
+  }
+
+  _animateRemovalWhileRemovingParent() {
+    if (!this.$anchor) {
+      // Allow remove animations for popups without an anchor
+      return true;
+    }
+    // If parent is the anchor, prevent remove animation to ensure popup will be removed together with the anchor
+    return widgets.get(this.$anchor) !== this.parent;
   }
 
   _isRemovalPrevented() {

--- a/eclipse-scout-core/src/table/TableHeaderMenu.js
+++ b/eclipse-scout-core/src/table/TableHeaderMenu.js
@@ -241,7 +241,9 @@ export default class TableHeaderMenu extends Popup {
     if (this.filterTable) {
       this.filterTable.off('rowsChecked', this._filterTableRowsCheckedHandler);
     }
-    this.tableHeader.$container.off('scroll', this._tableHeaderScrollHandler);
+    if (this.tableHeader.rendered) {
+      this.tableHeader.$container.off('scroll', this._tableHeaderScrollHandler);
+    }
     this.$headerItem.select(false);
     this.table.off('columnMoved', this._onColumnMovedHandler);
     this.table.off('filterAdded', this._tableFilterHandler);


### PR DESCRIPTION
The previous change prevented every remove animation if a parent is
being removed. For popups, this may not always be desired.
Example:
A popup belongs to a widget that will be removed but is rendered
into the $entryPoint -> Remove animation is unnecessarily prevented
because $entryPoint is still there. But, if the popup has an anchor, it
is fine if the popup will be removed immediately when the parent is
removed.

The previous commit also fixed an exception generated by the table
header menu: If menu was open and outline node selection changed
by keyboard, the menu created an exception because after the animation
this.tableHeader.$container was already null. It did not create
an exception when the mouse was used because the animation was started
and aborted right after by the _parentRemovingWhileAnimatingHandler
-> now it is consistent.

315364