### PR TITLE
Improve performance for ColumnSet#checkMultiline

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/ColumnSet.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/ColumnSet.java
@@ -1407,9 +1407,7 @@ public class ColumnSet {
   }
 
   private void checkMultiline() {
-    if (m_table != null
-        && !m_table.isInitialMultilineText()
-        && !ConfigurationUtility.isMethodOverwrite(AbstractTable.class, "getConfiguredMultilineText", null, m_table.getClass())) {
+    if (m_table != null && !m_table.isInitialMultilineText()) {
       //do automatic check for wrapping columns
       boolean m = false;
       for (IColumn col : getVisibleColumns()) {


### PR DESCRIPTION
ConfigurationUtility#isMethodOverwrite will throw an exception if
the method is not overwritten. Due to extension 2.0 this check does not
work properly anyways.