### PR TITLE
AbstractTabBox: avoid IooB exception if tab contains wrong field types

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/tabbox/AbstractTabBox.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/tabbox/AbstractTabBox.java
@@ -206,7 +206,7 @@ public abstract class AbstractTabBox extends AbstractCompositeField implements I
       int index = getFieldIndex(selectedBox);
       List<IGroupBox> boxes = getGroupBoxes();
       // next to right side
-      for (int i = index + 1; i < getFieldCount(); i++) {
+      for (int i = index + 1; i < boxes.size(); i++) {
         IGroupBox box = boxes.get(i);
         if (box.isVisible()) {
           return box;


### PR DESCRIPTION
It is possible, that a tab box has internal fields that are not group boxes (or instances of a group box). Although this is not allowed (JS error), it may be possible in certain application setups. This led to an index out of bounds exception. 

The change does not fix the issue, that it is possible to send not-allowed fields to the UI.

Ticket-Ref: 314351