### PR TITLE
Exclude maven dependency on xalan

### DIFF
--- a/org.eclipse.scout.rt.svg.client/pom.xml
+++ b/org.eclipse.scout.rt.svg.client/pom.xml
@@ -32,6 +32,12 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-swing</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Use openJDK built-in instead.

301013

(cherry picked from commit 5b46030a85463a6a7893d0fd8d1880d05cae5598)