### PR TITLE
TileGrid: fix _onAnimatedTileRemove

### DIFF
--- a/eclipse-scout-core/src/tile/TileGrid.js
+++ b/eclipse-scout-core/src/tile/TileGrid.js
@@ -396,7 +396,7 @@ export default class TileGrid extends Widget {
   }
 
   _onAnimatedTileRemove(tile) {
-    if (!tile.rendered || !tile.animateRemoval) {
+    if (!tile.removalPending) {
       return;
     }
     this.tileRemovalPendingCount++;


### PR DESCRIPTION
Due to change 3f392b0f (Widget: don't render property changes when
removal is pending), _onAnimatedTileRemove returned immediately
without increasing tileRemovalPendingCount. This led to an exception
in a tile accordion if tiles were deleted while a group was expanding
because invalidateLayoutTree was not prevented -> the tile grid layout
tried to render tiles that were being destroyed.

316288
311501