### PR TITLE
GroupBox: don't toggle expanded state if a menu is being clicked

### DIFF
--- a/eclipse-scout-core/src/form/fields/groupbox/GroupBox.js
+++ b/eclipse-scout-core/src/form/fields/groupbox/GroupBox.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, Button, ButtonAdapterMenu, CompositeField, fields, Form, FormField, GroupBoxGridConfig, GroupBoxLayout, GroupBoxMenuItemsOrder, HAlign, HtmlComponent, LogicalGridData, LogicalGridLayout, LogicalGridLayoutConfig, MenuBar, ResponsiveManager, scout, SplitBox, strings, TabBox, TabItemKeyStroke, tooltips, WrappedFormField} from '../../../index';
+import {arrays, Button, ButtonAdapterMenu, CompositeField, fields, Form, FormField, GroupBoxGridConfig, GroupBoxLayout, GroupBoxMenuItemsOrder, HAlign, HtmlComponent, LogicalGridData, LogicalGridLayout, LogicalGridLayoutConfig, Menu, MenuBar, ResponsiveManager, scout, SplitBox, strings, TabBox, TabItemKeyStroke, tooltips, WrappedFormField} from '../../../index';
 import $ from 'jquery';
 
 export default class GroupBox extends CompositeField {
@@ -779,9 +779,13 @@ export default class GroupBox extends CompositeField {
   }
 
   _onControlClick(event) {
-    if (this.expandable) {
-      this.setExpanded(!this.expanded);
+    const target = scout.widget(event.target);
+    if (!this.expandable || target instanceof Menu) {
+      // 311831 if the position of the menubar is set to title and a menu has been clicked, then the event must not be handled
+      return;
     }
+
+    this.setExpanded(!this.expanded);
     $.suppressEvent(event); // otherwise, the event would be triggered twice sometimes (by group-box-control and group-box-title)
   }
 


### PR DESCRIPTION
For an expandable group box with menu bar position set to 'title',
clicking on any menu or button within the menu bar toggles the expanded
state of the group box. This is not the expected behavior, which is an
unchanged toggle state.

311831