### PR TITLE
objects: isEmpty should return true for null and undefined

### DIFF
--- a/eclipse-scout-core/src/util/objects.js
+++ b/eclipse-scout-core/src/util/objects.js
@@ -693,11 +693,14 @@ export function resolveConstProperty(object, config) {
 /**
  * @param {object} obj
  * @returns {Boolean|undefined}
- *  - true if the obj is empty
+ *  - true if the obj is empty, null or undefined
  *  - false if the obj is not empty
  *  - nothing if the obj is not an object
  */
 export function isEmpty(obj) {
+  if (isNullOrUndefined(obj)) {
+    return true;
+  }
   if (!isPlainObject(obj)) {
     return;
   }

--- a/eclipse-scout-core/test/util/objectsSpec.js
+++ b/eclipse-scout-core/test/util/objectsSpec.js
@@ -702,14 +702,12 @@ describe('scout.objects', () => {
   describe('isEmpty', () => {
     it('returns true if argument is an empty object, false if it is a non-empty object, undefined if argument is not an object', () => {
       expect(objects.isEmpty({})).toBe(true);
+      expect(objects.isEmpty(undefined)).toBe(true);
+      expect(objects.isEmpty(null)).toBe(true);
 
       expect(objects.isEmpty({test: 'test'})).toBe(false);
       expect(objects.isEmpty({test: 42})).toBe(false);
 
-      expect(objects.isEmpty({})).toBe(true);
-
-      expect(objects.isEmpty(undefined)).toBe(undefined);
-      expect(objects.isEmpty(null)).toBe(undefined);
       expect(objects.isEmpty('test')).toBe(undefined);
       expect(objects.isEmpty(42)).toBe(undefined);
       expect(objects.isEmpty(['test'])).toBe(undefined);


### PR DESCRIPTION
isEmpty(undefined) returns undefined, but !isEmpty(undefined) returns
true. This is confusing and error-prone.

This makes it consistent with other utils like strings.empty.

312261