### PR TITLE
Table: update hover and active states for checkable table

### DIFF
--- a/eclipse-scout-core/src/table/Table.less
+++ b/eclipse-scout-core/src/table/Table.less
@@ -63,10 +63,6 @@
         &:hover {
           background-color: @hover-background-color;
         }
-
-        &:active, &.active {
-          background-color: @active-background-color;
-        }
       }
 
       & > .table-row.disabled,
@@ -83,6 +79,18 @@
           & > .table-cell {
             color: @table-row-checked-color;
           }
+
+          &:hover {
+            background-color: @selected-hover-background-color;
+          }
+        }
+      }
+
+      & > .table-row.disabled,
+      &.disabled > .table-row {
+        &.checked,
+        &.checked.selected {
+          background-color: @selected-disabled-background-color;
         }
       }
     }


### PR DESCRIPTION
- Remove active state because it is visible after deselecting a row due
  (to mouse down instead of click selection) which is a little
  distracting.
- Add missing hover effect for checked state.
- Use different color for disabled checked rows.