### PR TITLE
Table/Tree: increase icon size to 14px

### DIFF
--- a/eclipse-scout-core/src/form/fields/TextFieldIcon.less
+++ b/eclipse-scout-core/src/form/fields/TextFieldIcon.less
@@ -16,7 +16,7 @@
 
   &::before {
     #scout.font-icon();
-    font-size: 14px;
+    font-size: @font-size-icon-small;
     color: @text-field-icon-color;
     border-radius: @control-border-radius;
     width: @text-field-icon-size;

--- a/eclipse-scout-core/src/style/fonts.less
+++ b/eclipse-scout-core/src/style/fonts.less
@@ -33,6 +33,7 @@ Try these to switch between fonts:
 @font-size-large: 16px;
 @font-size-extra-large: 32px;
 
+@font-size-icon-small: 14px;
 @font-size-icon: 16px;
 @font-size-icon-large: 24px;
 
@@ -43,8 +44,11 @@ Try these to switch between fonts:
 // or are often placed to the side of widgets with icons
 @text-margin-top: 1px;
 
-@icon-font-weight-light: 300;
+// Icons aligned with line-height may use this variable.
+// It should have the same size as regular text (not the font-size, the actual size)
+@font-icon-line-height: 15px;
 
+@icon-font-weight-light: 300;
 @tooltip-font-weight: @font-weight-normal;
 
 @font-face {

--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -173,7 +173,7 @@
 @desktop-tab-border-radius: @view-tab-selected-border-radius;
 @desktop-tab-margin-top: @view-tab-selected-margin-top;
 @desktop-tool-box-item-border-radius: @view-tab-border-radius;
-@desktop-tool-box-item-font-size: 14px;
+@desktop-tool-box-item-font-size: @font-size-icon-small;
 @desktop-tool-box-item-margin: 3px;
 @desktop-tool-box-item-margin-top: @view-tab-margin-top;
 @detail-table-border-radius: 4px;
@@ -236,7 +236,7 @@
 @outline-node-control-padding-left: @outline-title-padding-left;
 @outline-node-control-padding-y: @outline-node-padding-y;
 @outline-node-control-line-height: @tree-node-control-line-height;
-@outline-node-font-icon-line-height: 14px;
+@outline-node-font-icon-line-height: @tree-node-font-icon-line-height;
 @outline-node-font-icon-size: 16px;
 @outline-node-padding-left: 37px;
 @outline-node-padding-right: 8px;
@@ -294,6 +294,8 @@
 @table-cell-padding-left: 10px;
 @table-cell-padding-right: @table-cell-padding-left;
 @table-cell-padding-right-last: @scrollbar-size;
+@table-cell-font-icon-size: @tree-node-font-icon-size;
+@table-cell-font-icon-line-height: @tree-node-font-icon-line-height;
 @table-control-content-padding: 10px;
 @table-control-container-height: 364px;
 @table-control-container-height-dense: 320px;
@@ -349,9 +351,10 @@
 @tree-node-checkbox-margin-top: -2px;
 @tree-node-control-checkbox-size: 20px + @tree-node-control-size;
 @tree-node-control-size: 16px;
-@tree-node-control-line-height: 14px;
+@tree-node-control-line-height: @font-icon-line-height;
 @tree-node-control-padding-left: 13px;
-@tree-node-font-icon-line-height: 15px;
+@tree-node-font-icon-line-height: @font-icon-line-height;
+@tree-node-font-icon-size: @font-size-icon-small;
 @tree-node-padding-left: 28px;
 @tree-node-padding-right: 7px;
 @tree-node-padding-y: 7px;

--- a/eclipse-scout-core/src/table/Table.less
+++ b/eclipse-scout-core/src/table/Table.less
@@ -442,6 +442,9 @@
 .table-cell-icon {
   .font-icon& {
     color: @icon-color;
+    font-size: @table-cell-font-icon-size;
+    line-height: @table-cell-font-icon-line-height;
+    vertical-align: top;
 
     .disabled & {
       color: @disabled-color;

--- a/eclipse-scout-core/src/table/columns/Column.js
+++ b/eclipse-scout-core/src/table/columns/Column.js
@@ -71,7 +71,7 @@ export default class Column {
 
   static DEFAULT_MIN_WIDTH = 60;
   static SMALL_MIN_WIDTH = 38;
-  static NARROW_MIN_WIDTH = 32;
+  static NARROW_MIN_WIDTH = 34;
 
   init(model) {
     this.session = model.session;

--- a/eclipse-scout-core/src/tree/Tree.less
+++ b/eclipse-scout-core/src/tree/Tree.less
@@ -132,6 +132,7 @@
     &.font-icon {
       /* Necessary to align with the text, depends on the used font size */
       line-height: @tree-node-font-icon-line-height;
+      font-size: @tree-node-font-icon-size;
     }
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/IColumn.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/IColumn.java
@@ -115,7 +115,7 @@ public interface IColumn<VALUE> extends IPropertyObserver, ITypeWithClassId, IOr
   /**
    * Default min width for narrow columns (e.g. Icon column)
    */
-  int NARROW_MIN_WIDTH = 32;
+  int NARROW_MIN_WIDTH = 34;
 
   void initColumn();
 


### PR DESCRIPTION
Currently, it uses the regular font-size which is 13px.
For icons, this is very small. Also, an uneven number makes centering
hard -> the icon is not exactly in the middle of a table row.

The tree already used line-height to center an icon. Now it is used
for the table as well.