### PR TITLE
Webpack: fix stats output

### DIFF
--- a/eclipse-scout-cli/bin/scout-scripts.js
+++ b/eclipse-scout-cli/bin/scout-scripts.js
@@ -182,8 +182,7 @@ function logWebpack(err, stats, statsConfig) {
   }
   statsConfig = statsConfig || {};
   if (typeof statsConfig === 'string') {
-    const webpack = require('webpack');
-    statsConfig = webpack.Stats.presetToOptions(statsConfig);
+    statsConfig = stats.compilation.createStatsOptions(statsConfig);
   }
   statsConfig.colors = true;
   console.log(stats.toString(statsConfig) + '\n\n');


### PR DESCRIPTION
The webpack build fails when the stats parameter is passed.
For example: npm run build:dev -- --stats detailed

The api to create the stats options has changed from webpack 4 to 5.