### PR TITLE
Tree: wrong cursor on checkable tree

### DIFF
--- a/eclipse-scout-core/src/checkbox/CheckBox.less
+++ b/eclipse-scout-core/src/checkbox/CheckBox.less
@@ -39,6 +39,7 @@
 #scout {
 
   .checkbox() {
+    cursor: pointer;
     position: relative;
     display: inline-block;
     text-align: center;
@@ -66,6 +67,7 @@
   }
 
   .checkbox-disabled() {
+    cursor: default;
     border-color: @check-box-disabled-border-color;
   }
 

--- a/eclipse-scout-core/src/tree/Tree.less
+++ b/eclipse-scout-core/src/tree/Tree.less
@@ -64,6 +64,13 @@
     & > .animation-wrapper > .tree-node {
       cursor: pointer;
     }
+
+    &.disabled > .tree-node,
+    &.disabled > .animation-wrapper > .tree-node,
+    & > .tree-node.disabled,
+    & > .animation-wrapper > .tree-node.disabled {
+      cursor: default;
+    }
   }
 }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/sequencebox/internal/ColumnBasedSequenceBoxGrid.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/sequencebox/internal/ColumnBasedSequenceBoxGrid.java
@@ -21,7 +21,7 @@ import org.eclipse.scout.rt.client.ui.form.fields.groupbox.internal.matrix.Horiz
 /**
  * Alternative sequence box grid that behaves in the same way as {@link HorizontalGroupBoxBodyGrid}. <br>
  * Compared to the default SequenceBoxGrid, there is no special treatment for {@link IButton} regarding weightX and
- * useUiWidth. You can set the button's weightX to 0 manually but consider that it will effect every field in the same
+ * useUiWidth. You can set the button's weightX to 0 manually but consider that it will affect every field in the same
  * column. <br>
  * Also you need to make sure the height will be correct, e.g. by setting useUiHeight to true (which is done by a
  * {@link IGroupBox} by default).


### PR DESCRIPTION
2 issues:
- check box does not show the pointer cursor when checkable style is set
  to checkbox
- a disabled checkable tree still shows the pointer cursor instead of
  the default one