### PR TITLE
Date and Time column: value picker does not work in mobile mode

### DIFF
--- a/eclipse-scout-core/src/form/fields/datefield/DateField.js
+++ b/eclipse-scout-core/src/form/fields/datefield/DateField.js
@@ -8,29 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {
-  arrays,
-  DateFormat,
-  DatePickerPopup,
-  DatePredictionFailedStatus,
-  dates,
-  DateTimeCompositeLayout,
-  Device,
-  fields,
-  focusUtils,
-  FormField,
-  HtmlComponent,
-  InputFieldKeyStrokeContext,
-  keys,
-  objects,
-  ParsingFailedStatus,
-  scout,
-  Status,
-  strings,
-  styles,
-  TimePickerPopup,
-  ValueField
-} from '../../../index';
+import {arrays, DateFormat, DatePickerPopup, DatePredictionFailedStatus, dates, DateTimeCompositeLayout, Device, fields, focusUtils, FormField, HtmlComponent, InputFieldKeyStrokeContext, keys, objects, ParsingFailedStatus, scout, Status, strings, styles, TimePickerPopup, ValueField} from '../../../index';
 import $ from 'jquery';
 
 export default class DateField extends ValueField {
@@ -1192,21 +1170,19 @@ export default class DateField extends ValueField {
   }
 
   _onDatePickerDateSelect(event) {
-    this._setDateValid(true);
-    this._setTimeValid(true);
-    let newValue = this._newTimestampAsDate(event.date, this.value);
-    this.setValue(newValue);
-    this.closePopup();
-    this._triggerAcceptInput();
+    this._setNewDateTimeValue(this._newTimestampAsDate(event.date, this.value));
   }
 
   _onTimePickerTimeSelect(event) {
+    this._setNewDateTimeValue(this._newTimestampAsDate(this.value, event.time));
+  }
+
+  _setNewDateTimeValue(newValue) {
     this._setDateValid(true);
     this._setTimeValid(true);
-    let newValue = this._newTimestampAsDate(this.value, event.time);
     this.setValue(newValue);
-    this.closePopup();
     this._triggerAcceptInput();
+    this.closePopup();
   }
 
   _createPredictionField($inputField) {


### PR DESCRIPTION
When in mobile mode, the quick value picker for date and time columns
can not update the column. Choosing the new value via text input works.

In mobile mode the picker popup will be closed as soon as a value is
chosen. Closing the popup so soon will fire the cell changed event
before the date field was able to fire an accept input event.

By calling triggerAcceptInput just before closePopup in the date field
we ensure to first send the new field value before the table sends a
cell changed event.

319005