### PR TITLE
Date field in an editable table throws an error in touch mode

### DIFF
--- a/eclipse-scout-core/src/form/fields/datefield/DateField.js
+++ b/eclipse-scout-core/src/form/fields/datefield/DateField.js
@@ -1385,10 +1385,12 @@ export default class DateField extends ValueField {
     this.popup = this.createDatePopup();
     this.popup.open();
     this.$dateField.addClass('focused');
-    this.popup.on('remove', event => {
-      this._onPopupRemove(event);
-      this.popup = null;
+    this.popup.one('destroy', event => {
+      // Removing the class must happen before _onPopupDestroy() is called, otherwise the date field no longer exists,
+      // because in touch mode _onPopupDestroy() destroys the date field.
       this.$dateField.removeClass('focused');
+      this._onPopupDestroy(event);
+      this.popup = null;
     });
     this.getDatePicker().on('dateSelect', this._onDatePickerDateSelect.bind(this));
   }
@@ -1416,10 +1418,12 @@ export default class DateField extends ValueField {
     this.popup = this.createTimePopup();
     this.popup.open();
     this.$timeField.addClass('focused');
-    this.popup.on('remove', event => {
-      this._onPopupRemove(event);
-      this.popup = null;
+    this.popup.one('destroy', event => {
+      // Removing the class must happen before _onPopupDestroy() is called, otherwise the date field no longer exists,
+      // because in touch mode _onPopupDestroy() destroys the date field.
       this.$timeField.removeClass('focused');
+      this._onPopupDestroy(event);
+      this.popup = null;
     });
     this.getTimePicker().on('timeSelect', this._onTimePickerTimeSelect.bind(this));
   }
@@ -1686,7 +1690,7 @@ export default class DateField extends ValueField {
     }
   }
 
-  _onPopupRemove(event) {
+  _onPopupDestroy(event) {
     if (!this.touchMode || !this._cellEditorPopup) {
       return;
     }


### PR DESCRIPTION
Prerequisites
1. a table with an editable date column
2. active touch mode by using a mobile device or browser developer tools

Use case:
1. click on the date column
2. pick a date -> UI error

Problem 1:
The date field registers a popup listener on the 'remove' event within
the method openDatePopup(). The listener calls the method
_onPopupRemove() and then calls the method removeClass() on the date
field, but at this point the field no longer exists. The method
_onPopupRemove() implicitly destroys the date field, because in touch
mode completeEdit() gets called on the cell editor popup and this will
destroy the corresponding field.

To fix problem 1 removeClass() must be called before _onPopupRemove().

Problem 2 (requires problem 1 to be solved):
By picking a date the method _onDatePickerDateSelect() gets called and
closes the popup, that leads to a call of destroy() on the popup itself.
The method Widget#destroy triggers a 'remove' event and then removes all
children from the owner (i.e. the date field), but at this point the
field no longer exists.

The popup listener mentioned in problem 1 is registered to the 'remove'
event and will call completeEdit() in touch mode, that will destroy the
corresponding field.

To fix problem 2 the listener must be registered to the 'close' event of
the popup, because this event will be called in the close method of the
popup before it gets destroyed.

319180