### PR TITLE
Date field does not accept cleared values in touch mode

### DIFF
--- a/eclipse-scout-core/src/datepicker/DatePickerTouchPopup.js
+++ b/eclipse-scout-core/src/datepicker/DatePickerTouchPopup.js
@@ -62,4 +62,12 @@ export default class DatePickerTouchPopup extends TouchPopup {
     }
     this._touchField._triggerAcceptInput();
   }
+
+  /**
+   * @override
+   */
+  _acceptInput() {
+    this._field.acceptDate();
+    this.close();
+  }
 }

--- a/eclipse-scout-core/src/timepicker/TimePickerTouchPopup.js
+++ b/eclipse-scout-core/src/timepicker/TimePickerTouchPopup.js
@@ -57,4 +57,12 @@ export default class TimePickerTouchPopup extends TouchPopup {
     }
     this._touchField._triggerAcceptInput();
   }
+
+  /**
+   * @override
+   */
+  _acceptInput() {
+    this._field.acceptTime();
+    this.close();
+  }
 }


### PR DESCRIPTION
Prerequisites
1. a DateField with date and time
2. active touch mode by using a mobile device or browser developer tools

Use case I:
1. pick a date
2. reopen the date picker
3. clear the value by pressing the X in the date preview field
4. click on the date picker header (to clear date preview field focus)
5. close the date picker by clicking outside the picker
-> date and time did not change (should be cleared)

Use case II:
1. pick a date
2. reopen the date picker
3. clear the value by pressing the X in the date preview field
4. close the date picker by clicking the X on the date picker
-> date and time did not change (should be cleared)

Problem:
Clicking outside the date picker or the X of the date picker will
trigger _onCloseIconCLick() of the TouchPopup and this leads to a call
of acceptInput() for the embedded date field. The method acceptInput()
for the DateField reads the current display text, parses it and sets the
value of the date field to the newly parsed value. The current display
text contains only the time and will be parsed to the current value of
the field, hence the value of the date field did not change.

To fix the problem the TouchPopup (more precisely the
DatePickerTouchPopup) must call acceptDate() on the date field instead
of acceptInput(), because this method will clear the corresponding time
field if necessary.

312390