### PR TITLE
Fix out-array to string signature for default auth. token

### DIFF
--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/DefaultAuthToken.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/DefaultAuthToken.java
@@ -223,7 +223,7 @@ public class DefaultAuthToken {
         out.write(partsDelimiter);
         bytesEncoder.accept(signature);
       }
-      return out.toString(StandardCharsets.US_ASCII);
+      return out.toString(StandardCharsets.US_ASCII.name());
     }
     catch (IOException ex) {
       throw new PlatformException("unexpected behaviour", ex);


### PR DESCRIPTION
Java 8 does not support ByteArrayOutputStream#toString(Charset) but only ByteArrayOutputStream#toString(String).