### PR TITLE
Planner: Wrong scale after horizontal scrolling and switching weeks

### DIFF
--- a/eclipse-scout-core/src/planner/Planner.js
+++ b/eclipse-scout-core/src/planner/Planner.js
@@ -1533,6 +1533,8 @@ export default class Planner extends Widget {
       this._renderViewRange();
       this._rerenderActivities();
       this._renderSelectedActivity();
+      this.validateLayoutTree(); // Layouting is required for adjusting the scroll position
+      this._reconcileScrollPos();
     }
   }
 


### PR DESCRIPTION
Prerequisites:
a PlannerField with horizontal scrollbars and at least one resource

Use case:
1. scroll to the right
2. press next or previous button
-> the scale is offset

Problem:
Pressing the next, today or previous button will set a new view range
and leads to a call of the _renderScale() method. This method empty and
recreate the scale but does not consider the current horizontal
scrollbar position.

To fix the problem the scroll position of the scale must be restored
after rendering.

317594