### PR TITLE
TreeSmartField: error when pressing esc with an unresolvable value

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/AbstractSmartFieldLookupRowFetcher.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/AbstractSmartFieldLookupRowFetcher.java
@@ -26,7 +26,6 @@ public abstract class AbstractSmartFieldLookupRowFetcher<LOOKUP_KEY> implements 
   }
 
   /**
-   * @param listener
    * @see BasicPropertySupport#addPropertyChangeListener(PropertyChangeListener)
    */
   @Override
@@ -35,7 +34,6 @@ public abstract class AbstractSmartFieldLookupRowFetcher<LOOKUP_KEY> implements 
   }
 
   /**
-   * @param listener
    * @see BasicPropertySupport#removePropertyChangeListener(PropertyChangeListener)
    */
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/HierarchicalSmartFieldDataFetcher.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/HierarchicalSmartFieldDataFetcher.java
@@ -100,6 +100,9 @@ public class HierarchicalSmartFieldDataFetcher<LOOKUP_KEY> extends AbstractSmart
     else if (query.is(QueryBy.ALL)) {
       return getSmartField().callBrowseLookupInBackground(true);
     }
+    else if (query.is(QueryBy.KEY)) {
+      return getSmartField().callKeyLookupInBackground(query.getKey(), true);
+    }
     else {
       throw new IllegalStateException();
     }


### PR DESCRIPTION
Use Case:
1. Set a value that cannot be resolved by the lookup call
2. Click in the field
3. Press ESC -> Exception

The SmartField does a key lookup because resetDisplayText is
called and no lookupRow is set, but
the HierarchicalSmartFieldDataFetcher is not able
to handle this case.

319703