### PR TITLE
SmartField: display text is empty but a value set

### DIFF
--- a/eclipse-scout-core/src/testing/index.js
+++ b/eclipse-scout-core/src/testing/index.js
@@ -20,6 +20,7 @@ export {default as TestBeanField} from './form/fields/beanfield/TestBeanField';
 export {default as TabBoxSpecHelper} from './form/fields/tabbox/TabBoxSpecHelper';
 export {default as OutlineSpecHelper} from './desktop/outline/OutlineSpecHelper';
 export {default as DummyLookupCall} from './lookup/DummyLookupCall';
+export {default as AbortableMicrotaskStaticLookupCall} from './lookup/AbortableMicrotaskStaticLookupCall';
 export {default as ActiveDummyLookupCall} from './lookup/ActiveDummyLookupCall';
 export {default as ColumnDescriptorDummyLookupCall} from './lookup/ColumnDescriptorDummyLookupCall';
 export {default as LanguageDummyLookupCall} from './lookup/LanguageDummyLookupCall';

--- a/eclipse-scout-core/src/testing/lookup/AbortableMicrotaskStaticLookupCall.js
+++ b/eclipse-scout-core/src/testing/lookup/AbortableMicrotaskStaticLookupCall.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {StaticLookupCall} from '../../index';
+import $ from 'jquery';
+
+export default class AbortableMicrotaskStaticLookupCall extends StaticLookupCall {
+  constructor() {
+    super();
+    this._deferred = null;
+  }
+
+  abort() {
+    this._deferred.reject({
+      canceled: true
+    });
+    super.abort();
+  }
+
+  _getByKey(key) {
+    this._deferred = $.Deferred();
+    queueMicrotask(this._queryByKey.bind(this, this._deferred, key));
+    return this._deferred.promise();
+  }
+
+  _getAll() {
+    this._deferred = $.Deferred();
+    queueMicrotask(this._queryByAll.bind(this, this._deferred));
+    return this._deferred.promise();
+  }
+
+  _getByText(text) {
+    this._deferred = $.Deferred();
+    queueMicrotask(this._queryByText.bind(this, this._deferred, text));
+    return this._deferred.promise();
+  }
+
+  _getByRec(rec) {
+    this._deferred = $.Deferred();
+    queueMicrotask(this._queryByRec.bind(this, this._deferred, rec));
+    return this._deferred.promise();
+  }
+}

--- a/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.js
+++ b/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.js
@@ -121,6 +121,29 @@ describe('SmartField', () => {
       expect(field.activeFilter).toEqual('FALSE');
     });
 
+    it('updates display text correctly even after consecutive setValue calls', done => {
+      jasmine.clock().uninstall();
+      field = createFieldWithLookupCall({}, {
+        objectType: 'AbortableMicrotaskStaticLookupCall',
+        data: [[1, 'Foo'], [2, 'Bar', 1]]
+      });
+      field.setValue(1);
+      expect(field.value).toBe(1);
+      expect(field.displayText).toBe(''); // Not updated yet
+
+      field.setValue(2);
+      expect(field.value).toBe(2);
+      expect(field.displayText).toBe(''); // Not updated yet
+
+      // Double setTimeout is necessary to ensure the expectations are checked at the end after every other task
+      setTimeout(() => {
+        setTimeout(() => {
+          expect(field.value).toBe(2);
+          expect(field.displayText).toBe('Bar'); // Updated to latest setValue call
+          done();
+        });
+      });
+    });
   });
 
   describe('clear', () => {


### PR DESCRIPTION
Use case:
1. Use RestLookupCall (which implements abort())
2. Call setValue multiple times -> display text may be empty

Problem:
The second setValue will call lookupCall.abort() which rejects the
lookup call promise. It will then schedule a new lookupCall to update
the text. Unfortunately, the fail callback of the aborted promise
will be executed after the done callback of the new pormise and
overrides the display text with empty string again.

Reason:
The fail callbacks will be executed at the end of a task,
even if the promises are rejected before another promise is resolved.

Example:
$.rejectedPromise()
  .then(() => console.log('resolve 1'))
  .catch(() => console.log('reject 1'))
$.resolvedPromise()
  .then(() => console.log('resolve 2'))
  .catch(() => console.log('reject 2'))

output:
resolve 2
reject 1

319091