### PR TITLE
FocusManager: Allow preventing to scroll when focusing an element

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.js
+++ b/eclipse-scout-core/src/focus/FocusContext.js
@@ -121,7 +121,7 @@ export default class FocusContext {
     this.focusedElement = event.target;
 
     // Do not update current focus context nor validate focus if target is $entryPoint.
-    // That is because focusing the $entryPoint is done whenever no control is currently focusable, e.g. due to glasspanes.
+    // That is because focusing the $entryPoint is done whenever no control is currently focusable, e.g. due to glass panes.
     if (event.target === this.$container.entryPoint(true)) {
       return;
     }
@@ -166,12 +166,12 @@ export default class FocusContext {
   /**
    * Focuses the given element if being a child of this context's container and matches the given filter (if provided).
    *
-   * @param element
-   *        the element to gain focus, or null to focus the context's first focusable element matching the given filter.
-   * @param filter
-   *        filter to control which element to gain focus, or null to accept all focusable candidates.
+   * @param {HTMLElement|$} [element]
+   *        the element to focus, or null to focus the context's first focusable element matching the given filter.
+   * @param {function} [filter]
+   *        filter that controls which element should be focused, or null to accept all focusable candidates.
    * @param {object} [options]
-   * @param {boolean} [options.preventScroll] a boolean whether to prevent scrolling to focused element or not (defaults to false)
+   * @param {boolean} [options.preventScroll] prevents scrolling to new focused element (defaults to false)
    */
   validateAndSetFocus(element, filter, options) {
     // Ensure the element to be a child element, or set it to null otherwise.
@@ -213,8 +213,11 @@ export default class FocusContext {
 
   /**
    * Focuses the requested element.
+   *
+   * @param {HTMLElement} element
+   *        the element to focus, or null to focus the context's first focusable element matching the given filter.
    * @param {object} [options]
-   * @param {boolean} [options.preventScroll] a boolean whether to prevent scrolling to focused element or not (defaults to false)
+   * @param {boolean} [options.preventScroll] prevents scrolling to new focused element (defaults to false)
    */
   _focus(elementToFocus, options) {
     options = options || {};
@@ -237,7 +240,7 @@ export default class FocusContext {
       elementToFocus = null;
     }
 
-    // Focus $entryPoint if current focus is to be blured.
+    // Focus $entryPoint if current focus is to be blurred.
     // Otherwise, the HTML body would be focused which makes global keystrokes (like backspace) not to work anymore.
     elementToFocus = elementToFocus || this.$container.entryPoint(true);
 

--- a/eclipse-scout-core/src/tile/TileGrid.js
+++ b/eclipse-scout-core/src/tile/TileGrid.js
@@ -764,16 +764,10 @@ export default class TileGrid extends Widget {
     if ($scrollables.length === 0) {
       return;
     }
-    let oldScrollTopArr = $scrollables.map((i, $elem) => {
-      return $elem.scrollTop();
-    }).toArray();
     // Make sure the tile grid has the focus when focusing a tile
-    if (this.focus()) {
-      // Restore old scroll to prevent scrolling by the browser due to the focus() call
-      oldScrollTopArr.forEach((val, idx) => {
-        $scrollables[idx].scrollTop(val);
-      }, this);
-    }
+    this.focus({
+      preventScroll: true
+    });
   }
 
   setSelectable(selectable) {
@@ -1386,7 +1380,7 @@ export default class TileGrid extends Widget {
   }
 
   _removeTileByFilter(tile) {
-    // In virtual mode, filtered tiles are not rendered. In normal mode, the filter animation is triggerd by _renderVisible of the tile.
+    // In virtual mode, filtered tiles are not rendered. In normal mode, the filter animation is triggered by _renderVisible of the tile.
     // Since the tile is removed immediately, the invisible animation would not start, so we use the remove animation instead.
     // But because the delete animation is a different one to the filter animation, the removeClass needs to be swapped
     // Remove class first to make sure animation won't be finished before the animationend listener is attached in Widget._removeAnimated (which may happen because a setTimeout is used there)

--- a/eclipse-scout-core/src/widget/Widget.js
+++ b/eclipse-scout-core/src/widget/Widget.js
@@ -2070,15 +2070,17 @@ export default class Widget {
    * Tries to set the focus on the widget.
    * <p>
    * By default the focus is set on the container but this may vary from widget to widget.
+   *
+   * @param {object} [options]
+   * @param {boolean} [options.preventScroll] prevents scrolling to new focused element (defaults to false)
    * @returns {boolean} true if the element could be focused, false if not
    */
-  focus() {
+  focus(options) {
     if (!this.rendered) {
-      this.session.layoutValidator.schedulePostValidateFunction(this.focus.bind(this));
+      this.session.layoutValidator.schedulePostValidateFunction(this.focus.bind(this, options));
       return false;
     }
-
-    return this.session.focusManager.requestFocus(this.getFocusableElement());
+    return this.session.focusManager.requestFocus(this.getFocusableElement(), null, options);
   }
 
   /**


### PR DESCRIPTION
Change to support _preventScroll_ when focusing elements. The second commit uses this feature to improve the TileGrid.