### PR TITLE
ProposalField: reset error status if search text changes

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
@@ -189,11 +189,12 @@ export default class ProposalField extends SmartField {
     // this causes a lookup which may fail and open a new proposal chooser (property
     // change for 'result').
     if (searchTextChanged) {
+      this.clearErrorStatus();
       this._acceptByText(sync, searchText);
     } else if (!this._hasUiError()) {
       this._inputAccepted(false);
     } else {
-      // even though there's nothing todo, someone could wait for our promise to be resolved
+      // even though there's nothing to do, someone could wait for our promise to be resolved
       this._acceptInputDeferred.resolve();
     }
 

--- a/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldSpec.js
+++ b/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldSpec.js
@@ -151,4 +151,10 @@ describe('ProposalField', () => {
     expect(field._getLastSearchText()).toBe('Bar');
   });
 
+  it('should clear error status on search text change', () => {
+    field.setErrorStatus(Status.error('functional'));
+    expect(field.errorStatus.containsStatus(Status)).toBe(true);
+    field._acceptInput(false, 'Bar', false, true, null);
+    expect(field.getErrorStatus).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Fixes an issue that a proposal field does not clear the error status if
the search text changes (only if a new lookup row is selected). This led
to a wrong error message if a wrong text value is replaced with a
correct text value.

314351