### PR TITLE
FormDataStatementBuilder does not respect negation for first node

### DIFF
--- a/org.eclipse.scout.rt.datamodel.server/src/main/java/org/eclipse/scout/rt/server/jdbc/builder/FormDataStatementBuilder.java
+++ b/org.eclipse.scout.rt.datamodel.server/src/main/java/org/eclipse/scout/rt/server/jdbc/builder/FormDataStatementBuilder.java
@@ -797,10 +797,10 @@ public class FormDataStatementBuilder implements DataModelConstants {
       if (subContrib.getWhereParts().size() + subContrib.getHavingParts().size() > 0) {
         if (count > 0) {
           buf.append(" OR ");
-          if (node.isNegative()) {
-            buf.append(" NOT ");
-          }
         }
+        if (node.isNegative()) {
+          buf.append(" NOT ");
+        }        
         buf.append("(");
         // remove possible outer join signs (+) in where / having constraint
         // this is necessary because outer joins are not allowed in OR clause


### PR DESCRIPTION
Solution: Negation must also be applied if first node is marked as
negative.

298580

Cherry-pick of commit 7876e11b0ed45b0e8ccfbf0fbd007e8ddbb0961c