### PR TITLE
Optimize height of legacy browser message.

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/legacy-browsers.js
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/legacy-browsers.js
@@ -30,9 +30,9 @@ var xmlHttp = new XMLHttpRequest();
 xmlHttp.onreadystatechange = function() {
   if (xmlHttp.readyState == 4 && xmlHttp.status >= 200 && xmlHttp.status < 300) {
     root.innerHTML = xmlHttp.responseText;
-    var buttons = document.getElementsByClassName('button');
-    for (var i = 0; i < buttons.length; i++) {
-      buttons[i].classList.add('hidden');
+    var buttonBar = document.getElementsByClassName('button-bar');
+    for (var i = 0; i < buttonBar.length; i++) {
+      buttonBar[i].classList.add('hidden');
     }
   }
 };


### PR DESCRIPTION
Hide button bar instead of button to prevent having an empty space
consumed by the button bar.