### PR TITLE
Tree: Mark node width dirty if last computation was executed when hidden

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.js
+++ b/eclipse-scout-core/src/tree/Tree.js
@@ -2926,6 +2926,10 @@ export default class Tree extends Widget {
       } else if (newWidth > this.maxNodeWidth) {
         this.maxNodeWidth = newWidth;
         this.nodeWidthDirty = true;
+      } else if (newWidth === oldWidth && newWidth === 0) {
+        // newWidth and oldWidth are 0: this might be because the tree is invisible while a node is added:
+        // Mark as dirty to update the width later during layouting (when the tree gets visible and the width is available)
+        this.nodeWidthDirty = true;
       }
       node.width = newWidth;
     }, this);


### PR DESCRIPTION
Use case: Tree is populated from an asynchronous lookup call while being
rendered but hidden. This also renders the tree nodes created from the
lookup call result. At the moment the nodes are created the measured
width is 0 because the whole tree is not visible.
In this scenario the node width must be marked as dirty because it is
not correct yet. As soon as the tree becomes visible, the layout will
recompute the width (if it has been marked dirty) and sets a correct
width.
This changes ensures that for this use case the dirty flag is set.

320681