### PR TITLE
DoValue/DoList: Use initialValue instead of creating new empty values

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoEntityTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoEntityTest.java
@@ -177,6 +177,8 @@ public class DoEntityTest {
     entity.put("foo", "value1");
     DoNode<?> attribute = entity.getNode("foo");
     assertEquals("value1", entity.get("foo"));
+
+    // update existing node value
     entity.put("foo", "value2");
     assertEquals("value2", entity.get("foo"));
     assertSame(attribute, entity.getNode("foo"));
@@ -185,9 +187,14 @@ public class DoEntityTest {
   @Test
   public void testPutListAttribute() {
     DoEntity entity = BEANS.get(DoEntity.class);
-    entity.putList("foo", Arrays.asList("value1"));
+    List<String> values = Arrays.asList("value1");
+    entity.putList("foo", values);
+    assertSame(values, entity.getList("foo"));
+
     DoNode<?> attribute = entity.getNode("foo");
     assertEquals("value1", entity.getList("foo", String.class).get(0));
+
+    // update existing node value
     entity.putList("foo", Arrays.asList("value2"));
     assertEquals("value2", entity.getList("foo", String.class).get(0));
     assertSame(attribute, entity.getNode("foo"));
@@ -640,6 +647,9 @@ public class DoEntityTest {
     entity2.putList("attribute3", Arrays.asList("l1", "l2"));
     assertEquals(entity1, entity2);
     assertEquals(entity1.hashCode(), entity2.hashCode());
+
+    //noinspection SimplifiableJUnitAssertion
+    assertFalse(entity1.equals(null));
   }
 
   @Test
@@ -708,5 +718,49 @@ public class DoEntityTest {
     actual.putListIf("listAttribute3", CollectionUtility.arrayList(4, 5, 6), v -> !v.isEmpty());
 
     assertEqualsWithComparisonFailure(expected, actual);
+  }
+
+  @Test
+  public void testDoValue() {
+    DoEntity entity = BEANS.get(DoEntity.class);
+    DoValue<String> foo = entity.doValue("foo");
+    assertNull(foo.get());
+
+    String value = "value";
+    foo.set(value);
+    assertEquals(value, entity.get("foo"));
+  }
+
+  @Test
+  public void testValueNode() {
+    DoEntity entity = BEANS.get(DoEntity.class);
+    assertThrows(AssertionException.class, () -> entity.getValueNode("foo"));
+
+    entity.put("foo", "value");
+    assertEquals("value", entity.get("foo"));
+
+    assertThrows(AssertionException.class, () -> entity.getListNode("foo"));
+  }
+
+  @Test
+  public void testDoList() {
+    DoEntity entity = BEANS.get(DoEntity.class);
+    DoList<String> foo = entity.doList("foo");
+    assertEquals(CollectionUtility.emptyArrayList(), foo.get());
+
+    List<String> values = Arrays.asList("value");
+    foo.set(values);
+    assertEquals(values, entity.get("foo"));
+  }
+
+  @Test
+  public void testListNode() {
+    DoEntity entity = BEANS.get(DoEntity.class);
+    assertThrows(AssertionException.class, () -> entity.getListNode("foo"));
+
+    entity.putList("foo", Arrays.asList("value"));
+    assertEquals("value", entity.getList("foo").get(0));
+
+    assertThrows(AssertionException.class, () -> entity.getValueNode("foo"));
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoValueTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoValueTest.java
@@ -10,15 +10,10 @@
  */
 package org.eclipse.scout.rt.dataobject;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.function.Consumer;
 
-import org.eclipse.scout.rt.dataobject.DoNode;
-import org.eclipse.scout.rt.dataobject.DoValue;
 import org.junit.Test;
 
 /**
@@ -32,17 +27,25 @@ public class DoValueTest {
     assertTrue(value.exists());
   }
 
+  @Test
+  public void testDoValueDetailedConstructor() {
+    String value = "foo";
+    DoValue<String> doValue = new DoValue<>("attributeName", m_lazyCreate, value);
+    assertFalse(doValue.exists());
+    assertSame(value, doValue.get());
+  }
+
   protected Consumer<DoNode<String>> m_lazyCreate = attribute -> {
     /* nop */ };
 
   @Test
   public void testCreateExists() {
-    DoValue<String> value = new DoValue<>(null, m_lazyCreate);
+    DoValue<String> value = new DoValue<>(null, m_lazyCreate, null);
     assertFalse(value.exists());
     value.create();
     assertTrue(value.exists());
 
-    value = new DoValue<>(null, m_lazyCreate);
+    value = new DoValue<>(null, m_lazyCreate, null);
     assertFalse(value.exists());
     value.set("foo");
     assertTrue(value.exists());
@@ -60,9 +63,11 @@ public class DoValueTest {
 
   @Test
   public void testOf() {
-    DoValue<String> value = DoValue.of("foo");
-    assertTrue(value.exists());
-    assertEquals("foo", value.get());
+    String value = "foo";
+    DoValue<String> doValue = DoValue.of("foo");
+    assertTrue(doValue.exists());
+    assertEquals("foo", doValue.get());
+    assertSame(value, doValue.get());
   }
 
   @Test
@@ -76,6 +81,6 @@ public class DoValueTest {
   public void testAttributeName() {
     assertNull(new DoValue<>().getAttributeName());
     assertNull(DoValue.of("").getAttributeName());
-    assertEquals("foo", new DoValue<>("foo", null).getAttributeName());
+    assertEquals("foo", new DoValue<>("foo", null, null).getAttributeName());
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoList.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoList.java
@@ -31,17 +31,19 @@ import java.util.stream.Stream;
 public final class DoList<V> extends DoNode<List<V>> implements IDataObject, Iterable<V> {
 
   public DoList() {
-    this(null, null);
+    this(null, null, null);
   }
 
-  DoList(String attributeName, Consumer<DoNode<List<V>>> lazyCreate) {
-    super(attributeName, lazyCreate, new ArrayList<>());
+  DoList(String attributeName, Consumer<DoNode<List<V>>> lazyCreate, List<V> initialValue) {
+    super(attributeName, lazyCreate, emptyListIfNull(initialValue));
   }
 
   public static <V> DoList<V> of(List<V> list) {
-    DoList<V> doList = new DoList<>();
-    doList.set(list);
-    return doList;
+    return new DoList<>(null, null, list);
+  }
+
+  static <V> List<V> emptyListIfNull(List<V> list) {
+    return list != null ? list : new ArrayList<>();
   }
 
   /**
@@ -61,7 +63,7 @@ public final class DoList<V> extends DoNode<List<V>> implements IDataObject, Ite
    */
   @Override
   public void set(List<V> newValue) {
-    super.set(newValue != null ? newValue : new ArrayList<>());
+    super.set(emptyListIfNull(newValue));
   }
 
   /**
@@ -136,7 +138,8 @@ public final class DoList<V> extends DoNode<List<V>> implements IDataObject, Ite
    *
    * @return {@code true} if this list changed as a result of the call
    */
-  public boolean removeAll(@SuppressWarnings("unchecked") V... items) {
+  @SafeVarargs
+  public final boolean removeAll(@SuppressWarnings("unchecked") V... items) {
     if (items != null) {
       return removeAll(Arrays.asList(items));
     }
@@ -156,7 +159,8 @@ public final class DoList<V> extends DoNode<List<V>> implements IDataObject, Ite
    * Replaces all items in this list with the given array of new {@code items}. If {@code items} is {@code null}, the
    * list is cleared without adding any items.
    */
-  public void updateAll(@SuppressWarnings("unchecked") V... items) {
+  @SafeVarargs
+  public final void updateAll(@SuppressWarnings("unchecked") V... items) {
     clear();
     addAll(items);
   }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoValue.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoValue.java
@@ -20,17 +20,15 @@ import java.util.function.Consumer;
 public final class DoValue<V> extends DoNode<V> {
 
   public DoValue() {
-    this(null, null);
+    this(null, null, null);
   }
 
-  protected DoValue(String attributeName, Consumer<DoNode<V>> lazyCreate) {
-    super(attributeName, lazyCreate, null);
+  DoValue(String attributeName, Consumer<DoNode<V>> lazyCreate, V initialValue) {
+    super(attributeName, lazyCreate, initialValue);
   }
 
   public static <V> DoValue<V> of(V value) {
-    DoValue<V> doValue = new DoValue<>();
-    doValue.set(value);
-    return doValue;
+    return new DoValue<>(null, null, value);
   }
 
   @Override


### PR DESCRIPTION
DoValue/DoList: use provided initial value directly instead of creating
an empty list which is replaced by the initial value later on while
constructing the DoEntity.

320299