### PR TITLE
Support column order update by id only

### DIFF
--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -5271,15 +5271,14 @@ export default class Table extends Widget {
 
     for (i = 0; i < columns.length; i++) {
       column = columns[i];
-      currentPosition = this.columns.indexOf(column);
+      currentPosition = arrays.findIndex(this.columns, element => element.id === column.id);
       if (currentPosition < 0) {
         throw new Error('Column with id ' + column.id + 'not found.');
       }
 
       if (currentPosition !== i) {
         // Update model
-        arrays.remove(this.columns, column);
-        arrays.insert(this.columns, column, i);
+        arrays.move(this.columns, currentPosition, i);
       }
     }
 

--- a/eclipse-scout-core/test/table/TableSpec.js
+++ b/eclipse-scout-core/test/table/TableSpec.js
@@ -2337,6 +2337,14 @@ describe('Table', () => {
       expect(table.columns[2]).toBe(column1);
     });
 
+    it('reorders the model columns by using only their id', () => {
+      table.updateColumnOrder([{id: column2.id}, {id: column0.id}, {id: column1.id}]);
+      expect(table.columns.length).toBe(3);
+      expect(table.columns[0]).toBe(column2);
+      expect(table.columns[1]).toBe(column0);
+      expect(table.columns[2]).toBe(column1);
+    });
+
     it('reorders the html nodes', () => {
       table.render();
 


### PR DESCRIPTION
When updating the column order, the new order must consist of a list
with whole column elements. However, the function itself would only need
an ordered list of ids.

To support both cases (whole column object or id only), updateColumnOrder
now only uses the id part of the column.
This allows updating by id only while maintaining the original api.

321037