### PR TITLE
DoValue/DoList: Use initialValue instead of creating new empty values

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoCollectionTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoCollectionTest.java
@@ -49,22 +49,33 @@ public class DoCollectionTest {
     assertTrue(collection.exists());
   }
 
+  @Test
+  public void testDoCollectionDetailedConstructor() {
+    Collection<String> collection = new ArrayList<>();
+    collection.add("one");
+    DoCollection<String> doCollection = new DoCollection<>("attributeName", m_lazyCreate, collection);
+    assertFalse(doCollection.exists());
+    assertNotNull(doCollection.get());
+    assertTrue(doCollection.get() instanceof ArrayList);
+    assertSame(collection, doCollection.get());
+  }
+
   protected Consumer<DoNode<Collection<String>>> m_lazyCreate = attribute -> {
     /* nop */ };
 
   @Test
   public void testCreateExists() {
-    DoCollection<String> collection = new DoCollection<>(null, m_lazyCreate);
+    DoCollection<String> collection = new DoCollection<>(null, m_lazyCreate, null);
     assertFalse(collection.exists());
     collection.create();
     assertTrue(collection.exists());
 
-    collection = new DoCollection<>(null, m_lazyCreate);
+    collection = new DoCollection<>(null, m_lazyCreate, null);
     assertFalse(collection.exists());
     collection.set(Arrays.asList("foo", "bar"));
     assertTrue(collection.exists());
 
-    collection = new DoCollection<>(null, m_lazyCreate);
+    collection = new DoCollection<>(null, m_lazyCreate, null);
     assertFalse(collection.exists());
     collection.get();
     assertTrue(collection.exists());
@@ -326,7 +337,7 @@ public class DoCollectionTest {
    */
   @Test
   public void testIdempotentMethodCalls() {
-    DoCollection<String> collection = new DoCollection<>(null, m_lazyCreate);
+    DoCollection<String> collection = new DoCollection<>(null, m_lazyCreate, null);
     assertFalse(collection.exists());
 
     assertFalse(collection.contains("value"));
@@ -387,7 +398,7 @@ public class DoCollectionTest {
     collection.valueHashCode();
     assertFalse(collection.exists());
 
-    DoCollection<String> otherCollection = new DoCollection<>(null, m_lazyCreate);
+    DoCollection<String> otherCollection = new DoCollection<>(null, m_lazyCreate, null);
     assertFalse(otherCollection.exists());
     assertTrue(collection.valueEquals(otherCollection));
     assertFalse(collection.exists());
@@ -408,7 +419,7 @@ public class DoCollectionTest {
   public void testAttributeName() {
     assertNull(new DoCollection<>().getAttributeName());
     assertNull(DoCollection.of(Collections.emptyList()).getAttributeName());
-    assertEquals("foo", new DoCollection<>("foo", null).getAttributeName());
+    assertEquals("foo", new DoCollection<>("foo", null, null).getAttributeName());
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoListTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoListTest.java
@@ -48,6 +48,27 @@ public class DoListTest {
   public void testDoListConstructor() {
     DoList<String> list = new DoList<>();
     assertTrue(list.exists());
+    assertNotNull(list.get());
+    assertTrue(list.get() instanceof ArrayList);
+  }
+
+  @Test
+  public void testDoListDetailedConstructor() {
+    ArrayList<String> list = new ArrayList<>();
+    list.add("one");
+    DoList<String> doList = new DoList<>("attributeName", m_lazyCreate, list);
+    assertFalse(doList.exists());
+    assertNotNull(doList.get());
+    assertTrue(doList.get() instanceof ArrayList);
+    assertSame(list, doList.get());
+  }
+
+  @Test
+  public void testDoListDetailedConstructorNullInitialValue() {
+    DoList<String> doList = new DoList<>("attributeName", m_lazyCreate, null);
+    assertFalse(doList.exists());
+    assertNotNull(doList.get());
+    assertTrue(doList.get() instanceof ArrayList);
   }
 
   protected Consumer<DoNode<List<String>>> m_lazyCreate = attribute -> {
@@ -55,17 +76,17 @@ public class DoListTest {
 
   @Test
   public void testCreateExists() {
-    DoList<String> list = new DoList<>(null, m_lazyCreate);
+    DoList<String> list = new DoList<>(null, m_lazyCreate, null);
     assertFalse(list.exists());
     list.create();
     assertTrue(list.exists());
 
-    list = new DoList<>(null, m_lazyCreate);
+    list = new DoList<>(null, m_lazyCreate, null);
     assertFalse(list.exists());
     list.set(Arrays.asList("foo", "bar"));
     assertTrue(list.exists());
 
-    list = new DoList<>(null, m_lazyCreate);
+    list = new DoList<>(null, m_lazyCreate, null);
     assertFalse(list.exists());
     list.get();
     assertTrue(list.exists());
@@ -73,10 +94,12 @@ public class DoListTest {
 
   @Test
   public void testOf() {
-    DoList<String> list = DoList.of(Arrays.asList("foo", "bar"));
-    assertTrue(list.exists());
-    assertEquals("foo", list.get(0));
-    assertEquals("bar", list.get(1));
+    List<String> list = Arrays.asList("foo", "bar");
+    DoList<String> doList = DoList.of(list);
+    assertTrue(doList.exists());
+    assertEquals("foo", doList.get(0));
+    assertEquals("bar", doList.get(1));
+    assertSame(list, doList.get());
   }
 
   @Test
@@ -94,8 +117,10 @@ public class DoListTest {
 
   @Test
   public void testSet() {
-    m_testDoList.set(Arrays.asList("foo"));
+    List<String> values = Arrays.asList("foo");
+    m_testDoList.set(values);
     assertEquals(Arrays.asList("foo"), m_testDoList.get());
+    assertSame(values, m_testDoList.get());
 
     m_testDoList.set(Collections.emptyList());
     assertEquals(Collections.emptyList(), m_testDoList.get());
@@ -446,7 +471,7 @@ public class DoListTest {
    */
   @Test
   public void testIdempotentMethodCalls() {
-    DoList<String> list = new DoList<>(null, m_lazyCreate);
+    DoList<String> list = new DoList<>(null, m_lazyCreate, null);
     assertFalse(list.exists());
 
     assertThrows(IndexOutOfBoundsException.class, () -> list.get(0));
@@ -475,7 +500,7 @@ public class DoListTest {
   public void testAttributeName() {
     assertNull(new DoList<>().getAttributeName());
     assertNull(DoList.of(Collections.emptyList()).getAttributeName());
-    assertEquals("foo", new DoList<>("foo", null).getAttributeName());
+    assertEquals("foo", new DoList<>("foo", null, null).getAttributeName());
   }
 
   @Test
@@ -498,6 +523,8 @@ public class DoListTest {
     assertEquals(list1, list2);
     assertEquals(list1.hashCode(), list2.hashCode());
 
+    assertNotEquals(null, list1);
+    assertNotEquals(list1, new Object());
     assertNotEquals(null, list1);
     assertNotEquals(list1, new Object());
 

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoSetTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoSetTest.java
@@ -47,22 +47,33 @@ public class DoSetTest {
     assertTrue(set.exists());
   }
 
+  @Test
+  public void testDoSetDetailedConstructor() {
+    Set<String> set = new HashSet<>();
+    set.add("one");
+    DoSet<String> doSet = new DoSet<>("attributeName", m_lazyCreate, set);
+    assertFalse(doSet.exists());
+    assertNotNull(doSet.get());
+    assertTrue(doSet.get() instanceof HashSet);
+    assertSame(set, doSet.get());
+  }
+
   protected Consumer<DoNode<Set<String>>> m_lazyCreate = attribute -> {
     /* nop */ };
 
   @Test
   public void testCreateExists() {
-    DoSet<String> set = new DoSet<>(null, m_lazyCreate);
+    DoSet<String> set = new DoSet<>(null, m_lazyCreate, null);
     assertFalse(set.exists());
     set.create();
     assertTrue(set.exists());
 
-    set = new DoSet<>(null, m_lazyCreate);
+    set = new DoSet<>(null, m_lazyCreate, null);
     assertFalse(set.exists());
     set.set(CollectionUtility.hashSet("foo", "bar"));
     assertTrue(set.exists());
 
-    set = new DoSet<>(null, m_lazyCreate);
+    set = new DoSet<>(null, m_lazyCreate, null);
     assertFalse(set.exists());
     set.get();
     assertTrue(set.exists());
@@ -334,7 +345,7 @@ public class DoSetTest {
    */
   @Test
   public void testIdempotentMethodCalls() {
-    DoSet<String> set = new DoSet<>(null, m_lazyCreate);
+    DoSet<String> set = new DoSet<>(null, m_lazyCreate, null);
     assertFalse(set.exists());
 
     assertNotNull(set.toString());
@@ -345,7 +356,7 @@ public class DoSetTest {
   public void testAttributeName() {
     assertNull(new DoSet<>().getAttributeName());
     assertNull(DoSet.of(Collections.emptySet()).getAttributeName());
-    assertEquals("foo", new DoSet<>("foo", null).getAttributeName());
+    assertEquals("foo", new DoSet<>("foo", null, null).getAttributeName());
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoValueTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoValueTest.java
@@ -10,15 +10,10 @@
  */
 package org.eclipse.scout.rt.dataobject;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.function.Consumer;
 
-import org.eclipse.scout.rt.dataobject.DoNode;
-import org.eclipse.scout.rt.dataobject.DoValue;
 import org.junit.Test;
 
 /**
@@ -32,17 +27,25 @@ public class DoValueTest {
     assertTrue(value.exists());
   }
 
+  @Test
+  public void testDoValueDetailedConstructor() {
+    String value = "foo";
+    DoValue<String> doValue = new DoValue<>("attributeName", m_lazyCreate, value);
+    assertFalse(doValue.exists());
+    assertSame(value, doValue.get());
+  }
+
   protected Consumer<DoNode<String>> m_lazyCreate = attribute -> {
     /* nop */ };
 
   @Test
   public void testCreateExists() {
-    DoValue<String> value = new DoValue<>(null, m_lazyCreate);
+    DoValue<String> value = new DoValue<>(null, m_lazyCreate, null);
     assertFalse(value.exists());
     value.create();
     assertTrue(value.exists());
 
-    value = new DoValue<>(null, m_lazyCreate);
+    value = new DoValue<>(null, m_lazyCreate, null);
     assertFalse(value.exists());
     value.set("foo");
     assertTrue(value.exists());
@@ -60,9 +63,11 @@ public class DoValueTest {
 
   @Test
   public void testOf() {
-    DoValue<String> value = DoValue.of("foo");
-    assertTrue(value.exists());
-    assertEquals("foo", value.get());
+    String value = "foo";
+    DoValue<String> doValue = DoValue.of("foo");
+    assertTrue(doValue.exists());
+    assertEquals("foo", doValue.get());
+    assertSame(value, doValue.get());
   }
 
   @Test
@@ -76,6 +81,6 @@ public class DoValueTest {
   public void testAttributeName() {
     assertNull(new DoValue<>().getAttributeName());
     assertNull(DoValue.of("").getAttributeName());
-    assertEquals("foo", new DoValue<>("foo", null).getAttributeName());
+    assertEquals("foo", new DoValue<>("foo", null, null).getAttributeName());
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoCollection.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoCollection.java
@@ -31,17 +31,19 @@ import org.eclipse.scout.rt.platform.util.CollectionUtility;
 public final class DoCollection<V> extends AbstractDoCollection<V, Collection<V>> {
 
   public DoCollection() {
-    this(null, null);
+    this(null, null, null);
   }
 
-  DoCollection(String attributeName, Consumer<DoNode<Collection<V>>> lazyCreate) {
-    super(attributeName, lazyCreate, new ArrayList<>());
+  DoCollection(String attributeName, Consumer<DoNode<Collection<V>>> lazyCreate, Collection<V> initialValue) {
+    super(attributeName, lazyCreate, emptyCollectionIfNull(initialValue));
   }
 
   public static <V> DoCollection<V> of(Collection<V> collection) {
-    DoCollection<V> doCollection = new DoCollection<>();
-    doCollection.set(collection);
-    return doCollection;
+    return new DoCollection<>(null, null, collection);
+  }
+
+  static <V> Collection<V> emptyCollectionIfNull(Collection<V> list) {
+    return list != null ? list : new ArrayList<>();
   }
 
   /**
@@ -53,7 +55,7 @@ public final class DoCollection<V> extends AbstractDoCollection<V, Collection<V>
    */
   @Override
   public void set(Collection<V> newValue) {
-    super.set(newValue != null ? newValue : new ArrayList<>());
+    super.set(emptyCollectionIfNull(newValue));
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoEntity.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoEntity.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.scout.rt.dataobject;
 
-import static org.eclipse.scout.rt.platform.util.Assertions.assertNotNull;
+import static org.eclipse.scout.rt.platform.util.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,10 +22,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import org.eclipse.scout.rt.platform.BEANS;
-import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.StreamUtility;
 
@@ -53,6 +51,7 @@ import org.eclipse.scout.rt.platform.util.StreamUtility;
 public class DoEntity implements IDoEntity {
 
   private final Map<String, DoNode<?>> m_attributes = new LinkedHashMap<>();
+
   private List<IDoEntityContribution> m_contributions; // lazy init, because contributions are used rarely
 
   /**
@@ -85,38 +84,66 @@ public class DoEntity implements IDoEntity {
   }
 
   /**
-   * Adds new value to attribute map. The value is wrapped within a {@link DoValue}.
+   * Associates the specified value with the specified attribute name in this entity. If the entity previously contained
+   * a mapping for the attribute name, the old value is replaced by the specified value wrapped within a
+   * {@link DoValue}.
    */
   @Override
   public void put(String attributeName, Object value) {
-    doValue(attributeName).set(value);
+    if (has(attributeName)) {
+      getValueNode(attributeName).set(value);
+    }
+    else {
+      newValueNode(attributeName, value).create();
+    }
   }
 
   /**
-   * Adds new list value to attribute map. The value is wrapped within a {@link DoList}.
+   * Associates the specified list value with the specified attribute name in this entity. If the entity previously
+   * contained a mapping for the attribute name, the old list value is replaced by the specified value wrapped within a
+   * {@link DoList}.
    */
   @Override
   public <V> void putList(String attributeName, List<V> value) {
-    DoList<V> doList = doList(attributeName);
-    doList.set(value);
+    if (has(attributeName)) {
+      DoList<V> node = getListNode(attributeName);
+      node.set(value);
+    }
+    else {
+      newListNode(attributeName, value).create();
+    }
   }
 
   /**
-   * Adds new set value to attribute map. The value is wrapped within a {@link DoSet}.
+   * Associates the specified set value with the specified attribute name in this entity. If the entity previously
+   * contained a mapping for the attribute name, the old set value is replaced by the specified value wrapped within a
+   * {@link DoSet}.
    */
   @Override
   public <V> void putSet(String attributeName, Set<V> value) {
-    DoSet<V> doSet = doSet(attributeName);
-    doSet.set(value);
+    if (has(attributeName)) {
+      DoSet<V> node = getSetNode(attributeName);
+      node.set(value);
+    }
+    else {
+      newSetNode(attributeName, value).create();
+    }
   }
 
   /**
-   * Adds new collection value to attribute map. The value is wrapped within a {@link DoCollection}.
+   * Associates the specified collection value with the specified attribute name in this entity. If the entity
+   * previously contained a mapping for the attribute name, the old collection value is replaced by the specified value
+   * wrapped within a {@link DoCollection}.
    */
   @Override
   public <V> void putCollection(String attributeName, Collection<V> value) {
-    DoCollection<V> doCollection = doCollection(attributeName);
-    doCollection.set(value);
+    if (has(attributeName)) {
+      DoCollection<V> node = getCollectionNode(attributeName);
+      node.set(value);
+    }
+    else {
+      newCollectionNode(attributeName, value).create();
+    }
   }
 
   /**
@@ -147,57 +174,6 @@ public class DoEntity implements IDoEntity {
     return all(Function.identity());
   }
 
-  /**
-   * @return the map of all attribute values mapped using specified {@code mapper} function.
-   */
-  protected <T> Map<String, T> all(Function<Object, T> mapper) {
-    return allNodes().entrySet().stream()
-        .collect(StreamUtility.toLinkedHashMap(Entry::getKey, entry -> mapper.apply(entry.getValue().get())));
-  }
-
-  /**
-   * Creates a new {@link DoValue} value attribute node wrapping a value of type {@code V}
-   */
-  protected <V> DoValue<V> doValue(String attributeName) {
-    //noinspection unchecked
-    return doNode(attributeName, DoValue.class, () -> new DoValue<V>(attributeName, attribute -> putNode(attributeName, attribute)));
-  }
-
-  /**
-   * Creates a new {@link DoList} list value attribute node wrapping a list of type {@code List<V>}
-   */
-  protected <V> DoList<V> doList(String attributeName) {
-    //noinspection unchecked
-    return doNode(attributeName, DoList.class, () -> new DoList<V>(attributeName, attribute -> putNode(attributeName, attribute)));
-  }
-
-  /**
-   * Creates a new {@link DoSet} set value attribute node wrapping a list of type {@code Set<V>}
-   */
-  protected <V> DoSet<V> doSet(String attributeName) {
-    //noinspection unchecked
-    return doNode(attributeName, DoSet.class, () -> new DoSet<V>(attributeName, attribute -> putNode(attributeName, attribute)));
-  }
-
-  /**
-   * Creates a new {@link DoCollection} collection value attribute node wrapping a list of type {@code Collection<V>}
-   */
-  protected <V> DoCollection<V> doCollection(String attributeName) {
-    //noinspection unchecked
-    return doNode(attributeName, DoCollection.class, () -> new DoCollection<V>(attributeName, attribute -> putNode(attributeName, attribute)));
-  }
-
-  protected <NODE> NODE doNode(String attributeName, Class<NODE> clazz, Supplier<NODE> nodeSupplier) {
-    assertNotNull(attributeName, "attribute name cannot be null");
-    DoNode<?> node = getNode(attributeName);
-    if (node != null) {
-      Assertions.assertInstance(node, clazz, "Existing node {} is not of type {}, cannot change the node type!", node, clazz);
-      //noinspection unchecked
-      return (NODE) node;
-    }
-    return nodeSupplier.get();
-  }
-
   @Override
   public boolean hasContributions() {
     return !CollectionUtility.isEmpty(m_contributions); // no call to getContributions because internal representation is created otherwise
@@ -209,10 +185,6 @@ public class DoEntity implements IDoEntity {
       m_contributions = new ArrayList<>(); // create on first access
     }
     return m_contributions;
-  }
-
-  protected boolean nvl(Boolean value) {
-    return value != null && value.booleanValue();
   }
 
   @Override
@@ -251,5 +223,142 @@ public class DoEntity implements IDoEntity {
   @Override
   public String toString() {
     return getClass().getSimpleName() + " " + BEANS.get(DataObjectHelper.class).toString(this);
+  }
+
+  // ------- helper methods ------- //
+
+  /**
+   * Returns the {@link DoValue} attribute node wrapping a value of type {@code V}. A new node is created, if this
+   * entity does not already contain a node for the given {@code attributeName}.
+   */
+  protected <V> DoValue<V> doValue(String attributeName) {
+    if (has(attributeName)) {
+      return getValueNode(attributeName);
+    }
+    else {
+      return newValueNode(attributeName, null);
+    }
+  }
+
+  /**
+   * Returns the {@link DoList} attribute node wrapping a value of type {@code List<V>}. A new node is created, if this
+   * entity does not already contain a node for the given {@code attributeName}.
+   */
+  protected <V> DoList<V> doList(String attributeName) {
+    if (has(attributeName)) {
+      return getListNode(attributeName);
+    }
+    else {
+      return newListNode(attributeName, null);
+    }
+  }
+
+  /**
+   * Returns the {@link DoSet} attribute node wrapping a value of type {@code Set<V>}. A new node is created, if this
+   * entity does not already contain a node for the given {@code attributeName}.
+   */
+  protected <V> DoSet<V> doSet(String attributeName) {
+    if (has(attributeName)) {
+      return getSetNode(attributeName);
+    }
+    else {
+      return newSetNode(attributeName, null);
+    }
+  }
+
+  /**
+   * Returns the {@link DoCollection} attribute node wrapping a value of type {@code Collection<V>}. A new node is
+   * created, if this entity does not already contain a node for the given {@code attributeName}.
+   */
+  protected <V> DoCollection<V> doCollection(String attributeName) {
+    if (has(attributeName)) {
+      return getCollectionNode(attributeName);
+    }
+    else {
+      return newCollectionNode(attributeName, null);
+    }
+  }
+
+  protected boolean nvl(Boolean value) {
+    return value != null && value.booleanValue();
+  }
+
+  /**
+   * @return the map of all attribute values mapped using specified {@code mapper} function.
+   */
+  protected <T> Map<String, T> all(Function<Object, T> mapper) {
+    return allNodes().entrySet().stream()
+        .collect(StreamUtility.toLinkedHashMap(Entry::getKey, entry -> mapper.apply(entry.getValue().get())));
+  }
+
+  /**
+   * @return DoNode for given {@code attributeName} having given {@code clazz} type.
+   */
+  <V, NODE extends DoNode<V>> NODE getNode(String attributeName, Class<NODE> clazz) {
+    assertNotNull(attributeName, "attribute name cannot be null");
+    DoNode<?> node = getNode(attributeName);
+    assertInstance(node, clazz, "Node {} is null or not of type {}", node, clazz);
+    //noinspection unchecked
+    return (NODE) node;
+  }
+
+  /**
+   * @return DoValue for given {@code attributeName}.
+   */
+  <V> DoValue<V> getValueNode(String attributeName) {
+    //noinspection unchecked
+    return getNode(attributeName, DoValue.class);
+  }
+
+  /**
+   * @return DoList for given {@code attributeName}.
+   */
+  <V> DoList<V> getListNode(String attributeName) {
+    //noinspection unchecked
+    return getNode(attributeName, DoList.class);
+  }
+
+  /**
+   * @return DoSet for given {@code attributeName}.
+   */
+  <V> DoSet<V> getSetNode(String attributeName) {
+    //noinspection unchecked
+    return getNode(attributeName, DoSet.class);
+  }
+
+  /**
+   * @return DoCollection for given {@code attributeName}.
+   */
+  <V> DoCollection<V> getCollectionNode(String attributeName) {
+    //noinspection unchecked
+    return getNode(attributeName, DoCollection.class);
+  }
+
+  /**
+   * Creates a new {@code DoValue} node using the given {@code initialValue}.
+   */
+  <V> DoValue<V> newValueNode(String attributeName, V initialValue) {
+    return new DoValue<>(attributeName, attribute -> putNode(attributeName, attribute), initialValue);
+  }
+
+  /**
+   * Creates a new {@code DoCollection} node using the given {@code initialValue}.
+   */
+  <V> DoCollection<V> newCollectionNode(String attributeName, Collection<V> initialValue) {
+    return new DoCollection<>(attributeName, attribute -> putNode(attributeName, attribute), initialValue);
+  }
+
+  /**
+   * Creates a new {@code DoList} node using the given {@code initialValue}.
+   */
+  <V> DoList<V> newListNode(String attributeName, List<V> initialValue) {
+    return new DoList<>(attributeName, attribute -> putNode(attributeName, attribute), initialValue);
+  }
+
+  /**
+   * Creates a new {@code DoSet} node using the given {@code initialValue}.
+   */
+  <V> DoSet<V> newSetNode(String attributeName, Set<V> initialValue) {
+    return new DoSet<>(attributeName, attribute -> putNode(attributeName, attribute), initialValue);
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoList.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoList.java
@@ -26,17 +26,19 @@ import java.util.function.Consumer;
 public final class DoList<V> extends AbstractDoCollection<V, List<V>> implements IDataObject {
 
   public DoList() {
-    this(null, null);
+    this(null, null, null);
   }
 
-  DoList(String attributeName, Consumer<DoNode<List<V>>> lazyCreate) {
-    super(attributeName, lazyCreate, new ArrayList<>());
+  DoList(String attributeName, Consumer<DoNode<List<V>>> lazyCreate, List<V> initialValue) {
+    super(attributeName, lazyCreate, emptyListIfNull(initialValue));
   }
 
   public static <V> DoList<V> of(List<V> list) {
-    DoList<V> doList = new DoList<>();
-    doList.set(list);
-    return doList;
+    return new DoList<>(null, null, list);
+  }
+
+  static <V> List<V> emptyListIfNull(List<V> list) {
+    return list != null ? list : new ArrayList<>();
   }
 
   /**
@@ -47,7 +49,7 @@ public final class DoList<V> extends AbstractDoCollection<V, List<V>> implements
    */
   @Override
   public void set(List<V> newValue) {
-    super.set(newValue != null ? newValue : new ArrayList<>());
+    super.set(emptyListIfNull(newValue));
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoSet.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoSet.java
@@ -27,18 +27,20 @@ import java.util.function.Consumer;
 public final class DoSet<V> extends AbstractDoCollection<V, Set<V>> {
 
   public DoSet() {
-    this(null, null);
+    this(null, null, null);
   }
 
-  DoSet(String attributeName, Consumer<DoNode<Set<V>>> lazyCreate) {
+  DoSet(String attributeName, Consumer<DoNode<Set<V>>> lazyCreate, Set<V> initialValue) {
     // Even if the order within a set is not relevant, using a LinkedHashSet here to have a deterministic behavior by default.
-    super(attributeName, lazyCreate, new LinkedHashSet<>());
+    super(attributeName, lazyCreate, emptySetIfNull(initialValue));
   }
 
   public static <V> DoSet<V> of(Set<V> set) {
-    DoSet<V> doSet = new DoSet<>();
-    doSet.set(set);
-    return doSet;
+    return new DoSet<>(null, null, set);
+  }
+
+  static <V> Set<V> emptySetIfNull(Set<V> set) {
+    return set != null ? set : new LinkedHashSet<>();
   }
 
   /**
@@ -49,7 +51,7 @@ public final class DoSet<V> extends AbstractDoCollection<V, Set<V>> {
    */
   @Override
   public void set(Set<V> newValue) {
-    super.set(newValue != null ? newValue : new LinkedHashSet<>());
+    super.set(emptySetIfNull(newValue));
   }
 
   // LinkedHashSet already implemented hashCode/equals without considering element position, thus no need to override valueHashCode/valueEquals.

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoValue.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoValue.java
@@ -20,17 +20,15 @@ import java.util.function.Consumer;
 public final class DoValue<V> extends DoNode<V> {
 
   public DoValue() {
-    this(null, null);
+    this(null, null, null);
   }
 
-  protected DoValue(String attributeName, Consumer<DoNode<V>> lazyCreate) {
-    super(attributeName, lazyCreate, null);
+  DoValue(String attributeName, Consumer<DoNode<V>> lazyCreate, V initialValue) {
+    super(attributeName, lazyCreate, initialValue);
   }
 
   public static <V> DoValue<V> of(V value) {
-    DoValue<V> doValue = new DoValue<>();
-    doValue.set(value);
-    return doValue;
+    return new DoValue<>(null, null, value);
   }
 
   @Override


### PR DESCRIPTION
DoValue/DoList: use provided initial value directly instead of creating
an empty list which is replaced by the initial value later on while
constructing the DoEntity.

320299