### PR TITLE
Rename private class RadioButton to P_RadioButton and make visible

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/radiobuttongroup/AbstractRadioButtonGroup.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/radiobuttongroup/AbstractRadioButtonGroup.java
@@ -275,7 +275,7 @@ public abstract class AbstractRadioButtonGroup<T> extends AbstractValueField<T> 
    * <code>null</code>!
    */
   protected IRadioButton<T> createEmptyRadioButtonForLookupRow() {
-    return new RadioButton();
+    return new P_RadioButton();
   }
 
   /**
@@ -682,7 +682,7 @@ public abstract class AbstractRadioButtonGroup<T> extends AbstractValueField<T> 
    */
   @ClassId("7fb44a3d-b3e5-4cae-bb93-0fa435802466")
   @SuppressWarnings("bsiRulesDefinition:orderMissing")
-  private final class RadioButton extends AbstractRadioButton<T> {
+  public final class P_RadioButton extends AbstractRadioButton<T> {
   }
 
   protected final void interceptPrepareLookup(ILookupCall<T> call) {


### PR DESCRIPTION
Make private class AbstractRadioButtonGroup$RadioButton public to
allow referencing it in tests and other modules.
Rename it to P_RadioButton to prevent inadvertent usage in
custom AbstractRadioButtonGroups.