### PR TITLE
TileAccordion: virtual groups might be empty on parent resize

### DIFF
--- a/eclipse-scout-core/src/tile/TileGrid.js
+++ b/eclipse-scout-core/src/tile/TileGrid.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -42,8 +42,6 @@ export default class TileGrid extends Widget {
     this.selectedTiles = [];
     this.selectionHandler = new TileGridSelectionHandler(this);
     this.scrollable = true;
-    this.scrolling = false;
-    this.scrollTopDirty = false;
     this.startupAnimationDone = false;
     this.startupAnimationEnabled = false;
     this.tiles = [];
@@ -594,18 +592,14 @@ export default class TileGrid extends Widget {
     let scrollTop = this.$container[0].scrollTop;
     let scrollLeft = this.$container[0].scrollLeft;
     if (this.scrollTop !== scrollTop && this.virtual) {
-      this.scrolling = true;
-      this.revalidateLayout();
-      this.scrolling = false;
+      this.htmlComp.layout.updateViewPort();
     }
     this.scrollTop = scrollTop;
     this.scrollLeft = scrollLeft;
   }
 
   _onScrollParentScroll(event) {
-    this.scrolling = true;
-    this.revalidateLayoutTree(false);
-    this.scrolling = false;
+    this.htmlComp.layout.updateViewPort();
   }
 
   setWithPlaceholders(withPlaceholders) {
@@ -961,12 +955,8 @@ export default class TileGrid extends Widget {
     this.ensureTileRendered(tile);
     // If tile was not rendered it is not yet positioned correctly -> make sure layout is valid before trying to scroll
     // Layout must not render the viewport because scroll position is not correct yet -> just make sure tiles are at the correct position
-    this.scrolling = true;
-    this.scrollTopDirty = true;
-    this.validateLayoutTree();
-    this.scrolling = false;
+    this.htmlComp.layout.updateViewPort(true);
     tile.reveal(options);
-    this.scrollTopDirty = false;
   }
 
   revealSelection() {

--- a/eclipse-scout-core/src/tile/TileGridLayout.js
+++ b/eclipse-scout-core/src/tile/TileGridLayout.js
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -44,18 +44,28 @@ export default class TileGridLayout extends LogicalGridLayout {
     this.maxWidth = -1;
   }
 
-  layout($container) {
-    let htmlComp = this.widget.htmlComp;
-    if (this.widget.scrolling) {
-      // Try to layout only as much as needed while scrolling in virtual mode
-      // Scroll top may be dirty when layout is validated before scrolling to a specific tile (see tileGrid.scrollTo)
-      if (!this.widget.scrollTopDirty) {
-        this.widget._renderViewPort();
-      }
-      this._layout($container);
-      this.widget.trigger('layoutAnimationDone');
+  /**
+   *
+   * @param {boolean} [scrollTopDirty] If the scroll top position should be considered dirty while updating the view port.
+   * If true, the view port is not rendered, as the scroll positions are not reliable anyway. Then only the layout of the TileGrid is updated.
+   */
+  updateViewPort(scrollTopDirty) {
+    let tileGrid = this.widget;
+    if (!tileGrid.rendered) {
       return;
     }
+
+    // Try to layout only as much as needed while scrolling in virtual mode
+    // Scroll top may be dirty when layout is validated before scrolling to a specific tile (see tileGrid.scrollTo)
+    if (!scout.nvl(scrollTopDirty, false)) {
+      tileGrid._renderViewPort();
+    }
+    this._layout(tileGrid.$container);
+    tileGrid.trigger('layoutAnimationDone');
+  }
+
+  layout($container) {
+    let htmlComp = this.widget.htmlComp;
 
     // Animate only once on startup (if enabled) but animate every time on resize
     let animated = htmlComp.layouted || (this.widget.startupAnimationEnabled && !this.widget.startupAnimationDone) || this.widget.renderAnimationEnabled;

--- a/eclipse-scout-core/src/tile/accordion/TileAccordion.js
+++ b/eclipse-scout-core/src/tile/accordion/TileAccordion.js
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -350,24 +350,7 @@ export default class TileAccordion extends Accordion {
   }
 
   _filter() {
-    this.groups.forEach(group => {
-      group.body.filter();
-
-      // If the layout has not been invalidated as part of the filtering above, it even though must be validated here.
-      // This is because groups above might have fewer visible Tiles now which makes room for this group.
-      // The revalidateLayout() with scrolling=true here ensures TileGrid._renderViewPort() is called to ensure these Tiles become visible as there is space available now.
-      // It is executed as postValidateFunction because the groups above must have completed their layouting so that
-      // TileGrid._renderViewPort() knows that there is more space available now.
-      if (group.body.htmlComp && group.body.htmlComp.valid && !group.body._accordionLayoutHandler /* skip if already registered */) {
-        group.body._accordionLayoutHandler = () => {
-          group.body.scrolling = true;
-          group.body.revalidateLayout();
-          group.body.scrolling = false;
-          group.body._accordionLayoutHandler = null;
-        };
-        this.session.layoutValidator.schedulePostValidateFunction(group.body._accordionLayoutHandler);
-      }
-    });
+    this.groups.forEach(group => group.body.filter());
   }
 
   /**
@@ -700,10 +683,8 @@ export default class TileAccordion extends Accordion {
         // Btw: another group may be doing it as well at the same time (e.g. because of exclusiveExpand)
         return;
       }
-      if (group.body.virtual) {
-        group.body.scrolling = true;
-        group.body.revalidateLayout();
-        group.body.scrolling = false;
+      if (group.body.virtual && group.body.htmlComp) {
+        group.body.htmlComp.layout.updateViewPort();
       }
     });
   }

--- a/eclipse-scout-core/src/tile/accordion/TileAccordionLayout.js
+++ b/eclipse-scout-core/src/tile/accordion/TileAccordionLayout.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -19,8 +19,45 @@ export default class TileAccordionLayout extends AccordionLayout {
   }
 
   layout($container) {
+    let previousGroupHeights = this.tileAccordion.groups
+      .map(group => group.body)
+      .map(tileGrid => this._getTileGridHeight(tileGrid));
+
     super.layout($container);
     this._updateFilterFieldMaxWidth($container);
+
+    this.tileAccordion.groups
+      .map(group => group.body)
+      .forEach((tileGrid, index) => this._updateTileGridViewPort(tileGrid, previousGroupHeights[index]));
+  }
+
+  _updateTileGridViewPort(tileGrid, previousHeight) {
+    if (!tileGrid.rendered || !tileGrid.htmlComp || previousHeight <= 0) {
+      return;
+    }
+
+    let newHeight = this._getTileGridHeight(tileGrid);
+    if (previousHeight === newHeight && tileGrid.virtual) {
+      // The viewPort of the virtual tileGrid has not been updated as no layout update was done for the grid because its height is unchanged.
+      // But as there might be more space available in the accordion now (its height might have changed), enforce a viewPort update to ensure all necessary tiles are rendered.
+      tileGrid.setViewRangeSize(tileGrid.calculateViewRangeSize(), false);
+      tileGrid.htmlComp.layout.updateViewPort();
+    }
+  }
+
+  _getTileGridHeight(tileGrid) {
+    if (!tileGrid) {
+      return 0;
+    }
+    let htmlComp = tileGrid.htmlComp;
+    if (!htmlComp) {
+      return 0;
+    }
+    let size = tileGrid.htmlComp.sizeCached;
+    if (!size) {
+      return 0;
+    }
+    return size.height;
   }
 
   _updateFilterFieldMaxWidth($container) {


### PR DESCRIPTION
If the height of a TileAccordion with virtual TileGrids is increased,
the height of already expanded grids does not change. The grids always
consume their full height in that case. Therefore, if the layout of the
accordion is updated, the layout of its children is checked as well. But
as their height does not change the layout of the grids is not updated.

As the grids are virtual, they might have no rendered
tiles yet, as they might be invisible in the beginning (before
increasing the height of the accordion). Later when they should become
visible they are not notified as the layout is never updated (see above)

320746