### PR TITLE
NotificationBadge: only add when necessary and fix compareTo

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/AbstractForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/AbstractForm.java
@@ -925,7 +925,9 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
   @Override
   public void setNotificationBadgeText(String notificationBadgeText) {
     getNotificationBadgeStatus().ifPresent(notificationBadgeStatus -> removeStatus(notificationBadgeStatus));
-    addStatus(new NotificationBadgeStatus(notificationBadgeText));
+    if (notificationBadgeText != null) {
+      addStatus(new NotificationBadgeStatus(notificationBadgeText));
+    }
   }
 
   protected Optional<NotificationBadgeStatus> getNotificationBadgeStatus() {

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/status/Status.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/status/Status.java
@@ -11,6 +11,7 @@
 package org.eclipse.scout.rt.platform.status;
 
 import java.io.Serializable;
+import java.util.Comparator;
 
 import org.eclipse.scout.rt.platform.IOrdered;
 import org.eclipse.scout.rt.platform.Order;
@@ -167,25 +168,14 @@ public class Status implements IStatus, Serializable {
 
   @Override
   public int compareTo(IStatus o) {
-    if (o.getSeverity() - getSeverity() != 0) {
-      return o.getSeverity() - getSeverity();
-    }
-    else if (o.getOrder() - getOrder() != 0) {
-      return (int) ((getOrder() - o.getOrder()));
-    }
-    else if (getMessage() != null && o.getMessage() != null) {
-      return getMessage().compareTo(o.getMessage());
-    }
-    else if (getCssClass() != null && o.getCssClass() != null) {
-      return getCssClass().compareTo(o.getCssClass());
-    }
-    else if (getMessage() != null) {
-      return -1;
-    }
-    else if (getCssClass() != null) {
-      return -1;
-    }
-    return 0;
+    return Comparator
+        .comparing(IStatus::getSeverity, Comparator.reverseOrder())
+        .thenComparing(IStatus::getOrder)
+        .thenComparing(IStatus::getMessage,Comparator.nullsLast(Comparator.naturalOrder()))
+        .thenComparing(IStatus::getIconId,Comparator.nullsLast(Comparator.naturalOrder()))
+        .thenComparing(IStatus::getCode)
+        .thenComparing(IStatus::getCssClass,Comparator.nullsLast(Comparator.naturalOrder()))
+        .compare(this, o);
   }
 
   @Override


### PR DESCRIPTION
Adding status with the same message did not work because
compareTo returned 0 and MultiStatus uses a TreeSet.