### PR TITLE
Security headers missing on /auth

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/AbstractHealthCheckServlet.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/AbstractHealthCheckServlet.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -23,6 +23,7 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Platform;
 import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.server.commons.servlet.AbstractHttpServlet;
+import org.eclipse.scout.rt.server.commons.servlet.HttpServletControl;
 import org.eclipse.scout.rt.server.commons.servlet.ServletExceptionTranslator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,8 +33,8 @@ import org.slf4j.LoggerFactory;
  * application status. If the application status is OK, the servlet returns HTTP 200. In case any
  * <code>IHealthChecker</code> fails, the servlet returns HTTP 503.
  * <p>
- * This servlet can be used in combination with load balancers or reverse proxies that use a HTTP-GET or HTTP-HEAD check
- * method to determine the availability of the application.
+ * This servlet can be used in combination with load balancers or reverse proxies that use an HTTP-GET or HTTP-HEAD
+ * check method to determine the availability of the application.
  *
  * @since 6.1
  * @see AbstractHealthChecker
@@ -48,6 +49,7 @@ public abstract class AbstractHealthCheckServlet extends AbstractHttpServlet {
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
     disableCaching(req, resp);
+    BEANS.get(HttpServletControl.class).doDefaults(this, req, resp);
 
     RunContext context;
     try {

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpServletControl.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpServletControl.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -80,6 +80,13 @@ public class HttpServletControl implements Serializable {
    * Every servlet should call this method to make sure the defaults are applied
    * <p>
    * This includes setting default security response headers, parsing default request attributes etc.
+   *
+   * @param servlet
+   *          might be {@code null}
+   * @param req
+   *          must not be {@code null}
+   * @param resp
+   *          must not be {@code null}
    */
   public void doDefaults(HttpServlet servlet, HttpServletRequest req, HttpServletResponse resp) {
     parseRequest(servlet, req, resp);
@@ -91,12 +98,13 @@ public class HttpServletControl implements Serializable {
   }
 
   protected void setResponseHeaders(HttpServlet servlet, HttpServletRequest req, HttpServletResponse resp) {
+    resp.setHeader(HTTP_HEADER_X_CONTENT_TYPE_OPTIONS, CONTENT_TYPE_OPTION_NO_SNIFF); // apply no-sniff header for all http-methods
+
     if (!"GET".equals(req.getMethod())) {
       return;
     }
     resp.setHeader(HTTP_HEADER_X_FRAME_OPTIONS, SAMEORIGIN);
     resp.setHeader(HTTP_HEADER_X_XSS_PROTECTION, XSS_MODE_BLOCK);
-    resp.setHeader(HTTP_HEADER_X_CONTENT_TYPE_OPTIONS, CONTENT_TYPE_OPTION_NO_SNIFF);
 
     if (isCspEnabled(req)) {
       if (HttpClientInfo.get(req).isMshtml()) {

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/cache/HttpCacheControl.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/cache/HttpCacheControl.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
  * <p>
  * In production it makes heavy use of the max-age concept.
  * <p>
- * Make sure to call {@link #checkAndSetCacheHeaders(HttpServletRequest, HttpServletResponse, String, HttpCacheObject)}
- * in every servlet.
+ * Make sure to call {@link #checkAndSetCacheHeaders(HttpServletRequest, HttpServletResponse, HttpCacheObject)} in every
+ * servlet.
  */
 @ApplicationScoped
 public class HttpCacheControl {
@@ -65,15 +65,13 @@ public class HttpCacheControl {
    * Does nothing if this request is a forward such as
    * {@link RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)}
    *
-   * @param req
-   * @param resp
    * @param obj
    *          is the cache object that decides if cache is to be used or not, may be null to disable caching
    * @return true if the obj hasn't changed in the meantime. The {@link HttpServletResponse#SC_NOT_MODIFIED} response is
    *         sent to the http response by this method and the caller should end its processing of this request.
    *         <p>
    *         false if the obj again needs to be fully returned, Etag, IfModifiedSince and MaxAge headers were set if
-   *         appropriate. If no caching is desired then the disable headers were set.
+   *         appropriate. If no caching is desired then the necessary headers were set.
    */
   public boolean checkAndSetCacheHeaders(HttpServletRequest req, HttpServletResponse resp, HttpCacheObject obj) {
     if (!UrlHints.isCacheHint(req)) {


### PR DESCRIPTION
/auth handled by FormBasedAccessController should send the default
servlet headers. Same for the health-check-servlet.
The no-sniff option should not be restricted to GET requests as other
requests may send responses as well.

320084