### PR TITLE
Security: download as attachment for HTML files not enforced

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/OpenUriHelper.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/OpenUriHelper.java
@@ -72,7 +72,10 @@ public class OpenUriHelper {
   }
 
   protected IOpenUriAction getOpenUriActionHtmlPage() {
-    return OpenUriAction.NEW_WINDOW;
+    // HTML files must not be opened directly because it could
+    // contain malicious JavaScript which will be executed in the context
+    // of the current http session -> always download
+    return OpenUriAction.DOWNLOAD;
   }
 
   protected boolean isZipArchive(BinaryResource resource) {


### PR DESCRIPTION
HTML files must not be opened directly because it could
contain malicious JavaScript which will be executed in the context
of the current http session

322241