### PR TITLE
Upgrade Selenium from 3.141.59 to 4.2.2

### DIFF
--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/AbstractSeleniumTest.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/AbstractSeleniumTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.ui.html.selenium.junit;
 
 import static org.eclipse.scout.rt.ui.html.selenium.util.SeleniumUtil.shortPause;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -431,7 +432,7 @@ public abstract class AbstractSeleniumTest {
   }
 
   protected <V> V waitUntil(Function<WebDriver, V> condition, int timeoutInSeconds) {
-    return new WebDriverWait(s_driver, timeoutInSeconds).until(condition);
+    return new WebDriverWait(s_driver, Duration.ofSeconds(timeoutInSeconds)).until(condition);
   }
 
   public void resetWaitUntilTimeout() {
@@ -585,16 +586,16 @@ public abstract class AbstractSeleniumTest {
 
   /**
    * Used as a replacement for WebElement#clear. Google changed the way clear() works in ChromeDriver > 2.43 and the
-   * method now causes the field to loose focus, which triggers a lot of focus-out handlers that haven't called before
-   * version 2.43. Thus this method works with 'select all' and backspace. Additionally it also triggers key/up down
-   * events which is also a desired side-effect of this method (clear() does not trigger key events).
+   * method now causes the field to lose focus, which triggers a lot of focus-out handlers that haven't called before
+   * version 2.43. Thus, this method works with 'select all' and backspace. Additionally, it also triggers key/up down
+   * events which is also a desired side effect of this method (clear() does not trigger key events).
    * <p>
    * Note: you can still use WebElement#clear if focus loss doesn't matter. But for a lot of widgets, especially
    * SmartFields it makes a difference.
    *
    * @param withPause
-   *          whether or not a short pause should be made after the field has been cleared, this may be necessary for
-   *          some SmartFields
+   *          whether a short pause should be made after the field has been cleared, this may be necessary for some
+   *          SmartFields
    */
   public void clearInput(WebElement input, boolean withPause) {
     selectAll(input);
@@ -605,12 +606,12 @@ public abstract class AbstractSeleniumTest {
   }
 
   /**
-   * Fails when the given element does not contain all of the given CSS classes.
+   * Fails when the given element does not contain all the given CSS classes.
    *
    * @param expectedCssClass
    *          A single CSS class-name or multiple CSS class-names separated by space. Example: <code>'menu-item'</code>
    *          or <code>'menu-item selected'</code>. If multiple CSS class-names are given, the given element must have
-   *          all of these classes, otherwise the assert will fail.
+   *          all of these classes, otherwise the assertion will fail.
    */
   public void assertCssClass(WebElement element, String expectedCssClass) {
     waitUntil(SeleniumExpectedConditions.elementToHaveCssClass(element, expectedCssClass));

--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/ScreenshotRule.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/ScreenshotRule.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -15,6 +15,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Date;
 
+import org.eclipse.scout.rt.platform.exception.PlatformException;
 import org.eclipse.scout.rt.platform.util.date.DateUtility;
 import org.eclipse.scout.rt.ui.html.selenium.util.SeleniumUtil;
 import org.junit.rules.TestRule;
@@ -65,7 +66,10 @@ public class ScreenshotRule implements TestRule {
   public void captureScreenshot(Description description) {
     try {
       File screenshotDir = new File("target/surefire-reports/");
-      screenshotDir.mkdirs(); // Ensure directory is there
+      boolean success = screenshotDir.mkdirs(); // Ensure directory is there
+      if (!success) {
+        throw new PlatformException("Error creating screenshot directories '{}'.", screenshotDir);
+      }
       String timestamp = DateUtility.format(new Date(), "yyyyMMddhhmmss");
       String className = description.getClassName();
       String methodName = description.getMethodName();

--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/SeleniumAssert.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/SeleniumAssert.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -24,13 +24,12 @@ public final class SeleniumAssert {
   }
 
   /**
-   * Fails when the given element does not contain all of the given CSS classes.
+   * Fails when the given element does not contain all the given CSS classes.
    *
-   * @param element
    * @param expectedCssClass
    *          A single CSS class-name or multiple CSS class-names separated by space. Example: <code>'menu-item'</code>
    *          or <code>'menu-item selected'</code>. If multiple CSS class-names are given, the given element must have
-   *          all of these classes, otherwise the assert will fail.
+   *          all of these classes, otherwise the assertion will fail.
    */
   public static void assertCssClass(AbstractSeleniumTest test, WebElement element, String expectedCssClass) {
     test.waitUntil(SeleniumExpectedConditions.elementToHaveCssClass(element, expectedCssClass));
@@ -38,9 +37,6 @@ public final class SeleniumAssert {
 
   /**
    * Fails when the given element contains at least one of the given CSS classes.
-   *
-   * @param element
-   * @param expectedCssClass
    */
   public static void assertCssClassNotExists(AbstractSeleniumTest test, WebElement element, String expectedCssClass) {
     test.waitUntil(SeleniumExpectedConditions.elementNotToHaveCssClass(element, expectedCssClass));

--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumExpectedConditions.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumExpectedConditions.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -54,7 +54,7 @@ public final class SeleniumExpectedConditions {
    * Used to wait until the given element is focused.
    */
   public static ExpectedCondition<Boolean> elementToBeFocused(final WebElement element) {
-    return new ExpectedCondition<Boolean>() {
+    return new ExpectedCondition<>() {
       @Override
       public Boolean apply(WebDriver driver) {
         try {
@@ -77,7 +77,7 @@ public final class SeleniumExpectedConditions {
    * Used to wait until the given element is <em>not</em> focused anymore.
    */
   public static ExpectedCondition<Boolean> elementNotToBeFocused(final WebElement element) {
-    return new ExpectedCondition<Boolean>() {
+    return new ExpectedCondition<>() {
       @Override
       public Boolean apply(WebDriver driver) {
         try {
@@ -156,7 +156,7 @@ public final class SeleniumExpectedConditions {
   }
 
   private static ExpectedCondition<Boolean> attributeToCompareValue(final TextComparator comparator, final WebElement element, final String attributeName, final String value) {
-    return new ExpectedCondition<Boolean>() {
+    return new ExpectedCondition<>() {
       private String m_actualValue = null;
 
       @Override
@@ -187,7 +187,7 @@ public final class SeleniumExpectedConditions {
    * Waits until the given element has the requested CSS class.
    */
   public static ExpectedCondition<Boolean> elementToHaveCssClass(final WebElement element, final String cssClass) {
-    return new ExpectedCondition<Boolean>() {
+    return new ExpectedCondition<>() {
       private String m_actualValue = null;
 
       @Override
@@ -216,7 +216,7 @@ public final class SeleniumExpectedConditions {
    * Waits until the given element doesn't have the requested CSS class.
    */
   public static ExpectedCondition<Boolean> elementNotToHaveCssClass(final WebElement element, final String cssClass) {
-    return new ExpectedCondition<Boolean>() {
+    return new ExpectedCondition<>() {
       private String m_actualValue = null;
 
       @Override
@@ -272,7 +272,7 @@ public final class SeleniumExpectedConditions {
    * @return Number of child divs found by the expected condition
    */
   public static ExpectedCondition<List<WebElement>> containerToHaveNumberOfChildDivs(final WebElement parentElement, final String divClass, final int numDivs) {
-    return new ExpectedCondition<List<WebElement>>() {
+    return new ExpectedCondition<>() {
       @Override
       public List<WebElement> apply(WebDriver driver) {
         try {
@@ -315,7 +315,7 @@ public final class SeleniumExpectedConditions {
    * @return The table-rows found by the expected condition
    */
   public static ExpectedCondition<List<WebElement>> tableToHaveNumberOfRows(final WebElement parentElement, final String rowText, final int numRows) {
-    return new ExpectedCondition<List<WebElement>>() {
+    return new ExpectedCondition<>() {
       @Override
       public List<WebElement> apply(WebDriver driver) {
         try {
@@ -349,7 +349,7 @@ public final class SeleniumExpectedConditions {
   }
 
   public static ExpectedCondition<Boolean> scriptToReturnTrue(final String script, final Object... args) {
-    return new ExpectedCondition<Boolean>() {
+    return new ExpectedCondition<>() {
       @Override
       public Boolean apply(WebDriver driver) {
         if (!(driver instanceof JavascriptExecutor)) {

--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumJavaScript.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumJavaScript.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -97,7 +97,7 @@ public final class SeleniumJavaScript {
    * Simulates we have a touch device by calling <code>scout.selenium.setSupportsTouch(boolean)</code>.
    */
   public static void setSupportsTouch(AbstractSeleniumTest test, boolean supportsTouch) {
-    executeScript(test, "scout.selenium.setSupportsTouch(" + Boolean.toString(supportsTouch) + ")");
+    executeScript(test, "scout.selenium.setSupportsTouch(" + supportsTouch + ")");
   }
 
   /**

--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumUtil.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumUtil.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -32,7 +32,7 @@ public final class SeleniumUtil {
   private static final String DEFAULT_QUERY_PARAMS = "debug=true"; // /&logging=1
 
   /**
-   * DOM attribute as used by Scout widgets to identify the Scout Java model class.
+   * DOM attribute used by Scout widgets to identify the Scout Java model class.
    */
   private static final String ATTR_DATA_MODELCLASS = "data-modelclass";
 
@@ -78,8 +78,8 @@ public final class SeleniumUtil {
   /**
    * Returns an XPath selector that matches an element with the given CSS class and containing the given text.
    * <p>
-   * Info: we use normalize-space to find text in elements that contain new-line <code>\n</code> characters. Also we use
-   * the dot locator (=current element) instead of the <code>text()</code> function.
+   * Info: we use normalize-space to find text in elements that contain new-line <code>\n</code> characters. Also, we
+   * use the dot locator (=current element) instead of the <code>text()</code> function.
    */
   private static By byCssClassAndText(String cssClass, String findFunction, String text) {
     return By.xpath("//*[" + cssClassQuery(cssClass) + " and " + findFunction + "(normalize-space(.), '" + text + "')]");
@@ -87,11 +87,8 @@ public final class SeleniumUtil {
 
   /**
    * This query solves the problem that we don't want to find partial matches for a CSS class-name when we query 'class'
-   * attribute in the DOM.
-   *
-   * @param className
-   * @see https://stackoverflow.com/questions/1604471/how-can-i-find-an-element-by-css-class-with-xpath
-   * @return
+   * attribute in the DOM. See
+   * https://stackoverflow.com/questions/1604471/how-can-i-find-an-element-by-css-class-with-xpath
    */
   private static String cssClassQuery(String cssClass) {
     return "contains(concat(' ', normalize-space(@class), ' '), ' " + cssClass + " ')";
@@ -101,7 +98,6 @@ public final class SeleniumUtil {
    * Returns an XPath selector that matches a tree node element has exactly the given text. Since the XPath query
    * matches the SPAN element, you should request the parent element to get to the tree node.
    *
-   * @param text
    * @return The SPAN element which contains the given text.
    */
   public static By byTreeNodeWithText(String text) {
@@ -165,7 +161,7 @@ public final class SeleniumUtil {
   }
 
   /**
-   * @return a CSS selector for the given model class, with double quoted strings. Example:<br>
+   * @return a CSS selector for the given model class, with double-quoted strings. Example:<br>
    *         <code>data-modelclass="com.bsiag.widgets.FooBar$MainBox"</code>
    */
   public static String getModelClassCssSelector(Class<?> modelClass) {
@@ -189,7 +185,7 @@ public final class SeleniumUtil {
   }
 
   /**
-   * Creates an Xpath expression that matches an element with the given model-class and an attribute that does NOT
+   * Creates a Xpath expression that matches an element with the given model-class and an attribute that does NOT
    * contain the given value.
    */
   public static By byModelClassAttributeContainsNot(Class<?> modelClass, String attribute, String value) {
@@ -298,7 +294,7 @@ public final class SeleniumUtil {
   }
 
   /**
-   * @return Whether or not the VM runs on Windows 8.x.
+   * @return Whether the VM runs on Windows 8.x.
    */
   public static boolean isWindows8() {
     return StringUtility.containsString(System.getProperty("os.name"), "Windows 8");

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -245,17 +245,7 @@
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-java</artifactId>
-        <version>3.141.59</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>4.2.2</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This is required to solve security issues with the okhttp client bundled
with the old Selenium version. It is not compatible with a newer okhttp
version which blocks the patching.
The new version no longer includes okhttp which solves this issue.