### PR TITLE
Detect content type from content or filename

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/UploadRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/UploadRequestHandler.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -236,10 +236,9 @@ public class UploadRequestHandler extends AbstractUiServletRequestHandler {
       try (InputStream in = item.openStream()) {
         content = IOUtility.readBytes(in);
       }
-      String contentType = item.getContentType();
       BinaryResource res = BinaryResources.create()
           .withFilename(filename)
-          .withContentType(contentType)
+          .withContentType(detectContentType(filename, content))
           .withContent(content)
           .build();
       verifyFileSafety(res);
@@ -259,6 +258,14 @@ public class UploadRequestHandler extends AbstractUiServletRequestHandler {
         uploadResources.add(res);
       }
     }
+  }
+
+  /**
+   * Override this method for custom content-type detection logic. Default implementation returns <code>null</code> and
+   * the content-type is detected from the file-extension in the constructor of {@link BinaryResource}
+   */
+  protected String detectContentType(String filename, byte[] content) throws IOException {
+    return null;
   }
 
   /**


### PR DESCRIPTION
Do not use content type passed by the browser as this can be influenced
by the uploader.

323187