### PR TITLE
Codes types: execOverwriteCode must also be called for children

### DIFF
--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/AbstractCodeTypeWithGeneric.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/AbstractCodeTypeWithGeneric.java
@@ -443,11 +443,12 @@ public abstract class AbstractCodeTypeWithGeneric<CODE_TYPE_ID, CODE_ID, CODE ex
     // 1a add configured codes
     List<? extends CODE> createdList = interceptCreateCodes();
     if (createdList != null) {
-      for (CODE code : createdList) {
+      visit(createdList, (CODE code, int treeLevel) -> {
         allCodesOrdered.add(code);
         idToCodeMap.put(code.getId(), code);
-        codeToParentCodeMap.put(code, null);
-      }
+        codeToParentCodeMap.put(code, code.getParentCode() != null ? idToCodeMap.get(code.getParentCode().getId()) : null);
+        return true;
+      }, false);
     }
     // 1b add dynamic codes
     List<? extends ICodeRow<CODE_ID>> result = interceptLoadCodes(getConfiguredCodeRowType());
@@ -585,10 +586,14 @@ public abstract class AbstractCodeTypeWithGeneric<CODE_TYPE_ID, CODE_ID, CODE ex
     return visit(visitor, true);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public <T extends ICode<CODE_ID>> boolean visit(ICodeVisitor<T> visitor, boolean activeOnly) {
-    for (CODE code : getCodes(activeOnly)) {
+    return visit(getCodes(activeOnly), visitor, activeOnly);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <T extends ICode<CODE_ID>> boolean visit(List<? extends CODE> codes, ICodeVisitor<T> visitor, boolean activeOnly) {
+    for (CODE code : codes) {
       if (!visitor.visit((T) code, 0)) {
         return false;
       }


### PR DESCRIPTION
For code types, codes for loadCodes are initially supplied by
execCreateCodes and additionally this list may be enriched by
execLoadCodes (e.g. modify existing codes or add additional codes). If
existing codes are modified execOverwriteCode should be called to
influence this modification. However, previously execOverwriteCode was
only called for the root codes but not for child codes, it must as well
be called for child codes.

297625

(cherry picked from commit a9c56f764ed164cb6498833c46a2469463c9810e)