### PR TITLE
Add JsForm

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/Page.js
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -198,6 +198,11 @@ export default class Page extends TreeNode {
     if (form instanceof Form) {
       form.setModal(false);
       form.setClosable(false);
+
+      form.setDisplayHint(Form.DisplayHint.VIEW);
+      form.setDisplayViewId('C');
+
+      form.setShowOnOpen(false);
     }
     if (form instanceof TileOverviewForm) {
       form.setPage(this);

--- a/eclipse-scout-core/src/form/Form.js
+++ b/eclipse-scout-core/src/form/Form.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -21,6 +21,7 @@ export default class Form extends Widget {
     this.askIfNeedSave = true;
     this.askIfNeedSaveText = null; // if not set, a default text is used (see Lifecycle.js)
     this.data = {};
+    this.displayViewId = null;
     this.displayHint = Form.DisplayHint.DIALOG;
     this.displayParent = null; // only relevant if form is opened, not relevant if form is just rendered into another widget (not managed by a form controller)
     this.maximized = false;
@@ -44,6 +45,7 @@ export default class Form extends Widget {
     this.messageBoxController = null;
     this.fileChooserController = null;
     this.closeKeyStroke = null;
+    this.showOnOpen = true;
     this._glassPaneRenderer = null;
     this._preMaximizedBounds = null;
     this._resizeHandler = this._onResize.bind(this);
@@ -239,7 +241,9 @@ export default class Form extends Widget {
           // If form has been closed right after it was opened don't try to show it
           return;
         }
-        this.show();
+        if (this.showOnOpen) {
+          this.show();
+        }
       });
   }
 
@@ -754,6 +758,10 @@ export default class Form extends Widget {
     }
   }
 
+  setDisplayViewId(displayViewId) {
+    this.setProperty('displayViewId', displayViewId);
+  }
+
   setDisplayHint(displayHint) {
     this.setProperty('displayHint', displayHint);
   }
@@ -818,6 +826,10 @@ export default class Form extends Widget {
       return $statusIcon;
     }
     return $prevIcon;
+  }
+
+  setShowOnOpen(showOnOpen) {
+    this.setProperty('showOnOpen', showOnOpen);
   }
 
   _updateTitleForWindow() {

--- a/eclipse-scout-core/src/form/js/JsFormAdapter.js
+++ b/eclipse-scout-core/src/form/js/JsFormAdapter.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {FormAdapter} from '../../index';
+
+/**
+ * @typedef JsFormModel
+ * @property {object} parent
+ * @property {object} owner
+ * @property {object} displayParent
+ * @property {object} inputData
+ * @property {string} jsFormObjectType
+ * @property {object} jsFormModel
+ */
+
+export default class JsFormAdapter extends FormAdapter {
+
+  constructor() {
+    super();
+  }
+
+  /**
+   * @param {JsFormModel} model
+   */
+  _initModel(model, parent) {
+    model = super._initModel(model, parent);
+
+    if (!model.jsFormObjectType || !model.jsFormObjectType.length) {
+      throw new Error('jsFormObjectType not set');
+    }
+
+    let jsFormModel = {
+      parent: model.parent,
+      owner: model.owner,
+      objectType: model.jsFormObjectType,
+      displayParent: model.displayParent,
+      data: model.inputData
+    };
+
+    if (model.jsFormModel) {
+      jsFormModel = $.extend(true, {}, model.jsFormModel, jsFormModel);
+    }
+
+    return jsFormModel;
+  }
+
+  _createWidget(model) {
+    let widget = super._createWidget(model);
+
+    widget.showOnOpen = false;
+    widget.open();
+
+    return widget;
+  }
+
+  _onWidgetEvent(event) {
+    if (event.type === 'save') {
+      this._onWidgetSave(event);
+    } else {
+      super._onWidgetEvent(event);
+    }
+  }
+
+  _onWidgetSave(event) {
+    this._send('save', {
+      outputData: this.widget.data
+    });
+  }
+
+  _onWidgetClose(event) {
+    // marks the end of the js lifecycle
+    // prevent remove/destroy of the widget as it will be done by the UI server
+    event.preventDefault();
+    // fromClosing will trigger a 'formHide' event on the desktop which then removes the widget
+    this._send('formClosing');
+  }
+
+  _onWidgetAbort(event) {
+    // completely handled by the js lifecycle -> no need to notify the UI server
+  }
+}

--- a/eclipse-scout-core/src/index.js
+++ b/eclipse-scout-core/src/index.js
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -294,6 +294,7 @@ export {default as GroupBoxResponsiveHandler} from './form/GroupBoxResponsiveHan
 export {default as DesktopResponsiveHandler} from './form/DesktopResponsiveHandler';
 export {default as TileOverviewForm} from './form/TileOverviewForm';
 export {default as TileOverviewFormAdapter} from './form/TileOverviewFormAdapter';
+export {default as JsFormAdapter} from './form/js/JsFormAdapter';
 export {default as Table} from './table/Table';
 export {default as TableAdapter} from './table/TableAdapter';
 export {default as TableCompactHandler} from './table/TableCompactHandler';

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/AbstractJsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/AbstractJsForm.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.client.ui.form.js;
+
+import java.lang.reflect.ParameterizedType;
+
+import org.eclipse.scout.rt.client.ModelContextProxy;
+import org.eclipse.scout.rt.client.ModelContextProxy.ModelContext;
+import org.eclipse.scout.rt.client.ui.form.AbstractForm;
+import org.eclipse.scout.rt.client.ui.form.fields.groupbox.AbstractGroupBox;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.platform.annotations.ConfigProperty;
+import org.eclipse.scout.rt.platform.classid.ClassId;
+import org.eclipse.scout.rt.platform.util.Assertions;
+
+@ClassId("371cbcfe-b79b-4d20-acfb-2a1b5ca375bf")
+public abstract class AbstractJsForm<IN extends IDataObject, OUT extends IDataObject> extends AbstractForm implements IJsForm<IN, OUT> {
+
+  private IJsFormUIFacade<OUT> m_uiFacade;
+
+  private final Class<IN> m_inputDataType;
+  private final Class<OUT> m_outputDataType;
+
+  // Transport from UI to model (different threads)
+  private volatile OUT m_outputData;
+
+  public AbstractJsForm() {
+    this(true);
+  }
+
+  public AbstractJsForm(boolean callInitializer) {
+    super(false);
+
+    Class<?> clazz = getClass();
+    while (clazz.getSuperclass() != AbstractJsForm.class) {
+      clazz = clazz.getSuperclass();
+    }
+
+    ParameterizedType parameterizedType = Assertions.assertInstance(clazz.getGenericSuperclass(), ParameterizedType.class);
+
+    //noinspection unchecked
+    m_inputDataType = (Class<IN>) parameterizedType.getActualTypeArguments()[0];
+    //noinspection unchecked
+    m_outputDataType = (Class<OUT>) parameterizedType.getActualTypeArguments()[1];
+    if (callInitializer) {
+      callInitializer();
+    }
+  }
+
+  @Override
+  protected void initConfig() {
+    super.initConfig();
+    setJsFormObjectType(getConfiguredJsFormObjectType());
+    setJsFormModel(getConfiguredJsFormModel());
+    m_uiFacade = BEANS.get(ModelContextProxy.class).newProxy(new P_UIFacade(), ModelContext.copyCurrent());
+  }
+
+  /**
+   * @return the objectType of the jsForm to be opened
+   */
+  @ConfigProperty(ConfigProperty.TEXT)
+  @Order(210)
+  protected String getConfiguredJsFormObjectType() {
+    return null;
+  }
+
+  /**
+   * @return additional model for the jsForm
+   */
+  @ConfigProperty(ConfigProperty.OBJECT)
+  @Order(220)
+  protected IDoEntity getConfiguredJsFormModel() {
+    return null;
+  }
+
+  @Override
+  protected boolean getConfiguredAskIfNeedSave() {
+    return false;
+  }
+
+  @Override
+  public IJsFormUIFacade<OUT> getUIFacade() {
+    return m_uiFacade;
+  }
+
+  @Override
+  public Class<IN> getInputDataType() {
+    return m_inputDataType;
+  }
+
+  @Override
+  public Class<OUT> getOutputDataType() {
+    return m_outputDataType;
+  }
+
+  @Override
+  public IN getInputData() {
+    //noinspection unchecked
+    return (IN) propertySupport.getProperty(PROP_INPUT_DATA);
+  }
+
+  @Override
+  public void setInputData(IN inputData) {
+    propertySupport.setProperty(PROP_INPUT_DATA, inputData);
+  }
+
+  @Override
+  public String getJsFormObjectType() {
+    return propertySupport.getPropertyString(PROP_JS_FORM_OBJECT_TYPE);
+  }
+
+  @Override
+  public void setJsFormObjectType(String jsFormObjectType) {
+    propertySupport.setPropertyString(PROP_JS_FORM_OBJECT_TYPE, jsFormObjectType);
+  }
+
+  @Override
+  public IDoEntity getJsFormModel() {
+    return (IDoEntity) propertySupport.getProperty(PROP_JS_FORM_MODEL);
+  }
+
+  @Override
+  public void setJsFormModel(IDoEntity jsFormModel) {
+    propertySupport.setProperty(PROP_JS_FORM_MODEL, jsFormModel);
+  }
+
+  @Override
+  public OUT getOutputData() {
+    return m_outputData;
+  }
+
+  protected void setOutputData(OUT outputData) {
+    m_outputData = outputData;
+    touch();
+  }
+
+  protected void save(OUT outputData) {
+    setOutputData(outputData);
+    doSave();
+  }
+
+  @Order(1000)
+  @ClassId("4d09d51a-2a15-4863-8921-2eead40957fa")
+  public class MainBox extends AbstractGroupBox {
+  }
+
+  protected class P_UIFacade extends AbstractForm.P_UIFacade implements IJsFormUIFacade<OUT> {
+
+    @Override
+    public void fireSaveFromUI(OUT outputData) {
+      save(outputData);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/IJsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/IJsForm.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.client.ui.form.js;
+
+import org.eclipse.scout.rt.client.ui.form.IForm;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+
+/**
+ * Wraps a form implemented in ScoutJS. This jsForm will be opened by the JsFormAdapter and its whole lifecycle will be
+ * handled by the browser. To determine which jsForm is opened the property {@code jsFormObjectType} is used, an
+ * additional model can be passed using {@code jsFormModel}. It is possible to pass some {@code inputData} into the
+ * jsForm and retrieve an {@code outputData} after the jsForm is closed.
+ */
+public interface IJsForm<IN extends IDataObject, OUT extends IDataObject> extends IForm {
+
+  String PROP_INPUT_DATA = "inputData";
+  String PROP_JS_FORM_OBJECT_TYPE = "jsFormObjectType";
+  String PROP_JS_FORM_MODEL = "jsFormModel";
+
+  @Override
+  IJsFormUIFacade<OUT> getUIFacade();
+
+  Class<IN> getInputDataType();
+
+  Class<OUT> getOutputDataType();
+
+  void setInputData(IN inputData);
+
+  IN getInputData();
+
+  OUT getOutputData();
+
+  String getJsFormObjectType();
+
+  void setJsFormObjectType(String jsFormObjectType);
+
+  IDoEntity getJsFormModel();
+
+  void setJsFormModel(IDoEntity jsFormModel);
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/IJsFormUIFacade.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/IJsFormUIFacade.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.client.ui.form.js;
+
+import org.eclipse.scout.rt.client.ui.form.IFormUIFacade;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+
+public interface IJsFormUIFacade<OUT extends IDataObject> extends IFormUIFacade {
+
+  void fireSaveFromUI(OUT outputData);
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/JsonObjectFactory.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/JsonObjectFactory.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -98,6 +98,7 @@ import org.eclipse.scout.rt.client.ui.form.fields.treebox.ITreeBox;
 import org.eclipse.scout.rt.client.ui.form.fields.treefield.ITreeField;
 import org.eclipse.scout.rt.client.ui.form.fields.wizard.IWizardProgressField;
 import org.eclipse.scout.rt.client.ui.form.fields.wrappedform.IWrappedFormField;
+import org.eclipse.scout.rt.client.ui.form.js.IJsForm;
 import org.eclipse.scout.rt.client.ui.group.IGroup;
 import org.eclipse.scout.rt.client.ui.label.ILabel;
 import org.eclipse.scout.rt.client.ui.messagebox.IMessageBox;
@@ -184,6 +185,7 @@ import org.eclipse.scout.rt.ui.html.json.form.fields.treebox.JsonTreeBox;
 import org.eclipse.scout.rt.ui.html.json.form.fields.treefield.JsonTreeField;
 import org.eclipse.scout.rt.ui.html.json.form.fields.wizard.JsonWizardProgressField;
 import org.eclipse.scout.rt.ui.html.json.form.fields.wrappedform.JsonWrappedFormField;
+import org.eclipse.scout.rt.ui.html.json.form.js.JsonJsForm;
 import org.eclipse.scout.rt.ui.html.json.group.JsonGroup;
 import org.eclipse.scout.rt.ui.html.json.label.JsonLabel;
 import org.eclipse.scout.rt.ui.html.json.menu.JsonComboMenu;
@@ -371,6 +373,9 @@ public class JsonObjectFactory extends AbstractJsonObjectFactory {
     }
     if (model instanceof IKeyStroke) {
       return new JsonKeyStroke<>((IKeyStroke) model, session, id, parent);
+    }
+    if (model instanceof IJsForm<?, ?>) {
+      return new JsonJsForm<>((IJsForm<?, ?>) model, session, id, parent);
     }
     if (model instanceof ITileOverviewForm) {
       return new JsonTileOverviewForm((ITileOverviewForm) model, session, id, parent);

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonDataObjectHelper.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonDataObjectHelper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.ui.html.json;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.scout.rt.dataobject.DoList;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Bean;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+@Bean
+public class JsonDataObjectHelper {
+
+  protected final IDataObjectMapper m_defaultDataObjectMapper = BEANS.get(IDataObjectMapper.class);
+  protected IDataObjectMapper m_dataObjectMapper = null;
+
+  public IDataObjectMapper getDataObjectMapper() {
+    return (m_dataObjectMapper == null ? m_defaultDataObjectMapper : m_dataObjectMapper);
+  }
+
+  public JsonDataObjectHelper withDataObjectMapper(IDataObjectMapper dataObjectMapper) {
+    m_dataObjectMapper = dataObjectMapper;
+    return this;
+  }
+
+  public JSONObject dataObjectToJson(IDoEntity dataObject) {
+    if (dataObject == null) {
+      return null;
+    }
+    String str = getDataObjectMapper().writeValue(dataObject);
+    return new JSONObject(str);
+  }
+
+  public JSONArray dataObjectsToJson(List<? extends IDoEntity> dataObjects) {
+    if (dataObjects == null) {
+      return null;
+    }
+    String str = getDataObjectMapper().writeValue(dataObjects);
+    return new JSONArray(str);
+  }
+
+  public <T extends IDoEntity> JSONArray dataObjectsToJson(List<T> dataObjects, Function<T, JSONObject> mapper) {
+    return dataObjectsToJson(dataObjects, mapper, true);
+  }
+
+  public <T extends IDoEntity> JSONArray dataObjectsToJson(List<T> dataObjects, Function<T, JSONObject> mapper, boolean skipNulls) {
+    if (dataObjects == null) {
+      return null;
+    }
+    return new JSONArray(dataObjects.stream()
+        .map(mapper)
+        .filter(skipNulls ? Objects::nonNull : x -> true)
+        .collect(Collectors.toList()));
+  }
+
+  public <T extends IDataObject> T jsonToDataObject(JSONObject jsonObject, Class<T> type) {
+    if (jsonObject == null) {
+      return null;
+    }
+    return getDataObjectMapper().readValue(jsonObject.toString(), type);
+  }
+
+  public <T extends IDataObject> List<T> jsonToDataObjects(JSONArray jsonArray, Class<T> type) {
+    if (jsonArray == null) {
+      return null;
+    }
+    @SuppressWarnings("unchecked")
+    DoList<T> list = getDataObjectMapper().readValue(jsonArray.toString(), DoList.class);
+    return list.get();
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/js/JsonJsForm.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/js/JsonJsForm.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.ui.html.json.form.js;
+
+import org.eclipse.scout.rt.client.ui.form.js.IJsForm;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.ui.html.IUiSession;
+import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
+import org.eclipse.scout.rt.ui.html.json.JsonDataObjectHelper;
+import org.eclipse.scout.rt.ui.html.json.JsonEvent;
+import org.eclipse.scout.rt.ui.html.json.JsonProperty;
+import org.eclipse.scout.rt.ui.html.json.form.JsonForm;
+import org.json.JSONObject;
+
+public class JsonJsForm<IN extends IDataObject, OUT extends IDataObject, T extends IJsForm<IN, OUT>> extends JsonForm<T> {
+
+  private static final String EVENT_SAVE = "save";
+
+  private final JsonDataObjectHelper m_jsonDoHelper = BEANS.get(JsonDataObjectHelper.class); // cached instance
+
+  public JsonJsForm(T model, IUiSession uiSession, String id, IJsonAdapter<?> parent) {
+    super(model, uiSession, id, parent);
+  }
+
+  @Override
+  public String getObjectType() {
+    return "JsForm";
+  }
+
+  @Override
+  protected void initJsonProperties(T model) {
+    putJsonProperty(new JsonProperty<IJsForm<IN, OUT>>(IJsForm.PROP_INPUT_DATA, model) {
+      @Override
+      protected IN modelValue() {
+        return getModel().getInputData();
+      }
+
+      @Override
+      public Object prepareValueForToJson(Object value) {
+        return jsonDoHelper().dataObjectToJson((IDoEntity) value);
+      }
+    });
+    putJsonProperty(new JsonProperty<IJsForm<IN, OUT>>(IJsForm.PROP_JS_FORM_OBJECT_TYPE, model) {
+      @Override
+      protected String modelValue() {
+        return getModel().getJsFormObjectType();
+      }
+    });
+    putJsonProperty(new JsonProperty<IJsForm<IN, OUT>>(IJsForm.PROP_JS_FORM_MODEL, model) {
+      @Override
+      protected IDoEntity modelValue() {
+        return getModel().getJsFormModel();
+      }
+
+      @Override
+      public Object prepareValueForToJson(Object value) {
+        return jsonDoHelper().dataObjectToJson((IDoEntity) value);
+      }
+    });
+  }
+
+  protected JsonDataObjectHelper jsonDoHelper() {
+    return m_jsonDoHelper;
+  }
+
+  @Override
+  public void handleUiEvent(JsonEvent event) {
+    if (EVENT_SAVE.equals(event.getType())) {
+      handleUiSave(event);
+    }
+    else {
+      super.handleUiEvent(event);
+    }
+  }
+
+  protected void handleUiSave(JsonEvent event) {
+    JSONObject outputDataJson = event.getData().optJSONObject("outputData");
+    OUT outputData = jsonDoHelper().jsonToDataObject(outputDataJson, getModel().getOutputDataType());
+    getModel().getUIFacade().fireSaveFromUI(outputData);
+  }
+}


### PR DESCRIPTION
The JsForm is a Java-form that wraps a form implemented in JS. This
allows a Scout Classic application to open a ScoutJS form. The whole
lifecycle of this form will be handled by ScoutJS.
Add possibility to not show a ScoutJS form on open().
Improve detailForm support of ScoutJS page.

325223