### PR TITLE
StringField: fix layout when hasAction was toggled while disabled

### DIFF
--- a/eclipse-scout-core/src/form/fields/stringfield/StringField.js
+++ b/eclipse-scout-core/src/form/fields/stringfield/StringField.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -246,6 +246,14 @@ export default class StringField extends BasicField {
       this._removeIcon();
       this.$container.removeClass('has-icon');
     }
+    this.revalidateLayout();
+  }
+
+  /**
+   * @override
+   */
+  _renderEnabled() {
+    super._renderEnabled();
     this.revalidateLayout();
   }
 


### PR DESCRIPTION
When hasAction is set to true while the field is disabled the layout
will not consider the icon as it is not visible and will therefore
position the clearIcon incorrectly. Revalidation of the layout after
enabled changes fixes this issue.

312042