### PR TITLE
Tree/Table/Planner: defaultValues must only be applied in adapter

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.js
+++ b/eclipse-scout-core/src/desktop/outline/Outline.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, defaultValues, Desktop, DetailTableTreeFilter, Device, FileChooserController, Form, GroupBoxMenuItemsOrder, HtmlComponent, keyStrokeModifier, MenuBar, menus as menuUtil, MessageBoxController, NavigateButton, NavigateDownButton, NavigateUpButton, OutlineKeyStrokeContext, OutlineLayout, OutlineNavigateToTopKeyStroke, OutlineOverview, Page, PageLayout, scout, TableControlAdapterMenu, TableRowDetail, TileOutlineOverview, Tree, TreeCollapseOrDrillUpKeyStroke, TreeExpandOrDrillDownKeyStroke, TreeNavigationDownKeyStroke, TreeNavigationEndKeyStroke, TreeNavigationUpKeyStroke} from '../../index';
+import {arrays, Desktop, DetailTableTreeFilter, Device, FileChooserController, Form, GroupBoxMenuItemsOrder, HtmlComponent, keyStrokeModifier, MenuBar, menus as menuUtil, MessageBoxController, NavigateButton, NavigateDownButton, NavigateUpButton, OutlineKeyStrokeContext, OutlineLayout, OutlineNavigateToTopKeyStroke, OutlineOverview, Page, PageLayout, scout, TableControlAdapterMenu, TableRowDetail, TileOutlineOverview, Tree, TreeCollapseOrDrillUpKeyStroke, TreeExpandOrDrillDownKeyStroke, TreeNavigationDownKeyStroke, TreeNavigationEndKeyStroke, TreeNavigationUpKeyStroke} from '../../index';
 import $ from 'jquery';
 
 /**
@@ -126,16 +126,12 @@ export default class Outline extends Tree {
     return this._createChild(model);
   }
 
-  _applyNodeDefaultValues(node) {
-    defaultValues.applyTo(node, 'Page');
-  }
-
   _createKeyStrokeContext() {
     return new OutlineKeyStrokeContext(this);
   }
 
   _filterMenus(menus, destination, onlyVisible, enableDisableKeyStroke) {
-    // show no contextmenues
+    // show no context menus
     return [];
   }
 

--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.js
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.js
@@ -143,6 +143,10 @@ export default class OutlineAdapter extends TreeAdapter {
     delete this._nodeIdToRowMap[page.id];
   }
 
+  _getDefaultNodeObjectType() {
+    return 'Page';
+  }
+
   /**
    * Static method to modify the prototype of Outline.
    */
@@ -154,6 +158,7 @@ export default class OutlineAdapter extends TreeAdapter {
     objects.replacePrototypeFunction(Outline, '_computeDetailContent', OutlineAdapter._computeDetailContentRemote, true);
     objects.replacePrototypeFunction(Outline, 'updateDetailMenus', OutlineAdapter.updateDetailMenusRemote, true);
     objects.replacePrototypeFunction(Outline, '_initTreeNodeInternal', OutlineAdapter._initTreeNodeInternalRemote, true);
+    objects.replacePrototypeFunction(Outline, '_createTreeNode', OutlineAdapter._createTreeNodeRemote, true);
   }
 
   /**

--- a/eclipse-scout-core/src/planner/Planner.js
+++ b/eclipse-scout-core/src/planner/Planner.js
@@ -8,29 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {
-  arrays,
-  DateFormat,
-  DateRange,
-  dates,
-  defaultValues,
-  graphics,
-  HtmlComponent,
-  KeyStrokeContext,
-  MenuBar,
-  menus as menus_1,
-  objects,
-  PlannerLayout,
-  PlannerMenuItemsOrder,
-  Range,
-  scout,
-  scrollbars,
-  strings,
-  styles,
-  tooltips,
-  TooltipSupport,
-  Widget
-} from '../index';
+import {arrays, DateFormat, DateRange, dates, graphics, HtmlComponent, KeyStrokeContext, MenuBar, menus as menus_1, objects, PlannerLayout, PlannerMenuItemsOrder, Range, scout, scrollbars, strings, styles, tooltips, TooltipSupport, Widget} from '../index';
 import $ from 'jquery';
 
 export default class Planner extends Widget {
@@ -146,17 +124,13 @@ export default class Planner extends Widget {
   }
 
   _initResource(resource) {
-    defaultValues.applyTo(resource, 'Resource');
-    resource.activities.forEach(function(activity) {
-      this._initActivity(activity);
-    }, this);
+    resource.activities.forEach(activity => this._initActivity(activity));
     this.resourceMap[resource.id] = resource;
   }
 
   _initActivity(activity) {
     activity.beginTime = dates.parseJsonDate(activity.beginTime);
     activity.endTime = dates.parseJsonDate(activity.endTime);
-    defaultValues.applyTo(activity, 'Activity');
     this.activityMap[activity.id] = activity;
   }
 

--- a/eclipse-scout-core/src/planner/PlannerAdapter.js
+++ b/eclipse-scout-core/src/planner/PlannerAdapter.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {DateRange, dates, ModelAdapter} from '../index';
+import {App, DateRange, dates, defaultValues, ModelAdapter, objects, Planner} from '../index';
 
 export default class PlannerAdapter extends ModelAdapter {
 
@@ -113,4 +113,29 @@ export default class PlannerAdapter extends ModelAdapter {
       super.onModelAction(event);
     }
   }
+
+  static _initResourceRemote(resource) {
+    if (this.modelAdapter) {
+      defaultValues.applyTo(resource, 'Resource');
+    }
+    return this._initResourceOrig(resource);
+  }
+
+  static _initActivityRemote(activity) {
+    if (this.modelAdapter) {
+      defaultValues.applyTo(activity, 'Activity');
+    }
+    return this._initActivityOrig(activity);
+  }
+
+  static modifyPlannerPrototype() {
+    if (!App.get().remote) {
+      return;
+    }
+
+    objects.replacePrototypeFunction(Planner, '_initResource', PlannerAdapter._initResourceRemote, true);
+    objects.replacePrototypeFunction(Planner, '_initActivity', PlannerAdapter._initActivityRemote, true);
+  }
 }
+
+App.addListener('bootstrap', PlannerAdapter.modifyPlannerPrototype);

--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -222,14 +222,19 @@ export default class Table extends Widget {
 
   _initRow(row) {
     if (!(row instanceof TableRow)) {
-      row.parent = this;
-      row = scout.create('TableRow', row);
+      row = this._createRow(row);
     }
     this.rowsMap[row.id] = row;
     this.trigger('rowInit', {
       row: row
     });
     return row;
+  }
+
+  _createRow(rowModel) {
+    rowModel = $.extend({objectType: 'TableRow'}, rowModel);
+    rowModel.parent = this;
+    return scout.create(rowModel);
   }
 
   _initColumns() {
@@ -5262,16 +5267,15 @@ export default class Table extends Widget {
   }
 
   updateColumnOrder(columns) {
-    let i, column, currentPosition, oldColumnOrder;
     if (columns.length !== this.columns.length) {
       throw new Error('Column order may not be updated because lengths of the arrays differ.');
     }
 
-    oldColumnOrder = this.columns.slice();
+    let oldColumnOrder = this.columns.slice();
 
-    for (i = 0; i < columns.length; i++) {
-      column = columns[i];
-      currentPosition = arrays.findIndex(this.columns, element => element.id === column.id);
+    for (let i = 0; i < columns.length; i++) {
+      let column = columns[i];
+      let currentPosition = arrays.findIndex(this.columns, element => element.id === column.id);
       if (currentPosition < 0) {
         throw new Error('Column with id ' + column.id + 'not found.');
       }

--- a/eclipse-scout-core/src/table/TableAdapter.js
+++ b/eclipse-scout-core/src/table/TableAdapter.js
@@ -627,6 +627,19 @@ export default class TableAdapter extends ModelAdapter {
     return adapterData;
   }
 
+  _initRowModel(rowModel) {
+    rowModel = $.extend({objectType: 'TableRow'}, rowModel);
+    defaultValues.applyTo(rowModel);
+    return rowModel;
+  }
+
+  static _createRowRemote(rowModel) {
+    if (this.modelAdapter) {
+      rowModel = this.modelAdapter._initRowModel(rowModel);
+    }
+    return this._createRowOrig(rowModel);
+  }
+
   /**
    * Static method to modify the prototype of Table.
    */
@@ -634,6 +647,8 @@ export default class TableAdapter extends ModelAdapter {
     if (!App.get().remote) {
       return;
     }
+
+    objects.replacePrototypeFunction(Table, '_createRow', TableAdapter._createRowRemote, true);
 
     // _sortAfterInsert
     objects.replacePrototypeFunction(Table, '_sortAfterInsert', function(wasEmpty) {

--- a/eclipse-scout-core/src/table/TableRow.js
+++ b/eclipse-scout-core/src/table/TableRow.js
@@ -8,7 +8,6 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {defaultValues} from '../index';
 import $ from 'jquery';
 
 export default class TableRow {
@@ -49,7 +48,6 @@ export default class TableRow {
       throw new Error('missing property \'parent\'');
     }
     $.extend(this, model);
-    defaultValues.applyTo(this);
     this._initCells();
   }
 

--- a/eclipse-scout-core/src/testing/desktop/outline/OutlineSpecHelper.js
+++ b/eclipse-scout-core/src/testing/desktop/outline/OutlineSpecHelper.js
@@ -31,8 +31,8 @@ export default class OutlineSpecHelper {
 
   createModelNode(id, text) {
     return {
-      'id': id,
-      'text': text
+      id: id,
+      text: text
     };
   }
 

--- a/eclipse-scout-core/src/tree/Tree.js
+++ b/eclipse-scout-core/src/tree/Tree.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, ContextMenuPopup, defaultValues, Device, DoubleClickSupport, dragAndDrop, FilterSupport, graphics, HtmlComponent, KeyStrokeContext, keyStrokeModifier, LazyNodeFilter, MenuBar, MenuDestinations, MenuItemsOrder, menus as menus_1, objects, Range, scout, scrollbars, tooltips, TreeBreadcrumbFilter, TreeCollapseAllKeyStroke, TreeCollapseOrDrillUpKeyStroke, TreeExpandOrDrillDownKeyStroke, TreeLayout, TreeNavigationDownKeyStroke, TreeNavigationEndKeyStroke, TreeNavigationUpKeyStroke, TreeNode, TreeSpaceKeyStroke, Widget} from '../index';
+import {arrays, ContextMenuPopup, Device, DoubleClickSupport, dragAndDrop, FilterSupport, graphics, HtmlComponent, KeyStrokeContext, keyStrokeModifier, LazyNodeFilter, MenuBar, MenuDestinations, MenuItemsOrder, menus as menus_1, objects, Range, scout, scrollbars, tooltips, TreeBreadcrumbFilter, TreeCollapseAllKeyStroke, TreeCollapseOrDrillUpKeyStroke, TreeExpandOrDrillDownKeyStroke, TreeLayout, TreeNavigationDownKeyStroke, TreeNavigationEndKeyStroke, TreeNavigationUpKeyStroke, TreeNode, TreeSpaceKeyStroke, Widget} from '../index';
 import $ from 'jquery';
 
 /**
@@ -180,9 +180,9 @@ export default class Tree extends Widget {
   }
 
   _createTreeNode(nodeModel) {
-    nodeModel = scout.nvl(nodeModel, {});
+    nodeModel = $.extend({objectType: 'TreeNode'}, nodeModel);
     nodeModel.parent = this;
-    return scout.create('TreeNode', nodeModel);
+    return scout.create(nodeModel);
   }
 
   /**
@@ -275,16 +275,12 @@ export default class Tree extends Widget {
     node.initialized = true;
   }
 
-  _applyNodeDefaultValues(node) {
-    defaultValues.applyTo(node, 'TreeNode');
-  }
-
   /**
    * Override this function if you want a custom node init before filtering.
-   * The default impl. applies default values to the given node.
+   * The default implementation does nothing.
    */
   _initTreeNodeInternal(node, parentNode) {
-    this._applyNodeDefaultValues(node);
+    // nop
   }
 
   _destroy() {
@@ -2241,7 +2237,6 @@ export default class Tree extends Widget {
       if (updatedNode === oldNode) {
         propertiesChanged = true;
       } else {
-        this._applyNodeDefaultValues(updatedNode);
         propertiesChanged = this._applyUpdatedNodeProperties(oldNode, updatedNode);
       }
 

--- a/eclipse-scout-core/src/tree/TreeAdapter.js
+++ b/eclipse-scout-core/src/tree/TreeAdapter.js
@@ -8,7 +8,8 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, defaultValues, ModelAdapter, objects, Tree} from '../index';
+import {App, arrays, defaultValues, ModelAdapter, objects, Tree} from '../index';
+import $ from 'jquery';
 
 export default class TreeAdapter extends ModelAdapter {
 
@@ -260,4 +261,34 @@ export default class TreeAdapter extends ModelAdapter {
   _onScrollToSelection() {
     this.widget.revealSelection();
   }
+
+  _initNodeModel(nodeModel) {
+    nodeModel = $.extend({objectType: this._getDefaultNodeObjectType()}, nodeModel);
+    defaultValues.applyTo(nodeModel);
+    return nodeModel;
+  }
+
+  _getDefaultNodeObjectType() {
+    return 'TreeNode';
+  }
+
+  static _createTreeNodeRemote(nodeModel) {
+    if (this.modelAdapter) {
+      nodeModel = this.modelAdapter._initNodeModel(nodeModel);
+    }
+    return this._createTreeNodeOrig(nodeModel);
+  }
+
+  /**
+   * Static method to modify the prototype of Tree.
+   */
+  static modifyTreePrototype() {
+    if (!App.get().remote) {
+      return;
+    }
+
+    objects.replacePrototypeFunction(Tree, '_createTreeNode', TreeAdapter._createTreeNodeRemote, true);
+  }
 }
+
+App.addListener('bootstrap', TreeAdapter.modifyTreePrototype);

--- a/eclipse-scout-core/src/tree/TreeNode.js
+++ b/eclipse-scout-core/src/tree/TreeNode.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {defaultValues, icons, objects, scout, styles, texts, Tree} from '../index';
+import {icons, objects, scout, styles, texts, Tree} from '../index';
 import $ from 'jquery';
 
 /**
@@ -88,7 +88,6 @@ export default class TreeNode {
     this.session = model.session || model.parent.session;
 
     $.extend(this, model);
-    defaultValues.applyTo(this);
 
     texts.resolveTextProperty(this, 'text');
     icons.resolveIconProperty(this, 'iconId');

--- a/eclipse-scout-core/test/planner/PlannerAdapterSpec.js
+++ b/eclipse-scout-core/test/planner/PlannerAdapterSpec.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {defaultValues, ObjectFactory, PlannerAdapter} from '../../src';
+
+describe('PlannerAdapter', () => {
+  let session;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    jasmine.Ajax.install();
+  });
+
+  afterEach(() => {
+    jasmine.Ajax.uninstall();
+  });
+
+  function createPlannerAdapter(model) {
+    let plannerAdapter = new PlannerAdapter();
+    plannerAdapter.init(model);
+    return plannerAdapter;
+  }
+
+  function createPlannerModel(numResources) {
+    let model = createSimpleModel('Planner', session);
+    model.resources = [];
+    for (let i = 0; i < numResources; i++) {
+      model.resources[i] = createResource('resource' + i);
+    }
+    return model;
+  }
+
+  function createResourcesInsertedEvent(model, resources) {
+    return {
+      target: model.id,
+      resources: resources,
+      type: 'resourcesInserted'
+    };
+  }
+
+  function createResourcesUpdatedEvent(model, resources) {
+    return {
+      target: model.id,
+      resources: resources,
+      type: 'resourcesUpdated'
+    };
+  }
+
+  function createResource(text) {
+    return {
+      id: ObjectFactory.get().createUniqueId(),
+      resourceCell: {
+        text: text
+      },
+      activities: [{
+        beginTime: '2015-04-01 01:23:45.678Z',
+        endTime: '2015-04-31 01:23:45.678Z',
+        id: ObjectFactory.get().createUniqueId()
+      }, {
+        beginTime: '2016-02-29 01:23:45.678Z',
+        endTime: '2400-02-29 01:23:45.678Z',
+        id: ObjectFactory.get().createUniqueId()
+      }]
+    };
+  }
+
+  describe('defaultValues', () => {
+    let defaults = {
+      'defaults': {
+        'Planner': {
+          'a': 123
+        },
+        'Resource': {
+          'b': 234
+        },
+        'Activity': {
+          'c': 345
+        }
+      },
+      'objectTypeHierarchy': {
+        'Widget': {
+          'Planner': null
+        }
+      }
+    };
+
+    it('are applied on init', () => {
+      defaultValues.init(defaults);
+      let model = createPlannerModel(2);
+      let adapter = createPlannerAdapter(model);
+      let planner = adapter.createWidget(model, session.desktop);
+      expect(planner.a).toBe(123);
+      expect(planner.resources[0].b).toBe(234);
+      expect(planner.resources[0].activities[0].c).toBe(345);
+    });
+
+    it('are applied when resources are inserted', () => {
+      defaultValues.init(defaults);
+      let model = createPlannerModel(0);
+      let adapter = createPlannerAdapter(model);
+      let planner = adapter.createWidget(model, session.desktop);
+      expect(planner.resources.length).toBe(0);
+
+      let event = createResourcesInsertedEvent(model, [createResource()]);
+      adapter.onModelAction(event);
+      expect(planner.a).toBe(123);
+      expect(planner.resources[0].b).toBe(234);
+      expect(planner.resources[0].activities[0].c).toBe(345);
+    });
+
+    it('are applied when resources are updated', () => {
+      defaultValues.init(defaults);
+      let model = createPlannerModel(1);
+      let adapter = createPlannerAdapter(model);
+      let planner = adapter.createWidget(model, session.desktop);
+
+      planner.resources[0].b = 999;
+      let resource = {
+        id: planner.resources[0].id,
+        activities: []
+      };
+      let event = createResourcesUpdatedEvent(model, [resource]);
+      adapter.onModelAction(event);
+      expect(planner.resources[0].b).toBe(234);
+    });
+  });
+});


### PR DESCRIPTION
Because default values should only be applied for remote elements,
the code should not be executed for Scout JS elements at all.

Also, defaultValues.apply cannot handle non string based object types.
But an upcoming feature requires class references as object type which
makes this refactoring necessary.

TreeNode and TableRow now also only add the object type to the model
if it is not already present. This allows for custom object types sent
by the ui server.

326215