### PR TITLE
Tree: improve TreeEventMerger and merge commonParentNode

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/TreeEvent.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/TreeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -246,6 +246,10 @@ public class TreeEvent extends EventObject implements IModelEvent {
     if (getType() != TYPE_ALL_CHILD_NODES_DELETED) {
       m_commonParentNode = TreeUtility.calculateCommonParentNode(nodes);
     }
+  }
+
+  protected void setCommonParentNode(ITreeNode commonParentNode) {
+    m_commonParentNode = commonParentNode;
   }
 
   /**

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/TreeEventBuffer.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/TreeEventBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -485,10 +485,12 @@ public class TreeEventBuffer extends AbstractEventBuffer<TreeEvent> {
     private Collection<ITreeNode> m_targetNodes;
     private Set<ITreeNode> m_targetNodeSet;
     private List<ITreeNode> m_mergedNodes;
+    private ITreeNode m_mergedCommonParentNode;
 
     public TreeEventMerger(TreeEvent targetEvent) {
       m_targetEvent = assertNotNull(targetEvent, "targetEvent must not be null");
       m_mergedNodes = new LinkedList<>();
+      m_mergedCommonParentNode = m_targetEvent.getCommonParentNode();
     }
 
     /**
@@ -503,6 +505,9 @@ public class TreeEventBuffer extends AbstractEventBuffer<TreeEvent> {
       }
       ensureInitialized();
       mergeCollections(event.getNodes(), m_mergedNodes, m_targetNodeSet);
+      if (event.getCommonParentNode() != m_mergedCommonParentNode) {
+        m_mergedCommonParentNode = null;
+      }
     }
 
     protected void ensureInitialized() {
@@ -517,6 +522,11 @@ public class TreeEventBuffer extends AbstractEventBuffer<TreeEvent> {
      * Completes the merge process. Subsequent invocations of this method does not have any effects.
      */
     public void complete() {
+      completeMergedNodes();
+      completeMergedCommonParentNode();
+    }
+
+    protected void completeMergedNodes() {
       if (m_mergedNodes == null) {
         return;
       }
@@ -525,6 +535,15 @@ public class TreeEventBuffer extends AbstractEventBuffer<TreeEvent> {
         m_targetEvent.setNodes(m_mergedNodes);
       }
       m_mergedNodes = null;
+
+    }
+
+    protected void completeMergedCommonParentNode() {
+      if (m_mergedCommonParentNode == null) {
+        return;
+      }
+      m_targetEvent.setCommonParentNode(m_mergedCommonParentNode);
+      m_mergedCommonParentNode = null;
     }
 
     /**


### PR DESCRIPTION
If multiple TreeEvents are merged into one, try to merge the
commonParentNode as well, because it is possible, that the nodes do no
longer contain their parentNode to determine a commonParent.

Example: all 3 childNodes A, B, C are removed from parent P individually
and the events are merged afterwards

 * remove A will produce following event: nodes_deleted[nodes: A,
   commonParent: P]
 * remove B -> nodes_deleted[nodes: B, commonParent: P]
 * remove C -> all_child_nodes_deleted[nodes: , commonParent: P]

Now the TreeEventBuffer will merge first two events. As A and B have
been removed their parent is null and it is not possible to determine
the commonParent just from A and B at this point. Therefore, also merge
the commonParent of the two events.
The merged event will look like this:
 * old: nodes_deleted[nodes: A, B, commonParent: ]
 * new: nodes_deleted[nodes: A, B, commonParent: P]

Afterwards the JsonTree tries to optimize the events as well. If there
is a nodes_deleted-event and the commonParent has no children left, it
will send an all_child_nodes_deleted-event instead. The old merged event
did no longer contain the commonParent and therefore this optimization
did not happen.
As the merged event will be sent after the
all_child_nodes_deleted-event triggered by the removal of C the tree in
the browser will remove A, B and C before processing the merged event.
If the merged event explicitly states something about A, B or C (like
the old one did), this will lead to errors because the nodes no longer
exist.

314646