### PR TITLE
Table.js: allow referencing a parentRow model

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.js
+++ b/eclipse-scout-core/src/desktop/outline/Outline.js
@@ -9,7 +9,6 @@
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 import {arrays, Desktop, DetailTableTreeFilter, Device, FileChooserController, Form, FormController, GroupBoxMenuItemsOrder, HtmlComponent, Icon, keyStrokeModifier, MenuBar, menus as menuUtil, MessageBoxController, NavigateButton, NavigateDownButton, NavigateUpButton, OutlineKeyStrokeContext, OutlineLayout, OutlineMediator, OutlineNavigateToTopKeyStroke, OutlineOverview, Page, PageLayout, scout, TableControlAdapterMenu, TableRowDetail, TileOutlineOverview, Tree, TreeCollapseOrDrillUpKeyStroke, TreeExpandOrDrillDownKeyStroke, TreeNavigationDownKeyStroke, TreeNavigationEndKeyStroke, TreeNavigationUpKeyStroke} from '../../index';
-import $ from 'jquery';
 
 /**
  * @extends {Tree}
@@ -120,10 +119,9 @@ export default class Outline extends Tree {
    * @override Tree.js
    */
   _createTreeNode(nodeModel) {
-    let model = $.extend({
-      objectType: Page
-    }, nodeModel);
-    return this._createChild(model);
+    nodeModel = nodeModel || {};
+    nodeModel.objectType = scout.nvl(nodeModel.objectType, Page);
+    return this._createChild(nodeModel);
   }
 
   _createKeyStrokeContext() {

--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -232,7 +232,8 @@ export default class Table extends Widget {
   }
 
   _createRow(rowModel) {
-    rowModel = $.extend({objectType: TableRow}, rowModel);
+    rowModel = rowModel || {};
+    rowModel.objectType = scout.nvl(rowModel.objectType, TableRow);
     rowModel.parent = this;
     return scout.create(rowModel);
   }

--- a/eclipse-scout-core/src/table/TableAdapter.js
+++ b/eclipse-scout-core/src/table/TableAdapter.js
@@ -628,7 +628,8 @@ export default class TableAdapter extends ModelAdapter {
   }
 
   _initRowModel(rowModel) {
-    rowModel = $.extend({objectType: 'TableRow'}, rowModel);
+    rowModel = rowModel || {};
+    rowModel.objectType = scout.nvl(rowModel.objectType, 'TableRow');
     defaultValues.applyTo(rowModel);
     return rowModel;
   }

--- a/eclipse-scout-core/src/tree/Tree.js
+++ b/eclipse-scout-core/src/tree/Tree.js
@@ -180,7 +180,8 @@ export default class Tree extends Widget {
   }
 
   _createTreeNode(nodeModel) {
-    nodeModel = $.extend({objectType: TreeNode}, nodeModel);
+    nodeModel = nodeModel || {};
+    nodeModel.objectType = scout.nvl(nodeModel.objectType, TreeNode);
     nodeModel.parent = this;
     return scout.create(nodeModel);
   }

--- a/eclipse-scout-core/src/tree/TreeAdapter.js
+++ b/eclipse-scout-core/src/tree/TreeAdapter.js
@@ -8,8 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {App, arrays, defaultValues, ModelAdapter, objects, Tree} from '../index';
-import $ from 'jquery';
+import {App, arrays, defaultValues, ModelAdapter, objects, scout, Tree} from '../index';
 
 export default class TreeAdapter extends ModelAdapter {
 
@@ -263,7 +262,8 @@ export default class TreeAdapter extends ModelAdapter {
   }
 
   _initNodeModel(nodeModel) {
-    nodeModel = $.extend({objectType: this._getDefaultNodeObjectType()}, nodeModel);
+    nodeModel = nodeModel || {};
+    nodeModel.objectType = scout.nvl(nodeModel.objectType, this._getDefaultNodeObjectType());
     defaultValues.applyTo(nodeModel);
     return nodeModel;
   }

--- a/eclipse-scout-core/test/table/HierarchicalTableSpec.js
+++ b/eclipse-scout-core/test/table/HierarchicalTableSpec.js
@@ -143,7 +143,7 @@ describe('HierarchicalTableSpec', () => {
 
     });
 
-    it('a child row to a row which is already a parent row (by TableRow)', () => {
+    it('a child row to a row which is already a parent row (by pseudo row)', () => {
       let newRow = helper.createModelRow(33, ['newRow']),
         pseudoParentRow = {
           id: '0'
@@ -166,7 +166,7 @@ describe('HierarchicalTableSpec', () => {
       expectRowIds(getUiRows(table), expectedRowIds);
     });
 
-    it('a child row to a row which is already a parent row (by pseudo row)', () => {
+    it('a child row to a row which is already a parent row (by TableRow)', () => {
       let newRow = helper.createModelRow(33, ['newRow']),
         parentRow = table.rows[0];
 
@@ -186,6 +186,21 @@ describe('HierarchicalTableSpec', () => {
       expectRowIds(table._filteredRows, expectedRowIds);
       expectRowIds(table.visibleRows, expectedRowIds);
       expectRowIds(getUiRows(table), expectedRowIds);
+    });
+
+    it('a child row to a model row that was inserted before', () => {
+      let parentRow = {cells: ['newRow'], expanded: true};
+      let childRow = {cells: ['childRow'], parentRow: parentRow};
+
+      table.deleteAllRows();
+      table.insertRows([parentRow, childRow]);
+      expect(table.rows.length).toBe(2);
+      expect(table._filteredRows.length).toBe(2);
+      expect(table.visibleRows.length).toBe(2);
+      expect(table.rootRows.length).toBe(1);
+      expect(table.rowsMap[parentRow.id].childRows.length).toBe(1);
+      expect(table.rowsMap[parentRow.id].childRows[0]).toBe(table.rows[1]);
+      expect(table.rowsMap[childRow.id].parentRow).toBe(table.rows[0]);
     });
 
     it('a child row to a row which is leaf', () => {

--- a/eclipse-scout-core/test/table/columns/ColumnSpec.js
+++ b/eclipse-scout-core/test/table/columns/ColumnSpec.js
@@ -544,7 +544,7 @@ describe('Column', () => {
         expect(table.columns[1].autoOptimizeWidthRequired).toBe(false);
         spyOn(table, 'resizeToFit').and.callThrough();
 
-        table.insertRow(['a', 'b', 'c']);
+        table.insertRow({cells: ['a', 'b', 'c']});
         expect(table.columns[0].autoOptimizeWidthRequired).toBe(true);
         expect(table.columns[1].autoOptimizeWidthRequired).toBe(true);
         table.validateLayout();


### PR DESCRIPTION
If a model row is inserted with a parentRow reference to another
model row that was inserted before, the parentRow cannot be resolved.

This worked before the defaultValues change because the id and
objectType were applied to the given model so the parentRow model
contained an id when the childRow was inserted.

Since this is a legitimate use case and these two properties will
be applied to every model if scout.create is called, it is now allowed
again.