### PR TITLE
Extract event related methods into separate class

### DIFF
--- a/eclipse-scout-core/src/App.js
+++ b/eclipse-scout-core/src/App.js
@@ -9,13 +9,13 @@
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 
-import {codes, Desktop, Device, ErrorHandler, EventSupport, fonts, locales, logging, numbers, ObjectFactory, objects, scout, Session, texts, webstorage} from './index';
+import {codes, Desktop, Device, ErrorHandler, EventEmitter, fonts, locales, logging, numbers, ObjectFactory, objects, scout, Session, texts, webstorage} from './index';
 import $ from 'jquery';
 
 let instance = null;
 let listeners = [];
 
-export default class App {
+export default class App extends EventEmitter {
 
   static addListener(type, func) {
     let listener = {
@@ -35,7 +35,7 @@ export default class App {
   }
 
   constructor() {
-    this.events = this._createEventSupport();
+    super();
     this.initialized = false;
     this.sessions = [];
     this._loadingTimeoutId = null;
@@ -481,49 +481,4 @@ export default class App {
   _installExtensions() {
     // NOP
   }
-
-  // --- Event handling methods ---
-  _createEventSupport() {
-    return new EventSupport();
-  }
-
-  trigger(type, event) {
-    event = event || {};
-    event.source = this;
-    this.events.trigger(type, event);
-  }
-
-  one(type, func) {
-    this.events.one(type, func);
-  }
-
-  on(type, func) {
-    return this.events.on(type, func);
-  }
-
-  off(type, func) {
-    this.events.off(type, func);
-  }
-
-  addListener(listener) {
-    this.events.addListener(listener);
-  }
-
-  removeListener(listener) {
-    this.events.removeListener(listener);
-  }
-
-  when(type) {
-    return this.events.when(type);
-  }
 }
-/*
- * Copyright (c) 2010-2019 BSI Business Systems Integration AG.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     BSI Business Systems Integration AG - initial API and implementation
- */

--- a/eclipse-scout-core/src/desktop/Desktop.js
+++ b/eclipse-scout-core/src/desktop/Desktop.js
@@ -1447,7 +1447,7 @@ export default class Desktop extends Widget {
   }
 
   dataChange(dataType) {
-    this.events.trigger('dataChange', dataType);
+    this.trigger('dataChange', dataType);
   }
 
   _activeTheme() {

--- a/eclipse-scout-core/src/desktop/PopupWindow.js
+++ b/eclipse-scout-core/src/desktop/PopupWindow.js
@@ -8,16 +8,17 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {Dimension, EventSupport, HtmlComponent, Rectangle, scout, SingleLayout} from '../index';
+import {Dimension, EventEmitter, HtmlComponent, Rectangle, scout, SingleLayout} from '../index';
 import $ from 'jquery';
 
-export default class PopupWindow {
+export default class PopupWindow extends EventEmitter {
 
   constructor(myWindow, form) { // use 'myWindow' in place of 'window' to prevent confusion with global window variable
+    super();
+
     this.myWindow = myWindow;
     this.form = form;
     this.session = form.session;
-    this.events = new EventSupport();
     this.initialized = false;
     this.$container = null;
     this.htmlComp = null;
@@ -38,7 +39,7 @@ export default class PopupWindow {
     if (this.form.destroyed) {
       $.log.isDebugEnabled() && $.log.debug('form ID ' + this.form.id + ' is already destroyed - don\'t trigger unload event');
     } else {
-      this.events.trigger('popupWindowUnload', this);
+      this.trigger('popupWindowUnload', this);
     }
   }
 
@@ -95,7 +96,7 @@ export default class PopupWindow {
 
     // Finally set initialized flag to true, at this point the PopupWindow is fully initialized
     this.initialized = true;
-    this.events.trigger('init');
+    this.trigger('init');
   }
 
   // Note: currently _onResize is only called when the window is resized, but not when the position of the window changes.
@@ -116,10 +117,6 @@ export default class PopupWindow {
 
   isClosed() {
     return this.myWindow.closed;
-  }
-
-  one(type, func) {
-    this.events.one(type, func);
   }
 
   close() {

--- a/eclipse-scout-core/src/events/Event.js
+++ b/eclipse-scout-core/src/events/Event.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation

--- a/eclipse-scout-core/src/events/EventDelegator.js
+++ b/eclipse-scout-core/src/events/EventDelegator.js
@@ -11,28 +11,21 @@
 import {arrays, objects, scout} from '../index';
 
 /**
- * Helper to support clone property and event handling between original and clone.
- *
- * OPTION                   DEFAULT VALUE   DESCRIPTION
- * --------------------------------------------------------------------------------------------------------
- * delegateProperties       []              An array of all properties to be delegated from the source
- *                                          to the to the target when changed on the source.
- *
- * excludeProperties        []              An array of all properties to be excluded from delegating to the
- *                                          in all cases.
- *
- * delegateEvents           []              An array of all events to be delegated from the source to
- *                                          the target when fired on the source.
- *
- * delegateAllProperties    false           True to delegate all property changes from the source to
- *                                          the target.
- *
- * delegateAllEvents        false           True to delegate all events from the source to
- *                                          the target.
- *
+ * Delegates events between two {@link EventEmitter}s.
  */
 export default class EventDelegator {
 
+  /**
+   * @param {EventEmitter} source
+   * @param {EventEmitter} target
+   * @param {object} [options]
+   * @param {boolean} [options.callSetter] True, to call the setter on the target on a property change event.
+   * @param {string[]} [options.delegateProperties] An array of all properties to be delegated from the source to the target when changed on the source. Default is [];
+   * @param {string[]} [options.excludeProperties] An array of all properties to be excluded from delegating to the target in all cases. Default is [].
+   * @param {string[]} [options.delegateEvents] An array of all events to be delegated from the source to the target when triggered on the source. Default is [].
+   * @param {string[]} [options.delegateAllProperties] True, to delegate all property changes from the source to the target. Default is false.
+   * @param {string[]} [options.delegateAllEvents] True, to delegate all events from the source to the target. Default is false.
+   */
   constructor(source, target, options) {
     options = options || {};
     this.source = source;
@@ -95,7 +88,7 @@ export default class EventDelegator {
         return;
       }
       if (this.callSetter) {
-        this.target.callSetter(event.propertyName, event.newValue);
+        (/** @type {PropertyEventEmitter} */ this.target).callSetter(event.propertyName, event.newValue);
       } else {
         this.target.trigger(event.type, event);
       }

--- a/eclipse-scout-core/src/events/EventEmitter.js
+++ b/eclipse-scout-core/src/events/EventEmitter.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {EventSupport} from '../index';
+
+export default class EventEmitter {
+
+  constructor() {
+    /** @type {EventSupport} */
+    this.events = this._createEventSupport();
+  }
+
+  _createEventSupport() {
+    return new EventSupport();
+  }
+
+  /**
+   * @param {string} type
+   * @param {Event|object} [event]
+   */
+  trigger(type, event) {
+    event = event || {};
+    event.source = this;
+    this.events.trigger(type, event);
+  }
+
+
+  /**
+   * Registers the given event handler for the event specified by the type param.
+   * The function will only be called once. After that it is automatically de-registered using {@link off}.
+   *
+   * @param {string} type One or more event names separated by space.
+   * @param {function} handler Event handler executed when the event is triggered. An event object is passed to the function as first parameter
+   */
+  one(type, handler) {
+    this.events.one(type, handler);
+  }
+
+  /**
+   * Registers the given event handler for the event specified by the type param.
+   *
+   * @param {string} type One or more event names separated by space.
+   * @param {function} handler Event handler executed when the event is triggered. An event object is passed to the function as first parameter.
+   **/
+  on(type, handler) {
+    return this.events.on(type, handler);
+  }
+
+  /**
+   * De-registers the given event handler for the event specified by the type param.
+   *
+   * @param {string} type One or more event names separated by space.<br/>
+   *      Important: the string must be equal to the one used for {@link on} or {@link one}. This also applies if a string containing multiple types separated by space was used.
+   * @param {function} [handler] The exact same event handler that was used for registration using {@link on} or {@link one}.
+   *      If no handler is specified, all handlers are de-registered for the given type.
+   */
+  off(type, handler) {
+    this.events.off(type, handler);
+  }
+
+  addListener(listener) {
+    this.events.addListener(listener);
+  }
+
+  removeListener(listener) {
+    this.events.removeListener(listener);
+  }
+
+  /**
+   * Adds an event handler using {@link one} and returns a promise.
+   * The promise is resolved as soon as the event is triggered.
+   * @returns {Promise}
+   */
+  when(type) {
+    return this.events.when(type);
+  }
+}

--- a/eclipse-scout-core/src/events/EventSupport.js
+++ b/eclipse-scout-core/src/events/EventSupport.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation

--- a/eclipse-scout-core/src/events/PropertyEventEmitter.js
+++ b/eclipse-scout-core/src/events/PropertyEventEmitter.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {Event, EventEmitter, objects, scout, strings} from '../index';
+
+export default class PropertyEventEmitter extends EventEmitter {
+  constructor() {
+    super();
+    this.events.registerSubTypePredicate('propertyChange', (event, propertyName) => {
+      return event.propertyName === propertyName;
+    });
+  }
+
+  /**
+   * Sets a new value for a specific property. If the new value is the same value as the old one, nothing happens.
+   * Otherwise, {@link _setProperty} is used to set the property and trigger a property change event.
+   * <p>
+   * This default behavior can be overridden by implementing a custom \_setXy function where XY is the property name.
+   * If such a function exists, it will be called instead of {@link _setProperty}
+   * @param {string} propertyName the name of the property
+   * @param {any} newValue the new value the property should get
+   * @return {boolean} true if the property has been changed, false if not.
+   */
+  setProperty(propertyName, value) {
+    if (objects.equals(this[propertyName], value)) {
+      return false;
+    }
+    this._callSetProperty(propertyName, value);
+    return true;
+  }
+
+  _callSetProperty(propertyName, value) {
+    let setFuncName = '_set' + strings.toUpperCaseFirstLetter(propertyName);
+    if (this[setFuncName]) {
+      this[setFuncName](value);
+    } else {
+      this._setProperty(propertyName, value);
+    }
+  }
+
+  /**
+   * Sets the value of the property 'propertyName' to 'newValue' and then triggers a propertyChange event for that property.
+   * <p>
+   * It is possible to prevent the setting of the property value by using {@link Event.preventDefault}.
+   *
+   * @param {string} propertyName the name of the property
+   * @param {any} newValue the new value the property should get
+   * @return {boolean} true if the property has been changed, false if not.
+   */
+  _setProperty(propertyName, newValue) {
+    scout.assertParameter('propertyName', propertyName);
+    let oldValue = this[propertyName];
+    if (objects.equals(oldValue, newValue)) {
+      return false;
+    }
+    this[propertyName] = newValue;
+    let event = this.triggerPropertyChange(propertyName, oldValue, newValue);
+    if (event.defaultPrevented) {
+      // Revert to old value if property change should be prevented
+      this[propertyName] = oldValue;
+      return false; // not changed
+    }
+    return true;
+  }
+
+  /**
+   * Triggers a property change for a single property.
+   */
+  triggerPropertyChange(propertyName, oldValue, newValue) {
+    scout.assertParameter('propertyName', propertyName);
+    let event = new Event({
+      propertyName: propertyName,
+      oldValue: oldValue,
+      newValue: newValue
+    });
+    this.trigger('propertyChange', event);
+    return event;
+  }
+
+  /**
+   * Calls the setter of the given property name if it exists. A setter has to be named setXy, where Xy is the property name.
+   * If there is no setter for the property name, {@link setProperty} is called.
+   */
+  callSetter(propertyName, value) {
+    let setterFuncName = 'set' + strings.toUpperCaseFirstLetter(propertyName);
+    if (this[setterFuncName]) {
+      this[setterFuncName](value);
+    } else {
+      this.setProperty(propertyName, value);
+    }
+  }
+}

--- a/eclipse-scout-core/src/index.js
+++ b/eclipse-scout-core/src/index.js
@@ -11,6 +11,11 @@
 import ObjectFactory from './ObjectFactory';
 
 export {default as scout} from './scout';
+export {default as Event} from './events/Event';
+export {default as EventEmitter} from './events/EventEmitter';
+export {default as PropertyEventEmitter} from './events/PropertyEventEmitter';
+export {default as EventSupport} from './events/EventSupport';
+export {default as EventDelegator} from './events/EventDelegator';
 export {default as App} from './App';
 export {default as ErrorHandler} from './ErrorHandler';
 export {default as RemoteApp} from './RemoteApp';
@@ -33,7 +38,6 @@ export {default as arrays} from './util/arrays';
 export {default as Call} from './util/Call';
 export {default as clipboard} from './util/clipboard';
 export {default as colorSchemes} from './util/colorSchemes';
-export {default as EventDelegator} from './util/EventDelegator';
 export {default as dates} from './util/dates';
 export {default as defaultValues} from './util/defaultValues';
 export {default as events} from './util/events';
@@ -42,8 +46,6 @@ export {default as Device} from './util/Device';
 export {default as DoubleClickSupport} from './util/DoubleClickSupport';
 export {default as DragAndDropHandler} from './util/DragAndDropHandler';
 export {default as dragAndDrop} from './util/dragAndDrop';
-export {default as Event} from './util/Event';
-export {default as EventSupport} from './util/EventSupport';
 export {default as fonts} from './util/fonts';
 export {default as icons} from './util/icons';
 export {default as inspector} from './util/inspector';

--- a/eclipse-scout-core/src/keystroke/KeyStrokeManager.js
+++ b/eclipse-scout-core/src/keystroke/KeyStrokeManager.js
@@ -8,18 +8,18 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {Action, arrays, EventSupport, filters as filters_1, keys, KeyStroke, ValueField, VirtualKeyStrokeEvent} from '../index';
+import {Action, arrays, EventEmitter, filters as filters_1, keys, KeyStroke, ValueField, VirtualKeyStrokeEvent} from '../index';
 import $ from 'jquery';
 
-export default class KeyStrokeManager {
+export default class KeyStrokeManager extends EventEmitter {
 
   constructor() {
+    super();
     this.session = null;
     this.helpKeyStroke = KeyStroke.parseKeyStroke('F1');
     this.swallowF1 = true;
     this._helpRendered = false;
     this._renderedKeys = [];
-    this.events = this._createEventSupport();
     this.filters = [];
   }
 
@@ -265,36 +265,5 @@ export default class KeyStrokeManager {
 
   removeFilter(filter) {
     arrays.remove(this.filters, filter);
-  }
-
-  // --- Event handling methods ---
-  _createEventSupport() {
-    return new EventSupport();
-  }
-
-  trigger(type, event) {
-    event = event || {};
-    event.source = this;
-    this.events.trigger(type, event);
-  }
-
-  one(type, func) {
-    this.events.one(type, func);
-  }
-
-  on(type, func) {
-    return this.events.on(type, func);
-  }
-
-  off(type, func) {
-    this.events.off(type, func);
-  }
-
-  addListener(listener) {
-    this.events.addListener(listener);
-  }
-
-  removeListener(listener) {
-    this.events.removeListener(listener);
   }
 }

--- a/eclipse-scout-core/src/layout/HtmlEnvironment.js
+++ b/eclipse-scout-core/src/layout/HtmlEnvironment.js
@@ -8,15 +8,17 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {App, EventSupport, scout, styles} from '../index';
+import {App, EventEmitter, scout, styles} from '../index';
 
 let instance;
 /**
  * @singleton
  */
-export default class HtmlEnvironment {
+export default class HtmlEnvironment extends EventEmitter {
 
   constructor() {
+    super();
+
     // -------------------------------
     // The values for these properties are defined using CSS (sizes.less).
     // The following values are default values in case the CSS values are not available.
@@ -29,7 +31,6 @@ export default class HtmlEnvironment {
     this.fieldLabelWidth = 140;
     this.fieldMandatoryIndicatorWidth = 8;
     this.fieldStatusWidth = 20;
-    this.events = new EventSupport();
   }
 
   init(additionalClass) {
@@ -46,15 +47,7 @@ export default class HtmlEnvironment {
     let event = {
       source: this
     };
-    this.events.trigger('propertyChange', event);
-  }
-
-  on(type, func) {
-    return this.events.on(type, func);
-  }
-
-  off(type, func) {
-    return this.events.off(type, func);
+    this.trigger('propertyChange', event);
   }
 
   /**

--- a/eclipse-scout-core/src/session/ModelAdapter.js
+++ b/eclipse-scout-core/src/session/ModelAdapter.js
@@ -8,15 +8,17 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {App, arrays, comparators, defaultValues, EventSupport, objects, PropertyChangeEventFilter, RemoteEvent, scout, strings, Widget, WidgetEventTypeFilter} from '../index';
+import {App, arrays, comparators, defaultValues, EventEmitter, objects, PropertyChangeEventFilter, RemoteEvent, scout, strings, Widget, WidgetEventTypeFilter} from '../index';
 import $ from 'jquery';
 
 /**
  * A model adapter is the connector with the server, it takes the events sent from the server and calls the corresponding methods on the widget.
  * It also sends events to the server whenever an action happens on the widget.
  */
-export default class ModelAdapter {
+export default class ModelAdapter extends EventEmitter {
   constructor() {
+    super();
+
     this.id = null;
     this.objectType = null;
     this.initialized = false;
@@ -33,7 +35,6 @@ export default class ModelAdapter {
 
     this._propertyChangeEventFilter = new PropertyChangeEventFilter();
     this._widgetEventTypeFilter = new WidgetEventTypeFilter();
-    this.events = new EventSupport();
     this.session = null;
   }
 
@@ -123,7 +124,7 @@ export default class ModelAdapter {
     };
     this.widget.addListener(this._widgetListener);
     this.attached = true;
-    this.events.trigger('attach');
+    this.trigger('attach');
   }
 
   _detachWidget() {
@@ -133,7 +134,7 @@ export default class ModelAdapter {
     this.widget.removeListener(this._widgetListener);
     this._widgetListener = null;
     this.attached = false;
-    this.events.trigger('detach');
+    this.trigger('detach');
   }
 
   goOffline() {

--- a/eclipse-scout-core/src/session/Session.js
+++ b/eclipse-scout-core/src/session/Session.js
@@ -8,11 +8,12 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {AjaxCall, App, arrays, BackgroundJobPollingStatus, BackgroundJobPollingSupport, BusyIndicator, Device, EventSupport, FileInput, files as fileUtil, FocusManager, fonts, icons, KeyStrokeManager, LayoutValidator, Locale, logging, MessageBox, ModelAdapter, NullWidget, ObjectFactory, objects, Reconnector, RemoteEvent, ResponseQueue, scout, Status, strings, TextMap, texts, TypeDescriptor, URL, UserAgent, webstorage} from '../index';
+import {AjaxCall, App, arrays, BackgroundJobPollingStatus, BackgroundJobPollingSupport, BusyIndicator, Device, EventEmitter, FileInput, files as fileUtil, FocusManager, fonts, icons, KeyStrokeManager, LayoutValidator, Locale, logging, MessageBox, ModelAdapter, NullWidget, ObjectFactory, objects, Reconnector, RemoteEvent, ResponseQueue, scout, Status, strings, TextMap, texts, TypeDescriptor, URL, UserAgent, webstorage} from '../index';
 import $ from 'jquery';
 
-export default class Session {
+export default class Session extends EventEmitter {
   constructor() {
+    super();
     this.$entryPoint = null;
     this.partId = 0;
 
@@ -83,7 +84,6 @@ export default class Session {
       id: '1',
       objectType: 'NullWidget'
     }, rootParent);
-    this.events = this._createEventSupport();
   }
 
   // Corresponds to constants in JsonResponse
@@ -1612,40 +1612,5 @@ export default class Session {
 
   textExists(textKey) {
     return this.textMap.exists(textKey);
-  }
-
-  // --- Event handling methods ---
-  _createEventSupport() {
-    return new EventSupport();
-  }
-
-  trigger(type, event) {
-    event = event || {};
-    event.source = this;
-    this.events.trigger(type, event);
-  }
-
-  one(type, func) {
-    this.events.one(type, func);
-  }
-
-  on(type, func) {
-    return this.events.on(type, func);
-  }
-
-  off(type, func) {
-    this.events.off(type, func);
-  }
-
-  addListener(listener) {
-    this.events.addListener(listener);
-  }
-
-  removeListener(listener) {
-    this.events.removeListener(listener);
-  }
-
-  when(type) {
-    return this.events.when(type);
   }
 }

--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -733,8 +733,7 @@ export default class Table extends Widget {
     this.trigger('columnStructureChanged');
     if (this._isDataRendered()) {
       this._updateRowWidth();
-      this._redraw();
-      this.invalidateLayoutTree();
+      this.redraw();
     }
   }
 
@@ -3906,17 +3905,15 @@ export default class Table extends Widget {
   /**
    * Resizes the given column to the new size.
    *
-   * @param column
-   *          column to resize
-   * @param width
-   *          new column size
+   * @param {Column} column column to resize
+   * @param {number} width new column size
    */
   resizeColumn(column, width) {
     if (column.fixedWidth) {
       return;
     }
     width = Math.floor(width);
-    column.width = width;
+    column.setWidth(width);
 
     let visibleColumnIndex = this.visibleColumns().indexOf(column);
     if (visibleColumnIndex !== -1) {
@@ -4450,8 +4447,7 @@ export default class Table extends Widget {
   _renderRowIconVisible() {
     this.columnLayoutDirty = true;
     this._updateRowWidth();
-    this._redraw();
-    this.invalidateLayoutTree();
+    this.redraw();
   }
 
   _renderRowIconColumnWidth() {
@@ -4676,8 +4672,7 @@ export default class Table extends Widget {
   _renderCheckable() {
     this.columnLayoutDirty = true;
     this._updateRowWidth();
-    this._redraw();
-    this.invalidateLayoutTree();
+    this.redraw();
   }
 
   setCheckableStyle(checkableStyle) {
@@ -4694,8 +4689,7 @@ export default class Table extends Widget {
     this.$container.toggleClass('table-row-check', this.checkableStyle === Table.CheckableStyle.TABLE_ROW);
     if (this._isDataRendered()) {
       this._updateRowWidth();
-      this._redraw();
-      this.invalidateLayoutTree();
+      this.redraw();
     }
   }
 
@@ -4743,8 +4737,7 @@ export default class Table extends Widget {
   _renderCompact() {
     this.columnLayoutDirty = true;
     this._updateRowWidth();
-    this._redraw();
-    this.invalidateLayoutTree();
+    this.redraw();
   }
 
   setGroupingStyle(groupingStyle) {
@@ -4760,11 +4753,13 @@ export default class Table extends Widget {
     this._rerenderViewport();
   }
 
-  _redraw() {
-    if (this._isDataRendered()) {
-      this._rerenderHeaderColumns();
-      this._rerenderViewport();
+  redraw() {
+    if (!this._isDataRendered()) {
+      return;
     }
+    this._rerenderHeaderColumns();
+    this._rerenderViewport();
+    this.invalidateLayoutTree();
   }
 
   _rerenderHeaderColumns() {
@@ -4902,8 +4897,7 @@ export default class Table extends Widget {
 
   _renderMultilineText() {
     this._markAutoOptimizeWidthColumnsAsDirty();
-    this._redraw();
-    this.invalidateLayoutTree();
+    this.redraw();
   }
 
   setDropType(dropType) {

--- a/eclipse-scout-core/src/table/columns/DateColumn.js
+++ b/eclipse-scout-core/src/table/columns/DateColumn.js
@@ -31,16 +31,7 @@ export default class DateColumn extends Column {
   }
 
   setFormat(format) {
-    if (this.format === format) {
-      return;
-    }
-    this._setFormat(format);
-    if (this.initialized) {
-      // if format changes on the fly, just update the cell text
-      this.table.rows.forEach(row => {
-        this._updateCellText(row, this.cell(row));
-      });
-    }
+    this.setProperty('format', format);
   }
 
   _setFormat(format) {
@@ -48,14 +39,7 @@ export default class DateColumn extends Column {
       format = this._getDefaultFormat(this.session.locale);
     }
     format = DateFormat.ensure(this.session.locale, format);
-    this.format = format;
-  }
-
-  setGroupFormat(format) {
-    if (this.groupFormat === format) {
-      return;
-    }
-    this._setGroupFormat(format);
+    this._setProperty('format', format);
     if (this.initialized) {
       // if format changes on the fly, just update the cell text
       this.table.rows.forEach(row => {
@@ -64,12 +48,19 @@ export default class DateColumn extends Column {
     }
   }
 
+  setGroupFormat(groupFormat) {
+    this.setProperty('groupFormat', groupFormat);
+  }
+
   _setGroupFormat(format) {
     if (!format) {
       format = this._getDefaultFormat(this.session.locale);
     }
     format = DateFormat.ensure(this.session.locale, format);
-    this.groupFormat = format;
+    this._setProperty('groupFormat', format);
+    if (this.initialized) {
+      this.table._group();
+    }
   }
 
   /**

--- a/eclipse-scout-core/src/table/columns/NumberColumn.js
+++ b/eclipse-scout-core/src/table/columns/NumberColumn.js
@@ -35,27 +35,25 @@ export default class NumberColumn extends Column {
   _init(model) {
     super._init(model);
     this._setDecimalFormat(this.decimalFormat);
-    this.setAggregationFunction(this.aggregationFunction);
+    this._setAggregationFunction(this.aggregationFunction);
   }
 
   setDecimalFormat(decimalFormat) {
-    if (this.decimalFormat === decimalFormat) {
-      return;
+    this.setProperty('decimalFormat', decimalFormat);
+  }
+
+  _setDecimalFormat(decimalFormat) {
+    if (!decimalFormat) {
+      decimalFormat = this._getDefaultFormat(this.session.locale);
     }
-    this._setDecimalFormat(decimalFormat);
+    decimalFormat = DecimalFormat.ensure(this.session.locale, decimalFormat);
+    this._setProperty('decimalFormat', decimalFormat);
     if (this.initialized) {
       // if format changes on the fly, just update the cell text
       this.table.rows.forEach(row => {
         this._updateCellText(row, this.cell(row));
       });
     }
-  }
-
-  _setDecimalFormat(format) {
-    if (!format) {
-      format = this._getDefaultFormat(this.session.locale);
-    }
-    this.decimalFormat = DecimalFormat.ensure(this.session.locale, format);
   }
 
   _getDefaultFormat(locale) {
@@ -77,8 +75,12 @@ export default class NumberColumn extends Column {
     return numbers.ensure(value);
   }
 
-  setAggregationFunction(func) {
-    this.aggregationFunction = func;
+  setAggregationFunction(aggregationFunction) {
+    this.setProperty('aggregationFunction', aggregationFunction);
+  }
+
+  _setAggregationFunction(func) {
+    this._setProperty('aggregationFunction', func);
     if (func === 'sum') {
       this.aggrStart = aggregation.sumStart;
       this.aggrStep = aggregation.sumStep;
@@ -144,12 +146,11 @@ export default class NumberColumn extends Column {
     return this.decimalFormat.round(value);
   }
 
-  setBackgroundEffect(effect) {
-    if (this.backgroundEffect === effect) {
+  setBackgroundEffect(backgroundEffect) {
+    let changed = this.setProperty('backgroundEffect', backgroundEffect);
+    if (!changed) {
       return;
     }
-
-    this.backgroundEffect = effect;
     this.backgroundEffectFunc = this._resolveBackgroundEffectFunc();
 
     this.table.trigger('columnBackgroundEffectChanged', {

--- a/eclipse-scout-core/src/table/columns/SmartColumn.js
+++ b/eclipse-scout-core/src/table/columns/SmartColumn.js
@@ -61,54 +61,52 @@ export default class SmartColumn extends Column {
   }
 
   setLookupCall(lookupCall) {
-    if (this.lookupCall === lookupCall) {
-      return;
-    }
-    this._setLookupCall(lookupCall);
-    this._updateAllCellSortCodes();
+    this.setProperty('lookupCall', lookupCall);
   }
 
   _setLookupCall(lookupCall) {
-    this.lookupCall = LookupCall.ensure(lookupCall, this.session);
+    lookupCall = LookupCall.ensure(lookupCall, this.session);
+    this._setProperty('lookupCall', lookupCall);
+    if (this.initialized) {
+      this._updateAllCellSortCodes();
+    }
   }
 
   setCodeType(codeType) {
-    if (this.codeType === codeType) {
-      return;
-    }
-    this._setCodeType(codeType);
-    this._updateAllCellSortCodes();
+    this.setProperty('codeType', codeType);
   }
 
   _setCodeType(codeType) {
-    this.codeType = codeType;
-    if (!codeType) {
-      return;
+    this._setProperty('codeType', codeType);
+    if (codeType) {
+      this.lookupCall = scout.create(CodeLookupCall, {
+        session: this.session,
+        codeType: codeType
+      });
     }
-    this.lookupCall = scout.create(CodeLookupCall, {
-      session: this.session,
-      codeType: codeType
-    });
+    if (this.initialized) {
+      this._updateAllCellSortCodes();
+    }
   }
 
   setBrowseHierarchy(browseHierarchy) {
-    this.browseHierarchy = browseHierarchy;
+    this.setProperty('browseHierarchy', browseHierarchy);
   }
 
   setBrowseMaxRowCount(browseMaxRowCount) {
-    this.browseMaxRowCount = browseMaxRowCount;
+    this.setProperty('browseMaxRowCount', browseMaxRowCount);
   }
 
   setBrowseAutoExpandAll(browseAutoExpandAll) {
-    this.browseAutoExpandAll = browseAutoExpandAll;
+    this.setProperty('browseAutoExpandAll', browseAutoExpandAll);
   }
 
   setBrowseLoadIncremental(browseLoadIncremental) {
-    this.browseLoadIncremental = browseLoadIncremental;
+    this.setProperty('browseLoadIncremental', browseLoadIncremental);
   }
 
   setActiveFilterEnabled(activeFilterEnabled) {
-    this.activeFilterEnabled = activeFilterEnabled;
+    this.setProperty('activeFilterEnabled', activeFilterEnabled);
   }
 
   _formatValue(value, row) {


### PR DESCRIPTION
This reduces duplicate code and improves reusability.

Also:
- Move event related classes to a new folder called events.
- A table column now triggers property change events when
  a column property changes.

323241