### PR TITLE
Allow to render dates with 5-digit years without JS errors

### DIFF
--- a/eclipse-scout-core/src/text/DateFormat.js
+++ b/eclipse-scout-core/src/text/DateFormat.js
@@ -86,11 +86,20 @@ export default class DateFormat {
     //   (e.g. MMMM) to short (e.g. M).
     this._patternDefinitions = [
       // --- Year ---
+      // This definition can _format_ dates with years with 4 or more digits.
+      // See: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html
+      //      chapter 'Date and Time Patterns', paragraph 'Year'
+      // We do not allow to _parse_ a date with 5 or more digits. We could allow that in a
+      // future release, but it could have an impact on backend logic, databases, etc.
       new DateFormatPatternDefinition({
         type: DateFormatPatternType.YEAR,
-        terms: ['yyyy'],
+        terms: ['yyyy'], // meaning: any number of digits is allowed
         dateFormat: this,
-        formatFunction: (formatContext, acceptedTerm) => strings.padZeroLeft(formatContext.inputDate.getFullYear(), 4).slice(-4),
+        formatFunction: (formatContext, acceptedTerm) => {
+          let year = formatContext.inputDate.getFullYear();
+          let numDigits = Math.max(4, year.toString().length); // min. digits = 4
+          return strings.padZeroLeft(formatContext.inputDate.getFullYear(), numDigits).slice(-numDigits);
+        },
         parseRegExp: /^(\d{4})(.*)$/,
         applyMatchFunction: (parseContext, match, acceptedTerm) => {
           parseContext.matchInfo.year = match;

--- a/eclipse-scout-core/src/util/dates.js
+++ b/eclipse-scout-core/src/util/dates.js
@@ -181,6 +181,8 @@ export function compareDays(date1, date2) {
  * are guaranteed to be digits. If the date argument is omitted, the current date is
  * used. The returned string in in UTC if the argument 'utc' is true, otherwise the
  * result is in local time (default).
+ *
+ * @deprecated this function will be deleted in release 23.1. Use DateFormat.js instead
  */
 export function timestamp(date, utc) {
   // (note: month is 0-indexed)
@@ -307,7 +309,7 @@ export function parseJsonDate(jsonDate) {
     utc = false;
 
   // Date + Time
-  let matches = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d{3})(Z?)$/.exec(jsonDate);
+  let matches = /^\+?(\d{4,5})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d{3})(Z?)$/.exec(jsonDate);
   if (matches !== null) {
     year = matches[1];
     month = matches[2];
@@ -319,7 +321,7 @@ export function parseJsonDate(jsonDate) {
     utc = matches[8] === 'Z';
   } else {
     // Date only
-    matches = /^(\d{4})-(\d{2})-(\d{2})(Z?)$/.exec(jsonDate);
+    matches = /^\+?(\d{4,5})-(\d{2})-(\d{2})(Z?)$/.exec(jsonDate);
     if (matches !== null) {
       year = matches[1];
       month = matches[2];
@@ -378,7 +380,7 @@ export function toJsonDate(date, utc, includeDate, includeTime) {
   let datePart, timePart, utcPart;
   if (utc) {
     // (note: month is 0-indexed)
-    datePart = strings.padZeroLeft(date.getUTCFullYear(), 4) + '-' +
+    datePart = getYearPart(date) + '-' +
       strings.padZeroLeft(date.getUTCMonth() + 1, 2) + '-' +
       strings.padZeroLeft(date.getUTCDate(), 2);
     timePart = strings.padZeroLeft(date.getUTCHours(), 2) + ':' +
@@ -388,7 +390,7 @@ export function toJsonDate(date, utc, includeDate, includeTime) {
     utcPart = 'Z';
   } else {
     // (note: month is 0-indexed)
-    datePart = strings.padZeroLeft(date.getFullYear(), 4) + '-' +
+    datePart = getYearPart(date) + '-' +
       strings.padZeroLeft(date.getMonth() + 1, 2) + '-' +
       strings.padZeroLeft(date.getDate(), 2);
     timePart = strings.padZeroLeft(date.getHours(), 2) + ':' +
@@ -409,6 +411,14 @@ export function toJsonDate(date, utc, includeDate, includeTime) {
   }
   result += utcPart;
   return result;
+
+  function getYearPart(date) {
+    let year = date.getFullYear();
+    if (year > 9999) {
+      return '+' + year;
+    }
+    return strings.padZeroLeft(year, 4);
+  }
 }
 
 export function toJsonDateRange(range) {
@@ -424,7 +434,7 @@ export function toJsonDateRange(range) {
  *
  * The format is as follows:
  *
- * [Year#4]-[Month#2]-[Day#2] [Hours#2]:[Minutes#2]:[Seconds#2].[Milliseconds#3][Z]
+ * [Year#4|5]-[Month#2]-[Day#2] [Hours#2]:[Minutes#2]:[Seconds#2].[Milliseconds#3][Z]
  *
  * The year component is mandatory, but all others are optional (starting from the beginning).
  * The date is constructed using the local time zone. If the last character is 'Z', then
@@ -432,7 +442,7 @@ export function toJsonDateRange(range) {
  */
 export function create(dateString) {
   if (dateString) {
-    let matches = /^(\d{4})(?:-(\d{2})(?:-(\d{2})(?: (\d{2})(?::(\d{2})(?::(\d{2})(?:\.(\d{3}))?(Z?))?)?)?)?)?/.exec(dateString);
+    let matches = /^(\d{4,5})(?:-(\d{2})(?:-(\d{2})(?: (\d{2})(?::(\d{2})(?::(\d{2})(?:\.(\d{3}))?(Z?))?)?)?)?)?/.exec(dateString);
     if (matches === null) {
       throw new Error('Unparsable date: ' + dateString);
     }

--- a/eclipse-scout-core/test/text/DateFormatSpec.js
+++ b/eclipse-scout-core/test/text/DateFormatSpec.js
@@ -36,6 +36,7 @@ describe('DateFormat', () => {
       pattern = 'dd.MM.yyyy';
       dateFormat = new DateFormat(locale, pattern);
       expect(dateFormat.format(dates.create('2014-03-21'))).toBe('21.03.2014');
+      expect(dateFormat.format(dates.create('20144-03-21'))).toBe('21.03.20144');
 
       pattern = 'd.M.y';
       dateFormat = new DateFormat(locale, pattern);

--- a/eclipse-scout-core/test/util/datesSpec.js
+++ b/eclipse-scout-core/test/util/datesSpec.js
@@ -399,6 +399,12 @@ describe('scout.dates', () => {
       // Date only
       date = dates.parseJsonDate('0025-11-21Z');
       expect(date.toISOString()).toBe('0025-11-21T00:00:00.000Z');
+
+      // Test 4 - year > 9999, see: https://en.wikipedia.org/wiki/ISO_8601#Years
+      date = dates.parseJsonDate('+20222-11-21 00:00:00.000Z');
+      expect(date.getFullYear()).toBe(20222);
+      jsonDate = dates.toJsonDate(date, true);
+      expect(jsonDate).toBe('+20222-11-21 00:00:00.000Z');
     });
 
   });
@@ -422,6 +428,10 @@ describe('scout.dates', () => {
       expect(dates.create('2014-10-31 23:59:58.882Z').toISOString()).toBe(dates.create('2014-10-31 23:59:58.882Z').toISOString());
     });
 
+    it('works with 5-digits years', () => {
+      let date = dates.create('20144-10-31 23:59:58.882Z');
+      expect(date.getFullYear()).toBe(20144);
+    });
   });
 
   describe('weekInYear', () => {


### PR DESCRIPTION
Note: it is still not allowed to _enter_ a 5-digit year via UI
(DateField), since this could lead to issues in the backend or in a
database.

327188