### PR TITLE
Remove transient modifier from DataObjectHolder#m_value field

### DIFF
--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DataObjectHolder.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DataObjectHolder.java
@@ -28,7 +28,7 @@ public class DataObjectHolder<T extends IDataObject> implements IHolder<T>, Seri
 
   private static final long serialVersionUID = 1L;
 
-  private transient T m_value;
+  private T m_value;
   private final Class<T> m_clazz;
 
   public DataObjectHolder() {


### PR DESCRIPTION
The transient keyword is not necessary for DataObjectHolder#m_value.
Most likely it was added to prevent the Sonar warning 'Fields in a
"Serializable" class should either be transient or serializable', as the
objects stored in m_value (DOs implementing IDataObject) usually do not
implement Serializable.
-> However this warning does not apply to classes implementing their own
   serialization and deserialization, and both #readObject and
   #writeObject use a custom implementation.
-> The Java Language Specification (8.3.1.3. transient Fields) states
   "Variables may be marked transient to indicate that they are not part
   of the persistent state of an object.". This is not the case for
   m_value, thus it should not be marked transient.

327286