### PR TITLE
Tree: don't try to modify dom while being removed

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.js
+++ b/eclipse-scout-core/src/tree/Tree.js
@@ -398,7 +398,7 @@ export default class Tree extends Widget {
     this.scrollToSelection = false;
     let scrollTop = this.$data[0].scrollTop;
     let scrollLeft = this.$data[0].scrollLeft;
-    if (this.scrollTop !== scrollTop) {
+    if (this.scrollTop !== scrollTop && this.rendered) {
       this._renderViewport();
     }
     this.scrollTop = scrollTop;
@@ -1915,9 +1915,7 @@ export default class Tree extends Widget {
   _addToVisibleFlatListNoCheck(node, insertIndex, animatedRendering) {
     arrays.insert(this.visibleNodesFlat, node, insertIndex);
     this.visibleNodesMap[node.id] = true;
-    if (this.rendered) {
-      this.showNode(node, animatedRendering, insertIndex);
-    }
+    this.showNode(node, animatedRendering, insertIndex);
   }
 
   scrollTo(node, options) {
@@ -2154,10 +2152,16 @@ export default class Tree extends Widget {
     }
   }
 
+  /**
+   * @param {TreeNode} [parentNode]
+   */
   insertNode(node, parentNode) {
     this.insertNodes([node], parentNode);
   }
 
+  /**
+   * @param {TreeNode} [parentNode]
+   */
   insertNodes(nodes, parentNode) {
     nodes = arrays.ensure(nodes).slice();
     if (nodes.length === 0) {
@@ -3023,7 +3027,7 @@ export default class Tree extends Widget {
   }
 
   hideNode(node, useAnimation, suppressDetachHandling) {
-    if (!node.attached) {
+    if (!this.rendered || !node.attached) {
       return;
     }
     this.viewRangeDirty = true;


### PR DESCRIPTION
Use case:
User clicks 'x' in the TreeSmartField.
TreePopup closes with an animation.
During that time, the results of the lookup call arrive.
The tree gets populated and the view range dirty.
Also, a scroll event happens because there are many nodes.
_renderViewRange fails because hideNode() detached the deleted nodes

326521