### PR TITLE
Hide menus with ValueFieldMenuType.NULL on SmartFields if value is present

### DIFF
--- a/eclipse-scout-core/src/form/fields/ValueField.js
+++ b/eclipse-scout-core/src/form/fields/ValueField.js
@@ -381,9 +381,9 @@ export default class ValueField extends FormField {
     }
 
     this._valueChanged();
-    this._updateMenus();
     this._updateTouched();
     this._updateEmpty();
+    this._updateMenus();
     this.triggerPropertyChange('value', oldValue, this.value);
   }
 
@@ -399,10 +399,10 @@ export default class ValueField extends FormField {
   }
 
   _getCurrentMenuTypes() {
-    if (this.value) {
-      return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.NotNull];
+    if (this.empty) {
+      return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.Null];
     }
-    return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.Null];
+    return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.NotNull];
   }
 
   /**


### PR DESCRIPTION
Previously, menus with menuType=ValueFieldMenuType.NULL were displayed on smartfields in some cases (e.g. when a value was set when opening a form, which used 0 as the smart field value, which was then interpreted as an empty field).

329690