### PR TITLE
Fix menuTypes for Scout Classic

### DIFF
--- a/eclipse-scout-core/src/form/fields/FormField.js
+++ b/eclipse-scout-core/src/form/fields/FormField.js
@@ -849,7 +849,7 @@ export default class FormField extends Widget {
   }
 
   getContextMenuItems(onlyVisible = true) {
-    let currentMenuTypes = this._getCurrentMenuTypes();
+    let currentMenuTypes = this.getCurrentMenuTypes();
     if (currentMenuTypes.length) {
       return menuUtil.filter(this.menus, currentMenuTypes, {onlyVisible, defaultMenuTypes: this.defaultMenuTypes});
     } else if (onlyVisible) {
@@ -904,6 +904,10 @@ export default class FormField extends Widget {
 
   _renderMenusVisible() {
     this._updateMenus();
+  }
+
+  getCurrentMenuTypes() {
+    return this._getCurrentMenuTypes();
   }
 
   _getCurrentMenuTypes() {

--- a/eclipse-scout-core/src/form/fields/FormFieldAdapter.js
+++ b/eclipse-scout-core/src/form/fields/FormFieldAdapter.js
@@ -73,17 +73,14 @@ export default class FormFieldAdapter extends ModelAdapter {
       return;
     }
 
-    objects.replacePrototypeFunction(FormField, '_getCurrentMenuTypes', FormFieldAdapter._getCurrentMenuTypes, true);
+    objects.replacePrototypeFunction(FormField, 'getCurrentMenuTypes', FormFieldAdapter.getCurrentMenuTypes, true);
   }
 
-  static _getCurrentMenuTypes() {
-    let currentMenuTypes = this._getCurrentMenuTypesOrig();
-
+  static getCurrentMenuTypes() {
     if (this.modelAdapter) {
-      currentMenuTypes = [...currentMenuTypes, ...this.modelAdapter._currentMenuTypes];
+      return this.modelAdapter._currentMenuTypes;
     }
-
-    return currentMenuTypes;
+    return this.getCurrentMenuTypesOrig();
   }
 }
 

--- a/eclipse-scout-core/src/form/fields/ValueField.js
+++ b/eclipse-scout-core/src/form/fields/ValueField.js
@@ -399,10 +399,10 @@ export default class ValueField extends FormField {
   }
 
   _getCurrentMenuTypes() {
-    if (this.value) {
-      return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.NotNull];
+    if (objects.isNullOrUndefined(this.value)) {
+      return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.Null];
     }
-    return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.Null];
+    return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.NotNull];
   }
 
   /**

--- a/eclipse-scout-core/test/form/fields/ValueFieldSpec.js
+++ b/eclipse-scout-core/test/form/fields/ValueFieldSpec.js
@@ -769,6 +769,14 @@ describe('ValueField', () => {
       $menu = $('body').find('.context-menu');
       expect($menu.find('.menu-item').length).toBe(1);
       expect($menu.find('.menu-item').eq(0).isVisible()).toBe(true);
+
+      // 0 does not change current menu types
+      formField.setValue(0);
+      formField.fieldStatus.showContextMenu();
+
+      $menu = $('body').find('.context-menu');
+      expect($menu.find('.menu-item').length).toBe(1);
+      expect($menu.find('.menu-item').eq(0).isVisible()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Do not consider any JS menuTypes for Scout Classic. Consider 0 as not null for ValueField.MenuTypes.

329690