### PR TITLE
Text post processors: Add text key and message arguments as parameters

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/nls/DefaultTextPostProcessor.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/nls/DefaultTextPostProcessor.java
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.platform.nls;
 
 import java.util.Locale;
 
+import org.eclipse.scout.rt.platform.text.NlsKey;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 
 public class DefaultTextPostProcessor implements ITextPostProcessor {
@@ -19,7 +20,7 @@ public class DefaultTextPostProcessor implements ITextPostProcessor {
   protected static final Locale DE_CH = new Locale("de", "CH");
 
   @Override
-  public String apply(Locale textLocale, String text) {
+  public String apply(Locale textLocale, @NlsKey String textKey, String text, String... messageArguments) {
     if (textLocale == null || StringUtility.isNullOrEmpty(text)) {
       return text;
     }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/nls/ITextPostProcessor.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/nls/ITextPostProcessor.java
@@ -13,26 +13,30 @@ package org.eclipse.scout.rt.platform.nls;
 import java.util.Locale;
 
 import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.text.NlsKey;
 
 /**
- * Represents a ext post processor.<br>
- * Use {@link NlsUtility#postProcessText(String)} or one of its overloads to post process a text.
+ * Represents a text post processor.<br>
+ * Use {@link NlsUtility#postProcessText(String, String, String...)} or one of its overloads to post process a text.
  *
- * @see NlsUtility#postProcessText(String)
+ * @see NlsUtility#postProcessText(String, String, String...)
  * @since 22.0
  */
 @ApplicationScoped
 public interface ITextPostProcessor {
 
   /**
-   * Applies the post processing to the text given.
+   * Applies the post-processing to the text given.
    *
    * @param textLocale
-   *          The {@link Locale} of the text given. May be {@code null}.
+   *     The {@link Locale} of the text given. May be {@code null}.
+   * @param textKey
+   *     The text key of the text to post-process. May be {@code null}.
    * @param text
-   *          The text to post process. May be {@code null}.
+   *     The text to post process. May be {@code null}.
+   * @param messageArguments
+   *     Values of possible placeholders, as used in {@link NlsUtility#bindText}.
    * @return The processed text.
    */
-  String apply(Locale textLocale, String text);
-
+  String apply(Locale textLocale, @NlsKey String textKey, String text, String... messageArguments);
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/nls/NlsUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/nls/NlsUtility.java
@@ -17,6 +17,8 @@ import java.util.regex.Pattern;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IBeanManager;
+import org.eclipse.scout.rt.platform.text.NlsKey;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
 public final class NlsUtility {
 
@@ -70,30 +72,17 @@ public final class NlsUtility {
    * Applies all {@link ITextPostProcessor text post processors} registered in the {@link IBeanManager} to the text
    * given. It is assumed that the given text uses the {@link NlsLocale}.
    *
+   * @param textKey
+   *          The text key of the text to post-process. May be {@code null}.
    * @param text
    *          The text to post-process. May be {@code null}.
+   * @param messageArguments
+   *          Values of possible placeholders, as used in {@link #bindText}.
    * @return The text with all post-processing applied.
-   * @see #postProcessText(Locale, String)
-   * @see #postProcessText(Locale, String, Collection)
+   * @see #postProcessText(Locale, String, String, Collection, String...)
    */
-  public static String postProcessText(String text) {
-    return postProcessText(NlsLocale.get(), text);
-  }
-
-  /**
-   * Applies the {@link ITextPostProcessor text post processors} given to the text given. It is assumed that the given
-   * text uses the {@link NlsLocale}.
-   *
-   * @param text
-   *          The text to post-process. May be {@code null}.
-   * @param postProcessors
-   *          The post processors to execute. May be {@code null}.
-   * @return The text with all post-processing applied.
-   * @see #postProcessText(Locale, String)
-   * @see #postProcessText(Locale, String, Collection)
-   */
-  public static String postProcessText(String text, Collection<? extends ITextPostProcessor> postProcessors) {
-    return postProcessText(NlsLocale.get(), text, postProcessors);
+  public static String postProcessText(@NlsKey String textKey, String text, String... messageArguments) {
+    return postProcessText(NlsLocale.get(), textKey, text, BEANS.all(ITextPostProcessor.class), messageArguments);
   }
 
   /**
@@ -102,14 +91,34 @@ public final class NlsUtility {
    *
    * @param textLocale
    *          The locale of the text given. May be {@code null}.
+   * @param textKey
+   *          The text key of the text to post-process. May be {@code null}.
    * @param text
    *          The text to post-process. May be {@code null}.
    * @return The text with all post-processing applied.
-   * @see #postProcessText(String)
-   * @see #postProcessText(Locale, String, Collection)
+   * @see #postProcessText(Locale, String, String, Collection, String...)
    */
-  public static String postProcessText(Locale textLocale, String text) {
-    return postProcessText(textLocale, text, BEANS.all(ITextPostProcessor.class));
+  public static String postProcessText(Locale textLocale, @NlsKey String textKey, String text, String... messageArguments) {
+    return postProcessText(textLocale, textKey, text, BEANS.all(ITextPostProcessor.class), messageArguments);
+  }
+
+  /**
+   * Applies given {@link ITextPostProcessor text post processors} to the text given. It is assumed that the given text
+   * uses the {@link NlsLocale}.
+   *
+   * @param textKey
+   *          The text key of the text to post-process. May be {@code null}.
+   * @param text
+   *          The text to post-process. May be {@code null}.
+   * @param postProcessors
+   *          The post processors to execute. May be {@code null}.
+   * @param messageArguments
+   *          Values of possible placeholders, as used in {@link #bindText}.
+   * @return The text with all post-processing applied.
+   * @see #postProcessText(Locale, String, String, Collection, String...)
+   */
+  public static String postProcessText(@NlsKey String textKey, String text, Collection<? extends ITextPostProcessor> postProcessors, String... messageArguments) {
+    return postProcessText(NlsLocale.get(), textKey, text, postProcessors, messageArguments);
   }
 
   /**
@@ -117,16 +126,18 @@ public final class NlsUtility {
    *
    * @param textLocale
    *          The locale of the text given. May be {@code null}.
+   * @param textKey
+   *          The text key of the text to post-process. May be {@code null}.
    * @param text
    *          The text to post-process. May be {@code null}.
    * @param postProcessors
    *          The post processors to execute. May be {@code null}.
+   * @param messageArguments
+   *          Values of possible placeholders, as used in {@link #bindText}.
    * @return The text with all post-processing applied.
-   * @see #postProcessText(Locale, String)
-   * @see #postProcessText(String)
    */
-  public static String postProcessText(Locale textLocale, String text, Collection<? extends ITextPostProcessor> postProcessors) {
-    if (text == null || postProcessors == null || postProcessors.isEmpty()) {
+  public static String postProcessText(Locale textLocale, @NlsKey String textKey, String text, Collection<? extends ITextPostProcessor> postProcessors, String... messageArguments) {
+    if (text == null && textKey == null || CollectionUtility.isEmpty(postProcessors)) {
       return text;
     }
 
@@ -135,7 +146,7 @@ public final class NlsUtility {
       if (postProcessor == null) {
         continue;
       }
-      result = postProcessor.apply(textLocale, result);
+      result = postProcessor.apply(textLocale, textKey, result, messageArguments);
     }
     return result;
   }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/text/ITextProviderService.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/text/ITextProviderService.java
@@ -38,7 +38,7 @@ public interface ITextProviderService extends IService {
    *          <li>getText("MissingFile3", fileName, dir); with MissingFile3="The File {0} in Folder {1} could not be
    *          found."</li>
    *          </ul>
-   * @return
+   * @return the resolved, translated text
    */
   String getText(Locale locale, @NlsKey String key, String... messageArguments);
 


### PR DESCRIPTION
- Adds text key and message arguments as new parameters in ITextPostProcessor#apply to allow more possibilities in any implementations
- Adjusts NlsUtility accordingly
- Adjusts DynamicNls to cache a text post-processor only once i.e., replaces the internal list of text post processors with a set
- Adjusts Java-Doc

320031