### PR TITLE
Don't execute keystrokes if widget is being removed

### DIFF
--- a/eclipse-scout-core/src/keystroke/KeyStroke.js
+++ b/eclipse-scout-core/src/keystroke/KeyStroke.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {Action, HAlign, Key, keys, scout} from '../index';
+import {Action, HAlign, Key, keys, scout, Widget} from '../index';
 import $ from 'jquery';
 
 export default class KeyStroke {
@@ -134,24 +134,29 @@ export default class KeyStroke {
   _isEnabled() {
     // Hint: do not check for which.length because there are keystrokes without a which, e.g. RangeKeyStroke.js
 
-    if (this.field) {
-      // Check visibility
-      if (this.field.visible !== undefined && !this.field.visible) {
-        return false;
-      }
-      // Check enabled state (if inheritAccessibility is true)
-      if (!this.inheritAccessibility) {
-        return true;
-      }
-      if (this.field.enabledComputed !== undefined) {
-        return this.field.enabledComputed;
-      }
-      if (this.field.enabled !== undefined) {
-        // This should actually not happen because this.field should always be a hypothetical case if this.field is not a widget
-        return this.field.enabled;
-      }
+    if (!this.field) {
+      return true;
     }
-    return true;
+    if (this.field instanceof Widget && this.field.isRemovalPending()) {
+      // Prevent possible exceptions or unexpected behavior if a keystroke is executed while a widget is being removed.
+      return false;
+    }
+    // Check visibility
+    if (this.field.visible !== undefined && !this.field.visible) {
+      return false;
+    }
+    // Check enabled state (if inheritAccessibility is true)
+    if (!this.inheritAccessibility) {
+      return true;
+    }
+    if (this.field.enabledComputed !== undefined) {
+      return this.field.enabledComputed;
+    }
+    if (this.field.enabled !== undefined) {
+      // This should actually not happen because this.field should always be a widget
+      return this.field.enabled;
+    }
+    return false;
   }
 
   /**

--- a/eclipse-scout-core/src/table/keystrokes/AbstractTableNavigationKeyStroke.js
+++ b/eclipse-scout-core/src/table/keystrokes/AbstractTableNavigationKeyStroke.js
@@ -197,6 +197,6 @@ export default class AbstractTableNavigationKeyStroke extends KeyStroke {
   }
 
   _isEnabled() {
-    return !this.field.tileMode;
+    return !this.field.tileMode && super._isEnabled();
   }
 }


### PR DESCRIPTION
Use case:

TileGrid in a popup. User closes popup and presses arrow key -> exception because grid tries to render an already rendered tile.

There is no need to execute keystrokes for a widget that is being removed.
Used isRemovalPending instead of rendered because there may be keystrokes for not rendered widgets, e.g. ActionKeyStroke.

330325