### PR TITLE
Tree: increase padding if parent has an icon

### DIFF
--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -351,6 +351,7 @@
 @tooltip-padding-x: 12px;
 @tooltip-padding-y: @context-menu-item-padding-y;
 @tree-node-icon-width: 16px;
+@tree-node-icon-padding-right: 9px;
 @tree-node-bitmap-icon-size: @tree-node-icon-width;
 @tree-node-bitmap-icon-margin-top: -2px;
 @tree-node-checkbox-size: 20px;
@@ -364,6 +365,7 @@
 @tree-node-padding-left: 28px;
 @tree-node-padding-right: 7px;
 @tree-node-padding-y: 7px;
+@tree-node-padding-level-diff-parent-has-icon: @tree-node-icon-width + @tree-node-icon-padding-right;
 @view-tab-key-box-bottom: 9px;
 @view-tab-icon-font-size: 20px;
 @view-tab-selected-width: 56px;

--- a/eclipse-scout-core/src/tree/Tree.less
+++ b/eclipse-scout-core/src/tree/Tree.less
@@ -10,6 +10,8 @@
  */
 .tree {
   position: relative;
+  // The value of the css variable is read by Tree.js and added to the level padding if the parent node has an icon
+  --node-padding-level-diff-parent-has-icon: @tree-node-padding-level-diff-parent-has-icon;
 
   &:focus,
   &.focused {
@@ -122,7 +124,7 @@
 
   & > .icon {
     vertical-align: top;
-    padding-right: 9px;
+    padding-right: @tree-node-icon-padding-right;
     display: inline-block;
     text-align: center;
     min-width: @tree-node-icon-width;

--- a/eclipse-scout-core/src/tree/TreeNode.js
+++ b/eclipse-scout-core/src/tree/TreeNode.js
@@ -258,7 +258,7 @@ export default class TreeNode {
 
   _updateControl($control, tree) {
     $control.toggleClass('checkable', tree.checkable);
-    $control.cssPaddingLeft(tree.nodeControlPaddingLeft + this.level * tree.nodePaddingLevel);
+    $control.cssPaddingLeft(tree._computeNodeControlPaddingLeft(this));
     $control.setVisible(!this.leaf);
   }
 


### PR DESCRIPTION
The hierarchy of the tree is not visible clearly and even looks broken if the parent node has an icon.

To improve that, the left padding of the tree node has been increased if the parent node has an icon.
This means, not every node in a tree has the same padding anymore, unless they have the same parent node. However, this seems to be a smaller problem than a hierarchy visualization issue.

329049