### PR TITLE
Tree: increase padding if parent has an icon

### DIFF
--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -351,6 +351,7 @@
 @tooltip-padding-x: 12px;
 @tooltip-padding-y: @context-menu-item-padding-y;
 @tree-node-icon-width: 16px;
+@tree-node-icon-padding-right: 9px;
 @tree-node-bitmap-icon-size: @tree-node-icon-width;
 @tree-node-bitmap-icon-margin-top: -2px;
 @tree-node-checkbox-size: 20px;
@@ -364,6 +365,7 @@
 @tree-node-padding-left: 28px;
 @tree-node-padding-right: 7px;
 @tree-node-padding-y: 7px;
+@tree-node-padding-level-diff-parent-has-icon: @tree-node-icon-width + @tree-node-icon-padding-right;
 @view-tab-key-box-bottom: 9px;
 @view-tab-icon-font-size: 20px;
 @view-tab-selected-width: 56px;

--- a/eclipse-scout-core/src/tree/Tree.less
+++ b/eclipse-scout-core/src/tree/Tree.less
@@ -10,6 +10,8 @@
  */
 .tree {
   position: relative;
+  // The value of the css variable is read by Tree.js and added to the level padding if the parent node has an icon
+  --node-padding-level-diff-parent-has-icon: @tree-node-padding-level-diff-parent-has-icon;
 
   &:focus,
   &.focused {
@@ -122,7 +124,7 @@
 
   & > .icon {
     vertical-align: top;
-    padding-right: 9px;
+    padding-right: @tree-node-icon-padding-right;
     display: inline-block;
     text-align: center;
     min-width: @tree-node-icon-width;

--- a/eclipse-scout-core/src/tree/TreeNode.js
+++ b/eclipse-scout-core/src/tree/TreeNode.js
@@ -253,12 +253,13 @@ export default class TreeNode {
 
   _renderControl() {
     let $control = this.$node.prependDiv('tree-node-control');
-    this._updateControl($control, this.getTree());
+    this._updateControl($control);
   }
 
-  _updateControl($control, tree) {
+  _updateControl($control) {
+    let tree = this.getTree();
     $control.toggleClass('checkable', tree.checkable);
-    $control.cssPaddingLeft(tree.nodeControlPaddingLeft + this.level * tree.nodePaddingLevel);
+    $control.cssPaddingLeft(tree._computeNodeControlPaddingLeft(this));
     $control.setVisible(!this.leaf);
   }
 

--- a/eclipse-scout-core/test/tree/TreeAdapterSpec.js
+++ b/eclipse-scout-core/test/tree/TreeAdapterSpec.js
@@ -414,7 +414,7 @@ describe('TreeAdapter', () => {
 
         let event = helper.createNodeChangedEvent(model, node0.id);
         adapter.onModelAction(event);
-        expect(tree.changeNode).toHaveBeenCalledWith(node0);
+        expect(tree.changeNode).toHaveBeenCalled();
       });
 
       it('updates the text of the node', () => {


### PR DESCRIPTION
The hierarchy of the tree is not visible clearly and even looks broken if the parent node has an icon.

To improve that, the left padding of the tree node has been increased if the parent node has an icon.

Note: if the nodes already have icons or checkboxes (in case of checkable trees), the padding won't be increased because the hierarchy is already visible well, and it would unnecessarly introduce large whitespace.
If the tree uses mixed icon states (some nodes have icons on the same level and some not), it may look confusing at first, but mixed icon states look confusing anyway and should be avoided if possible. If the new behavior is not desired for certain trees, it can be deactivated using CSS by setting the CSS variable
--node-padding-level-diff-parent-has-icon to 0.

329049