### PR TITLE
RemoteApp: handle errors while rendering of desktop

### DIFF
--- a/eclipse-scout-core/src/App.js
+++ b/eclipse-scout-core/src/App.js
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -341,8 +341,9 @@ export default class App {
     // Bluebird has a polyfill -> can it be ported to jQuery?
   }
 
-  _createErrorHandler() {
-    return scout.create('ErrorHandler');
+  _createErrorHandler(opts) {
+    opts = $.extend({}, opts);
+    return scout.create('ErrorHandler', opts);
   }
 
   /**
@@ -459,16 +460,33 @@ export default class App {
     $.log.error('App initialization failed.');
     this.setLoading(false);
 
-    return this.errorHandler.handle(error, ...args)
-      .then(errorInfo => {
-        let $error = $('body').appendDiv('startup-error');
-        $error.appendDiv('startup-error-title').text('The application could not be started');
-        if (errorInfo.message) {
-          $error.appendDiv('startup-error-message').text(errorInfo.message);
-        }
-        // Reject with original rejection arguments
-        return $.rejectedPromise(error, ...args);
-      });
+    let promises = [];
+    if (this.sessions.length === 0) {
+      promises.push(this.errorHandler.handle(error, ...args)
+        .then(errorInfo => {
+          this._appendStartupError($('body'), errorInfo.message);
+        }));
+    } else {
+      // Session.js may already display a fatal message box
+      // -> don't handle the error again and display multiple error messages
+      this.sessions
+        .filter(session => !session.ready && !session.isFatalMessageShown())
+        .forEach(session => {
+          session.$entryPoint.empty();
+          promises.push(this._createErrorHandler({session: session}).handle(error));
+        });
+    }
+
+    // Reject with original rejection arguments
+    return $.promiseAll(promises).then(errorInfo => $.rejectedPromise(error, ...args));
+  }
+
+  _appendStartupError($parent, message) {
+    let $error = $parent.appendDiv('startup-error');
+    $error.appendDiv('startup-error-title').text('The application could not be started');
+    if (message) {
+      $error.appendDiv('startup-error-message').text(message);
+    }
   }
 
   /**
@@ -517,13 +535,3 @@ export default class App {
     return this.events.when(type);
   }
 }
-/*
- * Copyright (c) 2010-2019 BSI Business Systems Integration AG.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     BSI Business Systems Integration AG - initial API and implementation
- */

--- a/eclipse-scout-core/src/ErrorHandler.js
+++ b/eclipse-scout-core/src/ErrorHandler.js
@@ -19,6 +19,7 @@ export default class ErrorHandler {
     this.displayError = true;
     this.sendError = false;
     this.windowErrorHandler = this._onWindowError.bind(this);
+    this.session = null;
   }
 
   /**
@@ -264,8 +265,8 @@ export default class ErrorHandler {
     // Note: The error handler is installed globally and we cannot tell in which scout session the error happened.
     // We simply use the first scout session to display the message box and log the error. This is not ideal in the
     // multi-session-case (portlet), but currently there is no other way. Besides, this feature is not in use yet.
-    if (App.get().sessions.length > 0) {
-      let session = App.get().sessions[0];
+    let session = this.session || App.get().sessions[0];
+    if (session) {
       if (this.displayError && errorInfo.level === logging.Level.ERROR) {
         this._showMessageBox(session, errorInfo.message, errorInfo.code, errorInfo.log);
       }

--- a/eclipse-scout-core/src/RemoteApp.js
+++ b/eclipse-scout-core/src/RemoteApp.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -31,10 +31,11 @@ export default class RemoteApp extends App {
     defaultValues.bootstrap();
   }
 
-  _createErrorHandler() {
-    return scout.create('ErrorHandler', {
+  _createErrorHandler(opts) {
+    opts = $.extend({
       sendError: true
-    });
+    }, opts);
+    return super._createErrorHandler(opts);
   }
 
   /**
@@ -46,13 +47,5 @@ export default class RemoteApp extends App {
     let session = this._createSession(options);
     App.get().sessions.push(session);
     return session.start();
-  }
-
-  _fail(options, error, ...args) {
-    $.log.error('App initialization failed', error);
-    this.setLoading(false);
-    // Session.js already handled the error -> don't show a message here
-    // Reject with original rejection arguments
-    return $.rejectedPromise(error, ...args);
   }
 }

--- a/eclipse-scout-core/src/main.less
+++ b/eclipse-scout-core/src/main.less
@@ -501,6 +501,7 @@ a,
   padding: 20px;
   border: 1px solid @error-border-color;
   background-color: @error-background-color;
+  border-radius: @border-radius-large;
 }
 
 .startup-error-title {

--- a/eclipse-scout-core/src/session/Session.js
+++ b/eclipse-scout-core/src/session/Session.js
@@ -1069,12 +1069,13 @@ export default class Session {
    *          do nothing. Can be used to prevent double messages for the same error.
    */
   showFatalMessage(options, errorCode) {
-    if (errorCode) {
-      if (this._fatalMessagesOnScreen[errorCode]) {
-        return;
-      }
-      this._fatalMessagesOnScreen[errorCode] = true;
+    if (!errorCode) {
+      errorCode = App.get().errorHandler.getJsErrorCode();
     }
+    if (this._fatalMessagesOnScreen[errorCode]) {
+      return;
+    }
+    this._fatalMessagesOnScreen[errorCode] = true;
 
     options = options || {};
     let model = {
@@ -1105,6 +1106,10 @@ export default class Session {
       }
     });
     messageBox.render($entryPoint);
+  }
+
+  isFatalMessageShown() {
+    return Object.keys(this._fatalMessagesOnScreen).length > 0;
   }
 
   uploadFiles(target, files, uploadProperties, maxTotalSize, allowedTypes) {


### PR DESCRIPTION
If there occurs an error while the desktop is rendering it might be only half rendered which leads to strange behaviour of the App (misplaced widgets, widgets that behave unexpected, ...). Therefore, do not display the half rendered desktop but an error message.