### PR TITLE
Outline: make defaultDetailForm not closable

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.js
+++ b/eclipse-scout-core/src/desktop/outline/Outline.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -482,6 +482,7 @@ export default class Outline extends Tree {
     }
     this._setProperty('defaultDetailForm', defaultDetailForm);
     if (this.defaultDetailForm) {
+      this.defaultDetailForm.setClosable(false);
       this.defaultDetailForm.detailForm = true;
     }
     if (this.initialized) {


### PR DESCRIPTION
The defaultDetailForm of an Outline must not be closable. Even if there is no CloseMenu or 'X' the form can be closed with the ESC-keystroke otherwise.

332223