### PR TITLE
TableControl: do not render content if control is not selected

### DIFF
--- a/eclipse-scout-core/src/table/TableFooter.js
+++ b/eclipse-scout-core/src/table/TableFooter.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -583,13 +583,13 @@ export default class TableFooter extends Widget {
       if (footer.animating) {
         // Layout may be called when container stays open but changes its size using an animation.
         // At that time the controlContainer has not yet the final size, therefore measuring is not possible, but not necessary anyway.
-        controlContainerHeight = control.height;
+        controlContainerHeight = scout.nvl(control && control.height, controlContainerHeight);
       } else {
         // Measure the real height
         controlContainerHeight = graphics.size(footer.$controlContainer).height;
         // Expand control height? (but only if not resizing)
         if (!footer.resizing && growControl) {
-          controlContainerHeight = Math.max(control.height, controlContainerHeight);
+          controlContainerHeight = Math.max(control && control.height, controlContainerHeight);
         }
       }
     }

--- a/eclipse-scout-core/src/table/controls/TableControl.js
+++ b/eclipse-scout-core/src/table/controls/TableControl.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -99,10 +99,15 @@ export default class TableControl extends Action {
   /**
    * Renders the content if not already rendered.<br>
    * Opens the container if the container is not already open.<br>
-   * Does nothing if the content is not available yet to -> don't open container if content is not rendered yet to prevent blank container or laggy opening.
+   * Does nothing if the content is not available yet to -> don't open container if content is not rendered yet to prevent blank container or laggy opening.<br>
+   * Does nothing if the control is not selected.
    */
   renderContent() {
     if (!this.contentRendered && !this.isContentAvailable()) {
+      return;
+    }
+
+    if (!this.selected) {
       return;
     }
 


### PR DESCRIPTION
If the content of a not selected table control is rendered, the table footer will open the control container. This will invalidate the layout of the table and when the table is layouted again the height of the selected table control is taken into account. As the control that opened the container was not selected the selected control taken into account is either null or a different control, both would be wrong.

241917