### PR TITLE
TileGrid: do not show placeholders if a tile spans over all columns

### DIFF
--- a/eclipse-scout-core/src/tile/TileGrid.js
+++ b/eclipse-scout-core/src/tile/TileGrid.js
@@ -635,7 +635,8 @@ export default class TileGrid extends Widget {
       placeholders = [];
 
     if (tiles.length > 0) {
-      lastX = tiles[tiles.length - 1].gridData.x;
+      let tile = tiles[tiles.length - 1];
+      lastX = tile.gridData.x + tile.gridData.w - 1;
     } else {
       // If there are no tiles, create one row with placeholders
       lastX = -1;


### PR DESCRIPTION
If a tile grid is used with placeholders and there is only one tile that spans over all columns, no placeholders should be visible.

Since the width of the only tile is not taken into account, placeholders are created and placed in the next row of the tile grid.

332525