### PR TITLE
DateField: allowed dates are not enabled if date has a time

### DIFF
--- a/eclipse-scout-core/src/datepicker/DatePicker.js
+++ b/eclipse-scout-core/src/datepicker/DatePicker.js
@@ -23,7 +23,7 @@ export default class DatePicker extends Widget {
     this.selectedDate = null;
     this.dateFormat = null;
     this.viewDate = null;
-    this.allowedDates = null;
+    this.allowedDates = [];
     this.currentMonth = null;
     this.$scrollable = null;
     // Contains the months to be rendered.
@@ -342,7 +342,7 @@ export default class DatePicker extends Widget {
     let date = this.preselectedDate;
 
     if (this.selectedDate) {
-      if (this.allowedDates) {
+      if (this.allowedDates.length > 0) {
         date = this._findNextAllowedDate(years, months, days);
       } else {
         date = dates.shift(this.selectedDate, years, months, days);
@@ -391,16 +391,12 @@ export default class DatePicker extends Widget {
 
   _isDateAllowed(date) {
     // when allowedDates is empty or not set, any date is allowed
-    if (!this.allowedDates || this.allowedDates.length === 0) {
+    if (this.allowedDates.length === 0) {
       return true;
     }
     // when allowedDates is set, only dates contained in this array are allowed
-    let allowedDateAsTimestamp,
-      dateAsTimestamp = date.getTime();
-    return this.allowedDates.some(allowedDate => {
-      allowedDateAsTimestamp = allowedDate.getTime();
-      return allowedDateAsTimestamp === dateAsTimestamp;
-    });
+    let dateAsTimestamp = dates.trunc(date).getTime();
+    return this.allowedDates.some(allowedDate => allowedDate.getTime() === dateAsTimestamp);
   }
 
   _build$DateBox(viewDate) {

--- a/eclipse-scout-core/src/form/fields/datefield/DateFieldAdapter.js
+++ b/eclipse-scout-core/src/form/fields/datefield/DateFieldAdapter.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, dates, ParsingFailedStatus, ValueFieldAdapter} from '../../../index';
+import {App, arrays, DateField, dates, objects, ParsingFailedStatus, ValueFieldAdapter} from '../../../index';
 
 export default class DateFieldAdapter extends ValueFieldAdapter {
 
@@ -17,13 +17,6 @@ export default class DateFieldAdapter extends ValueFieldAdapter {
   }
 
   static PROPERTIES_ORDER = ['hasTime', 'hasDate'];
-
-  /**
-   * @override
-   */
-  _initProperties(model) {
-    super._initProperties(model);
-  }
 
   /**
    * @override
@@ -64,4 +57,21 @@ export default class DateFieldAdapter extends ValueFieldAdapter {
     return Object.keys(newProperties).sort(this._createPropertySortFunc(DateFieldAdapter.PROPERTIES_ORDER));
   }
 
+  static isDateAllowedRemote(date) {
+    if (!this.modelAdapter) {
+      return this.isDateAllowedOrig(date);
+    }
+    // Server will take care of it
+    return true;
+  }
+
+  static modifyPrototype() {
+    if (!App.get().remote) {
+      return;
+    }
+
+    objects.replacePrototypeFunction(DateField, 'isDateAllowed', DateFieldAdapter.isDateAllowedRemote, true);
+  }
 }
+
+App.addListener('bootstrap', DateFieldAdapter.modifyPrototype);

--- a/eclipse-scout-core/src/timepicker/TimePicker.js
+++ b/eclipse-scout-core/src/timepicker/TimePicker.js
@@ -204,39 +204,6 @@ export default class TimePicker extends Widget {
 
   }
 
-  _findNextAllowedDate(years, months, days) {
-    let i, date,
-      sum = years + months + days,
-      dir = sum > 0 ? 1 : -1,
-      now = this.selectedDate || dates.trunc(new Date());
-
-    // if we shift by year or month, shift the 'now' date and then use that date as starting point
-    // to find the next allowed date.
-    if (years !== 0) {
-      now = dates.shift(now, years, 0, 0);
-    } else if (months !== 0) {
-      now = dates.shift(now, 0, months, 0);
-    }
-
-    if (dir === 1) { // find next allowed date, starting from currently selected date
-      for (i = 0; i < this.allowedDates.length; i++) {
-        date = this.allowedDates[i];
-        if (dates.compare(now, date) < 0) {
-          return date;
-        }
-      }
-    } else if (dir === -1) { // find previous allowed date, starting from currently selected date
-      for (i = this.allowedDates.length - 1; i >= 0; i--) {
-        date = this.allowedDates[i];
-        if (dates.compare(now, date) > 0) {
-          return date;
-        }
-      }
-    }
-
-    return null;
-  }
-
   _onNavigationMouseDown(event) {
     let $target = $(event.currentTarget);
     let diff = $target.data('shift');

--- a/eclipse-scout-core/test/form/fields/datefield/DateFieldSpec.js
+++ b/eclipse-scout-core/test/form/fields/datefield/DateFieldSpec.js
@@ -66,12 +66,6 @@ describe('DateField', () => {
     expect(dateField.$dateField).toBeFocused();
   }
 
-  function focusTime(dateField) {
-    dateField.$timeField.focus();
-    jasmine.clock().tick(101);
-    expect(dateField.$timeField).toBeFocused();
-  }
-
   function openDatePicker(dateField) {
     dateField.$dateField.triggerMouseDown();
     expect(findDatePicker().length).toBe(1);
@@ -579,7 +573,6 @@ describe('DateField', () => {
     describe('ENTER', () => {
 
       it('updates the model with the selected value and closes picker', () => {
-        let model = createModel();
         let dateField = scout.create('DateField', {
           parent: session.desktop,
           value: '2014-10-01'
@@ -884,7 +877,7 @@ describe('DateField', () => {
     it('_referenceDate returns only allowed date - choose nearest date in the future', () => {
       let dateField = scout.create('DateField', {
         parent: session.desktop,
-        allowedDates: ['2016-03-14', '2016-04-16', '2016-04-17'],
+        allowedDates: ['2016-07-14', '2016-04-16', '2016-04-17'],
         autoDate: '2016-04-15'
       });
       let date = dateField._referenceDate();
@@ -907,6 +900,15 @@ describe('DateField', () => {
       });
       dateField._setAllowedDates(['2016-02-14']);
       expectDate(dateField.allowedDates[0], 2016, 2, 14);
+    });
+
+    it('_setAllowedDates truncates dates', () => {
+      let dateField = scout.create('DateField', {
+        parent: session.desktop
+      });
+      dateField._setAllowedDates(['2016-02-14 15:13:00.000', '2016-05-18 11:08:00.000']);
+      expectDate(dateField.allowedDates[0], 2016, 2, 14, 0, 0);
+      expectDate(dateField.allowedDates[1], 2016, 5, 18, 0, 0);
     });
 
   });
@@ -940,7 +942,7 @@ describe('DateField', () => {
         dateField.$dateField.triggerClick();
         expect(dateField.popup.rendered).toBe(true);
 
-        let selectedDate = selectFirstDayInPicker(dateField.popup._widget.currentMonth.$container);
+        selectFirstDayInPicker(dateField.popup._widget.currentMonth.$container);
         expect(dateField.popup).toBe(null);
       });
 
@@ -1190,7 +1192,7 @@ describe('DateField', () => {
         dateField.$timeField.triggerClick();
         expect(dateField.popup.rendered).toBe(true);
 
-        let selectedDate = selectFirstTimeInPicker(dateField.popup._widget.$container);
+        selectFirstTimeInPicker(dateField.popup._widget.$container);
         expect(dateField.popup).toBe(null);
       });
 

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiTextContributor.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiTextContributor.java
@@ -24,6 +24,7 @@ public class UiTextContributor implements IUiTextContributor {
         "CloseButton",
         "Column",
         "ColumnSorting",
+        "DateIsNotAllowed",
         "ErrorWhileLoadingData",
         "FormEmptyMandatoryFieldsMessage",
         "FormInvalidFieldsMessage",


### PR DESCRIPTION
If the date (value of the date field) contains a time other than 00:00,
no dates can be picked.

Also make it work for Scout JS DateFields as well.
- sort and trunc allowed dates (picker needs the dates that way)
- make sure allowed dates validation does not happen on js side for
 remote fields because ui server does not know about validation errors
  -> error status would not be shown

332172