### PR TITLE
Add notification if max number of ui sessions is exceeded

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/ISessionStore.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/ISessionStore.java
@@ -104,4 +104,6 @@ public interface ISessionStore {
    * way.
    */
   void unregisterUiSession(IUiSession uiSession);
+
+  SessionStoreListeners listeners();
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/SessionStoreEvent.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/SessionStoreEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import java.util.EventObject;
+
+@SuppressWarnings({"serial", "squid:S2057"})
+public class SessionStoreEvent extends EventObject {
+
+  public static final int TYPE_UI_SESSION_REGISTERED = 100;
+  public static final int TYPE_UI_SESSION_UNREGISTERED = 200;
+
+  private final int m_type;
+
+  public SessionStoreEvent(SessionStore source, int type) {
+    super(source);
+    m_type = type;
+  }
+
+  @Override
+  public SessionStore getSource() {
+    return (SessionStore) super.getSource();
+  }
+
+  public int getType() {
+    return m_type;
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/SessionStoreListener.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/SessionStoreListener.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010-2019 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import java.util.EventListener;
+
+@FunctionalInterface
+public interface SessionStoreListener extends EventListener {
+  void changed(SessionStoreEvent e);
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/SessionStoreListeners.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/SessionStoreListeners.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.scout.rt.platform.util.event.AbstractGroupedListenerList;
+
+public final class SessionStoreListeners extends AbstractGroupedListenerList<SessionStoreListener, SessionStoreEvent, Integer> {
+  private static final Set<Integer> KNOWN_EVENT_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+      SessionStoreEvent.TYPE_UI_SESSION_REGISTERED, SessionStoreEvent.TYPE_UI_SESSION_UNREGISTERED)));
+
+  @Override
+  protected Integer eventType(SessionStoreEvent event) {
+    return event.getType();
+  }
+
+  @Override
+  protected Set<Integer> knownEventTypes() {
+    return KNOWN_EVENT_TYPES;
+  }
+
+  @Override
+  protected Integer otherEventsType() {
+    return null;
+  }
+
+  @Override
+  protected void handleEvent(SessionStoreListener listener, SessionStoreEvent event) {
+    listener.changed(event);
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiHtmlConfigProperties.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiHtmlConfigProperties.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.config.AbstractConfigProperty;
+import org.eclipse.scout.rt.platform.config.AbstractIntegerConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractPositiveIntegerConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractPositiveLongConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractStringConfigProperty;
@@ -154,6 +155,27 @@ public final class UiHtmlConfigProperties {
     @Override
     public Integer getDefaultValue() {
       return 30;
+    }
+  }
+
+  public static class MaxUiSessionsPerHttpSession extends AbstractIntegerConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.ui.maxUiSessionsPerHttpSession";
+    }
+
+    @Override
+    public String description() {
+      return "The maximum number of ui sessions per http session before a notification is shown to warn the user about poor performance."
+          + "The browsers only allow a small amount of connections per domain. Due to the background polling of Scout, each tab uses at least one connection."
+          + "This means, if the maximum number of connection exceeds, the user can hardly work anymore and needs to close a browser tab in order to release a connection."
+          + "Important: this feature only works if the browser sends an unload event when the tab is closed. Mobile browsers don't do that, so the features is only enabled for desktop browsers.";
+    }
+
+    @Override
+    public Integer getDefaultValue() {
+      return 5;
     }
   }
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts.properties
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts.properties
@@ -127,6 +127,7 @@ ui.SelectNone=Select none
 ui.SelectNoneFilter=None
 ui.ServerError=Server error
 ui.SessionExpiredMsg=The session has expired, please reload the page.
+ui.SessionLimitExceeded=The maximum number of sessions has been exceeded, which results in a significant loss of performance. Please close browser tabs that are not needed.
 ui.SessionTimeout=Session timeout
 ui.ShowAllNodes=Show all {0}
 ui.Sum=Sum

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_de.properties
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_de.properties
@@ -127,6 +127,7 @@ ui.SelectNone=Keine ausw\u00E4hlen
 ui.SelectNoneFilter=Keine
 ui.ServerError=Serverfehler
 ui.SessionExpiredMsg=Die Sitzung ist abgelaufen, bitte laden Sie die Seite neu.
+ui.SessionLimitExceeded=Die maximale Anzahl von Sitzungen wurde \u00FCberschritten, was zu erheblichen Leistungseinbu\u00DFen f\u00FChrt. Bitte schlie\u00DFen Sie Browser-Tabs, die nicht ben\u00F6tigt werden.
 ui.SessionTimeout=Zeit\u00FCberschreitung der Sitzung
 ui.ShowAllNodes=Alle {0} anzeigen
 ui.Sum=Summe


### PR DESCRIPTION
The browsers only allow a small amount of connections per domain. Due to
 the background polling of Scout, each tab uses at least one connection.
This means, if the maximum number of connection exceeds, the user can
 hardly work anymore and needs to close a browser tab in order to
 release a connection.

332683