### PR TITLE
Support multiple instances of BearerAuthAccessController

### DIFF
--- a/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenVerifierTest.java
+++ b/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenVerifierTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -31,5 +31,21 @@ public class SingleStringTokenVerifierTest {
     assertEquals(ITokenVerifier.AUTH_FORBIDDEN, verifier.verify(List.of("Wrong".getBytes())));
     assertEquals(ITokenVerifier.AUTH_FAILED, verifier.verify(null));
     assertEquals(ITokenVerifier.AUTH_FAILED, verifier.verify(List.of("Correct".getBytes(), "Wrong".getBytes())));
+  }
+
+  @Test
+  public void testMultipleVerifierInstances() {
+    SingleStringTokenVerifier verifier1 = BEANS.get(SingleStringTokenVerifier.class).init(token -> ObjectUtility.equals("Correct1".toCharArray(), token));
+    SingleStringTokenVerifier verifier2 = BEANS.get(SingleStringTokenVerifier.class).init(token -> ObjectUtility.equals("Correct2".toCharArray(), token));
+
+    assertEquals(ITokenVerifier.AUTH_OK, verifier1.verify(List.of("Correct1".getBytes())));
+    assertEquals(ITokenVerifier.AUTH_FORBIDDEN, verifier1.verify(List.of("Correct2".getBytes())));
+    assertEquals(ITokenVerifier.AUTH_FAILED, verifier1.verify(null));
+    assertEquals(ITokenVerifier.AUTH_FAILED, verifier1.verify(List.of("Correct1".getBytes(), "Wrong".getBytes())));
+
+    assertEquals(ITokenVerifier.AUTH_OK, verifier2.verify(List.of("Correct2".getBytes())));
+    assertEquals(ITokenVerifier.AUTH_FORBIDDEN, verifier2.verify(List.of("Correct1".getBytes())));
+    assertEquals(ITokenVerifier.AUTH_FAILED, verifier2.verify(null));
+    assertEquals(ITokenVerifier.AUTH_FAILED, verifier2.verify(List.of("Correct2".getBytes(), "Wrong".getBytes())));
   }
 }

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/ITokenPrincipalProducer.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/ITokenPrincipalProducer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -13,13 +13,10 @@ package org.eclipse.scout.rt.server.commons.authentication.token;
 import java.security.Principal;
 import java.util.List;
 
-import org.eclipse.scout.rt.platform.ApplicationScoped;
-
 /**
  * Producer for {@link Principal} objects to represent authenticated users.
  */
 @FunctionalInterface
-@ApplicationScoped
 public interface ITokenPrincipalProducer {
 
   /**

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/ITokenVerifier.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/ITokenVerifier.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -13,13 +13,10 @@ package org.eclipse.scout.rt.server.commons.authentication.token;
 import java.io.IOException;
 import java.util.List;
 
-import org.eclipse.scout.rt.platform.ApplicationScoped;
-
 /**
  * Verifies a token against a data source like database, config.properties or others.
  */
 @FunctionalInterface
-@ApplicationScoped
 public interface ITokenVerifier {
 
   /**

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenPrincipalProducer.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenPrincipalProducer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -14,11 +14,13 @@ import java.security.Principal;
 import java.util.List;
 import java.util.function.Function;
 
+import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.security.SimplePrincipal;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.TokenUtility;
 
+@Bean
 public class SingleStringTokenPrincipalProducer implements ITokenPrincipalProducer {
 
   protected Function<char[], String> m_tokenToPrincipalMapper;

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenVerifier.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/token/SingleStringTokenVerifier.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -13,10 +13,12 @@ package org.eclipse.scout.rt.server.commons.authentication.token;
 import java.util.List;
 import java.util.function.Predicate;
 
+import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.TokenUtility;
 
+@Bean
 public class SingleStringTokenVerifier implements ITokenVerifier {
 
   protected Predicate<char[]> m_verifier;


### PR DESCRIPTION
Removing the ApplicationScoped annotation from ITokenVerifier and ITokenPrincipalProducer allows to have different instances of the same implementation. This is necessary in case of multiple BearerAuthAccessController instance with different configurations/states are required.

333399