### PR TITLE
Data object migration: Value migrations

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/pom.xml
+++ b/org.eclipse.scout.rt.dataobject.test/pom.xml
@@ -44,6 +44,14 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
 
+    <!-- Jackson used to execute tests using JSON-serialization -->
+    <!-- Use org.eclipse.scout.rt.jackson instead of org.eclipse.scout.rt.jackson.test because of a cyclic dependency -->
+    <dependency>
+      <groupId>org.eclipse.scout.rt</groupId>
+      <artifactId>org.eclipse.scout.rt.jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoStructureMigrationHandlerTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoStructureMigrationHandlerTest.java
@@ -83,8 +83,9 @@ public abstract class AbstractDoStructureMigrationHandlerTest {
       actual = (IDoEntity) dataObjectMapper.readValueRaw(in);
     }
 
-    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class);
-    boolean changed = BEANS.get(DoStructureMigrator.class).migrateDataObject(ctx, actual, toVersion, initialLocalContextData);
+    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class)
+        .withInitialLocalContext(initialLocalContextData);
+    boolean changed = BEANS.get(DoStructureMigrator.class).applyStructureMigration(ctx, actual, toVersion);
 
     assertTrue("Data object was not changed by migration", changed);
 

--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDoStructureMigrationInventory.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDoStructureMigrationInventory.java
@@ -23,18 +23,21 @@ import org.eclipse.scout.rt.platform.namespace.INamespace;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
 @IgnoreBean
+// TODO 23.1 [data object migration] rename to TestDataObjectMigrationInventory
 public class TestDoStructureMigrationInventory extends DoStructureMigrationInventory {
 
   protected final List<INamespace> m_internalNamespaces = new ArrayList<>();
   protected final Collection<ITypeVersion> m_internalTypeVersions = new ArrayList<>();
   protected final Collection<Class<? extends IDoStructureMigrationTargetContextData>> m_internalContextDataClasses = new ArrayList<>();
-  protected final List<IDoStructureMigrationHandler> m_internalMigrationHandlers = new ArrayList<>();
+  protected final List<IDoStructureMigrationHandler> m_internalStructureMigrationHandlers = new ArrayList<>();
+  protected final List<IDoValueMigrationHandler<?>> m_internalValueMigrationHandlers = new ArrayList<>();
 
   public TestDoStructureMigrationInventory(
       List<INamespace> namespaces,
       Collection<ITypeVersion> typeVersions,
       Collection<Class<? extends IDoStructureMigrationTargetContextData>> contextDataClasses,
-      IDoStructureMigrationHandler... migrationHandlers) {
+      Collection<IDoStructureMigrationHandler> structureMigrationHandlers,
+      Collection<IDoValueMigrationHandler<?>> valueMigrationHandlers) {
     assertFalse(CollectionUtility.isEmpty(namespaces), "namespaces must be set");
     assertFalse(CollectionUtility.isEmpty(typeVersions), "typeVersions must be set");
 
@@ -44,11 +47,30 @@ public class TestDoStructureMigrationInventory extends DoStructureMigrationInven
       m_internalContextDataClasses.addAll(contextDataClasses);
     }
 
-    if (migrationHandlers != null) {
-      Collections.addAll(m_internalMigrationHandlers, migrationHandlers);
+    if (structureMigrationHandlers != null) {
+      m_internalStructureMigrationHandlers.addAll(structureMigrationHandlers);
+    }
+    if (valueMigrationHandlers != null) {
+      m_internalValueMigrationHandlers.addAll(valueMigrationHandlers);
     }
 
     init();
+  }
+
+  /**
+   * This constructor will be removed in a future release.
+   *
+   * @deprecated use {@link #TestDoStructureMigrationInventory(List, Collection, Collection, Collection, Collection)}
+   *             instead.
+   */
+  // TODO 23.1 [data object migration] remove deprecated constructor
+  @Deprecated
+  public TestDoStructureMigrationInventory(
+      List<INamespace> namespaces,
+      Collection<ITypeVersion> typeVersions,
+      Collection<Class<? extends IDoStructureMigrationTargetContextData>> contextDataClasses,
+      IDoStructureMigrationHandler... structureMigrationHandlers) {
+    this(namespaces, typeVersions, contextDataClasses, CollectionUtility.arrayList(structureMigrationHandlers), Collections.emptyList());
   }
 
   @Override
@@ -67,7 +89,12 @@ public class TestDoStructureMigrationInventory extends DoStructureMigrationInven
   }
 
   @Override
-  protected List<IDoStructureMigrationHandler> getAllMigrationHandlers() {
-    return m_internalMigrationHandlers;
+  protected List<IDoStructureMigrationHandler> getAllStructureMigrationHandlers() {
+    return m_internalStructureMigrationHandlers;
+  }
+
+  @Override
+  protected List<IDoValueMigrationHandler<?>> getAllValueMigrationHandlers() {
+    return m_internalValueMigrationHandlers;
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDoStructureMigrator.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDoStructureMigrator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
+
+@IgnoreBean
+// TODO 23.1 [data object migration] rename to TestDataObjectMigrator
+public class TestDoStructureMigrator extends DoStructureMigrator {
+
+  /**
+   * Override to change visibility from protected to public.
+   */
+  @Override
+  public boolean applyStructureMigration(DoStructureMigrationContext ctx, IDataObject dataObject, NamespaceVersion toVersion) {
+    return super.applyStructureMigration(ctx, dataObject, toVersion);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorStructureMigrationTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorStructureMigrationTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.scout.rt.platform.util.Assertions.assertTrue;
 import static org.eclipse.scout.rt.testing.platform.util.ScoutAssert.assertEqualsWithComparisonFailure;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
@@ -52,9 +54,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Tests for {@link DoStructureMigrator}.
+ * Tests for {@link DoStructureMigrator}, with focus on data object structure migrations
+ * ({@link IDoStructureMigrationHandler}).
  */
-public class DoStructureMigratorTest {
+public class DataObjectMigratorStructureMigrationTest {
 
   private static final List<IBean<?>> TEST_BEANS = new ArrayList<>();
 
@@ -68,20 +71,20 @@ public class DoStructureMigratorTest {
         testHelper.getFixtureNamespaces(),
         testHelper.getFixtureTypeVersions(),
         testHelper.getFixtureContextDataClasses(),
-        new PostalAddressFixtureUpdateVersionOnlyMigrationHandler_2(),
-        new PetFixtureCaseSensitiveNameMigrationHandler_2(),
-        new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3(),
-        new CustomerFixtureMigrationHandler_3(),
-        new CharlieCustomerFixtureMigrationHandler_3(),
-        new HouseFixtureDoStructureMigrationHandler_2(),
-        new RoomFixtureDoStructureMigrationHandler_2(),
-        new RoomFixtureDoStructureMigrationHandler_3(),
-        new RoomFixtureDoStructureMigrationHandler_4(),
-        new RoomFixtureDoStructureMigrationHandler_5(),
-        new PersonFixtureDoStructureMigrationHandler_2());
+        Arrays.asList(new PostalAddressFixtureUpdateVersionOnlyMigrationHandler_2(),
+            new PetFixtureCaseSensitiveNameMigrationHandler_2(),
+            new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3(),
+            new CustomerFixtureMigrationHandler_3(),
+            new CharlieCustomerFixtureMigrationHandler_3(),
+            new HouseFixtureDoStructureMigrationHandler_2(), // intentionally do not register HouseFixtureDoStructureMigrationHandler_3
+            new RoomFixtureDoStructureMigrationHandler_2(),
+            new RoomFixtureDoStructureMigrationHandler_3(),
+            new RoomFixtureDoStructureMigrationHandler_4(),
+            new RoomFixtureDoStructureMigrationHandler_5(),
+            new PersonFixtureDoStructureMigrationHandler_2()),
+        Collections.emptyList());
 
     TEST_BEANS.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(TestDoStructureMigrationInventory.class, inventory).withReplace(true)));
-
     s_migrationContext = BEANS.get(DoStructureMigrationContext.class);
     s_migrator = BEANS.get(DoStructureMigrator.class);
   }
@@ -103,7 +106,8 @@ public class DoStructureMigratorTest {
         .put("name", "CHARLIE")
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual, BravoFixture_2.VERSION)); // stop at bravoFixture-2, otherwise namespace will change too
+    // stop at bravoFixture-2, otherwise namespace will change too
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, BravoFixture_2.VERSION));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "bravoFixture.PetFixture")
@@ -127,7 +131,7 @@ public class DoStructureMigratorTest {
         .put("street", "Main street 12")
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PostalAddressFixture")
@@ -152,7 +156,7 @@ public class DoStructureMigratorTest {
         .put("street", "Main street 12")
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PostalAddressFixture")
@@ -177,7 +181,7 @@ public class DoStructureMigratorTest {
         .put("name", "JOHN")
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.PetFixture")
@@ -200,7 +204,7 @@ public class DoStructureMigratorTest {
         .put("firstName", "John")
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.CustomerFixture")
@@ -226,7 +230,7 @@ public class DoStructureMigratorTest {
         .put("firstName", "John")
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.CustomerFixture")
@@ -250,7 +254,7 @@ public class DoStructureMigratorTest {
             .build())
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.HouseFixture") // BuildingFixture -> HouseFixture
@@ -281,7 +285,7 @@ public class DoStructureMigratorTest {
             .build())
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.HouseFixture")
@@ -324,7 +328,7 @@ public class DoStructureMigratorTest {
             .build())
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PersonFixture")
@@ -360,7 +364,7 @@ public class DoStructureMigratorTest {
         .put("name", "example")
         .build();
 
-    assertTrue(s_migrator.migrateDataObject(s_migrationContext, actual));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, null));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PersonFixture")

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorValueMigrationTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorValueMigrationTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.*;
+import static org.eclipse.scout.rt.testing.platform.util.ScoutAssert.assertEqualsWithComparisonFailure;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrator.DoStructureMigratorResult;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDo;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDoStructureMigrationHandler_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDoValueMigrationHandler_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypeFixtureDoValueMigrationHandler_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypeFixtureStringId;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypesFixture;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureDo;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureDoValueMigrationHandler_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDo;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomSizeFixtureDoValueMigrationHandler_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomTypeFixtureDoValueMigrationHandler_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomTypesFixture;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for {@link DoStructureMigrator}, with focus on data object value migrations ({@link IDoValueMigrationHandler}).
+ */
+public class DataObjectMigratorValueMigrationTest {
+
+  private static final List<IBean<?>> TEST_BEANS = new ArrayList<>();
+
+  private static DoStructureMigrationContext s_migrationContext;
+  private static DoStructureMigrator s_migrator;
+
+  @BeforeClass
+  public static void beforeClass() {
+    DoStructureMigrationTestHelper testHelper = BEANS.get(DoStructureMigrationTestHelper.class);
+    TestDoStructureMigrationInventory inventory = new TestDoStructureMigrationInventory(
+        testHelper.getFixtureNamespaces(),
+        testHelper.getFixtureTypeVersions(),
+        Collections.emptyList(),
+        Arrays.asList(new HouseFixtureDoStructureMigrationHandler_3()),
+        Arrays.asList(
+            new PetFixtureDoValueMigrationHandler_3(),
+            new RoomSizeFixtureDoValueMigrationHandler_2(),
+            new RoomTypeFixtureDoValueMigrationHandler_2(),
+            new HouseTypeFixtureDoValueMigrationHandler_2(),
+            new HouseFixtureDoValueMigrationHandler_1()));
+
+    TEST_BEANS.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(TestDoStructureMigrationInventory.class, inventory).withReplace(true)));
+
+    s_migrationContext = BEANS.get(DoStructureMigrationContext.class)
+        .putGlobal(BEANS.get(DoValueMigrationIdsContextData.class)
+            // by default, all value migrations are executed, except RoomSizeFixtureDoValueMigrationHandler_2
+            .withAppliedValueMigrationIds(CollectionUtility.hashSet(RoomSizeFixtureDoValueMigrationHandler_2.ID)));
+    s_migrator = BEANS.get(DoStructureMigrator.class);
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    BEANS.get(BeanTestingHelper.class).unregisterBeans(TEST_BEANS);
+  }
+
+  /**
+   * Tests applied value migrations provided in context.
+   */
+  @Test
+  public void testAppliedValueMigrationHandlers() {
+    RoomFixtureDo original = BEANS.get(RoomFixtureDo.class)
+        .withName("example")
+        .withAreaInSquareMeter(10);
+
+    // no value migrations will match the provided data object
+    // RoomSizeFixtureDoValueMigrationHandler_2 is ignored by default in s_migrationContext
+    DoStructureMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+
+    assertFalse(result.isChanged()); // no changes (structure nor values changed)
+
+    RoomFixtureDo expected = BEANS.get(RoomFixtureDo.class)
+        .withName("example")
+        .withAreaInSquareMeter(10);
+
+    assertEqualsWithComparisonFailure(expected, result.getDataObject());
+  }
+
+  /**
+   * Tests non-idempotent value migration with {@link RoomSizeFixtureDoValueMigrationHandler_2}.<br>
+   * Migration handler matches and replaces whole data object (RoomFixtureDo).
+   */
+  @Test
+  public void testNonIdempotentValueMigration() {
+    RoomFixtureDo original = BEANS.get(RoomFixtureDo.class)
+        .withName("example")
+        .withAreaInSquareMeter(10);
+
+    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class)
+        .putGlobal(BEANS.get(DoValueMigrationIdsContextData.class)
+            .withAppliedValueMigrationIds(Collections.emptySet())); // run all value migrations
+
+    // migration run 1
+    DoStructureMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(ctx, original);
+
+    assertTrue(result.isChanged());
+
+    RoomFixtureDo expected = BEANS.get(RoomFixtureDo.class)
+        .withName("example")
+        .withAreaInSquareMeter(20); // increased by 10 through RoomSizeFixtureDoValueMigrationHandler_2
+
+    assertEqualsWithComparisonFailure(expected, result.getDataObject());
+
+    // migration run 2: data object is changed again, due to non-idempotent value migration
+    result = s_migrator.applyValueMigration(ctx, result.getDataObject());
+
+    assertTrue(result.isChanged());
+
+    expected = BEANS.get(RoomFixtureDo.class)
+        .withName("example")
+        .withAreaInSquareMeter(30); // increased by 10 through RoomSizeFixtureDoValueMigrationHandler_2
+
+    assertEqualsWithComparisonFailure(expected, result.getDataObject());
+  }
+
+  /**
+   * Tests StringId value rename with {@link HouseTypeFixtureDoValueMigrationHandler_2}.<br>
+   * Migration handler matches specific ID type.
+   */
+  @Test
+  public void testRenameStringIdValue() {
+    HouseFixtureDo original = BEANS.get(HouseFixtureDo.class)
+        .withName("example")
+        .withHouseType(HouseTypeFixtureStringId.of("house")); // will be migrated by HouseTypeFixtureDoValueMigrationHandler_2
+
+    // migration run 1
+    DoStructureMigratorResult<HouseFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+
+    assertTrue(result.isChanged());
+
+    HouseFixtureDo expected = BEANS.get(HouseFixtureDo.class)
+        .withName("example")
+        .withHouseType(HouseTypesFixture.DETACHED_HOUSE);
+
+    assertEqualsWithComparisonFailure(expected, result.getDataObject());
+
+    // migration run 2: re-apply the same (idempotent) value migration, no changes should occur
+    result = s_migrator.applyValueMigration(s_migrationContext, result.getDataObject());
+
+    assertFalse(result.isChanged());
+
+    assertEqualsWithComparisonFailure(expected, result.getDataObject());
+  }
+
+  /**
+   * Tests recursive value migrations with {@link HouseFixtureDoValueMigrationHandler_1} and
+   * {@link RoomTypeFixtureDoValueMigrationHandler_2}.<br>
+   * Migration handler matches and replaces whole data object (RoomFixtureDo).
+   */
+  @Test
+  public void testReplaceDataObject() {
+    HouseFixtureDo original = BEANS.get(HouseFixtureDo.class)
+        .withName("tiny house")
+        .withRooms(BEANS.get(RoomFixtureDo.class)
+            .withName("tiny room"));
+
+    DoStructureMigratorResult<HouseFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+
+    assertTrue(result.isChanged());
+
+    HouseFixtureDo expected = BEANS.get(HouseFixtureDo.class)
+        .withName("tiny house")
+        .withRooms(BEANS.get(RoomFixtureDo.class)
+            .withName("migrated tiny room")
+            .withRoomType(RoomTypesFixture.ROOM));
+
+    assertEqualsWithComparisonFailure(expected, result.getDataObject());
+  }
+
+  /**
+   * Value migration handler for PetFixtureDo matches a generic DoValue<IDoEntity> node.
+   */
+  @Test
+  public void testAssignableValueClass() {
+    RoomFixtureDo original = BEANS.get(RoomFixtureDo.class)
+        .withName("example")
+        .withCustomData(BEANS.get(PetFixtureDo.class)
+            .withName("Name: Fluffy")); // Will be migrated by PetFixtureDoValueMigrationHandler_3
+
+    DoStructureMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+
+    assertTrue(result.isChanged());
+
+    RoomFixtureDo expected = BEANS.get(RoomFixtureDo.class)
+        .withName("example")
+        .withCustomData(BEANS.get(PetFixtureDo.class)
+            .withName("Fluffy")); // migrated from "Name: Fluffy" to "Fluffy" by PetFixtureDoValueMigrationHandler_3
+
+    assertEqualsWithComparisonFailure(expected, result.getDataObject());
+  }
+
+  /**
+   * Tests combined data object structure and value migration with {@link HouseFixtureDoStructureMigrationHandler_3} and
+   * {@link RoomTypeFixtureDoValueMigrationHandler_2}.
+   */
+  @Test
+  public void testStructureAndValueMigrations() {
+    // raw DoEntity data object
+    IDoEntity original = BEANS.get(DoEntityBuilder.class)
+        .put("_type", "charlieFixture.HouseFixture")
+        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap()) // will be updated by HouseFixtureDoStructureMigrationHandler_3
+        .build();
+
+    DoStructureMigratorResult<IDoEntity> result = s_migrator.migrateDataObject(s_migrationContext, original, IDoEntity.class);
+
+    assertTrue(result.isChanged());
+
+    RoomFixtureDo room1 = BEANS.get(RoomFixtureDo.class)
+        .withName("example room 1")
+        .withRoomType(RoomTypesFixture.ROOM);
+    RoomFixtureDo room2 = BEANS.get(RoomFixtureDo.class)
+        .withName("example room 2")
+        .withRoomType(RoomTypesFixture.ROOM); // changed by RoomTypeFixtureDoValueMigrationHandler_2
+    HouseFixtureDo expected = BEANS.get(HouseFixtureDo.class)
+        .withRooms(room1, room2);
+
+    assertEqualsWithComparisonFailure(expected, result.getDataObject());
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationContextTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationContextTest.java
@@ -18,6 +18,7 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.junit.Test;
 
+// TODO 23.1 [data object migration] rename to DataObjectMigrationContextTest
 public class DoStructureMigrationContextTest {
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationHelperTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationHelperTest.java
@@ -191,12 +191,12 @@ public class DoStructureMigrationHelperTest {
         new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_5.VERSION.unwrap()))));
 
     assertFalse(s_helper.isAnyMigrationRequired(CollectionUtility.hashMap(
-        new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION.unwrap()),
+        new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_3.VERSION.unwrap()),
         new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_5.VERSION.unwrap()))));
   }
 
   /**
-   * References {@link HouseFixtureDo} that has type version {@link CharlieFixture_2}.
+   * References {@link HouseFixtureDo} that has type version {@link CharlieFixture_3}.
    */
   @Test
   public void testIsMigrationRequired() {
@@ -204,8 +204,8 @@ public class DoStructureMigrationHelperTest {
     assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", NamespaceVersion.of("unknown", "1.0.0"))); // unknown type version
     assertTrue(s_helper.isMigrationRequired("charlieFixture.BuildingFixture", CharlieFixture_1.VERSION)); // unknown type name (e.g. renamed)
     assertTrue(s_helper.isMigrationRequired("charlieFixture.HouseFixture", CharlieFixture_1.VERSION)); // lower type version
-    assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", CharlieFixture_2.VERSION)); // same type version
-    assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", CharlieFixture_3.VERSION)); // newer type version (invalid)
+    assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", CharlieFixture_3.VERSION)); // same type version
+    assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", CharlieFixture_5.VERSION)); // newer type version (invalid)
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationInventoryTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationInventoryTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,17 +25,21 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.house.CharlieCustomerFi
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.CharlieCustomerFixtureTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.CustomerFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.CustomerFixtureTargetContextData;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.DuplicateIdFixtureDoValueMigrationHandler_1;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDoStructureMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureRawOnlyDoStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureTypedOnlyDoStructureMigrationTargetContextData;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypeFixtureDoValueMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStructureMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStructureMigrationHandler_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStructureMigrationHandler_4;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStructureMigrationHandler_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomSizeFixtureDoValueMigrationHandler_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomTypeFixtureDoValueMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureNamespace;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_2;
@@ -51,6 +56,9 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureT
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_4;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureNamespace;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.exception.PlatformException;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
@@ -63,6 +71,7 @@ import org.junit.Test;
 /**
  * Tests for {@link DoStructureMigrationInventory}.
  */
+// TODO 23.1 [data object migration] rename to DataObjectMigrationInventoryTest
 public class DoStructureMigrationInventoryTest {
 
   private static DoStructureMigrationInventory s_inventory;
@@ -70,27 +79,34 @@ public class DoStructureMigrationInventoryTest {
   @BeforeClass
   public static void beforeClass() {
     s_inventory = new TestDoStructureMigrationInventory(
-        Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace()),
+        Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace()),
         Arrays.asList(
             new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(), // AlfaFixture_7 is explicitly not registered
             new BravoFixture_1(), new BravoFixture_2(), new BravoFixture_3(),
-            new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5()),
+            new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5(),
+            new DeltaFixture_1(), new DeltaFixture_2()),
         Arrays.asList(
             HouseFixtureStructureMigrationTargetContextData.class,
             HouseFixtureRawOnlyDoStructureMigrationTargetContextData.class,
             HouseFixtureTypedOnlyDoStructureMigrationTargetContextData.class,
             CustomerFixtureTargetContextData.class,
             CharlieCustomerFixtureTargetContextData.class),
-        new HouseFixtureDoStructureMigrationHandler_2(),
-        new RoomFixtureDoStructureMigrationHandler_2(),
-        new RoomFixtureDoStructureMigrationHandler_3(),
-        new RoomFixtureDoStructureMigrationHandler_4(),
-        new RoomFixtureDoStructureMigrationHandler_5(),
-        new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3());
+        Arrays.asList(
+            new HouseFixtureDoStructureMigrationHandler_2(),
+            new RoomFixtureDoStructureMigrationHandler_2(),
+            new RoomFixtureDoStructureMigrationHandler_3(),
+            new RoomFixtureDoStructureMigrationHandler_4(),
+            new RoomFixtureDoStructureMigrationHandler_5(),
+            new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3()),
+        Arrays.asList(
+            // registration order here is relevant for test method testValueMigrationHandlersOrdered
+            new RoomSizeFixtureDoValueMigrationHandler_2(),
+            new RoomTypeFixtureDoValueMigrationHandler_2(),
+            new HouseTypeFixtureDoValueMigrationHandler_2()));
   }
 
   /**
-   * Tests for {@link DoStructureMigrationInventory#validateMigrationHandlerUniqueness(Map)} ()}.
+   * Tests for {@link DoStructureMigrationInventory#validateStructureMigrationHandlerUniqueness(Map)} ()}.
    */
   @Test
   public void testValidateMigrationHandlerUniqueness() {
@@ -101,7 +117,8 @@ public class DoStructureMigrationInventoryTest {
             new BravoFixture_1(), new BravoFixture_2(), new BravoFixture_3(),
             new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5()),
         Collections.emptyList(),
-        new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3());
+        Arrays.asList(new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3()),
+        Collections.emptyList());
 
     assertNotNull(inventory); // no validation error on creation of inventory
 
@@ -112,8 +129,10 @@ public class DoStructureMigrationInventoryTest {
             new BravoFixture_1(), new BravoFixture_2(), new BravoFixture_3(),
             new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5()),
         Collections.emptyList(),
-        new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3(),
-        new PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3())); // added this migration handler here -> validation error because multiple migration handlers per type version/type name
+        Arrays.asList(
+            new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3(),
+            new PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3()), // added this migration handler here -> validation error because multiple migration handlers per type version/type name
+        Collections.emptyList()));
   }
 
   /**
@@ -123,8 +142,8 @@ public class DoStructureMigrationInventoryTest {
   public void testOrdered() {
     assertEquals(
         Arrays.asList(
-            AlfaFixture_1.VERSION, BravoFixture_1.VERSION, CharlieFixture_1.VERSION,
-            AlfaFixture_2.VERSION, BravoFixture_2.VERSION, CharlieFixture_2.VERSION,
+            AlfaFixture_1.VERSION, BravoFixture_1.VERSION, CharlieFixture_1.VERSION, DeltaFixture_1.VERSION,
+            AlfaFixture_2.VERSION, BravoFixture_2.VERSION, CharlieFixture_2.VERSION, DeltaFixture_2.VERSION,
             AlfaFixture_3.VERSION, BravoFixture_3.VERSION, CharlieFixture_3.VERSION,
             CharlieFixture_4.VERSION,
             AlfaFixture_6.VERSION,
@@ -148,7 +167,7 @@ public class DoStructureMigrationInventoryTest {
 
   @Test
   public void testTypeNameToCurrentTypeVersion() {
-    assertEquals(CharlieFixture_2.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.HouseFixture"));
+    assertEquals(CharlieFixture_3.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.HouseFixture"));
     assertEquals(CharlieFixture_5.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.RoomFixture"));
     assertEquals(CharlieFixture_2.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.PostalAddressFixture"));
   }
@@ -201,7 +220,7 @@ public class DoStructureMigrationInventoryTest {
     // invalid, BuildingFixture not available for this type version (next version from full list is returned due to possible renamings)
     assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.BuildingFixture", CharlieFixture_3.VERSION));
 
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.HouseFixture", CharlieFixture_2.VERSION)); // current type version
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.HouseFixture", CharlieFixture_3.VERSION)); // current type version
   }
 
   @Test
@@ -241,7 +260,7 @@ public class DoStructureMigrationInventoryTest {
         s_inventory.findNextMigrationHandlerVersion("charlieFixture.BuildingFixture", CharlieFixture_3.VERSION));
 
     assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.UP_TO_DATE, null),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.HouseFixture", CharlieFixture_2.VERSION)); // current type version
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.HouseFixture", CharlieFixture_3.VERSION)); // current type version
   }
 
   @Test
@@ -335,5 +354,41 @@ public class DoStructureMigrationInventoryTest {
     migrationHandlers = s_inventory.getMigrationHandlers(CharlieFixture_5.VERSION);
     assertEquals(1, migrationHandlers.size());
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_5);
+  }
+
+  /**
+   * Tests sort order of value migration handlers.
+   */
+  @Test
+  public void testValueMigrationHandlersOrdered() {
+    // all value migration handlers, ordered (see initialization of s_inventory)
+    List<IDoValueMigrationHandler<?>> valueMigrationHandlers = s_inventory.getValueMigrationHandlers();
+    assertEquals(3, valueMigrationHandlers.size());
+    assertEquals(RoomTypeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(0).id());
+    // HouseTypeFixtureDoValueMigrationHandler_2 after RoomTypeFixtureDoValueMigrationHandler_2 because of registration order (same type version)
+    assertEquals(HouseTypeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(1).id());
+    // RoomSizeFixtureDoValueMigrationHandler_2 after HouseTypeFixtureDoValueMigrationHandler_2 because of type version (registration order is overridden)
+    assertEquals(RoomSizeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(2).id());
+  }
+
+  /**
+   * Register two value migration handlers with identical ID -> exception expected
+   */
+  @Test
+  public void voidTestDuplicateValueMigrationIds() {
+    PlatformException exception = assertThrows(PlatformException.class, () -> new TestDoStructureMigrationInventory(
+        Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace()),
+        Arrays.asList(
+            new AlfaFixture_1(), new AlfaFixture_2(),
+            new BravoFixture_1(), new BravoFixture_2(),
+            new CharlieFixture_1(), new CharlieFixture_2(),
+            new DeltaFixture_1(), new DeltaFixture_2()),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Arrays.asList(
+            new RoomSizeFixtureDoValueMigrationHandler_2(),
+            new DuplicateIdFixtureDoValueMigrationHandler_1())));
+
+    assertTrue(exception.getMessage().contains(DuplicateIdFixtureDoValueMigrationHandler_1.ID.unwrapAsString()));
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationTestHelper.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationTestHelper.java
@@ -35,24 +35,29 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureT
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_4;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureNamespace;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.namespace.INamespace;
 
 /**
  * Helper methods used within tests to access common fixtures (namespaces, type versions, context data classes).
  */
+// TODO 23.1 [data object migration] rename to DataObjectMigrationTestHelper
 @ApplicationScoped
 public class DoStructureMigrationTestHelper {
 
   public List<INamespace> getFixtureNamespaces() {
-    return Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace());
+    return Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace());
   }
 
   public Collection<ITypeVersion> getFixtureTypeVersions() {
     return Arrays.asList(
         new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(), new AlfaFixture_7(),
         new BravoFixture_1(), new BravoFixture_2(), new BravoFixture_3(),
-        new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5());
+        new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5(),
+        new DeltaFixture_1(), new DeltaFixture_2());
   }
 
   public Collection<Class<? extends IDoStructureMigrationTargetContextData>> getFixtureContextDataClasses() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/DuplicateIdFixtureDoValueMigrationHandler_1.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/DuplicateIdFixtureDoValueMigrationHandler_1.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_1;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+
+@IgnoreBean
+public class DuplicateIdFixtureDoValueMigrationHandler_1 extends AbstractDoValueMigrationHandler<IDoEntity> {
+
+  // Same ID as RoomSizeFixtureDoValueMigrationHandler
+  public static final DoValueMigrationId ID = DoValueMigrationId.of("ce318ac4-8b6e-4022-8de0-a0becb7358e5");
+
+  @Override
+  public DoValueMigrationId id() {
+    return ID;
+  }
+
+  @Override
+  public Class<? extends ITypeVersion> typeVersionClass() {
+    return DeltaFixture_1.class;
+  }
+
+  @Override
+  public IDoEntity migrate(DoStructureMigrationContext ctx, IDoEntity value) {
+    return value; // no migration, used for checking for duplicate migration IDs
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDo.java
@@ -20,19 +20,20 @@ import org.eclipse.scout.rt.dataobject.DoList;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
 
 /**
  * Change history:
  * <ul>
  * <li>charlieFixture-2: charlieFixture.BuildingFixture -> charlieFixture.HouseFixture, postalAddress and owner
  * attributes were added</li>
+ * <li>charlieFixture-3: no structure change, used for value migration tests</li>
  * </ul>
  *
  * @since charlieFixture-1
  */
 @TypeName("charlieFixture.HouseFixture")
-@TypeVersion(CharlieFixture_2.class)
+@TypeVersion(CharlieFixture_3.class)
 public class HouseFixtureDo extends DoEntity {
 
   public DoValue<String> name() {
@@ -49,6 +50,10 @@ public class HouseFixtureDo extends DoEntity {
 
   public DoList<RoomFixtureDo> rooms() {
     return doList("rooms");
+  }
+
+  public DoValue<HouseTypeFixtureStringId> houseType() {
+    return doValue("houseType");
   }
 
   /* **************************************************************************
@@ -103,5 +108,16 @@ public class HouseFixtureDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public List<RoomFixtureDo> getRooms() {
     return rooms().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public HouseFixtureDo withHouseType(HouseTypeFixtureStringId houseType) {
+    houseType().set(houseType);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public HouseTypeFixtureStringId getHouseType() {
+    return houseType().get();
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoStructureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoStructureMigrationHandler_3.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+
+/**
+ * Structure migration used for value migration tests. Inserts two rooms with different room types, which will be
+ * migrated.
+ */
+@IgnoreBean
+public class HouseFixtureDoStructureMigrationHandler_3 extends AbstractDoStructureMigrationHandler {
+
+  @Override
+  public Class<? extends ITypeVersion> toTypeVersionClass() {
+    return CharlieFixture_3.class;
+  }
+
+  @Override
+  public Set<String> getTypeNames() {
+    return CollectionUtility.hashSet("charlieFixture.HouseFixture");
+  }
+
+  @Override
+  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+    List<IDoEntity> rooms = doEntity.getList("rooms", IDoEntity.class);
+
+    rooms.add(BEANS.get(DoEntityBuilder.class)
+        .put("_type", "charlieFixture.RoomFixture")
+        .put("_typeVersion", CharlieFixture_5.VERSION.unwrap()) // latest version, no structure migration will be applied
+        .put("name", "example room 1")
+        .put("roomType", "room") // valid room type (already migrated), will not be migrated by RoomTypeFixtureDoValueMigrationHandler_2
+        .build());
+
+    rooms.add(BEANS.get(DoEntityBuilder.class)
+        .put("_type", "charlieFixture.RoomFixture")
+        .put("_typeVersion", CharlieFixture_5.VERSION.unwrap()) // latest version, no structure migration will be applied
+        .put("name", "example room 2")
+        .put("roomType", "standard-room") // old room type value, will be migrated by RoomTypeFixtureDoValueMigrationHandler_2
+        .build());
+
+    return true;
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoValueMigrationHandler_1.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoValueMigrationHandler_1.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.DataObjectHelper;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+
+/**
+ * Replaces existing Room object, which contains values to be migrated.
+ */
+@IgnoreBean
+public class HouseFixtureDoValueMigrationHandler_1 extends AbstractDoValueMigrationHandler<HouseFixtureDo> {
+
+  public static final DoValueMigrationId ID = DoValueMigrationId.of("be93eba7-7691-4c16-bf79-16b5c1553a67");
+
+  @Override
+  public DoValueMigrationId id() {
+    return ID;
+  }
+
+  @Override
+  public Class<? extends ITypeVersion> typeVersionClass() {
+    return CharlieFixture_1.class;
+  }
+
+  @Override
+  public HouseFixtureDo migrate(DoStructureMigrationContext ctx, HouseFixtureDo value) {
+    if (!value.rooms().exists()) {
+      return value; // nothing to migrate
+    }
+    RoomFixtureDo room = CollectionUtility.firstElement(value.getRooms());
+    if (room == null || !"tiny room".equals(room.getName())) {
+      return value; // already migrated or nothing to migrate
+    }
+
+    // completely replace room object
+    RoomFixtureDo newRoom = BEANS.get(RoomFixtureDo.class)
+        .withName("migrated tiny room")
+        // Should normally reference a constant such as RoomTypesFixture.ROOM to make sure it is a valid ID.
+        // We intentionally insert a value which needs to be migrated by RoomTypeFixtureDoValueMigrationHandler_2.
+        .withRoomType(RoomTypeFixtureStringId.of("standard-room"));
+
+    return BEANS.get(DataObjectHelper.class).clone(value) // clone provided value to allow change detection by caller
+        .withRooms(newRoom);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypeFixtureDoValueMigrationHandler_2.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+
+/**
+ * Rename house type ID value: house -> detached-house
+ */
+@IgnoreBean
+public class HouseTypeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMigrationHandler<HouseTypeFixtureStringId> {
+
+  public static final DoValueMigrationId ID = DoValueMigrationId.of("e0d6af03-767a-4212-a4bc-3ff86fd5f3eb");
+
+  @Override
+  public DoValueMigrationId id() {
+    return ID;
+  }
+
+  @Override
+  public Class<? extends ITypeVersion> typeVersionClass() {
+    return CharlieFixture_2.class;
+  }
+
+  @Override
+  public HouseTypeFixtureStringId migrate(DoStructureMigrationContext ctx, HouseTypeFixtureStringId value) {
+    return "house".equals(value.unwrap()) ? HouseTypesFixture.DETACHED_HOUSE : value;
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypeFixtureStringId.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypeFixtureStringId.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.id.AbstractStringId;
+import org.eclipse.scout.rt.dataobject.id.IdTypeName;
+
+@IdTypeName("charlieFixture.HouseTypeFixtureStringId")
+public final class HouseTypeFixtureStringId extends AbstractStringId {
+
+  private static final long serialVersionUID = 1L;
+
+  public static HouseTypeFixtureStringId of(String id) {
+    if (id == null) {
+      return null;
+    }
+    return new HouseTypeFixtureStringId(id);
+  }
+
+  private HouseTypeFixtureStringId(String id) {
+    super(id);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypesFixture.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypesFixture.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+public interface HouseTypesFixture {
+  HouseTypeFixtureStringId DETACHED_HOUSE = HouseTypeFixtureStringId.of("detached-house"); // was 'house'
+  HouseTypeFixtureStringId APARTMENT = HouseTypeFixtureStringId.of("apartment");
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureDoValueMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureDoValueMigrationHandler_3.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.DataObjectHelper;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+
+/**
+ * Removes the prefix "Name: " from the name attribute (if the prefix is present).
+ */
+@IgnoreBean
+public class PetFixtureDoValueMigrationHandler_3 extends AbstractDoValueMigrationHandler<PetFixtureDo> {
+
+  public static final DoValueMigrationId ID = DoValueMigrationId.of("4650729f-1c79-4553-8eb0-715bd7dac9fd");
+
+  protected static final String NAME_PREFIX = "Name: ";
+
+  @Override
+  public DoValueMigrationId id() {
+    return ID;
+  }
+
+  @Override
+  public Class<? extends ITypeVersion> typeVersionClass() {
+    return AlfaFixture_3.class;
+  }
+
+  @Override
+  public PetFixtureDo migrate(DoStructureMigrationContext ctx, PetFixtureDo value) {
+    if (!value.getName().startsWith(NAME_PREFIX)) {
+      return value; // already migrated or nothing to migrate
+    }
+
+    return BEANS.get(DataObjectHelper.class).clone(value) // clone provided value to allow change detection by caller
+        .withName(StringUtility.removePrefixes(value.getName(), NAME_PREFIX));
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDo.java
@@ -14,6 +14,7 @@ import javax.annotation.Generated;
 
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
@@ -44,6 +45,14 @@ public class RoomFixtureDo extends DoEntity {
 
   public DoValue<Integer> areaInSquareMeter() {
     return doValue("areaInSquareMeter");
+  }
+
+  public DoValue<RoomTypeFixtureStringId> roomType() {
+    return doValue("roomType");
+  }
+
+  public DoValue<IDoEntity> customData() {
+    return doValue("customData");
   }
 
   /* **************************************************************************
@@ -81,5 +90,27 @@ public class RoomFixtureDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public Integer getAreaInSquareMeter() {
     return areaInSquareMeter().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public RoomFixtureDo withRoomType(RoomTypeFixtureStringId roomType) {
+    roomType().set(roomType);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public RoomTypeFixtureStringId getRoomType() {
+    return roomType().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public RoomFixtureDo withCustomData(IDoEntity customData) {
+    customData().set(customData);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IDoEntity getCustomData() {
+    return customData().get();
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomSizeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomSizeFixtureDoValueMigrationHandler_2.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.DataObjectHelper;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.util.NumberUtility;
+
+/**
+ * This is an example for a non-idempotent value migration.<br>
+ * <b>Only used for testing!</b><br>
+ * Real-world value migrations must always be idempotent.
+ */
+@IgnoreBean
+public class RoomSizeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMigrationHandler<RoomFixtureDo> {
+
+  public static final DoValueMigrationId ID = DoValueMigrationId.of("ce318ac4-8b6e-4022-8de0-a0becb7358e5");
+
+  @Override
+  public DoValueMigrationId id() {
+    return ID;
+  }
+
+  @Override
+  public Class<? extends ITypeVersion> typeVersionClass() {
+    return DeltaFixture_2.class; // after RoomTypeValueMigrationHandler
+  }
+
+  @Override
+  public RoomFixtureDo migrate(DoStructureMigrationContext ctx, RoomFixtureDo value) {
+    return BEANS.get(DataObjectHelper.class).clone(value) // clone provided value to allow change detection by caller
+        // increase area by 10
+        // non-idempotent migration for testing purposes only, real-world value migrations must be idempotent!
+        .withAreaInSquareMeter(NumberUtility.nvl(value.getAreaInSquareMeter(), 0) + 10);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeFixtureDoValueMigrationHandler_2.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+
+/**
+ * Rename room type value: standard-room -> room
+ */
+@IgnoreBean
+public class RoomTypeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMigrationHandler<RoomTypeFixtureStringId> {
+
+  public static final DoValueMigrationId ID = DoValueMigrationId.of("89b9576d-4374-48f8-96ad-5395f635eb36");
+
+  @Override
+  public DoValueMigrationId id() {
+    return ID;
+  }
+
+  @Override
+  public Class<? extends ITypeVersion> typeVersionClass() {
+    return CharlieFixture_2.class;
+  }
+
+  @Override
+  public RoomTypeFixtureStringId migrate(DoStructureMigrationContext ctx, RoomTypeFixtureStringId value) {
+    return "standard-room".equals(value.unwrap()) ? RoomTypesFixture.ROOM : value;
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeFixtureStringId.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeFixtureStringId.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.id.AbstractStringId;
+import org.eclipse.scout.rt.dataobject.id.IdTypeName;
+
+@IdTypeName("charlieFixture.RoomTypeFixtureStringId")
+public final class RoomTypeFixtureStringId extends AbstractStringId {
+
+  private static final long serialVersionUID = 1L;
+
+  public static RoomTypeFixtureStringId of(String id) {
+    if (id == null) {
+      return null;
+    }
+    return new RoomTypeFixtureStringId(id);
+  }
+
+  private RoomTypeFixtureStringId(String id) {
+    super(id);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypesFixture.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypesFixture.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+public interface RoomTypesFixture {
+  RoomTypeFixtureStringId ROOM = RoomTypeFixtureStringId.of("room"); // was 'standard-room'
+  RoomTypeFixtureStringId BEDROOM = RoomTypeFixtureStringId.of("bedroom");
+  RoomTypeFixtureStringId LIVING_ROOM = RoomTypeFixtureStringId.of("living-room");
+  RoomTypeFixtureStringId KITCHEN = RoomTypeFixtureStringId.of("kitchen");
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/DeltaFixtureNamespace.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/DeltaFixtureNamespace.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.version;
+
+import org.eclipse.scout.rt.platform.namespace.INamespace;
+
+public final class DeltaFixtureNamespace implements INamespace {
+
+  public static final String ID = "deltaFixture";
+  public static final double ORDER = 9300;
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public double getOrder() {
+    return ORDER;
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/DeltaFixtureTypeVersions.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/DeltaFixtureTypeVersions.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.version;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.scout.rt.dataobject.AbstractTypeVersion;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
+
+public final class DeltaFixtureTypeVersions {
+
+  public static final class DeltaFixture_1 extends AbstractTypeVersion {
+
+    public static final NamespaceVersion VERSION = NamespaceVersion.of(DeltaFixtureNamespace.ID, "1");
+
+    public DeltaFixture_1() {
+      super(VERSION);
+    }
+
+    @Override
+    protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
+      return Arrays.asList(CharlieFixture_1.class);
+    }
+  }
+
+  public static final class DeltaFixture_2 extends AbstractTypeVersion {
+
+    public static final NamespaceVersion VERSION = NamespaceVersion.of(DeltaFixtureNamespace.ID, "2");
+
+    public DeltaFixture_2() {
+      super(VERSION);
+    }
+
+    @Override
+    protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
+      return Arrays.asList(CharlieFixture_2.class);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoValueMigrationHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
+import org.eclipse.scout.rt.platform.util.TypeCastUtility;
+
+/**
+ * Abstract implementation of a {@link IDoValueMigrationHandler} providing an implementation of {@link #valueClass()}
+ * based on the class generic type and supporting {@link Class} of {@link ITypeVersion} instead of
+ * {@link NamespaceVersion}.
+ */
+public abstract class AbstractDoValueMigrationHandler<T> implements IDoValueMigrationHandler<T> {
+
+  private final NamespaceVersion m_typeVersion;
+
+  protected AbstractDoValueMigrationHandler() {
+    m_typeVersion = BEANS.get(typeVersionClass()).getVersion();
+  }
+
+  @Override
+  public NamespaceVersion typeVersion() {
+    return m_typeVersion;
+  }
+
+  public abstract Class<? extends ITypeVersion> typeVersionClass();
+
+  @Override
+  public Class<T> valueClass() {
+    // noinspection unchecked
+    return TypeCastUtility.getGenericsParameterClass(this.getClass(), AbstractDoValueMigrationHandler.class);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationContext.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationContext.java
@@ -31,6 +31,7 @@ import org.eclipse.scout.rt.platform.Bean;
  * threads, use {@link #copy()} in a new thread.
  */
 @Bean
+// TODO 23.1 [data object migration] rename to DataObjectMigrationContext
 public class DoStructureMigrationContext {
 
   // maybe accessed by different threads
@@ -66,16 +67,16 @@ public class DoStructureMigrationContext {
   }
 
   /**
-   * Clones the context via {@link #copy} and pushes the given initial local context datas to the local context data
-   * map. If no initial local context datas are provided behaves same as {@link #copy}.
+   * Pushes the given initial local context datas to the local context data map. This method must not be called on an
+   * exiting context object, but must be called on a fresh copy (see {@link #copy()} or on a fresh instance of
+   * {@link DoStructureMigrationContext}
    */
-  protected DoStructureMigrationContext initializedCopy(IDoStructureMigrationLocalContextData... initialLocalContextDatas) {
-    DoStructureMigrationContext copy = copy();
+  protected DoStructureMigrationContext withInitialLocalContext(IDoStructureMigrationLocalContextData... initialLocalContextDatas) {
     if (initialLocalContextDatas != null) {
-      // Calling push without a remove is okay here because these provided locale contexts are valid for the whole data object
-      Arrays.stream(initialLocalContextDatas).filter(Objects::nonNull).forEach(copy::push);
+      // Calling push without a remove is okay here because these provided local contexts are valid for the whole data object
+      Arrays.stream(initialLocalContextDatas).filter(Objects::nonNull).forEach(this::push);
     }
-    return copy;
+    return this;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationCountingPassThroughLogger.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationCountingPassThroughLogger.java
@@ -15,8 +15,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Thread-safe implementation for a DO structure migration logger that additional counts the log items per log level.
+ * Thread-safe implementation of a data object migration logger that additionally counts the log items per log level.
  */
+// TODO 23.1 [data object migration] rename to DataObjectMigrationCountingPassThroughLogger
 public class DoStructureMigrationCountingPassThroughLogger extends DoStructureMigrationPassThroughLogger {
 
   private static final Logger LOG = LoggerFactory.getLogger(DoStructureMigrationCountingPassThroughLogger.class);
@@ -80,10 +81,10 @@ public class DoStructureMigrationCountingPassThroughLogger extends DoStructureMi
   public void printSummary() {
     long total = m_traceCount.sum() + m_debugCount.sum() + m_infoCount.sum() + m_warnCount.sum() + m_errorCount.sum();
     if (total == 0) {
-      LOG.info("No DO structure migration log entries were made");
+      LOG.info("No data object migration log entries were made");
     }
     else {
-      LOG.info("{} DO structure migration log entries were made: {} trace, {} debug, {} info, {} warn, {} error", total, m_traceCount.sum(), m_debugCount.sum(), m_infoCount.sum(), m_warnCount.sum(), m_errorCount.sum());
+      LOG.info("{} data object migration log entries were made: {} trace, {} debug, {} info, {} warn, {} error", total, m_traceCount.sum(), m_debugCount.sum(), m_infoCount.sum(), m_warnCount.sum(), m_errorCount.sum());
     }
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationDataObjectVisitor.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationDataObjectVisitor.java
@@ -24,7 +24,7 @@ import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 /**
  * Data object visitor to migrate data objects.
  */
-public class MigrationDataObjectVisitor extends AbstractDataObjectVisitor {
+public class DoStructureMigrationDataObjectVisitor extends AbstractDataObjectVisitor {
 
   protected final DoStructureMigrationHelper m_helper;
   protected final DoStructureMigrationInventory m_inventory;
@@ -35,7 +35,7 @@ public class MigrationDataObjectVisitor extends AbstractDataObjectVisitor {
 
   protected boolean m_changed = false;
 
-  public MigrationDataObjectVisitor(DoStructureMigrationContext ctx, NamespaceVersion version) {
+  public DoStructureMigrationDataObjectVisitor(DoStructureMigrationContext ctx, NamespaceVersion version) {
     m_helper = BEANS.get(DoStructureMigrationHelper.class);
     m_inventory = BEANS.get(DoStructureMigrationInventory.class);
 

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationPassThroughLogger.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationPassThroughLogger.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
  * Thread-safe logger that directly outputs to {@link Logger}.
  */
 @Bean
+// TODO 23.1 [data object migration] rename to DataObjectMigrationPassThroughLogger
 public class DoStructureMigrationPassThroughLogger implements IDoStructureMigrationLogger {
 
   private static final Logger LOG = LoggerFactory.getLogger(DoStructureMigrationPassThroughLogger.class);

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationStatsContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationStatsContextData.java
@@ -20,9 +20,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Thread-safe implementation of stats for data object structure migration.
+ * Thread-safe implementation of stats for data object migration.
  */
 @Bean
+// TODO 23.1 [data object migration] rename to DataObjectMigrationStatsContextData
 public class DoStructureMigrationStatsContextData implements IDoStructureMigrationGlobalContextData {
 
   private static final Logger LOG = LoggerFactory.getLogger(DoStructureMigrationStatsContextData.class);
@@ -99,10 +100,10 @@ public class DoStructureMigrationStatsContextData implements IDoStructureMigrati
    *          Name to print for entities
    * @param entityCount
    *          Number of entities processed (optional), can be different than the number of calls made to
-   *          {@link DoStructureMigrator#migrateDataObject(DoStructureMigrationContext, IDataObject)}.
+   *          {@link DoStructureMigrator#migrateDataObject(DoStructureMigrationContext, IDataObject, Class)}.
    */
   public void printStats(String name, Integer entityCount) {
-    LOG.info("DO structure migration of {}{} entities finished in {} ms (accumulated raw data object migration took {} ms). Changed {} of {} processed data objects.",
+    LOG.info("Data object migration of {}{} entities finished in {} ms (accumulated raw data object migration took {} ms). Changed {} of {} processed data objects.",
         entityCount == null ? "" : entityCount + " ",
         name,
         m_startNanos.get() == 0 ? "?" : StringUtility.formatNanos(getOverallMigrationDurationNano()),

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationDataObjectVisitor.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationDataObjectVisitor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.scout.rt.dataobject.AbstractReplacingDataObjectVisitor;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
+
+/**
+ * Data object visitor to migrate data objects.
+ */
+public class DoValueMigrationDataObjectVisitor extends AbstractReplacingDataObjectVisitor {
+
+  protected final DoStructureMigrationInventory m_inventory;
+  protected final DoStructureMigrationContext m_ctx;
+
+  // ordered list of value migration handlers, which have not been applied
+  protected final List<IDoValueMigrationHandler<?>> m_valueMigrationHandlers;
+
+  protected boolean m_changed = false;
+
+  public DoValueMigrationDataObjectVisitor(DoStructureMigrationContext ctx) {
+    m_inventory = BEANS.get(DoStructureMigrationInventory.class);
+    m_ctx = ctx;
+
+    Set<DoValueMigrationId> appliedValueMigrationIds = m_ctx.getGlobal(DoValueMigrationIdsContextData.class).getAppliedValueMigrationIds();
+    assertNotNull(appliedValueMigrationIds, "Applied value migration IDs on context required.");
+    // ignore already applied value migrations
+    m_valueMigrationHandlers = m_inventory.getValueMigrationHandlers().stream()
+        .filter(handler -> !appliedValueMigrationIds.contains(handler.id()))
+        .collect(Collectors.toList());
+  }
+
+  public boolean isChanged() {
+    return m_changed;
+  }
+
+  public <T extends IDataObject> T migrate(T dataObject) {
+    if (m_valueMigrationHandlers.isEmpty()) {
+      return dataObject;
+    }
+    return replaceOrVisit(dataObject);
+  }
+
+  @Override
+  protected <T> T replaceOrVisit(T oldValue) {
+    if (oldValue == null) {
+      return null;
+    }
+    // apply all migration handlers in order
+    // feed the migrated value to the next handler
+    T currentValue = oldValue;
+    for (IDoValueMigrationHandler<?> handler : m_valueMigrationHandlers) {
+      if (handler.valueClass().isInstance(currentValue)) {
+        // noinspection unchecked
+        T migratedValue = ((IDoValueMigrationHandler<T>) handler).migrate(m_ctx, currentValue);
+        // handler must not change provided input value, but must return a fresh instance (clone or new instance)
+        m_changed |= ObjectUtility.notEquals(currentValue, migratedValue);
+        currentValue = migratedValue;
+      }
+    }
+    // recursively visit migrated value
+    visit(currentValue);
+    return currentValue;
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationId.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationId.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import org.eclipse.scout.rt.dataobject.id.AbstractStringId;
+import org.eclipse.scout.rt.dataobject.id.IdTypeName;
+
+/**
+ * Unique id for {@link IDoValueMigrationHandler}.
+ * <p>
+ * A value migration handler usually defines an ID constant using a uuid to guarantee that every migration handler uses
+ * a unique ID.
+ */
+@IdTypeName("scout.DoValueMigrationId")
+public final class DoValueMigrationId extends AbstractStringId {
+  private static final long serialVersionUID = 1L;
+
+  private DoValueMigrationId(String id) {
+    super(id);
+  }
+
+  public static DoValueMigrationId of(String id) {
+    if (id == null) {
+      return null;
+    }
+    return new DoValueMigrationId(id);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationIdsContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationIdsContextData.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.scout.rt.platform.Bean;
+
+/**
+ * Context to provide a set of all value migration IDs, which have been applied on the current system already, they will
+ * not be applied again during data object migration.
+ */
+@Bean
+public class DoValueMigrationIdsContextData implements IDoStructureMigrationGlobalContextData {
+
+  // Thead-safe because read-only after initialization.
+  // An empty set implies that all available value migrations will be applied. In case of a null value, value migrations will be skipped.
+  protected Set<DoValueMigrationId> m_appliedValueMigrationIds;
+
+  public DoValueMigrationIdsContextData withAppliedValueMigrationIds(Set<DoValueMigrationId> appliedValueMigrationIds) {
+    m_appliedValueMigrationIds = appliedValueMigrationIds == null ? null : Collections.unmodifiableSet(appliedValueMigrationIds);
+    return this;
+  }
+
+  /**
+   * @return unmodifiable set of value migration IDs
+   */
+  public Set<DoValueMigrationId> getAppliedValueMigrationIds() {
+    return m_appliedValueMigrationIds;
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationGlobalContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationGlobalContextData.java
@@ -19,6 +19,7 @@ package org.eclipse.scout.rt.dataobject.migration;
  * Because a global context data may be accessed concurrently by different threads each implementation must be
  * thread-safe.
  */
+// TODO 23.1 [data object migration] rename to IDataObjectMigrationGlobalContextData
 public interface IDoStructureMigrationGlobalContextData {
 
   /**

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationHandler.java
@@ -13,11 +13,18 @@ package org.eclipse.scout.rt.dataobject.migration;
 import java.util.Set;
 
 import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 
 /**
- * Interface for a data object structure migration handler.
+ * Interface for a data object structure migration handler. Typical use cases include renaming of a data objects
+ * {@link TypeName} or renaming or type change of attributes.
+ * <p>
+ * In contrast to {@link IDoValueMigrationHandler}, a structure migration handler operates on <i>untyped</i> objects
+ * (i.e. raw {@link IDoEntity} objects) and its implementation must not access constants and attribute names from the
+ * current code base (but must use string literals instead), such that a structure migration handler is not required to
+ * change if the code base is changed.
  */
 @ApplicationScoped
 public interface IDoStructureMigrationHandler {
@@ -59,7 +66,7 @@ public interface IDoStructureMigrationHandler {
    * @param ctx
    *          Context
    * @param doEntity
-   *          Do entity to apply migration, according to {@link #getTypeNames()} (non-<code>null</code>)
+   *          Raw DO entity to apply migration, according to {@link #getTypeNames()} (non-<code>null</code>)
    * @return <code>true</code> if data object was changed in any way (including type version update only),
    *         <code>false</code> otherwise.
    */

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationLocalContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationLocalContextData.java
@@ -21,6 +21,7 @@ package org.eclipse.scout.rt.dataobject.migration;
  * A local context data is stacked, i.e. if multiple context data for the same {@link #getIdentifierClass()} are added,
  * the last one is retrieved.
  */
+// TODO 23.1 [data object migration] rename to IDataObjectMigrationLocalContextData
 public interface IDoStructureMigrationLocalContextData {
 
   /**

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationLogger.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationLogger.java
@@ -13,6 +13,7 @@ package org.eclipse.scout.rt.dataobject.migration;
 /**
  * Interface of a global context data used as logger.
  */
+// TODO 23.1 [data object migration] rename to IDataObjectMigrationLogger
 public interface IDoStructureMigrationLogger extends IDoStructureMigrationGlobalContextData {
 
   @Override

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoValueMigrationHandler.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.enumeration.IEnum;
+import org.eclipse.scout.rt.dataobject.id.IId;
+import org.eclipse.scout.rt.dataobject.id.IUuId;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
+
+/**
+ * Interface for a data object value migration handler. In contrast to {@link IDoStructureMigrationHandler}, value
+ * migration handlers must not change the structure of a data object, but can replace values of specific attributes.
+ * <p>
+ * A value migration handler operates on typed values. Values can be of any type, typical use cases include merges,
+ * replacements or renaming of built-in IDs (such as {@link IUuId}s. However, values can also be {@link IDoEntity} data
+ * objects. Note that enum values from {@link IEnum} <i>cannot</i> be migrated with value migration handlers, but must
+ * be handled by custom resolve methods on the enum class itself.
+ * <p>
+ * Value migration handlers can and should use typed data objects and access ID values as constants defined in the code
+ * base. If the data objects or ID constants are refactored, the affected value migration handlers must be refactored
+ * too (in contrast to {@link IDoStructureMigrationHandler}s which operate on untyped data objects and must not access
+ * constants from the current code base, i.e. they are never refactored, if the code base changes).
+ * <p>
+ * Value migration handlers are always applied <i>after</i> all {@link IDoStructureMigrationHandler} have been applied.
+ * Value migrations are applied in a specific order, defined by the given {@link #typeVersion()}. Migration handlers
+ * with the same type version are applied in the order provided by the bean manager.
+ * <p>
+ * Value migration handlers <i>must be idempotent</i>, i.e. the result of a given migration must not change, even if the
+ * migration is applied multiple times. In general, value migrations are applied <i>exactly once</i>, as the system
+ * keeps track of all value migrations which have been applied already and won't be applied again. Idempotency is
+ * required, because structure migrations, which are applied before any value migration, might insert or change values
+ * as well - and those values might represent the source or the target of a given value migration, depending on the
+ * exact point in time, when the structure migration was introduced.
+ * <p>
+ * To avoid non-idempotent value migrations, do not re-use renamed or deleted ID values in the (future) code base. If
+ * non-idempotent value migrations cannot be avoided, consider using an {@link IDoStructureMigrationHandler} instead (if
+ * you are in control of the namespace of the relevant data objects and are able to introduce a new type version).
+ * <p>
+ * <b>Example 1:</b> built-in ID FOO is merged / replaced by built-in ID BAR<br>
+ * Note: this migration is only idempotent, if value FOO is not used anymore in the future code base.
+ *
+ * <pre>
+ * public class FooDoValueMigrationHandler extends AbstractDoValueMigrationHandler<FooTypeId> {
+ *
+ *   public static final DoValueMigrationId ID = DoValueMigrationId.of("3740d4ce-849b-449e-afb1-0986993c9463");
+ *
+ *   &#64;Override
+ *   public DoValueMigrationId id() {
+ *     return ID;
+ *   }
+ *
+ *   &#64;Override
+ *   public Class<? extends ITypeVersion> typeVersionClass() {
+ *     return Foo_2.class;
+ *   }
+ *
+ *   &#64;Override
+ *   public FooTypeId migrate(DoStructureMigrationContext ctx, FooTypeId value) {
+ *     return "foo".equals(value.unwrap()) ? FooTypes.BAR : value;
+ *   }
+ * }
+ * </pre>
+ *
+ * <b>Example 2:</b> Match a DO entity data object and migrate a specific (string) attribute. Make sure to return a
+ * modified copy of the input value instead of manipulating the provided input value itself, such that the caller is
+ * able to detect the change by an equals-comparison.
+ *
+ * <pre>
+ * public class BarDoValueMigrationHandler extends AbstractDoValueMigrationHandler<BarDo> {
+ *
+ *   public static final DoValueMigrationId ID = DoValueMigrationId.of("f73240b8-ca5d-4e4a-a257-9d4deb067b68");
+ *
+ *   protected static final String PREFIX = "prefix-";
+ *
+ *   &#64;Override
+ *   public DoValueMigrationId id() {
+ *     return ID;
+ *   }
+ *
+ *   &#64;Override
+ *   public Class<? extends ITypeVersion> typeVersionClass() {
+ *     return Bar_3.class;
+ *   }
+ *
+ *   &#64;Override
+ *   public BarDo migrate(DoStructureMigrationContext ctx, BarDo value) {
+ *     if (value.getName().startsWith(PREFIX)) {
+ *       return value; // no migration required
+ *     }
+ *
+ *     return BEANS.get(DataObjectHelper.class).clone(value) // clone provided value to allow change detection by caller
+ *         .withName(PREFIX + value.getName());
+ *   }
+ * }
+ * </pre>
+ */
+@ApplicationScoped
+public interface IDoValueMigrationHandler<T> {
+
+  /**
+   * Unique identifier for this value migration handler.
+   */
+  DoValueMigrationId id();
+
+  /**
+   * Class of the value nodes that need to be migrated. An assignable check is performed, so {@code ExampleId} will also
+   * be migrated in an {@link IId} node. To ensure that a value migration handler does not (unintentionally) change the
+   * type of the migrated value, the value class of a migration handler should always be a leaf in the inheritance
+   * hierarchy, i.e. {@code Class<ExampleId>} instead of {@code Class<IId>} and {@code Class<ExampleDo>} instead of
+   * {@code Class<IDoEntity>}.
+   */
+  Class<T> valueClass();
+
+  /**
+   * Type version used for sorting.
+   * <p>
+   * The type version defined on a value migration is used to obtain a sort order over all value migrations, including
+   * value migrations from other namespaces. Value migrations are always applied after all structure migrations have
+   * been applied, so the type version is independent of the type version defined on a structure migration handler.
+   * <p>
+   * Also, the type version defined on a value migration handler is independent of the type versions of the migrated
+   * data objects themselves, i.e. a value migration is applied to all data objects, including data objects from other
+   * namespaces, whenever a value node matches the {@link #valueClass()} of the value migration handler.
+   * <p>
+   * Example 1: Dependent value migrations within same namespace<br>
+   * Value migration M1 from A -> B with type version foo-2.0.0<br>
+   * Value migration M2 from B -> C with type version foo-2.0.1: Type version of M2 must be greater than type version of
+   * M1 to make sure that M1 is applied <i>before</i> M2.
+   * <p>
+   * Example 2: Dependent value migrations in different namespaces<br>
+   * Value migration M1 from A -> B with type version foo-2.0.0<br>
+   * Value migration M2 from B -> C with type version bar-3.1.0: Type version of M2 must define a dependency on type
+   * version foo-2.0.0 to make sure that M1 is applied <i>before</i> M2.
+   */
+  NamespaceVersion typeVersion();
+
+  /**
+   * Returns the migrated value for a given input value.
+   * <p>
+   * Callers of this method can detect changes to the migrated values by an equality check on the provided input value
+   * and the returned value. Implementations must consider the input value as immutable and either return a completely
+   * new object or a modified copy of the input value. If no migration is required, implementations may simply return
+   * the provided input value.
+   *
+   * @param value
+   *          never {@code null}
+   **/
+  T migrate(DoStructureMigrationContext ctx, T value);
+}


### PR DESCRIPTION
New interface IDoValueMigrationHandler to support data object value migrations. In contrast to IDoStructureMigrationHandler, value migration handlers must not change the structure of a data object, but can replace values of specific attributes.

A value migration handler operates on typed values. Values can be of any type, typical use cases include merges, replacements or renaming of built-in IDs, such as IUuIds. However, values can also be IDoEntity data objects.

Value migration handlers are always applied after all structure migration handlers have been applied. Value migrations are applied in a specific order, defined by a type version. Migration handlers with the same type version are applied according to the order provided by the bean manager.

315763