### PR TITLE
Calendar: allow time range selection in calendar

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.less
+++ b/eclipse-scout-core/src/calendar/Calendar.less
@@ -583,6 +583,7 @@
       & > .calendar-component-leftcolorborder {
         height: calc(~'100% + 10px');
         top: -10px;
+        position: relative;
       }
 
       &::before {
@@ -728,4 +729,11 @@
   left: 7px;
   color: @calendar-week-axis-color;
   content: attr(data-axis-name);
+}
+
+.calendar-range-selector {
+  background-color: @selected-background-color;
+  position: absolute;
+  opacity: 0.3;
+  width: 100%;
 }

--- a/eclipse-scout-core/src/calendar/CalendarAdapter.js
+++ b/eclipse-scout-core/src/calendar/CalendarAdapter.js
@@ -37,6 +37,8 @@ export default class CalendarAdapter extends ModelAdapter {
       this._sendSelectionChange();
     } else if (event.type === 'componentMove') {
       this._sendComponentMove(event);
+    } else if (event.type === 'selectedRangeChange') {
+      this._sendSelectedRangeChange();
     } else {
       super._onWidgetEvent(event);
     }
@@ -46,6 +48,13 @@ export default class CalendarAdapter extends ModelAdapter {
     return dates.toJsonDateRange(this.widget.viewRange);
   }
 
+  _jsonSelectedRange() {
+    if (!this.widget.selectedRange) {
+      return null;
+    }
+    return dates.toJsonDateRange(this.widget.selectedRange);
+  }
+
   _jsonSelectedDate() {
     return dates.toJsonDate(this.widget.selectedDate);
   }
@@ -53,6 +62,12 @@ export default class CalendarAdapter extends ModelAdapter {
   _sendViewRangeChange() {
     this._send('viewRangeChange', {
       viewRange: this._jsonViewRange()
+    });
+  }
+
+  _sendSelectedRangeChange() {
+    this._send('selectedRangeChange', {
+      selectedRange: this._jsonSelectedRange()
     });
   }
 

--- a/eclipse-scout-core/src/calendar/CalendarComponent.js
+++ b/eclipse-scout-core/src/calendar/CalendarComponent.js
@@ -269,6 +269,11 @@ export default class CalendarComponent extends Widget {
       return;
     }
 
+    // don't show popup when range selection is in progress
+    if (this.parent._rangeSelectionStarted) {
+      return;
+    }
+
     let $part = $(event.delegateTarget);
     this.updateSelectedComponent($part, false);
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/ICalendar.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/ICalendar.java
@@ -55,6 +55,10 @@ public interface ICalendar extends IWidget, IContextMenuOwner {
    */
   String PROP_SELECTED_DATE = "selectedDate";
   /**
+   * type {@link Date}[2]
+   */
+  String PROP_SELECTED_RANGE = "selectedRange";
+  /**
    * type {@link Boolean}
    */
   String PROP_LOAD_IN_PROGRESS = "loadInProgress";
@@ -70,6 +74,10 @@ public interface ICalendar extends IWidget, IContextMenuOwner {
    * type {@link Boolean}
    */
   String PROP_SHOW_DISPLAY_MODE_SELECTION = "showDisplayModeSelection";
+  /**
+   * type {@link Boolean}
+   */
+  String PROP_RANGE_SELECTION_ALLOWED = "rangeSelectionAllowed";
 
   /**
    * @since 4.0.0 {@link IContextMenu}
@@ -102,6 +110,15 @@ public interface ICalendar extends IWidget, IContextMenuOwner {
   Date getSelectedDate();
 
   void setSelectedDate(Date d);
+
+  /**
+   * @return a Date tupel [begin, end]
+   */
+  Range<Date> getSelectedRange();
+
+  void setSelectedRange(Date selectedRangeStart, Date selectedRangeEnd);
+
+  void setSelectedRange(Range<Date> dateRange);
 
   CalendarComponent getSelectedComponent();
 
@@ -194,6 +211,15 @@ public interface ICalendar extends IWidget, IContextMenuOwner {
   boolean getShowDisplayModeSelection();
 
   void setShowDisplayModeSelection(boolean showDisplayModeSelection);
+
+  /**
+   * Specifies whether a range in the calendar can be selected.
+   * <p>
+   * Default {@code false}.
+   */
+  boolean getRangeSelectionAllowed();
+
+  void setRangeSelectionAllowed(boolean rangeSelectionAllowed);
 
   /*
    * UI interface

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/ICalendarUIFacade.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/ICalendarUIFacade.java
@@ -28,6 +28,10 @@ public interface ICalendarUIFacade {
 
   void setViewRangeFromUI(Date from, Date to);
 
+  void setSelectedRangeFromUI(Range<Date> selectedRange);
+
+  void setSelectedRangeFromUI(Date from, Date to);
+
   void setDisplayModeFromUI(int displayMode);
 
   void setSelectionFromUI(Date date, CalendarComponent comp);


### PR DESCRIPTION
Add logic to select a time range in the calendar when in day, work week or week mode. This feature is disabled by default, use the property rangeSelectionAllowed to configure. Feature is not available for mobile devices.

325051