### PR TITLE
E-Mail: Fixed wrong IDN conversion

### DIFF
--- a/org.eclipse.scout.rt.mail.test/src/test/java/org/eclipse/scout/rt/mail/MailHelperTest.java
+++ b/org.eclipse.scout.rt.mail.test/src/test/java/org/eclipse/scout/rt/mail/MailHelperTest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.IDN;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
@@ -366,7 +365,7 @@ public class MailHelperTest {
   public void testInternetAddress3() {
     // test an invalid address, expect a ProcessingException
     MailParticipant participant = new MailParticipant()
-        .withEmail("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com")
+        .withEmail("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com")
         .withName("Invalid address");
     BEANS.get(MailHelper.class).createInternetAddress(participant);
   }
@@ -384,10 +383,10 @@ public class MailHelperTest {
     assertEquals(addressToString, address2.toString());
     assertEquals(addressPersonal, address2.getPersonal());
 
-    assertEquals(IDN.toASCII(email), address2.getAddress());
-    assertEquals(email, IDN.toUnicode(address2.getAddress()));
+    assertEquals(BEANS.get(MailIDNConverter.class).toASCII(email), address2.getAddress());
+    assertEquals(email, BEANS.get(MailIDNConverter.class).toUnicode(address2.getAddress()));
 
-    assertEquals("xn--peter@mller-zhb.de", BEANS.get(MailHelper.class).createInternetAddress("peter@müller.de").getAddress());
+    assertEquals("peter@xn--mller-kva.de", BEANS.get(MailHelper.class).createInternetAddress("peter@müller.de").getAddress());
   }
 
   @Test
@@ -424,8 +423,8 @@ public class MailHelperTest {
     InternetAddress[] addresses = BEANS.get(MailHelper.class).parseInternetAddressList(StringUtility.join(",", inputAddresses));
     assertEquals(inputAddresses.length, addresses.length);
     for (int i = 0; i < inputAddresses.length; i++) {
-      assertEquals(IDN.toASCII(inputAddresses[i]), addresses[i].getAddress());
-      assertEquals(inputAddresses[i], IDN.toUnicode(addresses[i].getAddress()));
+      assertEquals(BEANS.get(MailIDNConverter.class).toASCII(inputAddresses[i]), addresses[i].getAddress());
+      assertEquals(inputAddresses[i], BEANS.get(MailIDNConverter.class).toUnicode(addresses[i].getAddress()));
     }
   }
 
@@ -478,7 +477,7 @@ public class MailHelperTest {
     assertFalse(mailHelper.isEmailAddressValid("foo@bär@de.de"));
     assertFalse(mailHelper.isEmailAddressValid("foo@domain/test.みんな"));
     assertFalse(mailHelper.isEmailAddressValid("foo@domain\test.みんな"));
-    assertFalse(mailHelper.isEmailAddressValid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com"));
+    assertFalse(mailHelper.isEmailAddressValid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com"));
   }
 
   @Test

--- a/org.eclipse.scout.rt.mail.test/src/test/java/org/eclipse/scout/rt/mail/MailIDNConverterTest.java
+++ b/org.eclipse.scout.rt.mail.test/src/test/java/org/eclipse/scout/rt/mail/MailIDNConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.mail;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.junit.Test;
+
+/**
+ * JUnit tests for {@link MailIDNConverter}
+ */
+public class MailIDNConverterTest {
+
+  @Test
+  public void testAsciiConvertionWithoutSpecialChar() {
+    // Arrange
+    String emailAddress = "someone@example.com";
+
+    // Act
+    String convertedAddress = BEANS.get(MailIDNConverter.class).toASCII(emailAddress);
+
+    // Assert
+    assertEquals(emailAddress, convertedAddress);
+  }
+
+  @Test
+  public void testAsciiConvertionWithSpecialCharInLocalPart() {
+    // Arrange
+    String emailAddress = "sömeöne@example.com";
+
+    // Act
+    String convertedAddress = BEANS.get(MailIDNConverter.class).toASCII(emailAddress);
+
+    // Assert
+    assertEquals(emailAddress, convertedAddress);
+  }
+
+  @Test
+  public void testAsciiConvertionWithSpecialChar() {
+    // Arrange
+    String emailAddress = "sömeone@exämple.com";
+    String punycodeAddress = "sömeone@xn--exmple-cua.com";
+
+    // Act
+    String convertedAddress = BEANS.get(MailIDNConverter.class).toASCII(emailAddress);
+
+    // Assert
+    assertEquals(punycodeAddress, convertedAddress);
+  }
+
+  @Test
+  public void testUnicodeConvertionWithSpecialChar() {
+    // Arrange
+    String punycodeAddress = "sömeöne@xn--exmple-cua.com";
+    String emailAddress = "sömeöne@exämple.com";
+
+    // Act
+    String convertedAddress = BEANS.get(MailIDNConverter.class).toUnicode(punycodeAddress);
+
+    // Assert
+    assertEquals(emailAddress, convertedAddress);
+  }
+}

--- a/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/MailHelper.java
+++ b/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/MailHelper.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.net.IDN;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
@@ -812,7 +811,7 @@ public class MailHelper {
     }
 
     try {
-      InternetAddress internetAddress = new InternetAddress(IDN.toASCII(email));
+      InternetAddress internetAddress = new InternetAddress(BEANS.get(MailIDNConverter.class).toASCII(email));
       if (StringUtility.hasText(name)) {
         internetAddress.setPersonal(name, StandardCharsets.UTF_8.name());
       }
@@ -959,7 +958,7 @@ public class MailHelper {
     }
 
     try {
-      new InternetAddress(IDN.toASCII(emailAddress), true);
+      new InternetAddress(BEANS.get(MailIDNConverter.class).toASCII(emailAddress), true);
       return true;
     }
     catch (AddressException | IllegalArgumentException e) {

--- a/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/MailIDNConverter.java
+++ b/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/MailIDNConverter.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.mail;
+
+import java.net.IDN;
+import java.util.function.Function;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+
+@ApplicationScoped
+public class MailIDNConverter {
+
+  /**
+   * Converts a email address with non-ASCII characters in the domain part into a ASCII compatible form using the
+   * punycode encoding. <br>
+   * Examples: <br>
+   * someone@exämple.com -> someone@xn--exmple-cua.com <br>
+   * sömeöne@example.com -> sömeöne@example.com
+   *
+   * @param email
+   *          email address to convert.
+   * @return punycode encoded email address.
+   */
+  public String toASCII(String email) {
+    return convertToCharset(email, IDN::toASCII);
+  }
+
+  /**
+   * Converts a punycode encoded email address into a Unicode String. <br>
+   * Examples: <br>
+   * someone@xn--exmple-cua.com -> someone@exämple.com
+   *
+   * @param email
+   *          punycode encoded email address.
+   * @return email address as Unicode String.
+   */
+  public String toUnicode(String email) {
+    return convertToCharset(email, IDN::toUnicode);
+  }
+
+  /**
+   * Helper-method to convert the email address into an IDN conform way using a function as the conversion method to
+   * reduce boilerplate code.
+   *
+   * @param email
+   *          email address
+   * @param conversionMethod
+   *          convert function
+   * @return converted email address
+   */
+  protected String convertToCharset(String email, Function<String, String> conversionMethod) {
+    int index = getSplitIndex(email);
+
+    if (index < 0) {
+      return email;
+    }
+
+    return getLocalPart(email, index) + "@" + conversionMethod.apply(getDomainPart(email, index));
+  }
+
+  /**
+   * Helper method to extract the local part of the email. <br>
+   * Example: <a href="mailto:someone@example.com">someone@example.com</a> - Local-part: someone; domain-part:
+   * example.com <br>
+   * Note: If the length of the local part is above 64, a {@link ProcessingException} is thrown.
+   *
+   * @param email
+   *          full email address.
+   * @param index
+   *          index of the '@' symbol.
+   * @return local-part of the email.
+   * @throws IllegalArgumentException
+   *           if the length of the local part is above 64 characters.
+   */
+  protected String getLocalPart(String email, int index) {
+    String localPart = email.substring(0, index);
+
+    if (localPart.length() > 64) {
+      throw new IllegalArgumentException(
+          String.format("The maximum length of a local part in a email address can not be above 64 characters,"
+              + " the length of %s is %d", localPart, localPart.length()));
+    }
+
+    return localPart;
+  }
+
+  /**
+   * Helper method to extract the domain part of the email. <br>
+   * Example: <a href="mailto:someone@example.com">someone@example.com</a> - Local-part: someone; domain-part:
+   * example.com
+   *
+   * @param email
+   *          full email address.
+   * @param index
+   *          index of the '@' symbol.
+   * @return domain-part of the email.
+   * @throws IllegalArgumentException
+   *           if the length of the local part is above 255 characters.
+   */
+  protected String getDomainPart(String email, int index) {
+    String domainPart = email.substring(index + 1);
+
+    if (domainPart.length() > 255) {
+      throw new IllegalArgumentException(
+          String.format("The maximum length of a domain part in a email address can not be above 255 characters,"
+              + " the length of %s is %d", domainPart, domainPart.length()));
+    }
+
+    return domainPart;
+  }
+
+  /**
+   * Finds the null-safe index of the '@' symbol in a given email address.
+   *
+   * @param email
+   *          email address.
+   * @return first index of the '@' symbol or {@code -1} if there is no occurrence or if the email is null or empty.
+   */
+  protected int getSplitIndex(String email) {
+    if (StringUtility.isNullOrEmpty(email)) {
+      return -1;
+    }
+    return email.indexOf("@");
+  }
+}


### PR DESCRIPTION
Email addresses containing umlauts were incorrectly converted into their punycode representation. Instead of just the domain, the full address was converted. This issue was fixed with this commit. Example:
Incorrect: info@exämple.com -> xn--info@exmple-cua.com Correct: info@exämple.com -> info@xn--exmple-cua.com

333134