### PR TITLE
UriUtility#getQueryParameters: fix handling of '=' in an URI query pa…

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/UriUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/UriUtilityTest.java
@@ -47,6 +47,10 @@ public class UriUtilityTest {
     assertTrue(UriUtility.getQueryParameters(URI.create("scheme://test.com/path/path2")).isEmpty());
     assertEquals(Collections.singletonMap("key", ""), UriUtility.getQueryParameters(new UriBuilder("http://www.example.com?key").createURI()));
     assertEquals(Collections.singletonMap("key", ""), UriUtility.getQueryParameters(new UriBuilder("http://www.example.com?key=").createURI()));
+    assertEquals(Collections.singletonMap("code", "bG9yZW0="), UriUtility.getQueryParameters(new UriBuilder("http://www.example.com/api/customers?code=bG9yZW0=").createURI()));
+    assertEquals(Collections.singletonMap("code", "YW1lZA=="), UriUtility.getQueryParameters(new UriBuilder("http://www.example.com/api/customers?code=YW1lZA==").createURI()));
+    assertEquals(Collections.singletonMap("code", "=="), UriUtility.getQueryParameters(new UriBuilder("http://www.example.com/api/customers?code===").createURI()));
+    assertEquals(Collections.singletonMap("code", "a=b=c=d"), UriUtility.getQueryParameters(new UriBuilder("http://www.example.com/api/customers?code=a=b=c=d").createURI()));
   }
 
   @Test

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/UriUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/UriUtility.java
@@ -96,10 +96,7 @@ public final class UriUtility {
       if (StringUtility.isNullOrEmpty(param)) {
         continue;
       }
-      String[] parts = StringUtility.split(param, "=");
-      if (parts.length > 2) {
-        throw new ProcessingException("invalid query parameter: '" + param + "'");
-      }
+      String[] parts = StringUtility.split(param, "=", 2);
       String key = decode(parts[0], encoding);
       String value = parts.length < 2 ? "" : decode(parts[1], encoding);
       String existingMapping = result.put(key, value);


### PR DESCRIPTION
…rameter value

A '=' in query parameter resulted in the character itself and all following characters to be ignored.

335458