### PR TITLE
Do not cache defaultValues.json with maxAge

### DIFF
--- a/org.eclipse.scout.rt.chart.ui.html/src/main/java/org/eclipse/scout/rt/chart/ui/html/json/DefaultValuesConfigurationContributor.java
+++ b/org.eclipse.scout.rt.chart.ui.html/src/main/java/org/eclipse/scout/rt/chart/ui/html/json/DefaultValuesConfigurationContributor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.chart.ui.html.json;
+
+import java.net.URL;
+
+import org.eclipse.scout.rt.chart.ui.html.ResourceBase;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.ui.html.json.IDefaultValuesConfigurationContributor;
+
+@Order(5450)
+public class DefaultValuesConfigurationContributor implements IDefaultValuesConfigurationContributor {
+
+  @Override
+  public URL contributeDefaultValuesConfigurationUrl() {
+    return ResourceBase.class.getResource("json/defaultValues.json");
+  }
+}

--- a/org.eclipse.scout.rt.chart.ui.html/src/main/resources/org/eclipse/scout/rt/chart/ui/html/json/defaultValues.json
+++ b/org.eclipse.scout.rt.chart.ui.html/src/main/resources/org/eclipse/scout/rt/chart/ui/html/json/defaultValues.json
@@ -1,0 +1,53 @@
+/**
+ * Note: This file is not a well-formed JSON file according to RFC 4627 because of the comments.
+ * You can remove the comments (and thus create a compliant JSON file again) with
+ * JsonUtility.stripJsonComments(). If the file is served by StaticResourceRequestInterceptor,
+ * this is done automatically.
+ */
+{
+  /* *** Default value definitions *** */
+  /* (Note: Array values are always tested without considering the order) */
+  "defaults": {
+    "Chart": {
+      "~data": {
+        "axes": []
+      },
+      "~config": {
+        "~options": {
+          "autoColor": true,
+          "maxSegments": 5,
+          "clickable": false,
+          "~animation": {
+            "duration": 600
+          },
+          "~plugins": {
+            "~legend": {
+              "display": true,
+              "position": "right"
+            }
+          }
+        }
+      }
+    },
+    "ChartTableControl": {
+      "chartType": 3,
+      "chartAggregation": {
+        "modifier": -1
+      }
+    }
+  },
+  /* *** Object type hierarchy *** */
+  "objectTypeHierarchy": {
+    "Widget": {
+      "Chart": null,
+      "FormField": {
+        "ChartField": null
+      },
+      "Action": {
+        "TableControl": {
+          "ChartTableControl": null
+        }
+      }
+    }
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/DefaultValuesFilterService.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/DefaultValuesFilterService.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -169,7 +169,7 @@ public class DefaultValuesFilterService implements IDefaultValuesFilterService {
         .withContent(content)
         .withLastModified(m_lastModified)
         .withCachingAllowed(true)
-        .withCacheMaxAge(HttpCacheControl.MAX_AGE_4_HOURS)
+        .withCacheMaxAge(HttpCacheControl.MAX_AGE_NONE)
         .build();
   }
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/json/defaultValues.json
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/json/defaultValues.json
@@ -11,6 +11,7 @@
     // Model adapters
     "Widget": {
       "enabled": true,
+      "visible": true,
       "loading": false,
       "inheritAccessibility": true
     },
@@ -18,7 +19,6 @@
       "currentMenuTypes": [],
       "disabledStyle": 0,
       "fieldStyle": "alternative",
-      "visible": true,
       "keyStrokes": [],
       "labelVisible": true,
       "labelPosition": 0,
@@ -62,7 +62,6 @@
       "statusMenuMappings": []
     },
     "Action": {
-      "visible": true,
       "selected": false,
       "horizontalAlignment": -1,
       "toggleAction": false,


### PR DESCRIPTION
A defaultValues.json that is cached with maxAge 4 hours may be still valid in the browser after a new release was deployed. This will result in strange behaviour as the default values on the server and in the browser are no longer in sync.
Add defaultValues for chart.

335505