### PR TITLE
Add categories for health checking

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/AbstractHealthChecker.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/AbstractHealthChecker.java
@@ -64,14 +64,14 @@ public abstract class AbstractHealthChecker implements IHealthChecker {
   }
 
   /**
-   * @return The health check timeout duration in milliseconds. If greater than zero, {@link #execCheckHealth()} will
-   *         time out after given duration.
+   * @return The health check timeout duration in milliseconds. If greater than zero,
+   *         {@link #execCheckHealth(HealthCheckCategoryId)} will time out after given duration.
    */
   protected long getConfiguredTimeoutMillis() {
     return 0;
   }
 
-  protected abstract boolean execCheckHealth() throws Exception;
+  protected abstract boolean execCheckHealth(HealthCheckCategoryId category) throws Exception;
 
   @Override
   public String getName() {
@@ -102,7 +102,7 @@ public abstract class AbstractHealthChecker implements IHealthChecker {
   }
 
   @Override
-  public boolean checkHealth(RunContext context) {
+  public boolean checkHealth(RunContext context, HealthCheckCategoryId category) {
     if (!isExpired()) {
       return m_lastStatus.get();
     }
@@ -143,7 +143,7 @@ public abstract class AbstractHealthChecker implements IHealthChecker {
         m_future = Jobs.schedule(() -> {
           LOG.debug("HealthCheck[{}] has started", getName());
           try {
-            boolean result = execCheckHealth();
+            boolean result = execCheckHealth(category);
             notifyHealthCheckResult(result);
             return result;
           }
@@ -166,7 +166,7 @@ public abstract class AbstractHealthChecker implements IHealthChecker {
 
   /**
    * Called after a health check was executed.
-   * 
+   *
    * @param result
    *          status of last executed health check
    */

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/HealthCheckCategoryId.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/HealthCheckCategoryId.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.server.commons.healthcheck;
+
+import org.eclipse.scout.rt.dataobject.id.AbstractStringId;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.server.commons.healthcheck.IHealthChecker.IHealthCheckCategory;
+
+/**
+ * Identifier for a specific check category.
+ *
+ * @see IHealthCheckCategory
+ */
+public final class HealthCheckCategoryId extends AbstractStringId {
+
+  private static final long serialVersionUID = 1L;
+
+  private HealthCheckCategoryId(String id) {
+    super(id);
+  }
+
+  public static HealthCheckCategoryId of(String id) {
+    if (StringUtility.isNullOrEmpty(id)) {
+      return null;
+    }
+    return new HealthCheckCategoryId(id);
+  }
+}

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/IHealthChecker.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/IHealthChecker.java
@@ -29,10 +29,60 @@ public interface IHealthChecker {
   boolean isActive();
 
   /**
+   * @param category
+   *          the {@link IHealthCheckCategory} if provided, <code>null</code> if none is provided
    * @param context
    *          {@link RunContext} used to run the check in.
    * @return <code>true</code> if check was successful, <code>false</code> otherwise.
    */
-  boolean checkHealth(RunContext context);
+  boolean checkHealth(RunContext context, HealthCheckCategoryId category);
 
+  /**
+   * @param category
+   *          non-null category; if no category is available all checks are considered which are marked as
+   *          {@link #isActive()}
+   * @return <code>true</code> if this <code>IHealthChecker</code> accepts the provided category; <code>false</code> to
+   *         exclude this check for this category
+   */
+  default boolean acceptCategory(HealthCheckCategoryId category) {
+    return true;
+  }
+
+  /**
+   * Interface defining the possible health check categories
+   */
+  @ApplicationScoped
+  public static interface IHealthCheckCategory {
+    HealthCheckCategoryId getId();
+  }
+
+  // --------------------------------------
+  // default categories
+
+  public static final class Startup implements IHealthCheckCategory {
+    public static final HealthCheckCategoryId ID = HealthCheckCategoryId.of("startup");
+
+    @Override
+    public HealthCheckCategoryId getId() {
+      return ID;
+    }
+  }
+
+  public static final class Readiness implements IHealthCheckCategory {
+    public static final HealthCheckCategoryId ID = HealthCheckCategoryId.of("readiness");
+
+    @Override
+    public HealthCheckCategoryId getId() {
+      return ID;
+    }
+  }
+
+  public static final class Liveness implements IHealthCheckCategory {
+    public static final HealthCheckCategoryId ID = HealthCheckCategoryId.of("liveness");
+
+    @Override
+    public HealthCheckCategoryId getId() {
+      return ID;
+    }
+  }
 }

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/PlatformHealthChecker.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/PlatformHealthChecker.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.server.commons.healthcheck;
+
+import org.eclipse.scout.rt.platform.IPlatform.State;
+import org.eclipse.scout.rt.platform.Platform;
+
+public class PlatformHealthChecker extends AbstractHealthChecker {
+
+  @Override
+  protected boolean execCheckHealth(HealthCheckCategoryId category) throws Exception {
+    return Platform.get().getState() == State.PlatformStarted;
+  }
+}

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/RemoteHealthChecker.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/healthcheck/RemoteHealthChecker.java
@@ -11,6 +11,7 @@
 package org.eclipse.scout.rt.server.commons.healthcheck;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.scout.rt.platform.BEANS;
@@ -48,11 +49,14 @@ public class RemoteHealthChecker extends AbstractHealthChecker {
   }
 
   @Override
-  protected boolean execCheckHealth() throws Exception {
+  protected boolean execCheckHealth(HealthCheckCategoryId category) throws Exception {
     boolean status = true;
     if (m_remoteUrls != null) {
       for (String remote : m_remoteUrls) {
         GenericUrl remoteUrl = remote != null ? new GenericUrl(remote) : null;
+        if (remoteUrl != null && category != null) {
+          remoteUrl.put(AbstractHealthCheckServlet.QUERY_PARAMETER_NAME_CATEGORY, category.unwrap());
+        }
         HttpRequest req = BEANS.get(DefaultHttpTransportManager.class).getHttpRequestFactory().buildHeadRequest(remoteUrl);
         req.getHeaders().setCacheControl("no-cache");
         HttpResponse resp = req.execute();
@@ -66,4 +70,8 @@ public class RemoteHealthChecker extends AbstractHealthChecker {
     return status;
   }
 
+  @Override
+  public boolean acceptCategory(HealthCheckCategoryId category) {
+    return Objects.equals(category, Readiness.ID);
+  }
 }

--- a/org.eclipse.scout.rt.server.jdbc/src/main/java/org/eclipse/scout/rt/server/jdbc/JdbcHealthCecker.java
+++ b/org.eclipse.scout.rt.server.jdbc/src/main/java/org/eclipse/scout/rt/server/jdbc/JdbcHealthCecker.java
@@ -13,6 +13,7 @@ package org.eclipse.scout.rt.server.jdbc;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.scout.rt.server.commons.healthcheck.AbstractHealthChecker;
+import org.eclipse.scout.rt.server.commons.healthcheck.HealthCheckCategoryId;
 import org.eclipse.scout.rt.server.jdbc.style.ISqlStyle;
 
 /**
@@ -28,7 +29,7 @@ public class JdbcHealthCecker extends AbstractHealthChecker {
   }
 
   @Override
-  protected boolean execCheckHealth() throws Exception {
+  protected boolean execCheckHealth(HealthCheckCategoryId category) throws Exception {
     ISqlStyle s = SQL.getSqlStyle();
     if (s != null) {
       s.testConnection(SQL.getConnection());

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/mom/AbstractMomHealthChecker.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/mom/AbstractMomHealthChecker.java
@@ -16,6 +16,7 @@ import org.eclipse.scout.rt.mom.api.AbstractMomTransport;
 import org.eclipse.scout.rt.mom.api.IMomImplementor;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.server.commons.healthcheck.AbstractHealthChecker;
+import org.eclipse.scout.rt.server.commons.healthcheck.HealthCheckCategoryId;
 
 /**
  * @since 6.1
@@ -52,7 +53,7 @@ public abstract class AbstractMomHealthChecker extends AbstractHealthChecker {
   }
 
   @Override
-  protected boolean execCheckHealth() throws Exception {
+  protected boolean execCheckHealth(HealthCheckCategoryId category) throws Exception {
     IMomImplementor implementor = BEANS.get(getConfiguredMomClass()).getImplementor();
     if (implementor == null) {
       return false;


### PR DESCRIPTION
Health check servlet may be called with a category as query parameter controlling which health checkers should be checked; if no category is specified previous behavior (= all active health checkers) is applied.

321465