### PR TITLE
Renaming DoStructureMigration -> DataObjectMigration

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoStructureMigrationHandlerTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoStructureMigrationHandlerTest.java
@@ -69,11 +69,11 @@ public abstract class AbstractDoStructureMigrationHandlerTest {
    * @param toVersionClass
    *          To version is required to determine the file to load that contains the expected data object (target)
    */
-  public void testMigration(String filenamePrefix, Class<? extends ITypeVersion> fromVersionClass, Class<? extends ITypeVersion> toVersionClass, IDoStructureMigrationLocalContextData... initialLocalContextData) throws IOException {
+  public void testMigration(String filenamePrefix, Class<? extends ITypeVersion> fromVersionClass, Class<? extends ITypeVersion> toVersionClass, IDataObjectMigrationLocalContextData... initialLocalContextData) throws IOException {
     testMigration(filenamePrefix, BEANS.get(fromVersionClass).getVersion().unwrap(), toVersionClass, initialLocalContextData);
   }
 
-  public void testMigration(String filenamePrefix, String fromVersionText, Class<? extends ITypeVersion> toVersionClass, IDoStructureMigrationLocalContextData... initialLocalContextData) throws IOException {
+  public void testMigration(String filenamePrefix, String fromVersionText, Class<? extends ITypeVersion> toVersionClass, IDataObjectMigrationLocalContextData... initialLocalContextData) throws IOException {
     NamespaceVersion toVersion = BEANS.get(toVersionClass).getVersion();
     IPrettyPrintDataObjectMapper dataObjectMapper = BEANS.get(IPrettyPrintDataObjectMapper.class);
 
@@ -83,9 +83,9 @@ public abstract class AbstractDoStructureMigrationHandlerTest {
       actual = (IDoEntity) dataObjectMapper.readValueRaw(in);
     }
 
-    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class)
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class)
         .withInitialLocalContext(initialLocalContextData);
-    boolean changed = BEANS.get(DoStructureMigrator.class).applyStructureMigration(ctx, actual, toVersion);
+    boolean changed = BEANS.get(DataObjectMigrator.class).applyStructureMigration(ctx, actual, toVersion);
 
     assertTrue("Data object was not changed by migration", changed);
 

--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDataObjectMigrationInventory.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDataObjectMigrationInventory.java
@@ -14,7 +14,6 @@ import static org.eclipse.scout.rt.platform.util.Assertions.assertFalse;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
@@ -23,8 +22,7 @@ import org.eclipse.scout.rt.platform.namespace.INamespace;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
 @IgnoreBean
-// TODO 23.1 [data object migration] rename to TestDataObjectMigrationInventory
-public class TestDoStructureMigrationInventory extends DoStructureMigrationInventory {
+public class TestDataObjectMigrationInventory extends DataObjectMigrationInventory {
 
   protected final List<INamespace> m_internalNamespaces = new ArrayList<>();
   protected final Collection<ITypeVersion> m_internalTypeVersions = new ArrayList<>();
@@ -32,7 +30,7 @@ public class TestDoStructureMigrationInventory extends DoStructureMigrationInven
   protected final List<IDoStructureMigrationHandler> m_internalStructureMigrationHandlers = new ArrayList<>();
   protected final List<IDoValueMigrationHandler<?>> m_internalValueMigrationHandlers = new ArrayList<>();
 
-  public TestDoStructureMigrationInventory(
+  public TestDataObjectMigrationInventory(
       List<INamespace> namespaces,
       Collection<ITypeVersion> typeVersions,
       Collection<Class<? extends IDoStructureMigrationTargetContextData>> contextDataClasses,
@@ -55,22 +53,6 @@ public class TestDoStructureMigrationInventory extends DoStructureMigrationInven
     }
 
     init();
-  }
-
-  /**
-   * This constructor will be removed in a future release.
-   *
-   * @deprecated use {@link #TestDoStructureMigrationInventory(List, Collection, Collection, Collection, Collection)}
-   *             instead.
-   */
-  // TODO 23.1 [data object migration] remove deprecated constructor
-  @Deprecated
-  public TestDoStructureMigrationInventory(
-      List<INamespace> namespaces,
-      Collection<ITypeVersion> typeVersions,
-      Collection<Class<? extends IDoStructureMigrationTargetContextData>> contextDataClasses,
-      IDoStructureMigrationHandler... structureMigrationHandlers) {
-    this(namespaces, typeVersions, contextDataClasses, CollectionUtility.arrayList(structureMigrationHandlers), Collections.emptyList());
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDataObjectMigrator.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDataObjectMigrator.java
@@ -15,14 +15,13 @@ import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 
 @IgnoreBean
-// TODO 23.1 [data object migration] rename to TestDataObjectMigrator
-public class TestDoStructureMigrator extends DoStructureMigrator {
+public class TestDataObjectMigrator extends DataObjectMigrator {
 
   /**
    * Override to change visibility from protected to public.
    */
   @Override
-  public boolean applyStructureMigration(DoStructureMigrationContext ctx, IDataObject dataObject, NamespaceVersion toVersion) {
+  public boolean applyStructureMigration(DataObjectMigrationContext ctx, IDataObject dataObject, NamespaceVersion toVersion) {
     return super.applyStructureMigration(ctx, dataObject, toVersion);
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationContextTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationContextTest.java
@@ -18,28 +18,27 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.junit.Test;
 
-// TODO 23.1 [data object migration] rename to DataObjectMigrationContextTest
-public class DoStructureMigrationContextTest {
+public class DataObjectMigrationContextTest {
 
   @Test
   public void testDefaults() {
-    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class);
-    assertTrue(ctx.getGlobal(IDoStructureMigrationLogger.class) instanceof DoStructureMigrationPassThroughLogger);
-    assertTrue(ctx.getLogger() instanceof DoStructureMigrationPassThroughLogger);
-    assertEquals(ctx.getLogger(), ctx.getGlobal(IDoStructureMigrationLogger.class));
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class);
+    assertTrue(ctx.getGlobal(IDataObjectMigrationLogger.class) instanceof DataObjectMigrationPassThroughLogger);
+    assertTrue(ctx.getLogger() instanceof DataObjectMigrationPassThroughLogger);
+    assertEquals(ctx.getLogger(), ctx.getGlobal(IDataObjectMigrationLogger.class));
   }
 
   @Test
   public void testGlobalBean() {
-    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class);
-    assertTrue(ctx.getGlobal(DoStructureMigrationStatsContextData.class) instanceof DoStructureMigrationStatsContextData);
-    assertTrue(ctx.getStats() instanceof DoStructureMigrationStatsContextData);
-    assertEquals(ctx.getStats(), ctx.getGlobal(DoStructureMigrationStatsContextData.class));
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class);
+    assertTrue(ctx.getGlobal(DataObjectMigrationStatsContextData.class) instanceof DataObjectMigrationStatsContextData);
+    assertTrue(ctx.getStats() instanceof DataObjectMigrationStatsContextData);
+    assertEquals(ctx.getStats(), ctx.getGlobal(DataObjectMigrationStatsContextData.class));
   }
 
   @Test
   public void testGlobalManually() {
-    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class);
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class);
     assertNull(ctx.getGlobal(ZipCodeFixtureGlobalContextData.class));
     ZipCodeFixtureGlobalContextData zipCodeContextData = new ZipCodeFixtureGlobalContextData();
     ctx.putGlobal(zipCodeContextData);
@@ -48,7 +47,7 @@ public class DoStructureMigrationContextTest {
 
   @Test
   public void testLocal() {
-    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class);
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class);
     assertNull(ctx.get(HouseFixtureStructureMigrationTargetContextData.class));
 
     HouseFixtureStructureMigrationTargetContextData houseFixtureContextData = BEANS.get(HouseFixtureStructureMigrationTargetContextData.class);
@@ -77,7 +76,7 @@ public class DoStructureMigrationContextTest {
 
   @Test
   public void testClone() {
-    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class);
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class);
 
     ZipCodeFixtureGlobalContextData zipCodeContextData = new ZipCodeFixtureGlobalContextData();
     ctx.putGlobal(zipCodeContextData);
@@ -85,7 +84,7 @@ public class DoStructureMigrationContextTest {
     HouseFixtureStructureMigrationTargetContextData houseFixtureContextData = BEANS.get(HouseFixtureStructureMigrationTargetContextData.class);
     ctx.push(houseFixtureContextData); // not initialized, for this test okay
 
-    DoStructureMigrationContext ctxCopy = ctx.copy();
+    DataObjectMigrationContext ctxCopy = ctx.copy();
 
     // Global (same reference)
     assertSame(ctx.getGlobal(ZipCodeFixtureGlobalContextData.class), ctxCopy.getGlobal(ZipCodeFixtureGlobalContextData.class));

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventoryTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventoryTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationInventory.FindNextMigrationHandlerVersionStatus;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationInventory.FindNextMigrationHandlerVersionStatus;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.CharlieCustomerFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.CharlieCustomerFixtureTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.CustomerFixtureDo;
@@ -28,9 +28,9 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.house.CustomerFixtureTa
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.DuplicateIdFixtureDoValueMigrationHandler_1;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDoStructureMigrationHandler_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureRawOnlyDoStructureMigrationTargetContextData;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureRawOnlyStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureStructureMigrationTargetContextData;
-import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureTypedOnlyDoStructureMigrationTargetContextData;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureTypedOnlyStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypeFixtureDoValueMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3;
@@ -69,16 +69,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Tests for {@link DoStructureMigrationInventory}.
+ * Tests for {@link DataObjectMigrationInventory}.
  */
-// TODO 23.1 [data object migration] rename to DataObjectMigrationInventoryTest
-public class DoStructureMigrationInventoryTest {
+public class DataObjectMigrationInventoryTest {
 
-  private static DoStructureMigrationInventory s_inventory;
+  private static DataObjectMigrationInventory s_inventory;
 
   @BeforeClass
   public static void beforeClass() {
-    s_inventory = new TestDoStructureMigrationInventory(
+    s_inventory = new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace()),
         Arrays.asList(
             new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(), // AlfaFixture_7 is explicitly not registered
@@ -87,8 +86,8 @@ public class DoStructureMigrationInventoryTest {
             new DeltaFixture_1(), new DeltaFixture_2()),
         Arrays.asList(
             HouseFixtureStructureMigrationTargetContextData.class,
-            HouseFixtureRawOnlyDoStructureMigrationTargetContextData.class,
-            HouseFixtureTypedOnlyDoStructureMigrationTargetContextData.class,
+            HouseFixtureRawOnlyStructureMigrationTargetContextData.class,
+            HouseFixtureTypedOnlyStructureMigrationTargetContextData.class,
             CustomerFixtureTargetContextData.class,
             CharlieCustomerFixtureTargetContextData.class),
         Arrays.asList(
@@ -106,11 +105,11 @@ public class DoStructureMigrationInventoryTest {
   }
 
   /**
-   * Tests for {@link DoStructureMigrationInventory#validateStructureMigrationHandlerUniqueness(Map)} ()}.
+   * Tests for {@link DataObjectMigrationInventory#validateStructureMigrationHandlerUniqueness(Map)} ()}.
    */
   @Test
   public void testValidateMigrationHandlerUniqueness() {
-    TestDoStructureMigrationInventory inventory = new TestDoStructureMigrationInventory(
+    TestDataObjectMigrationInventory inventory = new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace()),
         Arrays.asList(
             new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(),
@@ -122,7 +121,7 @@ public class DoStructureMigrationInventoryTest {
 
     assertNotNull(inventory); // no validation error on creation of inventory
 
-    assertThrows(PlatformException.class, () -> new TestDoStructureMigrationInventory(
+    assertThrows(PlatformException.class, () -> new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace()),
         Arrays.asList(
             new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(),
@@ -136,7 +135,7 @@ public class DoStructureMigrationInventoryTest {
   }
 
   /**
-   * Validates internal structure of inventory ({@link DoStructureMigrationInventory#m_orderedVersions}.
+   * Validates internal structure of inventory ({@link DataObjectMigrationInventory#m_orderedVersions}.
    */
   @Test
   public void testOrdered() {
@@ -153,7 +152,7 @@ public class DoStructureMigrationInventoryTest {
   }
 
   /**
-   * Validates internal structure of inventory ({@link DoStructureMigrationInventory#m_typeNameVersions}.
+   * Validates internal structure of inventory ({@link DataObjectMigrationInventory#m_typeNameVersions}.
    */
   @Test
   public void testTypeNameVersions() {
@@ -174,24 +173,24 @@ public class DoStructureMigrationInventoryTest {
 
   @Test
   public void testGetDoMigrationContextValues() {
-    Assert.assertThrows(AssertionException.class, () -> s_inventory.getDoMigrationContextValues(null));
+    Assert.assertThrows(AssertionException.class, () -> s_inventory.getStructureMigrationTargetContextDataClasses(null));
 
-    assertEquals(0, s_inventory.getDoMigrationContextValues(BEANS.get(DoEntityBuilder.class).put("_type", "unknown").build()).size());
+    assertEquals(0, s_inventory.getStructureMigrationTargetContextDataClasses(BEANS.get(DoEntityBuilder.class).put("_type", "unknown").build()).size());
 
     Set<Class<? extends IDoStructureMigrationTargetContextData>> contextDataSet;
 
-    assertEquals(CollectionUtility.hashSet(HouseFixtureStructureMigrationTargetContextData.class, HouseFixtureRawOnlyDoStructureMigrationTargetContextData.class),
-        s_inventory.getDoMigrationContextValues(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.HouseFixture").build()));
+    assertEquals(CollectionUtility.hashSet(HouseFixtureStructureMigrationTargetContextData.class, HouseFixtureRawOnlyStructureMigrationTargetContextData.class),
+        s_inventory.getStructureMigrationTargetContextDataClasses(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.HouseFixture").build()));
 
-    assertEquals(CollectionUtility.hashSet(HouseFixtureStructureMigrationTargetContextData.class, HouseFixtureTypedOnlyDoStructureMigrationTargetContextData.class),
-        s_inventory.getDoMigrationContextValues(BEANS.get(HouseFixtureDo.class)));
+    assertEquals(CollectionUtility.hashSet(HouseFixtureStructureMigrationTargetContextData.class, HouseFixtureTypedOnlyStructureMigrationTargetContextData.class),
+        s_inventory.getStructureMigrationTargetContextDataClasses(BEANS.get(HouseFixtureDo.class)));
 
     // Subclasses data object, using origin instance (thus new instead of BEANS.get) [not a real case]
     assertEquals(CollectionUtility.hashSet(CustomerFixtureTargetContextData.class),
-        s_inventory.getDoMigrationContextValues(new CustomerFixtureDo()));
+        s_inventory.getStructureMigrationTargetContextDataClasses(new CustomerFixtureDo()));
 
     assertEquals(CollectionUtility.hashSet(CustomerFixtureTargetContextData.class, CharlieCustomerFixtureTargetContextData.class),
-        s_inventory.getDoMigrationContextValues(BEANS.get(CharlieCustomerFixtureDo.class)));
+        s_inventory.getStructureMigrationTargetContextDataClasses(BEANS.get(CharlieCustomerFixtureDo.class)));
   }
 
   @Test
@@ -319,39 +318,39 @@ public class DoStructureMigrationInventoryTest {
 
   @Test
   public void testGetMigrationHandlers() {
-    assertThrows(AssertionException.class, () -> s_inventory.getMigrationHandlers(null));
-    assertThrows(AssertionException.class, () -> s_inventory.getMigrationHandlers(AlfaFixture_7.VERSION)); // no registered
+    assertThrows(AssertionException.class, () -> s_inventory.getStructureMigrationHandlers(null));
+    assertThrows(AssertionException.class, () -> s_inventory.getStructureMigrationHandlers(AlfaFixture_7.VERSION)); // no registered
 
     // alfaFixture-1
-    assertTrue(s_inventory.getMigrationHandlers(AlfaFixture_1.VERSION).isEmpty()); // no handlers
+    assertTrue(s_inventory.getStructureMigrationHandlers(AlfaFixture_1.VERSION).isEmpty()); // no handlers
 
     Map<String, IDoStructureMigrationHandler> migrationHandlers;
 
     // charlieFixture-2
-    migrationHandlers = s_inventory.getMigrationHandlers(CharlieFixture_2.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(CharlieFixture_2.VERSION);
     assertEquals(2, migrationHandlers.size());
 
     assertTrue(migrationHandlers.get("charlieFixture.BuildingFixture") instanceof HouseFixtureDoStructureMigrationHandler_2);
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_2);
 
     // bravoFixture-3
-    migrationHandlers = s_inventory.getMigrationHandlers(BravoFixture_3.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(BravoFixture_3.VERSION);
     assertEquals(1, migrationHandlers.size());
 
     assertTrue(migrationHandlers.get("bravoFixture.PetFixture") instanceof PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3);
 
     // charlieFixture-3
-    migrationHandlers = s_inventory.getMigrationHandlers(CharlieFixture_3.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(CharlieFixture_3.VERSION);
     assertEquals(1, migrationHandlers.size());
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_3);
 
     // charlieFixture-4
-    migrationHandlers = s_inventory.getMigrationHandlers(CharlieFixture_4.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(CharlieFixture_4.VERSION);
     assertEquals(1, migrationHandlers.size());
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_4);
 
     // charlieFixture-5
-    migrationHandlers = s_inventory.getMigrationHandlers(CharlieFixture_5.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(CharlieFixture_5.VERSION);
     assertEquals(1, migrationHandlers.size());
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_5);
   }
@@ -376,7 +375,7 @@ public class DoStructureMigrationInventoryTest {
    */
   @Test
   public void voidTestDuplicateValueMigrationIds() {
-    PlatformException exception = assertThrows(PlatformException.class, () -> new TestDoStructureMigrationInventory(
+    PlatformException exception = assertThrows(PlatformException.class, () -> new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace()),
         Arrays.asList(
             new AlfaFixture_1(), new AlfaFixture_2(),

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationTestHelper.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationTestHelper.java
@@ -15,9 +15,9 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureRawOnlyDoStructureMigrationTargetContextData;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureRawOnlyStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureStructureMigrationTargetContextData;
-import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureTypedOnlyDoStructureMigrationTargetContextData;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureTypedOnlyStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PersonFixtureTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureNamespace;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
@@ -44,9 +44,8 @@ import org.eclipse.scout.rt.platform.namespace.INamespace;
 /**
  * Helper methods used within tests to access common fixtures (namespaces, type versions, context data classes).
  */
-// TODO 23.1 [data object migration] rename to DataObjectMigrationTestHelper
 @ApplicationScoped
-public class DoStructureMigrationTestHelper {
+public class DataObjectMigrationTestHelper {
 
   public List<INamespace> getFixtureNamespaces() {
     return Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace());
@@ -63,8 +62,8 @@ public class DoStructureMigrationTestHelper {
   public Collection<Class<? extends IDoStructureMigrationTargetContextData>> getFixtureContextDataClasses() {
     return Arrays.asList(
         HouseFixtureStructureMigrationTargetContextData.class,
-        HouseFixtureRawOnlyDoStructureMigrationTargetContextData.class,
-        HouseFixtureTypedOnlyDoStructureMigrationTargetContextData.class,
+        HouseFixtureRawOnlyStructureMigrationTargetContextData.class,
+        HouseFixtureTypedOnlyStructureMigrationTargetContextData.class,
         PersonFixtureTargetContextData.class);
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorStructureMigrationTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorStructureMigrationTest.java
@@ -54,20 +54,20 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Tests for {@link DoStructureMigrator}, with focus on data object structure migrations
+ * Tests for {@link DataObjectMigrator}, with focus on data object structure migrations
  * ({@link IDoStructureMigrationHandler}).
  */
 public class DataObjectMigratorStructureMigrationTest {
 
   private static final List<IBean<?>> TEST_BEANS = new ArrayList<>();
 
-  private static DoStructureMigrationContext s_migrationContext;
-  private static DoStructureMigrator s_migrator;
+  private static DataObjectMigrationContext s_migrationContext;
+  private static DataObjectMigrator s_migrator;
 
   @BeforeClass
   public static void beforeClass() {
-    DoStructureMigrationTestHelper testHelper = BEANS.get(DoStructureMigrationTestHelper.class);
-    TestDoStructureMigrationInventory inventory = new TestDoStructureMigrationInventory(
+    DataObjectMigrationTestHelper testHelper = BEANS.get(DataObjectMigrationTestHelper.class);
+    TestDataObjectMigrationInventory inventory = new TestDataObjectMigrationInventory(
         testHelper.getFixtureNamespaces(),
         testHelper.getFixtureTypeVersions(),
         testHelper.getFixtureContextDataClasses(),
@@ -84,9 +84,9 @@ public class DataObjectMigratorStructureMigrationTest {
             new PersonFixtureDoStructureMigrationHandler_2()),
         Collections.emptyList());
 
-    TEST_BEANS.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(TestDoStructureMigrationInventory.class, inventory).withReplace(true)));
-    s_migrationContext = BEANS.get(DoStructureMigrationContext.class);
-    s_migrator = BEANS.get(DoStructureMigrator.class);
+    TEST_BEANS.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(TestDataObjectMigrationInventory.class, inventory).withReplace(true)));
+    s_migrationContext = BEANS.get(DataObjectMigrationContext.class);
+    s_migrator = BEANS.get(DataObjectMigrator.class);
   }
 
   @AfterClass

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorValueMigrationTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorValueMigrationTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrator.DoStructureMigratorResult;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrator.DataObjectMigratorResult;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDoStructureMigrationHandler_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDoValueMigrationHandler_1;
@@ -45,19 +45,19 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Tests for {@link DoStructureMigrator}, with focus on data object value migrations ({@link IDoValueMigrationHandler}).
+ * Tests for {@link DataObjectMigrator}, with focus on data object value migrations ({@link IDoValueMigrationHandler}).
  */
 public class DataObjectMigratorValueMigrationTest {
 
   private static final List<IBean<?>> TEST_BEANS = new ArrayList<>();
 
-  private static DoStructureMigrationContext s_migrationContext;
-  private static DoStructureMigrator s_migrator;
+  private static DataObjectMigrationContext s_migrationContext;
+  private static DataObjectMigrator s_migrator;
 
   @BeforeClass
   public static void beforeClass() {
-    DoStructureMigrationTestHelper testHelper = BEANS.get(DoStructureMigrationTestHelper.class);
-    TestDoStructureMigrationInventory inventory = new TestDoStructureMigrationInventory(
+    DataObjectMigrationTestHelper testHelper = BEANS.get(DataObjectMigrationTestHelper.class);
+    TestDataObjectMigrationInventory inventory = new TestDataObjectMigrationInventory(
         testHelper.getFixtureNamespaces(),
         testHelper.getFixtureTypeVersions(),
         Collections.emptyList(),
@@ -70,13 +70,13 @@ public class DataObjectMigratorValueMigrationTest {
             new HouseTypeFixtureDoValueMigrationHandler_2(),
             new HouseFixtureDoValueMigrationHandler_1()));
 
-    TEST_BEANS.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(TestDoStructureMigrationInventory.class, inventory).withReplace(true)));
+    TEST_BEANS.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(TestDataObjectMigrationInventory.class, inventory).withReplace(true)));
 
-    s_migrationContext = BEANS.get(DoStructureMigrationContext.class)
+    s_migrationContext = BEANS.get(DataObjectMigrationContext.class)
         .putGlobal(BEANS.get(DoValueMigrationIdsContextData.class)
             // by default, all value migrations are executed, except RoomSizeFixtureDoValueMigrationHandler_2 (PetFixtureAlwaysAcceptDoValueMigrationHandler_3 always accepts)
             .withAppliedValueMigrationIds(CollectionUtility.hashSet(PetFixtureAlwaysAcceptDoValueMigrationHandler_3.ID, RoomSizeFixtureDoValueMigrationHandler_2.ID)));
-    s_migrator = BEANS.get(DoStructureMigrator.class);
+    s_migrator = BEANS.get(DataObjectMigrator.class);
   }
 
   @AfterClass
@@ -95,7 +95,7 @@ public class DataObjectMigratorValueMigrationTest {
 
     // no value migrations will match the provided data object
     // RoomSizeFixtureDoValueMigrationHandler_2 is ignored by default in s_migrationContext
-    DoStructureMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+    DataObjectMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
 
     assertFalse(result.isChanged()); // no changes (structure nor values changed)
 
@@ -116,12 +116,12 @@ public class DataObjectMigratorValueMigrationTest {
         .withName("example")
         .withAreaInSquareMeter(10);
 
-    DoStructureMigrationContext ctx = BEANS.get(DoStructureMigrationContext.class)
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class)
         .putGlobal(BEANS.get(DoValueMigrationIdsContextData.class)
             .withAppliedValueMigrationIds(Collections.emptySet())); // run all value migrations
 
     // migration run 1
-    DoStructureMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(ctx, original);
+    DataObjectMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(ctx, original);
 
     assertTrue(result.isChanged());
 
@@ -154,7 +154,7 @@ public class DataObjectMigratorValueMigrationTest {
         .withHouseType(HouseTypeFixtureStringId.of("house")); // will be migrated by HouseTypeFixtureDoValueMigrationHandler_2
 
     // migration run 1
-    DoStructureMigratorResult<HouseFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+    DataObjectMigratorResult<HouseFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
 
     assertTrue(result.isChanged());
 
@@ -184,7 +184,7 @@ public class DataObjectMigratorValueMigrationTest {
         .withRooms(BEANS.get(RoomFixtureDo.class)
             .withName("tiny room"));
 
-    DoStructureMigratorResult<HouseFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+    DataObjectMigratorResult<HouseFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
 
     assertTrue(result.isChanged());
 
@@ -207,7 +207,7 @@ public class DataObjectMigratorValueMigrationTest {
         .withCustomData(BEANS.get(PetFixtureDo.class)
             .withName("Name: Fluffy")); // Will be migrated by PetFixtureDoValueMigrationHandler_3
 
-    DoStructureMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+    DataObjectMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
 
     assertTrue(result.isChanged());
 
@@ -231,7 +231,7 @@ public class DataObjectMigratorValueMigrationTest {
 
     // check that part of the set of applied value migration IDs
     assertTrue(s_migrationContext.getGlobal(DoValueMigrationIdsContextData.class).getAppliedValueMigrationIds().contains(PetFixtureAlwaysAcceptDoValueMigrationHandler_3.ID));
-    DoStructureMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
+    DataObjectMigratorResult<RoomFixtureDo> result = s_migrator.applyValueMigration(s_migrationContext, original);
 
     // executed even if already applied
     assertTrue(result.isChanged());
@@ -256,7 +256,7 @@ public class DataObjectMigratorValueMigrationTest {
         .put("_typeVersion", CharlieFixture_2.VERSION.unwrap()) // will be updated by HouseFixtureDoStructureMigrationHandler_3
         .build();
 
-    DoStructureMigratorResult<IDoEntity> result = s_migrator.migrateDataObject(s_migrationContext, original, IDoEntity.class);
+    DataObjectMigratorResult<IDoEntity> result = s_migrator.migrateDataObject(s_migrationContext, original, IDoEntity.class);
 
     assertTrue(result.isChanged());
 

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CharlieCustomerFixtureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CharlieCustomerFixtureMigrationHandler_3.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -39,7 +39,7 @@ public class CharlieCustomerFixtureMigrationHandler_3 extends AbstractDoStructur
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (!doEntity.has("firstName")) {
       return false; // nothing to migrate
     }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CharlieCustomerFixtureTargetContextData.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CharlieCustomerFixtureTargetContextData.java
@@ -11,7 +11,7 @@
 package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
 import org.eclipse.scout.rt.dataobject.IDoEntity;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContextDataTarget;
 import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationTargetContextData;
 
@@ -25,7 +25,7 @@ public class CharlieCustomerFixtureTargetContextData implements IDoStructureMigr
   }
 
   @Override
-  public boolean initialize(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  public boolean initialize(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (doEntity instanceof CharlieCustomerFixtureDo) {
       CharlieCustomerFixtureDo house = (CharlieCustomerFixtureDo) doEntity;
       m_emailAddress = house.getEmailAddress();

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerFixtureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerFixtureMigrationHandler_3.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -39,7 +39,7 @@ public class CustomerFixtureMigrationHandler_3 extends AbstractDoStructureMigrat
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (!doEntity.has("firstName")) {
       return false; // nothing to migrate
     }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerFixtureTargetContextData.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerFixtureTargetContextData.java
@@ -11,7 +11,7 @@
 package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
 import org.eclipse.scout.rt.dataobject.IDoEntity;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContextDataTarget;
 import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationTargetContextData;
 
@@ -25,7 +25,7 @@ public class CustomerFixtureTargetContextData implements IDoStructureMigrationTa
   }
 
   @Override
-  public boolean initialize(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  public boolean initialize(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (doEntity instanceof CustomerFixtureDo) {
       CustomerFixtureDo house = (CustomerFixtureDo) doEntity;
       m_firstName = house.getFirstName();

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/DuplicateIdFixtureDoValueMigrationHandler_1.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/DuplicateIdFixtureDoValueMigrationHandler_1.java
@@ -13,7 +13,7 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_1;
 import org.eclipse.scout.rt.platform.IgnoreBean;
@@ -35,7 +35,7 @@ public class DuplicateIdFixtureDoValueMigrationHandler_1 extends AbstractDoValue
   }
 
   @Override
-  public IDoEntity migrate(DoStructureMigrationContext ctx, IDoEntity value) {
+  public IDoEntity migrate(DataObjectMigrationContext ctx, IDoEntity value) {
     return value; // no migration, used for checking for duplicate migration IDs
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoStructureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoStructureMigrationHandler_3.java
@@ -17,7 +17,7 @@ import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
 import org.eclipse.scout.rt.platform.BEANS;
@@ -42,7 +42,7 @@ public class HouseFixtureDoStructureMigrationHandler_3 extends AbstractDoStructu
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     List<IDoEntity> rooms = doEntity.getList("rooms", IDoEntity.class);
 
     rooms.add(BEANS.get(DoEntityBuilder.class)

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoValueMigrationHandler_1.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoValueMigrationHandler_1.java
@@ -13,7 +13,7 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 import org.eclipse.scout.rt.dataobject.DataObjectHelper;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
 import org.eclipse.scout.rt.platform.BEANS;
@@ -39,7 +39,7 @@ public class HouseFixtureDoValueMigrationHandler_1 extends AbstractDoValueMigrat
   }
 
   @Override
-  public HouseFixtureDo migrate(DoStructureMigrationContext ctx, HouseFixtureDo value) {
+  public HouseFixtureDo migrate(DataObjectMigrationContext ctx, HouseFixtureDo value) {
     if (!value.rooms().exists()) {
       return value; // nothing to migrate
     }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureRawOnlyStructureMigrationTargetContextData.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureRawOnlyStructureMigrationTargetContextData.java
@@ -11,12 +11,12 @@
 package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
 import org.eclipse.scout.rt.dataobject.IDoEntity;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContextDataTarget;
 import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationTargetContextData;
 
 @DoStructureMigrationContextDataTarget(typeNames = {"charlieFixture.HouseFixture"})
-public class HouseFixtureRawOnlyDoStructureMigrationTargetContextData implements IDoStructureMigrationTargetContextData {
+public class HouseFixtureRawOnlyStructureMigrationTargetContextData implements IDoStructureMigrationTargetContextData {
 
   private String m_name;
 
@@ -25,7 +25,7 @@ public class HouseFixtureRawOnlyDoStructureMigrationTargetContextData implements
   }
 
   @Override
-  public boolean initialize(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  public boolean initialize(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     m_name = doEntity.getString("name");
     return true;
   }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureStructureMigrationTargetContextData.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureStructureMigrationTargetContextData.java
@@ -11,7 +11,7 @@
 package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
 import org.eclipse.scout.rt.dataobject.IDoEntity;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContextDataTarget;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationHelper;
 import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationTargetContextData;
@@ -32,7 +32,7 @@ public class HouseFixtureStructureMigrationTargetContextData implements IDoStruc
   }
 
   @Override
-  public boolean initialize(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  public boolean initialize(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (doEntity instanceof HouseFixtureDo) {
       HouseFixtureDo house = (HouseFixtureDo) doEntity;
       m_name = house.getName();

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureTypedOnlyStructureMigrationTargetContextData.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureTypedOnlyStructureMigrationTargetContextData.java
@@ -11,12 +11,12 @@
 package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
 import org.eclipse.scout.rt.dataobject.IDoEntity;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContextDataTarget;
 import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationTargetContextData;
 
 @DoStructureMigrationContextDataTarget(doEntityClasses = {HouseFixtureDo.class})
-public class HouseFixtureTypedOnlyDoStructureMigrationTargetContextData implements IDoStructureMigrationTargetContextData {
+public class HouseFixtureTypedOnlyStructureMigrationTargetContextData implements IDoStructureMigrationTargetContextData {
 
   private String m_name;
 
@@ -25,7 +25,7 @@ public class HouseFixtureTypedOnlyDoStructureMigrationTargetContextData implemen
   }
 
   @Override
-  public boolean initialize(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  public boolean initialize(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (doEntity instanceof HouseFixtureDo) {
       HouseFixtureDo house = (HouseFixtureDo) doEntity;
       m_name = house.getName();

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypeFixtureDoValueMigrationHandler_2.java
@@ -12,7 +12,7 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
@@ -36,7 +36,7 @@ public class HouseTypeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMi
   }
 
   @Override
-  public HouseTypeFixtureStringId migrate(DoStructureMigrationContext ctx, HouseTypeFixtureStringId value) {
+  public HouseTypeFixtureStringId migrate(DataObjectMigrationContext ctx, HouseTypeFixtureStringId value) {
     return "house".equals(value.unwrap()) ? HouseTypesFixture.DETACHED_HOUSE : value;
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureDoStructureMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureDoStructureMigrationHandler_2.java
@@ -17,7 +17,7 @@ import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
@@ -43,7 +43,7 @@ public class PersonFixtureDoStructureMigrationHandler_2 extends AbstractDoStruct
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (doEntity.has("relation")) {
       return false; // already migrated
     }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureTargetContextData.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureTargetContextData.java
@@ -13,7 +13,7 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 import static org.eclipse.scout.rt.platform.util.Assertions.*;
 
 import org.eclipse.scout.rt.dataobject.IDoEntity;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContextDataTarget;
 import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
@@ -29,7 +29,7 @@ public class PersonFixtureTargetContextData implements IDoStructureMigrationTarg
   }
 
   @Override
-  public boolean initialize(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  public boolean initialize(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     // There are no migrations for charlieFixture-1, thus this context may only be initialized for >= charlieFixture-2.
     // A context data must only be initialized with an already migrated data object for a certain version.
     // The data object itself must be migrated as well as the correct type version must be set (in case type version switches are used within context)

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationHelper;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_3;
@@ -49,7 +49,7 @@ public class PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3 extends Abs
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     boolean changed = false;
     changed |= BEANS.get(DoStructureMigrationHelper.class).renameTypeName(doEntity, "alfaFixture.PetFixture");
 

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureAlwaysAcceptDoValueMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureAlwaysAcceptDoValueMigrationHandler_3.java
@@ -13,7 +13,7 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 import org.eclipse.scout.rt.dataobject.DataObjectHelper;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
 import org.eclipse.scout.rt.platform.BEANS;
@@ -41,12 +41,12 @@ public class PetFixtureAlwaysAcceptDoValueMigrationHandler_3 extends AbstractDoV
   }
 
   @Override
-  public boolean accept(DoStructureMigrationContext ctx) {
+  public boolean accept(DataObjectMigrationContext ctx) {
     return true;
   }
 
   @Override
-  public PetFixtureDo migrate(DoStructureMigrationContext ctx, PetFixtureDo value) {
+  public PetFixtureDo migrate(DataObjectMigrationContext ctx, PetFixtureDo value) {
     if (!value.getName().startsWith(NAME_PREFIX)) {
       return value; // already migrated or nothing to migrate
     }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureCaseSensitiveNameMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureCaseSensitiveNameMigrationHandler_2.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -39,7 +39,7 @@ public class PetFixtureCaseSensitiveNameMigrationHandler_2 extends AbstractDoStr
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (!doEntity.has("name")) {
       return false; // nothing to migrate
     }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureDoValueMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureDoValueMigrationHandler_3.java
@@ -13,7 +13,7 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 import org.eclipse.scout.rt.dataobject.DataObjectHelper;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
 import org.eclipse.scout.rt.platform.BEANS;
@@ -41,7 +41,7 @@ public class PetFixtureDoValueMigrationHandler_3 extends AbstractDoValueMigratio
   }
 
   @Override
-  public PetFixtureDo migrate(DoStructureMigrationContext ctx, PetFixtureDo value) {
+  public PetFixtureDo migrate(DataObjectMigrationContext ctx, PetFixtureDo value) {
     if (!value.getName().startsWith(NAME_PREFIX)) {
       return value; // already migrated or nothing to migrate
     }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3.java
@@ -15,9 +15,9 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationInventoryTest;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationHelper;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationInventoryTest;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_3;
 import org.eclipse.scout.rt.platform.BEANS;
@@ -27,7 +27,7 @@ import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
 /**
  * A second migration handler for type version {@link BravoFixture_3} for the type name 'bravoFixture.PetFixture', only
- * used within {@link DoStructureMigrationInventoryTest#testValidateMigrationHandlerUniqueness()}.
+ * used within {@link DataObjectMigrationInventoryTest#testValidateMigrationHandlerUniqueness()}.
  */
 @IgnoreBean
 public class PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3 extends AbstractDoStructureMigrationHandler {
@@ -50,7 +50,7 @@ public class PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (doEntity.has("lorem")) {
       return false; // already migrated
     }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PostalAddressFixtureUpdateVersionOnlyMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PostalAddressFixtureUpdateVersionOnlyMigrationHandler_2.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -37,7 +37,7 @@ public class PostalAddressFixtureUpdateVersionOnlyMigrationHandler_2 extends Abs
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     return false; // only update version, no real migration
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_3.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -37,7 +37,7 @@ public class RoomFixtureDoStructureMigrationHandler_3 extends AbstractDoStructur
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     return false; // type version update only, no real migration
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_4.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_4.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_4;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -37,7 +37,7 @@ public class RoomFixtureDoStructureMigrationHandler_4 extends AbstractDoStructur
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (!doEntity.has("areaInSquareFoot")) {
       // already migrated or nothing to migrate
       return false;

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_5.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_5.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -38,7 +38,7 @@ public class RoomFixtureDoStructureMigrationHandler_5 extends AbstractDoStructur
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     if (doEntity.has("displayText")) {
       // already migrated
       return false;

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomSizeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomSizeFixtureDoValueMigrationHandler_2.java
@@ -13,7 +13,7 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 import org.eclipse.scout.rt.dataobject.DataObjectHelper;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
@@ -41,7 +41,7 @@ public class RoomSizeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMig
   }
 
   @Override
-  public RoomFixtureDo migrate(DoStructureMigrationContext ctx, RoomFixtureDo value) {
+  public RoomFixtureDo migrate(DataObjectMigrationContext ctx, RoomFixtureDo value) {
     return BEANS.get(DataObjectHelper.class).clone(value) // clone provided value to allow change detection by caller
         // increase area by 10
         // non-idempotent migration for testing purposes only, real-world value migrations must be idempotent!

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeFixtureDoValueMigrationHandler_2.java
@@ -12,7 +12,7 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
@@ -36,7 +36,7 @@ public class RoomTypeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMig
   }
 
   @Override
-  public RoomTypeFixtureStringId migrate(DoStructureMigrationContext ctx, RoomTypeFixtureStringId value) {
+  public RoomTypeFixtureStringId migrate(DataObjectMigrationContext ctx, RoomTypeFixtureStringId value) {
     return "standard-room".equals(value.unwrap()) ? RoomTypesFixture.ROOM : value;
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/ZipCodeFixtureGlobalContextData.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/ZipCodeFixtureGlobalContextData.java
@@ -12,10 +12,10 @@ package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationGlobalContextData;
+import org.eclipse.scout.rt.dataobject.migration.IDataObjectMigrationGlobalContextData;
 
 // not a Bean, manually created
-public class ZipCodeFixtureGlobalContextData implements IDoStructureMigrationGlobalContextData {
+public class ZipCodeFixtureGlobalContextData implements IDataObjectMigrationGlobalContextData {
 
   private final ConcurrentHashMap<String, String> m_zipCodeToCityMap = new ConcurrentHashMap<>();
 

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoStructureMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoStructureMigrationHandler.java
@@ -35,7 +35,7 @@ public abstract class AbstractDoStructureMigrationHandler implements IDoStructur
   public abstract Class<? extends ITypeVersion> toTypeVersionClass();
 
   @Override
-  public boolean applyMigration(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  public boolean applyMigration(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     boolean changed = false;
     changed |= migrate(ctx, doEntity);
     changed |= updateTypeVersion(doEntity); // new type version needs to be applied because migration is only completed when data object has an updated type version
@@ -43,7 +43,7 @@ public abstract class AbstractDoStructureMigrationHandler implements IDoStructur
   }
 
   /**
-   * For convenience. Same as {@link #applyMigration(DoStructureMigrationContext, IDoEntity)} except that the type
+   * For convenience. Same as {@link #applyMigration(DataObjectMigrationContext, IDoEntity)} except that the type
    * version of the data object itself must not be updated, the caller of this method takes care of handling type
    * version updates.
    * <p>
@@ -55,7 +55,7 @@ public abstract class AbstractDoStructureMigrationHandler implements IDoStructur
    *          Do entity to apply migration, according to {@link #getTypeNames()} (non-<code>null</code>)
    * @return <code>true</code> if data object was changed in any way, <code>false</code> otherwise.
    */
-  protected abstract boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity);
+  protected abstract boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity);
 
   /**
    * Updates the type version of the data object to {@link #toTypeVersion()}.

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoStructureRenameMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoStructureRenameMigrationHandler.java
@@ -67,7 +67,7 @@ public abstract class AbstractDoStructureRenameMigrationHandler extends Abstract
   }
 
   @Override
-  protected boolean migrate(DoStructureMigrationContext ctx, IDoEntity doEntity) {
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
     DoStructureMigrationHelper helper = BEANS.get(DoStructureMigrationHelper.class);
     boolean changed = false;
     String typeName = helper.getType(doEntity);

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoValueMigrationHandler.java
@@ -46,7 +46,7 @@ public abstract class AbstractDoValueMigrationHandler<T> implements IDoValueMigr
    * choose to always accept (despite being already applied) or to not accept in case some context data is missing.
    */
   @Override
-  public boolean accept(DoStructureMigrationContext ctx) {
+  public boolean accept(DataObjectMigrationContext ctx) {
     return !ctx.getGlobal(DoValueMigrationIdsContextData.class).getAppliedValueMigrationIds().contains(id());
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationContext.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationContext.java
@@ -26,27 +26,26 @@ import org.eclipse.scout.rt.platform.Bean;
 /**
  * This class represents the context used during migration of data objects.
  * <p>
- * Methods related with global context data are thread-safe ({@link #putGlobal(IDoStructureMigrationGlobalContextData)}
+ * Methods related with global context data are thread-safe ({@link #putGlobal(IDataObjectMigrationGlobalContextData)}
  * and {@link #getGlobal(Class)}). Methods related with local context data aren't. To use this context in multiple
  * threads, use {@link #copy()} in a new thread.
  */
 @Bean
-// TODO 23.1 [data object migration] rename to DataObjectMigrationContext
-public class DoStructureMigrationContext {
+public class DataObjectMigrationContext {
 
   // maybe accessed by different threads
-  protected final ConcurrentHashMap<Class<? extends IDoStructureMigrationGlobalContextData>, IDoStructureMigrationGlobalContextData> m_globalContextDataMap;
+  protected final ConcurrentHashMap<Class<? extends IDataObjectMigrationGlobalContextData>, IDataObjectMigrationGlobalContextData> m_globalContextDataMap;
 
   // always access by single thread only
-  protected final Map<Class<? extends IDoStructureMigrationLocalContextData>, Deque<IDoStructureMigrationLocalContextData>> m_localContextDataMap;
+  protected final Map<Class<? extends IDataObjectMigrationLocalContextData>, Deque<IDataObjectMigrationLocalContextData>> m_localContextDataMap;
 
-  public DoStructureMigrationContext() {
+  public DataObjectMigrationContext() {
     m_globalContextDataMap = new ConcurrentHashMap<>();
     m_localContextDataMap = new HashMap<>();
     initDefaults();
   }
 
-  protected DoStructureMigrationContext(DoStructureMigrationContext other) {
+  protected DataObjectMigrationContext(DataObjectMigrationContext other) {
     m_globalContextDataMap = other.m_globalContextDataMap; // use the same one
     m_localContextDataMap = new HashMap<>(); // use new one (single thread usage only).
   }
@@ -55,23 +54,23 @@ public class DoStructureMigrationContext {
    * Initializes default context data.
    */
   protected void initDefaults() {
-    putGlobal(BEANS.get(DoStructureMigrationPassThroughLogger.class));
+    putGlobal(BEANS.get(DataObjectMigrationPassThroughLogger.class));
   }
 
   /**
    * Clones the context and keeps the same reference for global context data map but creates a new context map for local
    * context data.
    */
-  protected DoStructureMigrationContext copy() {
-    return new DoStructureMigrationContext(this);
+  protected DataObjectMigrationContext copy() {
+    return new DataObjectMigrationContext(this);
   }
 
   /**
    * Pushes the given initial local context datas to the local context data map. This method must not be called on an
    * exiting context object, but must be called on a fresh copy (see {@link #copy()} or on a fresh instance of
-   * {@link DoStructureMigrationContext}
+   * {@link DataObjectMigrationContext}
    */
-  protected DoStructureMigrationContext withInitialLocalContext(IDoStructureMigrationLocalContextData... initialLocalContextDatas) {
+  protected DataObjectMigrationContext withInitialLocalContext(IDataObjectMigrationLocalContextData... initialLocalContextDatas) {
     if (initialLocalContextDatas != null) {
       // Calling push without a remove is okay here because these provided local contexts are valid for the whole data object
       Arrays.stream(initialLocalContextDatas).filter(Objects::nonNull).forEach(this::push);
@@ -84,9 +83,9 @@ public class DoStructureMigrationContext {
    *
    * @return Value for given global context data class.
    */
-  public <T extends IDoStructureMigrationGlobalContextData> T getGlobal(Class<T> contextDataClass) {
+  public <T extends IDataObjectMigrationGlobalContextData> T getGlobal(Class<T> contextDataClass) {
     assertNotNull(contextDataClass, "contextDataClass is required");
-    IDoStructureMigrationGlobalContextData contextData = m_globalContextDataMap.computeIfAbsent(contextDataClass, k -> {
+    IDataObjectMigrationGlobalContextData contextData = m_globalContextDataMap.computeIfAbsent(contextDataClass, k -> {
       // auto-create global context data with @Bean annotation if not present yet
       if (contextDataClass.getAnnotation(Bean.class) != null) {
         return BEANS.get(contextDataClass);
@@ -99,7 +98,7 @@ public class DoStructureMigrationContext {
   /**
    * Put given global context data.
    */
-  public DoStructureMigrationContext putGlobal(IDoStructureMigrationGlobalContextData contextData) {
+  public DataObjectMigrationContext putGlobal(IDataObjectMigrationGlobalContextData contextData) {
     assertNotNull(contextData, "contextData is required");
     m_globalContextDataMap.put(contextData.getIdentifierClass(), contextData);
     return this;
@@ -108,10 +107,10 @@ public class DoStructureMigrationContext {
   /**
    * @return Value for given locale context data class.
    */
-  public <T extends IDoStructureMigrationLocalContextData> T get(Class<T> contextDataClass) {
+  public <T extends IDataObjectMigrationLocalContextData> T get(Class<T> contextDataClass) {
     assertNotNull(contextDataClass, "contextDataClass is required");
 
-    Deque<IDoStructureMigrationLocalContextData> deque = m_localContextDataMap.get(contextDataClass);
+    Deque<IDataObjectMigrationLocalContextData> deque = m_localContextDataMap.get(contextDataClass);
     if (deque == null || deque.isEmpty()) {
       return null;
     }
@@ -133,9 +132,9 @@ public class DoStructureMigrationContext {
    * }
    * </pre>
    */
-  protected DoStructureMigrationContext push(IDoStructureMigrationLocalContextData contextData) {
+  protected DataObjectMigrationContext push(IDataObjectMigrationLocalContextData contextData) {
     assertNotNull(contextData, "contextData is required");
-    Deque<IDoStructureMigrationLocalContextData> deque = m_localContextDataMap.computeIfAbsent(contextData.getIdentifierClass(), k -> new ArrayDeque<>());
+    Deque<IDataObjectMigrationLocalContextData> deque = m_localContextDataMap.computeIfAbsent(contextData.getIdentifierClass(), k -> new ArrayDeque<>());
     deque.push(contextData);
     return this;
   }
@@ -144,13 +143,13 @@ public class DoStructureMigrationContext {
    * Internal usage only.
    * <p>
    * Remove context data from context (instance must be the same as used for
-   * {@link #push(IDoStructureMigrationLocalContextData)}.
+   * {@link #push(IDataObjectMigrationLocalContextData)}.
    */
-  protected void remove(IDoStructureMigrationLocalContextData contextData) {
+  protected void remove(IDataObjectMigrationLocalContextData contextData) {
     assertNotNull(contextData, "contextData is required");
-    Deque<IDoStructureMigrationLocalContextData> deque = m_localContextDataMap.get(contextData.getIdentifierClass());
+    Deque<IDataObjectMigrationLocalContextData> deque = m_localContextDataMap.get(contextData.getIdentifierClass());
     assertNotNull(deque, "no context data found for {}", contextData.getIdentifierClass());
-    IDoStructureMigrationLocalContextData dequeElement = deque.peek(); // implementation detail: first peek only and check if same instance, then remove
+    IDataObjectMigrationLocalContextData dequeElement = deque.peek(); // implementation detail: first peek only and check if same instance, then remove
     assertTrue(contextData == dequeElement, "last element in deque is not element to remove: remove '{}', deque: '{}'", contextData, dequeElement);
     deque.pop();
     if (deque.isEmpty()) {
@@ -162,14 +161,14 @@ public class DoStructureMigrationContext {
   /**
    * Convenience method to access global logger.
    */
-  public IDoStructureMigrationLogger getLogger() {
-    return getGlobal(IDoStructureMigrationLogger.class);
+  public IDataObjectMigrationLogger getLogger() {
+    return getGlobal(IDataObjectMigrationLogger.class);
   }
 
   /**
    * Convenience method to access global stats.
    */
-  public DoStructureMigrationStatsContextData getStats() {
-    return getGlobal(DoStructureMigrationStatsContextData.class);
+  public DataObjectMigrationStatsContextData getStats() {
+    return getGlobal(DataObjectMigrationStatsContextData.class);
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationCountingPassThroughLogger.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationCountingPassThroughLogger.java
@@ -17,10 +17,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Thread-safe implementation of a data object migration logger that additionally counts the log items per log level.
  */
-// TODO 23.1 [data object migration] rename to DataObjectMigrationCountingPassThroughLogger
-public class DoStructureMigrationCountingPassThroughLogger extends DoStructureMigrationPassThroughLogger {
+public class DataObjectMigrationCountingPassThroughLogger extends DataObjectMigrationPassThroughLogger {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DoStructureMigrationCountingPassThroughLogger.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DataObjectMigrationCountingPassThroughLogger.class);
 
   protected final LongAdder m_traceCount = new LongAdder();
   protected final LongAdder m_debugCount = new LongAdder();

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventory.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventory.java
@@ -55,8 +55,7 @@ import org.eclipse.scout.rt.platform.util.Pair;
  * context data classes).
  */
 @ApplicationScoped
-// TODO 23.1 [data object migration] rename to DataObjectMigrationInventory
-public class DoStructureMigrationInventory {
+public class DataObjectMigrationInventory {
 
   protected final LinkedHashSet<String> m_namespaces = new LinkedHashSet<>();
   protected final LinkedHashSet<NamespaceVersion> m_orderedVersions = new LinkedHashSet<>(); // ordered versions according to VersionedItemInventory
@@ -627,14 +626,13 @@ public class DoStructureMigrationInventory {
     return ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, versions.get(insertionPoint));
   }
 
-  // TODO 23.1 [data object migration] rename to getStructureMigrationHandlers
-  public Map<String, IDoStructureMigrationHandler> getMigrationHandlers(NamespaceVersion version) {
+  public Map<String, IDoStructureMigrationHandler> getStructureMigrationHandlers(NamespaceVersion version) {
     assertNotNull(version, "version is required");
     assertTrue(m_orderedVersions.contains(version), "version is unknown");
     return m_structureMigrationHandlers.computeIfAbsent(version, k -> Collections.emptyMap());
   }
 
-  public Set<Class<? extends IDoStructureMigrationTargetContextData>> getDoMigrationContextValues(IDoEntity doEntity) {
+  public Set<Class<? extends IDoStructureMigrationTargetContextData>> getStructureMigrationTargetContextDataClasses(IDoEntity doEntity) {
     assertNotNull(doEntity, "doEntity is required");
 
     String typeName = BEANS.get(DoStructureMigrationHelper.class).getType(doEntity);

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationPassThroughLogger.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationPassThroughLogger.java
@@ -18,10 +18,9 @@ import org.slf4j.LoggerFactory;
  * Thread-safe logger that directly outputs to {@link Logger}.
  */
 @Bean
-// TODO 23.1 [data object migration] rename to DataObjectMigrationPassThroughLogger
-public class DoStructureMigrationPassThroughLogger implements IDoStructureMigrationLogger {
+public class DataObjectMigrationPassThroughLogger implements IDataObjectMigrationLogger {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DoStructureMigrationPassThroughLogger.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DataObjectMigrationPassThroughLogger.class);
 
   @Override
   public void trace(String message, Object... args) {

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationStatsContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationStatsContextData.java
@@ -23,10 +23,9 @@ import org.slf4j.LoggerFactory;
  * Thread-safe implementation of stats for data object migration.
  */
 @Bean
-// TODO 23.1 [data object migration] rename to DataObjectMigrationStatsContextData
-public class DoStructureMigrationStatsContextData implements IDoStructureMigrationGlobalContextData {
+public class DataObjectMigrationStatsContextData implements IDataObjectMigrationGlobalContextData {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DoStructureMigrationStatsContextData.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DataObjectMigrationStatsContextData.class);
 
   protected final AtomicLong m_startNanos = new AtomicLong();
   protected final LongAdder m_dataObjectsProcessed = new LongAdder();
@@ -100,7 +99,7 @@ public class DoStructureMigrationStatsContextData implements IDoStructureMigrati
    *          Name to print for entities
    * @param entityCount
    *          Number of entities processed (optional), can be different than the number of calls made to
-   *          {@link DoStructureMigrator#migrateDataObject(DoStructureMigrationContext, IDataObject, Class)}.
+   *          {@link DataObjectMigrator#migrateDataObject(DataObjectMigrationContext, IDataObject, Class)}.
    */
   public void printStats(String name, Integer entityCount) {
     LOG.info("Data object migration of {}{} entities finished in {} ms (accumulated raw data object migration took {} ms). Changed {} of {} processed data objects.",

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationDataObjectVisitor.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationDataObjectVisitor.java
@@ -27,22 +27,22 @@ import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 public class DoStructureMigrationDataObjectVisitor extends AbstractDataObjectVisitor {
 
   protected final DoStructureMigrationHelper m_helper;
-  protected final DoStructureMigrationInventory m_inventory;
+  protected final DataObjectMigrationInventory m_inventory;
 
-  protected final DoStructureMigrationContext m_ctx;
+  protected final DataObjectMigrationContext m_ctx;
   protected final NamespaceVersion m_version;
   protected final Map<String, IDoStructureMigrationHandler> m_migrationHandlerPerTypeName;
 
   protected boolean m_changed = false;
 
-  public DoStructureMigrationDataObjectVisitor(DoStructureMigrationContext ctx, NamespaceVersion version) {
+  public DoStructureMigrationDataObjectVisitor(DataObjectMigrationContext ctx, NamespaceVersion version) {
     m_helper = BEANS.get(DoStructureMigrationHelper.class);
-    m_inventory = BEANS.get(DoStructureMigrationInventory.class);
+    m_inventory = BEANS.get(DataObjectMigrationInventory.class);
 
     m_ctx = ctx;
     m_version = version;
 
-    m_migrationHandlerPerTypeName = m_inventory.getMigrationHandlers(version);
+    m_migrationHandlerPerTypeName = m_inventory.getStructureMigrationHandlers(version);
   }
 
   public boolean isChanged() {
@@ -71,7 +71,7 @@ public class DoStructureMigrationDataObjectVisitor extends AbstractDataObjectVis
 
   protected List<IDoStructureMigrationTargetContextData> pushLocalContextData(IDoEntity doEntity) {
     List<IDoStructureMigrationTargetContextData> localContextDataList = new ArrayList<>();
-    Set<Class<? extends IDoStructureMigrationTargetContextData>> contextDataClasses = m_inventory.getDoMigrationContextValues(doEntity);
+    Set<Class<? extends IDoStructureMigrationTargetContextData>> contextDataClasses = m_inventory.getStructureMigrationTargetContextDataClasses(doEntity);
     for (Class<? extends IDoStructureMigrationTargetContextData> contextDataClass : contextDataClasses) {
       IDoStructureMigrationTargetContextData contextValue = BEANS.get(contextDataClass);
       if (contextValue.initialize(m_ctx, doEntity)) {

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationDataObjectVisitor.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationDataObjectVisitor.java
@@ -26,16 +26,16 @@ import org.eclipse.scout.rt.platform.util.ObjectUtility;
  */
 public class DoValueMigrationDataObjectVisitor extends AbstractReplacingDataObjectVisitor {
 
-  protected final DoStructureMigrationInventory m_inventory;
-  protected final DoStructureMigrationContext m_ctx;
+  protected final DataObjectMigrationInventory m_inventory;
+  protected final DataObjectMigrationContext m_ctx;
 
   // ordered list of value migration handlers, which have not been applied
   protected final List<IDoValueMigrationHandler<?>> m_valueMigrationHandlers;
 
   protected boolean m_changed = false;
 
-  public DoValueMigrationDataObjectVisitor(DoStructureMigrationContext ctx) {
-    m_inventory = BEANS.get(DoStructureMigrationInventory.class);
+  public DoValueMigrationDataObjectVisitor(DataObjectMigrationContext ctx) {
+    m_inventory = BEANS.get(DataObjectMigrationInventory.class);
     m_ctx = ctx;
 
     Set<DoValueMigrationId> appliedValueMigrationIds = m_ctx.getGlobal(DoValueMigrationIdsContextData.class).getAppliedValueMigrationIds();

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationIdsContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationIdsContextData.java
@@ -20,7 +20,7 @@ import org.eclipse.scout.rt.platform.Bean;
  * not be applied again during data object migration.
  */
 @Bean
-public class DoValueMigrationIdsContextData implements IDoStructureMigrationGlobalContextData {
+public class DoValueMigrationIdsContextData implements IDataObjectMigrationGlobalContextData {
 
   // Thead-safe because read-only after initialization.
   // An empty set implies that all available value migrations will be applied. In case of a null value, value migrations will be skipped.

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDataObjectMigrationGlobalContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDataObjectMigrationGlobalContextData.java
@@ -14,18 +14,17 @@ package org.eclipse.scout.rt.dataobject.migration;
  * A global structure migration context data.
  * <p>
  * If a concrete subclass contains an @Bean annotation, it is auto-created when first accessed via
- * {@link DoStructureMigrationContext#getGlobal(Class)} and not existing yet.
+ * {@link DataObjectMigrationContext#getGlobal(Class)} and not existing yet.
  * <p>
  * Because a global context data may be accessed concurrently by different threads each implementation must be
  * thread-safe.
  */
-// TODO 23.1 [data object migration] rename to IDataObjectMigrationGlobalContextData
-public interface IDoStructureMigrationGlobalContextData {
+public interface IDataObjectMigrationGlobalContextData {
 
   /**
    * @return Class used as identifier for context data (map key).
    */
-  default Class<? extends IDoStructureMigrationGlobalContextData> getIdentifierClass() {
+  default Class<? extends IDataObjectMigrationGlobalContextData> getIdentifierClass() {
     return this.getClass();
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDataObjectMigrationLocalContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDataObjectMigrationLocalContextData.java
@@ -15,19 +15,18 @@ package org.eclipse.scout.rt.dataobject.migration;
  * <p>
  * Only implement this interface directly instead of {@link IDoStructureMigrationTargetContextData} if
  * {@link #getIdentifierClass()} is used (because local context data cannot be pushed manually to
- * {@link DoStructureMigrationContext}, only classes implementing {@link IDoStructureMigrationTargetContextData} are
+ * {@link DataObjectMigrationContext}, only classes implementing {@link IDoStructureMigrationTargetContextData} are
  * auto-created when a data object is traversed).
  * <p>
  * A local context data is stacked, i.e. if multiple context data for the same {@link #getIdentifierClass()} are added,
  * the last one is retrieved.
  */
-// TODO 23.1 [data object migration] rename to IDataObjectMigrationLocalContextData
-public interface IDoStructureMigrationLocalContextData {
+public interface IDataObjectMigrationLocalContextData {
 
   /**
    * @return Class used as identifier for context data (map key).
    */
-  default Class<? extends IDoStructureMigrationLocalContextData> getIdentifierClass() {
+  default Class<? extends IDataObjectMigrationLocalContextData> getIdentifierClass() {
     return this.getClass();
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDataObjectMigrationLogger.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDataObjectMigrationLogger.java
@@ -13,12 +13,11 @@ package org.eclipse.scout.rt.dataobject.migration;
 /**
  * Interface of a global context data used as logger.
  */
-// TODO 23.1 [data object migration] rename to IDataObjectMigrationLogger
-public interface IDoStructureMigrationLogger extends IDoStructureMigrationGlobalContextData {
+public interface IDataObjectMigrationLogger extends IDataObjectMigrationGlobalContextData {
 
   @Override
-  default Class<? extends IDoStructureMigrationGlobalContextData> getIdentifierClass() {
-    return IDoStructureMigrationLogger.class;
+  default Class<? extends IDataObjectMigrationGlobalContextData> getIdentifierClass() {
+    return IDataObjectMigrationLogger.class;
   }
 
   void trace(String message, Object... args);

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationHandler.java
@@ -36,7 +36,7 @@ public interface IDoStructureMigrationHandler {
    * namespaces are equal and the type version of the data object is lower than the version of the migration handler.
    * <p>
    * This type version is usually the one the migrated data object must have after
-   * {@link #applyMigration(DoStructureMigrationContext, IDoEntity)} was called. Two exceptions:
+   * {@link #applyMigration(DataObjectMigrationContext, IDoEntity)} was called. Two exceptions:
    * <ul>
    * <li>A data object changes its namespace (e.g. triggered with bravo-2 but updated to alfa-3)
    * <li>A data object is replaced by an existing one: no type version update (e.g. LoremDo is integrated into IpsumDo)
@@ -47,7 +47,7 @@ public interface IDoStructureMigrationHandler {
   NamespaceVersion toTypeVersion();
 
   /**
-   * {@link #applyMigration(DoStructureMigrationContext, IDoEntity)} is called for these type names if type version
+   * {@link #applyMigration(DataObjectMigrationContext, IDoEntity)} is called for these type names if type version
    * requirements are satisfied (see {@link #toTypeVersion()}).
    * <p>
    * One migration handler may be triggered by several different type names (e.g. one migration handler for a bunch of
@@ -70,5 +70,5 @@ public interface IDoStructureMigrationHandler {
    * @return <code>true</code> if data object was changed in any way (including type version update only),
    *         <code>false</code> otherwise.
    */
-  boolean applyMigration(DoStructureMigrationContext ctx, IDoEntity doEntity);
+  boolean applyMigration(DataObjectMigrationContext ctx, IDoEntity doEntity);
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationTargetContextData.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoStructureMigrationTargetContextData.java
@@ -15,11 +15,11 @@ import org.eclipse.scout.rt.platform.Bean;
 
 /**
  * Interface for migration context data classes that are created and pushed as local context data to
- * {@link DoStructureMigrationContext} when a corresponding data object is traversed (see
+ * {@link DataObjectMigrationContext} when a corresponding data object is traversed (see
  * {@link DoStructureMigrationContextDataTarget} annotation for data object matching).
  */
 @Bean
-public interface IDoStructureMigrationTargetContextData extends IDoStructureMigrationLocalContextData {
+public interface IDoStructureMigrationTargetContextData extends IDataObjectMigrationLocalContextData {
 
   /**
    * A context for a data object is initialized after the corresponding data object was migrated to the specific
@@ -27,5 +27,5 @@ public interface IDoStructureMigrationTargetContextData extends IDoStructureMigr
    *
    * @return <code>true</true> if it's a valid context and should be used, <code>false</false> to discard context.
    **/
-  boolean initialize(DoStructureMigrationContext ctx, IDoEntity doEntity);
+  boolean initialize(DataObjectMigrationContext ctx, IDoEntity doEntity);
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoValueMigrationHandler.java
@@ -156,7 +156,7 @@ public interface IDoValueMigrationHandler<T> {
    * @return <code>true</code> if value migration is accepted and therefore considered for execution, <code>false</code>
    *         otherwise.
    */
-  boolean accept(DoStructureMigrationContext ctx);
+  boolean accept(DataObjectMigrationContext ctx);
 
   /**
    * Returns the migrated value for a given input value.
@@ -169,5 +169,5 @@ public interface IDoValueMigrationHandler<T> {
    * @param value
    *          never {@code null}
    **/
-  T migrate(DoStructureMigrationContext ctx, T value);
+  T migrate(DataObjectMigrationContext ctx, T value);
 }


### PR DESCRIPTION
Because the `DoStructureMigrator` executes value migrations too (`IDoValueMigrationHandler`), several renamings were applied.

315763