### PR TITLE
Close form on load error via lifecycle

### DIFF
--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -344,7 +344,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
    *
    */
   protected _handleLoadError(error: Error): JQuery.Promise<Status> {
-    this.destroy();
+    this.close();
     throw error;
   }
 


### PR DESCRIPTION
If an error occurs while loading the form, the form needs to be closed via its lifecycle instead of just being destroyed. This ensures that the form is completely closed and listeners for close are notified (e.g. a JsForm needs to be closed on the server as well).

334491