### PR TITLE
Disable automatic LogbackServletContainerInitializer

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/AbstractLoggerSupport.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/AbstractLoggerSupport.java
@@ -40,4 +40,9 @@ public abstract class AbstractLoggerSupport implements ILoggerSupport {
   public void setLogLevel(Logger logger, LogLevel level) {
     setLogLevel(assertNotNull(logger).getName(), level);
   }
+
+  @Override
+  public void shutdown() {
+    // nop
+  }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/ILoggerSupport.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/ILoggerSupport.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
  * A logger support allows to interact with the particular slf4j logger implementations in use.
  * <p>
  * <b>Note:</b> This class is not a bean by intention. The appropriate logger support is determined and installed by
- * {@link LoggerPlatformListener} or manually by the scout project.
+ * {@link LoggerInstallPlatformListener} or manually by the scout project.
  *
  * @since 5.2
  */
@@ -73,4 +73,12 @@ public interface ILoggerSupport {
    *          a level or <code>null</code>.
    */
   void setLogLevel(Logger logger, LogLevel level);
+
+  /**
+   * Shutdown the logger, called during shutdown to flush and/or free resources. Method should not throw if logger is
+   * not even started (actually all known loggers do not have a state or are started implicitly by using them), however
+   * some loggers should be explicitly shutdown. This method is called by a platform listener as late as possible during
+   * shutdown as there is no guarantee that any more logging is possible after this call.
+   */
+  void shutdown();
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/LogbackLoggerSupport.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/LogbackLoggerSupport.java
@@ -10,10 +10,12 @@
  */
 package org.eclipse.scout.rt.platform.logger;
 
+import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 
 /**
  * Logger support for Logback.
@@ -95,6 +97,18 @@ public class LogbackLoggerSupport extends AbstractLoggerSupport {
       default:
         LOG.info("unknown scout log level '{}'. Falling back to logback level '{}'", level, Level.WARN);
         return Level.WARN;
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    // similar to ch.qos.logback.classic.servlet.LogbackServletContextListener.contextDestroyed(ServletContextEvent)
+    // however we explicitly want to decide in which order/when this code is run
+    ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+    if (factory instanceof LoggerContext) {
+      LoggerContext loggerContext = (LoggerContext) factory;
+      LOG.info("About to stop {}", loggerContext);
+      loggerContext.stop();
     }
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/LoggerInstallPlatformListener.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/LoggerInstallPlatformListener.java
@@ -41,7 +41,7 @@ import org.slf4j.impl.StaticLoggerBinder;
  *
  * @since 5.2
  */
-public class LoggerPlatformListener implements IPlatformListener {
+public class LoggerInstallPlatformListener implements IPlatformListener {
 
   public static final String LOGGER_FACTORY_CLASS_STR_LOGBACK = "ch.qos.logback.classic.util.ContextSelectorStaticBinder";
   public static final String LOGGER_FACTORY_CLASS_STR_JUL = "org.slf4j.impl.JDK14LoggerFactory";
@@ -49,11 +49,11 @@ public class LoggerPlatformListener implements IPlatformListener {
   public static final String LOGGER_SUPPORT_CLASS_NAME_LOGBACK = LOGGER_SUPPORT_PACKAGE_NAME_PREFIX + "LogbackLoggerSupport";
   public static final String LOGGER_SUPPORT_CLASS_NAME_JUL = LOGGER_SUPPORT_PACKAGE_NAME_PREFIX + "JulLoggerSupport";
 
-  private static final Logger LOG = LoggerFactory.getLogger(LoggerPlatformListener.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LoggerInstallPlatformListener.class);
 
   private final Map<String, String> m_loggerSupportByLoggerFactoryId;
 
-  public LoggerPlatformListener() {
+  public LoggerInstallPlatformListener() {
     m_loggerSupportByLoggerFactoryId = new HashMap<>();
     registerLoggerSupportMappings(m_loggerSupportByLoggerFactoryId);
   }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/LoggerShutdownPlatformListener.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/LoggerShutdownPlatformListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.platform.logger;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IPlatform.State;
+import org.eclipse.scout.rt.platform.IPlatformListener;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.platform.PlatformEvent;
+
+/**
+ * This listener should be run as late as possible, therefore a high order has been chosen and the lister just acts on
+ * stopped (not stopping) event. Depending on the logger no more logging is possible after it has been shutdown.
+ */
+@Order(5950)
+public class LoggerShutdownPlatformListener implements IPlatformListener {
+
+  @Override
+  public void stateChanged(PlatformEvent event) {
+    if (event.getState() == State.PlatformStopped) {
+      ILoggerSupport loggerSupport = BEANS.get(ILoggerSupport.class);
+      if (loggerSupport != null) {
+        loggerSupport.shutdown();
+      }
+    }
+  }
+}

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.dev/src/main/webapp/WEB-INF/web.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.dev/src/main/webapp/WEB-INF/web.xml
@@ -88,4 +88,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.war/src/main/webapp/WEB-INF/web.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.war/src/main/webapp/WEB-INF/web.xml
@@ -33,9 +33,9 @@
     <filter-name>HttpServerRunContextFilter</filter-name>
     <filter-class>org.eclipse.scout.rt.server.context.HttpServerRunContextFilter</filter-class>
     <init-param>
-     <param-name>session</param-name>
-     <param-value>false</param-value>
-   </init-param>    
+      <param-name>session</param-name>
+      <param-value>false</param-value>
+    </init-param>
   </filter>
   <filter-mapping>
     <filter-name>HttpServerRunContextFilter</filter-name>
@@ -89,5 +89,10 @@
       <secure>true</secure>
     </cookie-config>
   </session-config>
+
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
 
 </web-app>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.dev/src/main/webapp/WEB-INF/web.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.dev/src/main/webapp/WEB-INF/web.xml
@@ -54,4 +54,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.war/src/main/webapp/WEB-INF/web.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.war/src/main/webapp/WEB-INF/web.xml
@@ -56,4 +56,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.dev/src/main/webapp/WEB-INF/web.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.dev/src/main/webapp/WEB-INF/web.xml
@@ -62,4 +62,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.war/src/main/webapp/WEB-INF/web.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.war/src/main/webapp/WEB-INF/web.xml
@@ -63,4 +63,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>


### PR DESCRIPTION
Logback provides an automatic LogbackServletContainerInitializer which registers LogbackServletContextListener to stop logback during web application context stop. However this listener may be run to early as we cannot control at what time during context stop this listener is run,
 this may lead to logging messages which are not logged anymore.

Solution: Stop logback a little bit later during context stop using a platform listener and disable LogbackServletContainerInitializer.

LogbackServletContainerInitializer may be disabled by adding

<context-param>
  <param-name>logbackDisableServletContainerInitializer</param-name>
  <param-value>true</param-value>
</context-param>

in the web.xml; the new LoggerShutdownPlatformListener is automatically run during platform stop as late as possible (using a high order).

331773