### PR TITLE
Improve detail form destroy handling for DesktopBench

### DIFF
--- a/eclipse-scout-core/src/desktop/bench/DesktopBench.js
+++ b/eclipse-scout-core/src/desktop/bench/DesktopBench.js
@@ -450,7 +450,9 @@ export default class DesktopBench extends Widget {
   }
 
   _onOutlineContentDestroy(event) {
-    this.setOutlineContent(null);
+    if (event.source === this.outlineContent) {
+      this.setOutlineContent(null);
+    }
   }
 
   _onOutlineContentCssClassChange(event) {


### PR DESCRIPTION
The DesktopBench should only reset the current outlineContent when the
destroy handler was called from the current outlineContent.

This case occurs when a detailForm is the current outline content and
the detailForm is destroyed, before any other change to the content of
the outline is made. The Outline, as well as the
DesktopBench, hold a destroy listener on the detailForm. Both try to
reset the outlineContent to a valid state. The destroy listener of
the outline, which is attached and therefore called first, might change
the outlineContent.
For this scenario, this additional check is necessary.

334262