### PR TITLE
Add TestingDefaultPlatform to avoid duplicate logger shutdown

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/TestingDefaultPlatform.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/TestingDefaultPlatform.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.testing.platform;
+
+import org.eclipse.scout.rt.platform.DefaultPlatform;
+import org.eclipse.scout.rt.platform.internal.BeanFilter;
+import org.eclipse.scout.rt.platform.internal.BeanManagerImplementor;
+import org.eclipse.scout.rt.platform.inventory.ClassInventory;
+import org.eclipse.scout.rt.platform.logger.LoggerShutdownPlatformListener;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithNewPlatform;
+
+/**
+ * Replacement for {@link DefaultPlatform} which is used for {@link RunWithNewPlatform} if no other platform is
+ * specified.
+ * <p>
+ * This platform offers an {@link #acceptBean(Class)} method to exclude specific beans from being added to the bean
+ * manager (e.g. some or all platform listeners).
+ * </p>
+ */
+public class TestingDefaultPlatform extends DefaultPlatform {
+
+  @Override
+  protected BeanManagerImplementor createBeanManager() {
+    BeanManagerImplementor context = newBeanManagerImplementor();
+    new BeanFilter().collect(ClassInventory.get())
+        .stream()
+        .filter(this::acceptBean)
+        .forEach(context::registerClass);
+    return context;
+  }
+
+  protected boolean acceptBean(Class<?> bean) {
+    if (LoggerShutdownPlatformListener.class.isAssignableFrom(bean)) {
+      // do not register this platform listener if multiple platforms may be started and stopped again
+      // as logger shutdown may also trigger logger shutdown outside platform (e.g. if one platform is
+      // used while another has been already started
+      return false;
+    }
+    return true;
+  }
+}

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/RunWithNewPlatform.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/RunWithNewPlatform.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -16,12 +16,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.eclipse.scout.rt.platform.DefaultPlatform;
 import org.eclipse.scout.rt.platform.IPlatform;
+import org.eclipse.scout.rt.testing.platform.TestingDefaultPlatform;
 
 /**
  * Annotation to execute test-methods using a new {@link IPlatform}, not the globally shared Platform. This annotation
  * requires to be executed by the {@link PlatformTestRunner} ore one of its subclasses.
+ * <p>
+ * If no platform is specified, the {@link TestingDefaultPlatform} will be used. This platform may also be used as a
+ * template or super-class whenever using own platforms.
+ * </p>
  *
  * @since 5.1
  */
@@ -32,5 +36,5 @@ public @interface RunWithNewPlatform {
   /**
    * @return the platform class to be used
    */
-  Class<? extends IPlatform> platform() default DefaultPlatform.class;
+  Class<? extends IPlatform> platform() default TestingDefaultPlatform.class;
 }


### PR DESCRIPTION
Some platform listeners must not be used within another platform (which can happen during tests)

331773