### PR TITLE
Table: fix TS migration error

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -2579,7 +2579,7 @@ export class Table extends Widget implements TableModel {
    */
   protected _updateBackgroundEffect() {
     this.columns.forEach((column: NumberColumn) => {
-      if (!column.updateBackgroundEffect) {
+      if (!column.backgroundEffect) {
         return;
       }
       column.updateBackgroundEffect();
@@ -2591,7 +2591,7 @@ export class Table extends Widget implements TableModel {
    */
   protected _calculateValuesForBackgroundEffect() {
     this.columns.forEach((column: NumberColumn) => {
-      if (!column.calculateMinMaxValues) {
+      if (!column.backgroundEffect) {
         return;
       }
       column.calculateMinMaxValues();
@@ -4661,7 +4661,7 @@ export class Table extends Widget implements TableModel {
    */
   protected _renderBackgroundEffect() {
     this.columns.forEach((column: NumberColumn) => {
-      if (!column._renderBackgroundEffect) {
+      if (!column.backgroundEffect) {
         return;
       }
       column._renderBackgroundEffect();


### PR DESCRIPTION
Condition was changed incorrectly during TS migration. This caused wrong column sizes for tables with hidden columns, because table#$cell would get a negative columnIndex and return the wrong DOM element.