### PR TITLE
Scrollbar: don't fail if scroll listener cannot be removed

### DIFF
--- a/eclipse-scout-core/src/scrollbar/Scrollbar.ts
+++ b/eclipse-scout-core/src/scrollbar/Scrollbar.ts
@@ -119,15 +119,18 @@ export class Scrollbar extends Widget implements ScrollbarModel {
 
   protected override _remove() {
     // Uninstall listeners
-    let scrollbars = this.$parent.data('scrollbars');
     this.$parent
       .off('DOMMouseScroll mousewheel', this._onScrollWheelHandler)
       .off('scroll', this._onScrollHandler)
       .offPassive('touchstart', this._onTouchStartHandler);
-    scrollbars.forEach(scrollbar => {
-      scrollbar.off('scrollStart', this._fixScrollbarHandler);
-      scrollbar.off('scrollEnd', this._unfixScrollbarHandler);
-    });
+    let scrollbars = this.$parent.data('scrollbars');
+    if (scrollbars) {
+      // Scrollbars may be undefined if this.$parent is detached -> don't fail
+      scrollbars.forEach(scrollbar => {
+        scrollbar.off('scrollStart', this._fixScrollbarHandler);
+        scrollbar.off('scrollEnd', this._unfixScrollbarHandler);
+      });
+    }
     this.$container.off('mousedown', this._onScrollbarMouseDownHandler);
     this._$thumb.off('mousedown', '', this._onThumbMouseDownHandler);
     this._$ancestors.off('scroll resize', this._onAncestorScrollOrResizeHandler);


### PR DESCRIPTION
In the Scout contacts app, an error is briefly visible in the console on logout.

It seems that this.$parent has already been detached when Scrollbar._remove() runs. Probably because remove animation ends after the page content has already been removed by reloadPage in Session.logout().