### PR TITLE
DataObject: Suppress writing type information for raw DoEntity

### DIFF
--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
@@ -90,6 +90,7 @@ import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItem3Do;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemContributionOneDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemContributionTwoDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemDo;
+import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemEntityDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemExDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemPojo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemPojo2;
@@ -2806,6 +2807,120 @@ public class JsonDataObjectsSerializationTest {
     return BEANS.get(FixtureHierarchicalLookupRowDo.class)
         .withId(id)
         .withText("Mock");
+  }
+
+  @Test
+  public void testSerializeWithUnknownNestedEntity() throws Exception {
+    IDoEntity raw = BEANS.get(DoEntityBuilder.class)
+        .put("_type", "UnknownType")
+        .put("nr", 12345)
+        .build();
+    TestMapDo obj = BEANS.get(TestMapDo.class);
+    // add 'wrong' item into map using a non-existent _type
+    obj.put(obj.stringDoTestItemMapAttribute().getAttributeName(), CollectionUtility.hashMap(ImmutablePair.of("one", raw)));
+    // typed access to attribute is not possible
+    assertThrows(ClassCastException.class, () -> obj.getStringDoTestItemMapAttribute().get("one").getId());
+
+    String serialized = s_dataObjectMapper.writeValueAsString(obj);
+    assertJsonEquals("TestEntityWithUnknownNestedEntity.json", serialized);
+
+    TestMapDo entityMarshalled = s_dataObjectMapper.readValue(serialized, TestMapDo.class);
+    assertEquals(Integer.valueOf(12345), ((IDoEntity) entityMarshalled.get("stringDoTestItemMapAttribute", Map.class).get("one")).get("nr"));
+  }
+
+  @Test
+  public void testSerializeWithUnknownNestedEntity2() throws Exception {
+    IDoEntity raw = BEANS.get(DoEntityBuilder.class)
+        .put("_type", "UnknownType")
+        .put("nr", 12345)
+        .build();
+
+    TestMapDo obj = BEANS.get(TestMapDo.class);
+    // add 'wrong' item into map using a non-existent _type
+    obj.put(obj.iDoEntityAttribute().getAttributeName(), raw);
+    assertEquals(Integer.valueOf(12345), obj.getIDoEntityAttribute().get("nr", Integer.class));
+
+    String serialized = s_dataObjectMapper.writeValueAsString(obj);
+    assertJsonEquals("TestEntityWithUnknownNestedEntity2.json", serialized);
+
+    TestMapDo entityMarshalled = s_dataObjectMapper.readValue(serialized, TestMapDo.class);
+    assertEquals(Integer.valueOf(12345), entityMarshalled.getIDoEntityAttribute().get("nr", Integer.class));
+  }
+
+  @Test
+  public void testSerializeWithUnknownNestedEntity3() throws Exception {
+    IDoEntity raw = BEANS.get(DoEntityBuilder.class)
+        .put("_type", "UnknownType")
+        .put("nr", 12345)
+        .build();
+
+    TestItemEntityDo itemEntity = BEANS.get(TestItemEntityDo.class);
+    // add 'wrong' item into object using a non-existent _type
+    itemEntity.put(itemEntity.item().getAttributeName(), raw);
+    // typed access to attribute is not possible
+    assertThrows(ClassCastException.class, () -> itemEntity.getItem().getId());
+
+    String serialized = s_dataObjectMapper.writeValueAsString(itemEntity);
+    assertJsonEquals("TestEntityWithUnknownNestedEntity3.json", serialized);
+
+    TestItemEntityDo entityMarshalled = s_dataObjectMapper.readValue(serialized, TestItemEntityDo.class);
+    assertEquals(Integer.valueOf(12345), entityMarshalled.get("item", IDoEntity.class).get("nr", Integer.class));
+  }
+
+  @Test
+  public void testSerializeWithUnknownNestedEntity4() throws Exception {
+    IDoEntity raw = BEANS.get(DoEntityBuilder.class)
+        .put("nr", 12345)
+        .build();
+
+    TestItemEntityDo itemEntity = BEANS.get(TestItemEntityDo.class);
+    // add 'wrong' item into object using a non-existent _type
+    itemEntity.put(itemEntity.item().getAttributeName(), raw);
+    assertThrows(ClassCastException.class, () -> itemEntity.getItem().getId());
+
+    String serialized = s_dataObjectMapper.writeValueAsString(itemEntity);
+    assertJsonEquals("TestEntityWithUnknownNestedEntity4.json", serialized);
+
+    TestItemEntityDo entityMarshalled = s_dataObjectMapper.readValue(serialized, TestItemEntityDo.class);
+    assertEquals(Integer.valueOf(12345), entityMarshalled.get("item", IDoEntity.class).get("nr", Integer.class));
+  }
+
+  @Test
+  public void testSerializeWithUnknownNestedEntity5() throws Exception {
+    IDoEntity raw = BEANS.get(DoEntityBuilder.class)
+        .put("_type", "UnknownType")
+        .put("nr", 12345)
+        .build();
+
+    TestItemEntityDo itemEntity = BEANS.get(TestItemEntityDo.class);
+    // add 'wrong' item into object using a non-existent _type
+    itemEntity.put(itemEntity.itemIfc().getAttributeName(), raw);
+    assertThrows(ClassCastException.class, () -> itemEntity.getItemIfc().stringAttribute());
+
+    String serialized = s_dataObjectMapper.writeValueAsString(itemEntity);
+    assertJsonEquals("TestEntityWithUnknownNestedEntity5.json", serialized);
+
+    TestItemEntityDo entityMarshalled = s_dataObjectMapper.readValue(serialized, TestItemEntityDo.class);
+    assertEquals(Integer.valueOf(12345), entityMarshalled.get("itemIfc", IDoEntity.class).get("nr", Integer.class));
+  }
+
+  @Test
+  public void testSerializeWithUnknownNestedEntity6() throws Exception {
+    IDoEntity raw = BEANS.get(DoEntityBuilder.class)
+        .put("_type", "TestEntityWithInterface1")
+        .put("stringAttribute", "foo")
+        .build();
+
+    TestItemEntityDo itemEntity = BEANS.get(TestItemEntityDo.class);
+    // add 'wrong' item into object using a non-existent _type
+    itemEntity.put(itemEntity.itemIfc().getAttributeName(), raw);
+    assertThrows(ClassCastException.class, () -> itemEntity.getItemIfc().stringAttribute());
+
+    String serialized = s_dataObjectMapper.writeValueAsString(itemEntity);
+    assertJsonEquals("TestEntityWithUnknownNestedEntity6.json", serialized);
+
+    TestItemEntityDo entityMarshalled = s_dataObjectMapper.readValue(serialized, TestItemEntityDo.class);
+    assertEquals("foo", entityMarshalled.getItemIfc().stringAttribute().get());
   }
 
   // ------------------------------------ common test helper methods ------------------------------------

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestItemEntityDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestItemEntityDo.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import javax.annotation.Generated;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+
+@TypeName("TestItemEntity")
+public class TestItemEntityDo extends DoEntity {
+
+  public DoValue<TestItemDo> item() {
+    return doValue("item");
+  }
+
+  public DoValue<ITestBaseEntityDo> itemIfc() {
+    return doValue("itemIfc");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestItemEntityDo withItem(TestItemDo item) {
+    item().set(item);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestItemDo getItem() {
+    return item().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestItemEntityDo withItemIfc(ITestBaseEntityDo itemIfc) {
+    itemIfc().set(itemIfc);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public ITestBaseEntityDo getItemIfc() {
+    return itemIfc().get();
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestMapDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestMapDo.java
@@ -19,6 +19,7 @@ import javax.annotation.Generated;
 
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.TypeName;
 
 @TypeName("TestMap")
@@ -42,6 +43,14 @@ public class TestMapDo extends DoEntity {
 
   public DoValue<Map<String, TestItemDo>> stringDoTestItemMapAttribute() {
     return doValue("stringDoTestItemMapAttribute");
+  }
+
+  public DoValue<Map<String, IDoEntity>> stringIDoEntityMapAttribute() {
+    return doValue("stringIDoEntityMapAttribute");
+  }
+
+  public DoValue<IDoEntity> iDoEntityAttribute() {
+    return doValue("iDoEntityAttribute");
   }
 
   public DoValue<Map<Date, UUID>> dateUUIDMapAttribute() {
@@ -109,6 +118,28 @@ public class TestMapDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public Map<String, TestItemDo> getStringDoTestItemMapAttribute() {
     return stringDoTestItemMapAttribute().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestMapDo withStringIDoEntityMapAttribute(Map<String, IDoEntity> stringIDoEntityMapAttribute) {
+    stringIDoEntityMapAttribute().set(stringIDoEntityMapAttribute);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, IDoEntity> getStringIDoEntityMapAttribute() {
+    return stringIDoEntityMapAttribute().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestMapDo withIDoEntityAttribute(IDoEntity iDoEntityAttribute) {
+    iDoEntityAttribute().set(iDoEntityAttribute);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IDoEntity getIDoEntityAttribute() {
+    return iDoEntityAttribute().get();
   }
 
   @Generated("DoConvenienceMethodsGenerator")

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestNestedRawDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestNestedRawDo.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import javax.annotation.Generated;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.TypeName;
+
+@TypeName("TestNestedRaw")
+public class TestNestedRawDo extends DoEntity {
+
+  public DoValue<DoEntity> doEntity() {
+    return doValue("doEntity");
+  }
+
+  public DoValue<IDoEntity> iDoEntity() {
+    return doValue("iDoEntity");
+  }
+
+  public DoValue<IDataObject> iDataObject() {
+    return doValue("iDataObject");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withDoEntity(DoEntity doEntity) {
+    doEntity().set(doEntity);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public DoEntity getDoEntity() {
+    return doEntity().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withIDoEntity(IDoEntity iDoEntity) {
+    iDoEntity().set(iDoEntity);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IDoEntity getIDoEntity() {
+    return iDoEntity().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withIDataObject(IDataObject iDataObject) {
+    iDataObject().set(iDataObject);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IDataObject getIDataObject() {
+    return iDataObject().get();
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity.json
@@ -1,0 +1,9 @@
+{
+  "_type" : "TestMap",
+  "stringDoTestItemMapAttribute" : {
+    "one" : {
+      "_type" : "UnknownType",
+      "nr" : 12345
+    }
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity2.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity2.json
@@ -1,0 +1,7 @@
+{
+  "_type" : "TestMap",
+  "iDoEntityAttribute" : {
+    "_type" : "UnknownType",
+    "nr" : 12345
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity3.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity3.json
@@ -1,0 +1,7 @@
+{
+  "_type" : "TestItemEntity",
+  "item" : {
+    "_type" : "UnknownType",
+    "nr" : 12345
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity4.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity4.json
@@ -1,0 +1,6 @@
+{
+  "_type" : "TestItemEntity",
+  "item" : {
+    "nr" : 12345
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity4.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity4.json
@@ -1,6 +1,7 @@
 {
   "_type" : "TestItemEntity",
   "item" : {
+    "id" : "myId",
     "nr" : 12345
   }
 }

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity5.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity5.json
@@ -1,0 +1,7 @@
+{
+  "_type" : "TestItemEntity",
+  "itemIfc" : {
+    "_type" : "UnknownType",
+    "nr" : 12345
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity6.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithUnknownNestedEntity6.json
@@ -1,0 +1,7 @@
+{
+  "_type" : "TestItemEntity",
+  "itemIfc" : {
+    "_type" : "TestEntityWithInterface1",
+    "stringAttribute" : "foo"
+  }
+}

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DataObjectTypeResolverBuilder.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DataObjectTypeResolverBuilder.java
@@ -10,18 +10,24 @@
  */
 package org.eclipse.scout.rt.jackson.dataobject;
 
+import java.io.IOException;
 import java.util.Collection;
 
 import org.eclipse.scout.rt.dataobject.DataObjectInventory;
+import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.LazyValue;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeSerializer;
 import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
 
 @Bean
@@ -36,7 +42,7 @@ public class DataObjectTypeResolverBuilder extends StdTypeResolverBuilder {
 
   @Override
   public TypeSerializer buildTypeSerializer(SerializationConfig config, JavaType baseType, Collection<NamedType> subtypes) {
-    return useForType(baseType) ? super.buildTypeSerializer(config, baseType, subtypes) : null;
+    return useForType(baseType) ? new DataObjectAsPropertyTypeSerializer(_customIdResolver, getTypeProperty()) : null;
   }
 
   protected boolean useForType(JavaType t) {
@@ -46,5 +52,32 @@ public class DataObjectTypeResolverBuilder extends StdTypeResolverBuilder {
     }
     // write type name if class is annotated with a type name
     return m_dataObjectInventory.get().toTypeName(t.getRawClass()) != null;
+  }
+
+  /**
+   * Custom {@link AsPropertyTypeSerializer} implementation used to add type information to serialized data object, but
+   * only if the class of the runtime value is annotated with type information (see {@link TypeName}).
+   */
+  protected static class DataObjectAsPropertyTypeSerializer extends AsPropertyTypeSerializer {
+
+    public DataObjectAsPropertyTypeSerializer(TypeIdResolver idRes, String propName) {
+      super(idRes, null, propName);
+    }
+
+    @Override
+    public WritableTypeId writeTypePrefix(JsonGenerator g, WritableTypeId idMetadata) throws IOException {
+      _generateTypeId(idMetadata);
+      if (idMetadata.id != null) {
+        return g.writeTypePrefix(idMetadata);
+      }
+      else {
+        // Skip writing type information if no type id could be generated for given value (e.g. class structure
+        // indicated a type name, but runtime class of value to be serialized is DoEntity which does not provide any
+        // type information by class). Note that the raw DoEntity which is serialized could contain a raw type
+        // information as ordinary attribute (which is preserved as is).
+        g.writeStartObject(idMetadata.forValue);
+        return idMetadata;
+      }
+    }
   }
 }

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntityDeserializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntityDeserializer.java
@@ -19,9 +19,11 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoList;
 import org.eclipse.scout.rt.dataobject.DoMapEntity;
 import org.eclipse.scout.rt.dataobject.DoNode;
+import org.eclipse.scout.rt.dataobject.IDataObject;
 import org.eclipse.scout.rt.dataobject.IDoCollection;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
@@ -214,16 +216,26 @@ public class DoEntityDeserializer extends StdDeserializer<IDoEntity> {
       // try to lookup DoEntity with specified entityType
       Class<? extends IDoEntity> clazz = m_doEntityDeserializerTypeStrategy.resolveTypeName(entityType);
       if (clazz != null) {
+        // (1) Class could be resolved by given entityType, validate that resolved class is assignable from class handled by this deserializer instance
+        if (!m_handledClass.isAssignableFrom(clazz)) {
+          throw JsonMappingException.from(ctxt, "Class resolved by parsed entity type is not assignable from class expected by deserializer. ["
+              + "entityType=" + entityType + " resolvedClass=" + clazz.getName() + " handledClassByDeserializer=" + m_handledClass + "]");
+        }
         return newObject(ctxt, clazz);
       }
       else {
-        // use generic DoEntity instance with a type attribute to preserve the type information even if correct DoEntity class could not be resolved
+        // (2) Class could be not resolved by given entityType, validate that handled class (e.g. class expected to be created by this deserializer instance) is of raw type
+        if (!ObjectUtility.isOneOf(m_handledClass, DoEntity.class, IDoEntity.class, IDataObject.class)) {
+          throw JsonMappingException.from(ctxt, "Could not resolve a class by parsed entity type and deserializer expect a concrete class to be created. ["
+              + "entityType=" + entityType + " handledClassByDeserializer=" + m_handledClass + "]");
+        }
+        // Use generic DoEntity instance with a type attribute to preserve the type information even if correct DoEntity class could not be resolved
         DoEntity entity = newObject(ctxt, DoEntity.class);
         entity.put(m_moduleContext.getTypeAttributeName(), entityType);
         return entity;
       }
     }
-    // fallback to handled type of deserializer
+    // Fallback to handled type of deserializer
     return newObject(ctxt, m_handledClass);
   }
 


### PR DESCRIPTION
Skip writing type information for raw DoEntity if serialized as attribute of a typed entity indicating that type information should be available.

321546