### PR TITLE
BeanMetaData: fix inherited annotations

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/BeanMetaData.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/BeanMetaData.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -96,7 +96,7 @@ public class BeanMetaData {
     for (Annotation a : clazz.getAnnotations()) {
       if (inheritedOnly) {
         if (a.annotationType().getAnnotation(Inherited.class) != null) {
-          m_beanAnnotations.put(a.annotationType(), a);
+          m_beanAnnotations.putIfAbsent(a.annotationType(), a);
         }
       }
       else {


### PR DESCRIPTION
Do not override annotations from a subclass with annotations from a superclass.

337682