### PR TITLE
Desktop: improve no-view-buttons-mode

### DIFF
--- a/eclipse-scout-core/src/desktop/navigation/DesktopNavigation.less
+++ b/eclipse-scout-core/src/desktop/navigation/DesktopNavigation.less
@@ -16,11 +16,45 @@
   background-color: @desktop-navigation-background-color;
   color: @desktop-navigation-color;
 
+  & > .desktop-tool-box {
+    right: 0;
+
+    & > .menu-item {
+      margin-bottom: @view-tab-margin;
+
+      & > .font-icon {
+        font-size: @view-tab-icon-font-size;
+      }
+
+      &.ellipsis > .font-icon {
+        font-size: @view-tab-icon-font-size + 2px;
+      }
+    }
+  }
+
   &.view-button-box-invisible {
-    & > .navigation-body {
-      & > .outline > .outline-title {
+    & > .desktop-tool-box > .menu-item {
+      margin-bottom: @desktop-tool-box-item-margin-top;
+    }
+
+    & > .navigation-body > .outline > .outline-title {
+      background-color: @desktop-header-background-color;
+      border-bottom: 0;
+      color: @desktop-header-color;
+
+      &.measure {
+        display: inline-flex;
+      }
+
+      &.touch:active {
         background-color: @desktop-header-background-color;
-        border-bottom: 0;
+      }
+
+      & > .text {
+        flex-grow: 0;
+      }
+
+      & > .menubar > .menubar-box > .menu-item {
         color: @desktop-header-color;
       }
     }
@@ -37,19 +71,5 @@
 
   .desktop-navigation.in-background > & {
     background-color: @desktop-navigation-body-in-background-background-color;
-  }
-}
-
-.desktop-navigation > .desktop-tool-box {
-  & > .menu-item {
-    margin-bottom: @view-tab-margin;
-
-    & > .font-icon {
-      font-size: @view-tab-icon-font-size;
-    }
-
-    &.ellipsis > .font-icon {
-      font-size: @view-tab-icon-font-size + 2px;
-    }
   }
 }

--- a/eclipse-scout-core/src/desktop/navigation/DesktopNavigationLayout.ts
+++ b/eclipse-scout-core/src/desktop/navigation/DesktopNavigationLayout.ts
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {AbstractLayout, DesktopNavigation, Dimension, HtmlCompPrefSizeOptions} from '../../index';
+import {AbstractLayout, DesktopNavigation, Dimension, graphics, HtmlCompPrefSizeOptions} from '../../index';
 
 export class DesktopNavigationLayout extends AbstractLayout {
   navigation: DesktopNavigation;
@@ -41,9 +41,20 @@ export class DesktopNavigationLayout extends AbstractLayout {
     }
 
     if (toolBox) {
-      toolBox.$container.cssLeft(viewButtonBoxWidth);
-      let toolBoxSize = new Dimension(containerSize.width - viewButtonBoxWidth, viewButtonBoxHeight)
-        .subtract(toolBox.htmlComp.margins());
+      let toolBoxSize;
+      let outline = this.navigation.outline;
+      if (viewButtonBoxWidth === 0 && outline && outline.$title) {
+        // If there is no view button box, the outline title will be moved up.
+        // If there is no outline title, the tool box will take the whole width (else case)
+        outline.$title.addClass('measure');
+        let outlineTitleWidth = graphics.prefSize(outline.$title).width;
+        outline.$title.removeClass('measure');
+        toolBoxSize = new Dimension(containerSize.width - outlineTitleWidth, 0) // height is set by css
+          .subtract(toolBox.htmlComp.margins());
+      } else {
+        toolBoxSize = new Dimension(containerSize.width - viewButtonBoxWidth, viewButtonBoxHeight)
+          .subtract(toolBox.htmlComp.margins());
+      }
       toolBox.htmlComp.setSize(toolBoxSize);
     }
 

--- a/eclipse-scout-core/src/desktop/outline/Outline.less
+++ b/eclipse-scout-core/src/desktop/outline/Outline.less
@@ -131,8 +131,14 @@
     flex-grow: 0;
     margin-right: -10px;
 
-    & > .menubar-box > .menu-item.last {
-      margin-right: 0;
+    & > .menubar-box > .menu-item {
+      &.first {
+        margin-left: 4px;
+      }
+
+      &.last {
+        margin-right: 0;
+      }
     }
   }
 }

--- a/eclipse-scout-core/src/desktop/outline/SearchOutline.less
+++ b/eclipse-scout-core/src/desktop/outline/SearchOutline.less
@@ -21,6 +21,15 @@
   position: relative;
   border-bottom: 1px solid @outline-title-border-color;
   padding: 0 @outline-title-padding-right @search-outline-panel-padding-bottom @outline-title-padding-left;
+
+  .view-button-box-invisible & {
+    padding-top: @search-outline-panel-no-title-padding-top;
+    padding-bottom: @search-outline-panel-no-title-padding-top + 1xp;
+
+    & > .clear-icon {
+      top: @search-outline-panel-no-title-padding-top;
+    }
+  }
 }
 
 .search-outline-field {

--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -276,6 +276,7 @@
 @scroll-shadow-blur: @scroll-shadow-size;
 @scroll-shadow-spread: @scroll-shadow-size + 1; // +1 to ensure firefox does not draw a light shadow on the side of the scrollable
 @search-outline-panel-padding-bottom: 16px;
+@search-outline-panel-no-title-padding-top: 14px;
 @simple-tab-padding: 5px;
 @split-box-splitter-line-size: 3px;
 @split-box-x-splitter-padding: 19px;


### PR DESCRIPTION
If there are no view buttons, the outline title is moved up. If that happens, following issues occur:
- search field is too much on top -> center it
- on mobile:
  - title cannot be clicked because tool box is too large
  - tool box items draw over title if there are several tools
  - menu items in outline-title are not visible

329903