### PR TITLE
ContextMenuPopup: check if default is prevented before closing popup

### DIFF
--- a/eclipse-scout-core/src/menu/ContextMenuPopup.ts
+++ b/eclipse-scout-core/src/menu/ContextMenuPopup.ts
@@ -521,6 +521,9 @@ export class ContextMenuPopup extends Popup implements ContextMenuPopupModel {
     if (event.source.isToggleAction()) {
       return;
     }
+    if (event.defaultPrevented) {
+      return;
+    }
     this.close();
   }
 

--- a/eclipse-scout-core/test/menu/ContextMenuPopupSpec.ts
+++ b/eclipse-scout-core/test/menu/ContextMenuPopupSpec.ts
@@ -241,4 +241,55 @@ describe('ContextMenuPopup', () => {
 
   });
 
+  describe('preventDefault', () => {
+
+    it('closes the popup when default is not prevented', () => {
+      let menu1 = helper.createMenu(helper.createModel());
+      let menu2 = helper.createMenu(helper.createModel());
+
+      let menu1Clicked = false;
+      menu1.on('action', event => {
+        menu1Clicked = true;
+      });
+
+      let popup = scout.create(ContextMenuPopup, {
+        parent: session.desktop,
+        session: session,
+        menuItems: [menu1, menu2],
+        animateOpening: false,
+        animateRemoval: false
+      });
+
+      popup.open();
+      findClone(popup, menu1).doAction();
+      expect(menu1Clicked).toBe(true);
+      expect(popup.rendered).toBe(false);
+    });
+
+    it('does not close the popup when default is prevented', () => {
+      let menu1 = helper.createMenu(helper.createModel());
+      let menu2 = helper.createMenu(helper.createModel());
+
+      let menu1Clicked = false;
+      menu1.on('action', event => {
+        event.preventDefault(); // <--
+        menu1Clicked = true;
+      });
+
+      let popup = scout.create(ContextMenuPopup, {
+        parent: session.desktop,
+        session: session,
+        menuItems: [menu1, menu2],
+        animateOpening: false,
+        animateRemoval: false
+      });
+
+      popup.open();
+      findClone(popup, menu1).doAction();
+      expect(menu1Clicked).toBe(true);
+      expect(popup.rendered).toBe(true); // <--
+
+      popup.close();
+    });
+  });
 });


### PR DESCRIPTION
By default, clicking a menu automatically closes the context menu popup. When "toggleAction" is true, this does not happen. This change also allows non-toggle menus to keep the context menu popup open by calling event.preventDefault() in the action handler.