### PR TITLE
Table & TileGrid: apply sort to initial elements

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -350,9 +350,9 @@ export class Table extends Widget implements TableModel {
     this._setTableControls(this.tableControls);
     this._setTableStatus(this.tableStatus);
     this._calculateValuesForBackgroundEffect();
-    this._group();
     this._setTileMode(this.tileMode);
     this._setTileTableHeader(this.tileTableHeader);
+    this._sortWhileInit(); // required in case the rows are already provided in the initial model
   }
 
   protected _initRow(row: ObjectOrModel<TableRow>): TableRow {
@@ -2837,6 +2837,11 @@ export class Table extends Widget implements TableModel {
   }
 
   protected _sortAfterInsert(wasEmpty: boolean) {
+    this._sort();
+  }
+
+  protected _sortWhileInit() {
+    // Only in Scout JS mode. Modified for Scout Classic (see TableAdapter).
     this._sort();
   }
 

--- a/eclipse-scout-core/src/table/TableAdapter.ts
+++ b/eclipse-scout-core/src/table/TableAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -655,6 +655,16 @@ export class TableAdapter extends ModelAdapter {
     }
 
     objects.replacePrototypeFunction(Table, '_createRow', TableAdapter._createRowRemote, true);
+
+    // _sortWhileInit
+    objects.replacePrototypeFunction(Table, '_sortWhileInit', function() {
+      if (this.modelAdapter) {
+        // Scout classic: not necessary to sort in init as the rows are already sorted on the Java UI. Only apply grouping here.
+        this._group();
+      } else {
+        this._sortWhileInitOrig();
+      }
+    }, true);
 
     // _sortAfterInsert
     objects.replacePrototypeFunction(Table, '_sortAfterInsert', function(wasEmpty: boolean) {

--- a/eclipse-scout-core/src/tile/TileGrid.ts
+++ b/eclipse-scout-core/src/tile/TileGrid.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -128,8 +128,9 @@ export class TileGrid extends Widget implements TileGridModel {
     this._initTiles();
     this.setFilters(this.filters, false);
     this.filter();
-    this.updateFilteredElements();
     this._setMenus(this.menus);
+    this._sortWhileInit();
+    this.updateFilteredElements();
   }
 
   protected override _createKeyStrokeContext(): KeyStrokeContext {
@@ -461,6 +462,10 @@ export class TileGrid extends Widget implements TileGridModel {
       return;
     }
     this.comparator = comparator;
+  }
+
+  protected _sortWhileInit() {
+    this.sort();
   }
 
   sort() {

--- a/eclipse-scout-core/src/tile/TileGridAdapter.ts
+++ b/eclipse-scout-core/src/tile/TileGridAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {Event, ModelAdapter, objects, RemoteTileFilter, scout, TileActionEvent, TileClickEvent, TileGrid, TileGridModel} from '../index';
+import {App, Event, ModelAdapter, objects, RemoteTileFilter, scout, TileActionEvent, TileClickEvent, TileGrid, TileGridModel} from '../index';
 
 export class TileGridAdapter extends ModelAdapter {
   declare widget: TileGrid;
@@ -85,4 +85,20 @@ export class TileGridAdapter extends ModelAdapter {
       super._onWidgetEvent(event);
     }
   }
+
+  static modifyTileGridPrototype() {
+    if (!App.get().remote) {
+      return;
+    }
+
+    // _sortWhileInit
+    objects.replacePrototypeFunction(TileGrid, '_sortWhileInit', function() {
+      if (this.modelAdapter) {
+        return; // Do nothing. Was sorted in Java UI already.
+      }
+      this._sortWhileInitOrig();
+    }, true);
+  }
 }
+
+App.addListener('bootstrap', TileGridAdapter.modifyTileGridPrototype);

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1192,6 +1192,18 @@ describe('Table', () => {
       expect(table.columns[0].sortActive).toBe(true);
       expect(table.columns[0].sortAscending).toBe(false);
       expect(table.columns[0].sortIndex).toBe(0);
+    });
+
+    it('works if rows are passed in model', () => {
+      let sortColumnIndex = 0;
+      model = helper.createModelFixture(3, 3);
+      model.columns[sortColumnIndex].sortActive = true;
+      model.columns[sortColumnIndex].sortIndex = 0;
+      model.columns[sortColumnIndex].sortAscending = false;
+      table = helper.createTable(model);
+      expect(table.rows[0].cells[sortColumnIndex].value).toBe('cell2_0');
+      expect(table.rows[1].cells[sortColumnIndex].value).toBe('cell1_0');
+      expect(table.rows[2].cells[sortColumnIndex].value).toBe('cell0_0');
     });
 
     describe('model update', () => {

--- a/eclipse-scout-core/test/tile/TileGridSpec.ts
+++ b/eclipse-scout-core/test/tile/TileGridSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -485,6 +485,30 @@ describe('TileGrid', () => {
   });
 
   describe('sort', () => {
+
+    it('works if tiles are passed in model', () => {
+      let model: InitModelOf<TileGrid> = {
+        parent: session.desktop,
+        comparator: (t0, t1) => {
+          // desc
+          return (t0['label'] < t1['label'] ? 1 : ((t0['label'] > t1['label']) ? -1 : 0));
+        },
+        tiles: [{
+          objectType: Tile,
+          label: 'Tile 0'
+        }, {
+          objectType: Tile,
+          label: 'Tile 2'
+        }, {
+          objectType: Tile,
+          label: 'Tile 1'
+        }]
+      };
+      let tileGrid = scout.create(TileGrid, model);
+      expect(tileGrid.tiles[0]['label']).toBe('Tile 2');
+      expect(tileGrid.tiles[1]['label']).toBe('Tile 1');
+      expect(tileGrid.tiles[2]['label']).toBe('Tile 0');
+    });
 
     it('uses the comparator to sort the tiles and filteredTiles', () => {
       let tileGrid = createTileGrid(0);


### PR DESCRIPTION
Elements (rows or tiles) passed to the init model of a Table or TileGrid should respect the sort order configured.

267919