### PR TITLE
UNSAFE_UPLOAD and REJECTED_UPLOAD error responses are not fatal

### DIFF
--- a/eclipse-scout-core/src/session/Session.js
+++ b/eclipse-scout-core/src/session/Session.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -367,8 +367,10 @@ export default class Session {
   _processStartupResponse(data) {
     // Handle errors from server
     if (data.error) {
-      this._processErrorJsonResponse(data.error);
-      return;
+      let isFatalError = this._processErrorJsonResponse(data.error);
+      if (isFatalError) {
+        return;
+      }
     }
 
     webstorage.removeItemFromSessionStorage('scout:versionMismatch');
@@ -904,12 +906,13 @@ export default class Session {
    * Otherwise, the response queue's expected sequence number will get out of sync.
    */
   processJsonResponseInternal(data) {
-    let success = false;
+    let success = true;
     if (data.error) {
-      this._processErrorJsonResponse(data.error);
-    } else {
+      let isFatalError = this._processErrorJsonResponse(data.error);
+      success = !isFatalError;
+    }
+    if (success) {
       this._processSuccessResponse(data);
-      success = true;
     }
     return success;
   }
@@ -980,6 +983,7 @@ export default class Session {
   }
 
   _processErrorJsonResponse(jsonError) {
+    let isFatalError = true;
     if (jsonError.code === Session.JsonResponseError.VERSION_MISMATCH) {
       let loopDetection = webstorage.getItemFromSessionStorage('scout:versionMismatch');
       if (!loopDetection) {
@@ -1033,14 +1037,17 @@ export default class Session {
       boxOptions.yesButtonText = this.optText('ui.Ok', 'Ok');
       boxOptions.yesButtonAction = () => {
       };
+      isFatalError = false; // unsafe upload allows the application to continue
     } else if (jsonError.code === Session.JsonResponseError.REJECTED_UPLOAD) {
       boxOptions.header = this.optText('ui.RejectedUpload', boxOptions.header);
       boxOptions.body = this.optText('ui.RejectedUploadMsg', boxOptions.body);
       boxOptions.yesButtonText = this.optText('ui.Ok', 'Ok');
       boxOptions.yesButtonAction = () => {
       };
+      isFatalError = false; // rejected upload allows the application to continue
     }
     this.showFatalMessage(boxOptions, jsonError.code);
+    return isFatalError;
   }
 
   _fireRequestFinished(message) {

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/AbstractJsonPropertyObserver.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/AbstractJsonPropertyObserver.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -198,7 +198,7 @@ public abstract class AbstractJsonPropertyObserver<T extends IPropertyObserver> 
       //    1. Table, rowClick   -> sets displayText to 'B' (via Java model)
       //    2. StringField, acceptProposal -> sets displayText to 'A'
       //
-      // Expected: after all events have been processed, displayText in the UI should be A
+      // Expected: after all events have been processed, displayText in the UI should be 'A',
       // but without this check below, it would be 'B', because the second event sets a filter
       // for 'A', so when displayText is changed to 'A' it is not sent back to the UI
       // which is wrong in that case.
@@ -230,7 +230,7 @@ public abstract class AbstractJsonPropertyObserver<T extends IPropertyObserver> 
     for (JsonProperty<?> lazyProperty : masterProperty.getLazyProperties()) {
       Object modelValue = lazyProperty.modelValue();
       lazyProperty.handlePropertyChange(null, modelValue);
-      // Note: at this point we don'check if the a property-change-event is filtered or not
+      // Note: at this point we don't check if a property-change-event is filtered or not
       if (modelValue != null && lazyProperty.accept() && !lazyProperty.isValueSent()) {
         addPropertyChangeEvent(lazyProperty, modelValue);
       }
@@ -243,7 +243,8 @@ public abstract class AbstractJsonPropertyObserver<T extends IPropertyObserver> 
 
   protected void addPropertyChangeEvent(JsonProperty<?> jsonProperty, Object newValue) {
     String propertyName = jsonProperty.jsonPropertyName();
-    addPropertyChangeEvent(propertyName, jsonProperty.prepareValueForToJson(newValue));
+    newValue = jsonProperty.prepareValueForToJson(newValue);
+    addPropertyChangeEvent(propertyName, newValue);
     jsonProperty.setValueSent(true);
     LOG.debug("Added property change event '{}: {}' for {} with id {}. Model: {}", propertyName, newValue, getObjectType(), getId(), getModel());
   }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/BinaryResourceUrlUtility.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/BinaryResourceUrlUtility.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -105,8 +105,7 @@ public final class BinaryResourceUrlUtility {
       return null;
     }
     Matcher m = ICON_REGEX_PATTERN.matcher(str);
-    @SuppressWarnings("squid:S1149")
-    StringBuffer ret = new StringBuffer();
+    StringBuilder ret = new StringBuilder();
     while (m.find()) {
       m.appendReplacement(ret, m.group(1) + createIconUrl(m.group(2)) + m.group(1));
     }
@@ -188,8 +187,7 @@ public final class BinaryResourceUrlUtility {
       return null;
     }
     Matcher m = BINARY_RESOURCE_REGEX_PATTERN.matcher(str);
-    @SuppressWarnings("squid:S1149")
-    StringBuffer ret = new StringBuffer();
+    StringBuilder ret = new StringBuilder();
     while (m.find()) {
       m.appendReplacement(ret, m.group(1) + createDynamicAdapterResourceUrl(jsonAdapter, m.group(2)) + m.group(1));
     }
@@ -205,8 +203,7 @@ public final class BinaryResourceUrlUtility {
       return null;
     }
     Matcher m = BINARY_REF_REGEX_PATTERN.matcher(str);
-    @SuppressWarnings("squid:S1149")
-    StringBuffer ret = new StringBuffer();
+    StringBuilder ret = new StringBuilder();
     while (m.find()) {
       m.appendReplacement(ret, m.group(1) + createBinaryRefResourceUrl(m.group(2)) + m.group(1));
     }


### PR DESCRIPTION
JsonResponseError.UNSAFE_UPLOAD and JsonResponseError.REJECTED_UPLOAD may be set on the json response in addition to regular events. As these error types are not fatal (the application continues to work) the events must be processed as well. Otherwise, the UI might end up in an inconsistent state because some events have been skipped (e.g. about a destroyed widget).

299642