### PR TITLE
HtmlField displayText must not be read from DOM

### DIFF
--- a/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.ts
+++ b/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ export class HtmlField extends ValueField<string> implements HtmlFieldModel {
   }
 
   protected override _readDisplayText(): string {
-    return this.$field.html();
+    return this.displayText;
   }
 
   protected override _renderDisplayText() {

--- a/eclipse-scout-core/test/form/fields/htmlfield/HtmlFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/htmlfield/HtmlFieldSpec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {HtmlField, scout} from '../../../../src/index';
+
+describe('HtmlField', () => {
+  let session: SandboxSession;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+  });
+
+  describe('acceptInput', () => {
+    it('does not change field value and displayText', () => {
+      let field = scout.create(HtmlField, {
+        parent: session.desktop,
+        scrollBarEnabled: true
+      });
+      field.render();
+      field.setValue('<ul>\n' +
+        '  <li>AppLink: <span class="app-link" data-ref="param1=XY&param2=YZ">Click me</span></li>\n' +
+        '  <li>HTML Link: <a href="https://www.eclipse.org/scout" target="_blank">eclipse.org/scout</a></li>\n' +
+        '</ul>\n' +
+        '<!-- This is an invisible comment -->\n');
+      let origValue = field.value;
+      let origDisplayText = field.displayText;
+      field.acceptInput();
+
+      // value and displayText are unchanged after acceptInput
+      expect(field.value).toBe(origValue);
+      expect(field.displayText).toBe(origDisplayText);
+    });
+  });
+});


### PR DESCRIPTION
The displayText is rendered to the DOM with some modification:
- App-Links are decorated
- Scrollbars are added if enabled & necessary

Therefore the DOM does not reflect the original displayText. If the html is read from the DOM to compute the displayText, these modifications are included. If acceptInput is called (e.g. after focusing the field and then switching to another field), the displayText is recomputed and then includes these modifications. Is the field rendered again, the scrollbars are duplicated but only one is functional.

Instead, the displayText should always return the property as the content of the HtmlField cannot be changed anyway by the user. Therefore, it is not necessary to read it form the current DOM.

334077