### PR TITLE
Prevent focus change outside forms and popups on mouse down

### DIFF
--- a/eclipse-scout-core/src/focus/focusUtils.js
+++ b/eclipse-scout-core/src/focus/focusUtils.js
@@ -27,7 +27,7 @@ export function isFocusableByMouse(element) {
  */
 export function containsParentFocusableByMouse(element, entryPoint) {
   let $focusableParentElements = $(element)
-    .parents(':focusable')
+    .parentsUntil('.focus-boundary', ':focusable') // Stay inside focus boundaries (e.g. search forms should not consider parent table)
     .not(entryPoint) /* Exclude $entryPoint as all elements are its descendants. However, the $entryPoint is only focusable to provide Portlet support. */
     .filter(function() {
       return isFocusableByMouse(this);

--- a/eclipse-scout-core/src/table/TableFooter.js
+++ b/eclipse-scout-core/src/table/TableFooter.js
@@ -58,7 +58,7 @@ export default class TableFooter extends Widget {
 
     // --- container for an open control ---
     this.$controlContainer = this.$container.appendDiv('table-control-container').hide();
-    this.$controlContent = this.$controlContainer.appendDiv('table-control-content');
+    this.$controlContent = this.$controlContainer.appendDiv('table-control-content focus-boundary');
 
     // --- table controls section ---
     this._$controls = this.$container.appendDiv('table-controls');

--- a/eclipse-scout-core/src/table/controls/FormTableControl.js
+++ b/eclipse-scout-core/src/table/controls/FormTableControl.js
@@ -68,6 +68,10 @@ export default class FormTableControl extends TableControl {
     return !!this.form;
   }
 
+  setForm(form) {
+    this.setProperty('form', form);
+  }
+
   _setForm(form) {
     if (this.form) {
       this.form.off('destroy', this._formDestroyedHandler);

--- a/eclipse-scout-core/test/table/controls/AggregateTableControlSpec.js
+++ b/eclipse-scout-core/test/table/controls/AggregateTableControlSpec.js
@@ -71,7 +71,7 @@ describe('AggregateTableControl', () => {
         table: table
       });
       tableControl.selected = true;
-      table._setTableControls([tableControl]);
+      table.setTableControls([tableControl]);
 
       column0 = table.columns[0];
       column1 = table.columns[1];
@@ -282,7 +282,7 @@ describe('AggregateTableControl', () => {
         selected: true,
         table: table
       });
-      table._setTableControls([tableControl]);
+      table.setTableControls([tableControl]);
       table.render();
 
       expect(tableControl.enabled).toBe(false);
@@ -304,7 +304,7 @@ describe('AggregateTableControl', () => {
         selected: true,
         table: table
       });
-      table._setTableControls([tableControl]);
+      table.setTableControls([tableControl]);
       table.render();
 
       expect(tableControl.enabled).toBe(true);
@@ -326,7 +326,7 @@ describe('AggregateTableControl', () => {
         selected: false,
         table: table
       });
-      table._setTableControls([tableControl]);
+      table.setTableControls([tableControl]);
       table.render();
 
       expect(tableControl.enabled).toBe(false);

--- a/eclipse-scout-core/test/table/controls/TableControlSpec.js
+++ b/eclipse-scout-core/test/table/controls/TableControlSpec.js
@@ -8,8 +8,8 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {RemoteEvent, scout, TableControlAdapter} from '../../../src/index';
-import {TableSpecHelper} from '../../../src/testing/index';
+import {focusUtils, RemoteEvent, scout, TableControlAdapter} from '../../../src/index';
+import {FormSpecHelper, TableSpecHelper} from '../../../src/testing/index';
 
 describe('TableControl', () => {
   let session;
@@ -60,7 +60,7 @@ describe('TableControl', () => {
 
     it('opens and closes the control container', () => {
       let action = createAction(createModel());
-      table._setTableControls([action]);
+      table.setTableControls([action]);
       table.render();
       let $controlContainer = table.footer.$controlContainer;
       expect($controlContainer).toBeHidden();
@@ -76,7 +76,7 @@ describe('TableControl', () => {
     it('removes the content of the previous selected control without closing the container', () => {
       let action = createAction(createModel());
       let action2 = createAction(createModel());
-      table._setTableControls([action, action2]);
+      table.setTableControls([action, action2]);
 
       action.selected = true;
       table.render();
@@ -106,7 +106,7 @@ describe('TableControl', () => {
       let model2 = createModel();
       let adapter2 = createTableControlAdapter(model2);
       let action2 = adapter2.createWidget(model2, session.desktop);
-      table._setTableControls([action, action2]);
+      table.setTableControls([action, action2]);
 
       action.selected = true;
       table.render();
@@ -123,5 +123,21 @@ describe('TableControl', () => {
       ];
       expect(mostRecentJsonRequest()).toContainEvents(events);
     });
+  });
+
+  it('clicking in the control container does not focus the table', () => {
+    let table = createTable();
+    let action = scout.create('FormTableControl', {
+      parent: table,
+      selected: true
+    });
+    action.setForm(new FormSpecHelper(session).createFormWithOneField());
+    table.setTableControls([action]);
+    table.render();
+    jasmine.clock().tick(1); // Ensure animation complete function is executed (animation uses a 1ms delay)
+    expect(action.form.rootGroupBox.fields[0].isFocused()).toBeTrue();
+
+    // Focus must not leave the field when clicking outside (it cannot be simulated in a test -> test the function that causes the problem)
+    expect(focusUtils.containsParentFocusableByMouse(action.form.$container, session.desktop.$container)).toBe(false);
   });
 });


### PR DESCRIPTION
When a non-focusable element is clicked, the focus manager finds the nearest parent that is focusable and focuses it. For example, when clicking a table row, the table will receive the focus.

This logic sometimes fails. Search forms are rendered inside the table, thus clicking the "white space" on a search form (non-focusable) would cause the focus to be transferred to the table. In this case, the focus should remain on the form.

Stopping the element selector at "natural" focus boundaries like forms or popups fixes the issue.

333099