### PR TITLE
Removed duplicate utility function getFileExtension

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/FileUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/FileUtilityTest.java
@@ -1,19 +1,16 @@
 /*
- * Copyright (c) 2010-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.platform.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,6 +32,7 @@ public class FileUtilityTest {
   private static final String FILE_NAME = "fooBar.txt";
   private static final String FILE_NAME_MULTIPLE_DOTS = "foo.bar.txt";
   private static final String FILE_NAME_NO_EXT = "fooBar";
+  private static final String FILE_NAME_ONLY_DOT = "fooBar";
   private static final String PLATFORM_PATH = "org/eclipse/scout/rt/platform/";
 
   @Test
@@ -93,7 +91,9 @@ public class FileUtilityTest {
   public void testGetFileExtension_String() {
     assertEquals(TEXT_EXT, FileUtility.getFileExtension(FILE_NAME));
     assertEquals(TEXT_EXT, FileUtility.getFileExtension(FILE_NAME_MULTIPLE_DOTS));
+    assertNull(FileUtility.getFileExtension(FILE_NAME_ONLY_DOT));
     assertNull(FileUtility.getFileExtension(FILE_NAME_NO_EXT));
+    assertNull(FileUtility.getFileExtension(""));
     assertNull(FileUtility.getFileExtension((String) null));
   }
 
@@ -101,7 +101,9 @@ public class FileUtilityTest {
   public void testGetFileExtension_File() {
     assertEquals(TEXT_EXT, FileUtility.getFileExtension(new File(FILE_NAME)));
     assertEquals(TEXT_EXT, FileUtility.getFileExtension(new File(FILE_NAME_MULTIPLE_DOTS)));
-    assertNull(FileUtility.getFileExtension((File) new File(FILE_NAME_NO_EXT)));
+    assertNull(FileUtility.getFileExtension(new File(FILE_NAME_ONLY_DOT)));
+    assertNull(FileUtility.getFileExtension(new File(FILE_NAME_NO_EXT)));
+    assertNull(FileUtility.getFileExtension(new File("")));
     assertNull(FileUtility.getFileExtension((File) null));
   }
 

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/IOUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/IOUtilityTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -169,17 +169,6 @@ public class IOUtilityTest {
     finally {
       IOUtility.deleteFile(tempFile);
     }
-  }
-
-  @Test
-  public void testFileExtension() {
-    assertEquals("temp", IOUtility.getFileExtension("Test.temp"));
-    assertEquals("temp", IOUtility.getFileExtension("Test.xy.temp"));
-    assertEquals("temp", IOUtility.getFileExtension(".temp"));
-    assertEquals("", IOUtility.getFileExtension("Test."));
-    assertEquals("", IOUtility.getFileExtension("."));
-    assertNull(IOUtility.getFileExtension(""));
-    assertNull(IOUtility.getFileExtension(null));
   }
 
   @Test

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/IOUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/IOUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -828,22 +828,6 @@ public final class IOUtility {
     }
     else {
       return new File(s.replace('\\', File.separatorChar).replace('/', File.separatorChar));
-    }
-  }
-
-  /**
-   * @return the extension of the file
-   */
-  public static String getFileExtension(String filename) {
-    if (filename == null) {
-      return null;
-    }
-    int i = filename.lastIndexOf('.');
-    if (i < 0) {
-      return null;
-    }
-    else {
-      return filename.substring(i + 1);
     }
   }
 


### PR DESCRIPTION
The IOUtility and the FileUtility class both implement the getFileExtension method. The occurrence in the IOUtility was removed.

323620