### PR TITLE
Create SMTP connection outside of synchronized block

### DIFF
--- a/org.eclipse.scout.rt.mail.test/src/test/java/org/eclipse/scout/rt/mail/smtp/SmtpConnectionPoolTest.java
+++ b/org.eclipse.scout.rt.mail.test/src/test/java/org/eclipse/scout/rt/mail/smtp/SmtpConnectionPoolTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.mail.smtp;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import javax.mail.NoSuchProviderException;
+import javax.mail.Session;
+import javax.mail.Transport;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.job.IBlockingCondition;
+import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.job.Jobs;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
+import org.eclipse.scout.rt.platform.util.ImmutablePair;
+import org.eclipse.scout.rt.platform.util.Pair;
+import org.eclipse.scout.rt.testing.platform.mock.RegisterBeanTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SmtpConnectionPoolTest {
+
+  protected SmtpHelper m_mockSmtpHelper;
+
+  @Rule
+  public final RegisterBeanTestRule<SmtpHelper> m_smtpHelperBeanTestRule = new RegisterBeanTestRule<SmtpHelper>(SmtpHelper.class, () -> m_mockSmtpHelper = createMockSmtpHelper());
+
+  protected SmtpHelper createMockSmtpHelper() {
+    SmtpHelper mock = mock(SmtpHelper.class);
+    Session session = mock(Session.class);
+    try {
+      when(session.getTransport()).thenReturn(mock(Transport.class));
+    }
+    catch (NoSuchProviderException e) {
+      throw new ProcessingException("Mocking error", e);
+    }
+    when(mock.createSession(any())).thenReturn(session);
+    return mock;
+  }
+
+  @Test(timeout = 15000)
+  public void testLeaseAndReleaseConnection() {
+    SmtpServerConfig config = createDefaultServerConfig();
+    SmtpConnectionPool pool = createDefaultSmtpConnectionPool();
+
+    assertPoolCount(pool, 0, 0, 0);
+
+    SmtpConnectionPoolEntry entry = pool.leaseConnection(config);
+    assertPoolCount(pool, 1, 0, 0);
+    assertNotNull(entry);
+
+    pool.releaseConnection(entry);
+    assertPoolCount(pool, 0, 1, 0);
+  }
+
+  @Test(timeout = 15000)
+  public void testLeaseMultipleConnections() {
+    SmtpServerConfig config = createDefaultServerConfig();
+
+    SmtpConnectionPool pool = createDefaultSmtpConnectionPool();
+    assertPoolCount(pool, 0, 0, 0);
+
+    SmtpConnectionPoolEntry entry = pool.leaseConnection(config);
+    assertPoolCount(pool, 1, 0, 0);
+    assertNotNull(entry);
+
+    SmtpConnectionPoolEntry entry2 = pool.leaseConnection(config);
+    assertPoolCount(pool, 2, 0, 0);
+    assertNotNull(entry2);
+
+    pool.releaseConnection(entry);
+    assertPoolCount(pool, 1, 1, 0);
+
+    pool.releaseConnection(entry2);
+    assertPoolCount(pool, 0, 2, 0);
+  }
+
+  /**
+   * Test whether multiple connections are requested in parallel and if configured pool size is respected.
+   */
+  @Test(timeout = 15000)
+  public void testLeaseMultipleConnectionsBlockingCreation() {
+    SmtpServerConfig config = createDefaultServerConfig();
+
+    SmtpConnectionPool pool = createDefaultSmtpConnectionPool();
+    assertPoolCount(pool, 0, 0, 0); // expect an empty pool
+
+    // request first connection (expect pool to count the connection request)
+    Pair<IFuture<SmtpConnectionPoolEntry>, IBlockingCondition> request1 = leaseConnectionAsynchronouslyAndBlockUntilConnectionRequested(pool, config);
+    assertPoolCount(pool, 0, 0, 1);
+
+    // request second connection (expect pool to count the connection request)
+    Pair<IFuture<SmtpConnectionPoolEntry>, IBlockingCondition> request2 = leaseConnectionAsynchronouslyAndBlockUntilConnectionRequested(pool, config);
+    assertPoolCount(pool, 0, 0, 2);
+
+    // request again (expect pool to open no other connection request as pool size is limited to 2)
+    IFuture<SmtpConnectionPoolEntry> request3 = Jobs.getJobManager().schedule(() -> {
+      SmtpConnectionPoolEntry entry = pool.leaseConnection(config);
+      assertNotNull(entry);
+      return entry;
+    }, Jobs.newInput());
+    assertPoolCount(pool, 0, 0, 2);
+
+    // fulfill second connection lease request, expect one connection to be leased
+    request2.getRight().setBlocking(false);
+    SmtpConnectionPoolEntry entry = request2.getLeft().awaitDoneAndGet();
+    assertPoolCount(pool, 1, 0, 1);
+
+    // release second entry and expect it to be returned by the third request
+    pool.releaseConnection(entry);
+    entry = request3.awaitDoneAndGet();
+    assertPoolCount(pool, 1, 0, 1);
+
+    // release third entry, expect one idle connection now in pool as there are no additional requests
+    pool.releaseConnection(entry);
+    assertPoolCount(pool, 0, 1, 1);
+
+    // fulfill first connection lease request, expect connecting count to be zero again, one leased and one idle
+    request1.getRight().setBlocking(false);
+    entry = request1.getLeft().awaitDoneAndGet();
+    assertPoolCount(pool, 1, 1, 0);
+
+    // release first entry, expect two idle entries now
+    pool.releaseConnection(entry);
+    assertPoolCount(pool, 0, 2, 0);
+  }
+
+  @Test(timeout = 15000)
+  public void testDestroyAndLease() {
+    SmtpServerConfig config = createDefaultServerConfig();
+    SmtpConnectionPool pool = createDefaultSmtpConnectionPool();
+
+    pool.destroy();
+    assertThrows(AssertionException.class, () -> pool.leaseConnection(config));
+  }
+
+  @Test(timeout = 15000)
+  public void testDestroyAndRelease() {
+    SmtpServerConfig config = createDefaultServerConfig();
+    SmtpConnectionPool pool = createDefaultSmtpConnectionPool();
+    SmtpConnectionPoolEntry entry = pool.leaseConnection(config);
+
+    pool.destroy();
+    assertThrows(AssertionException.class, () -> pool.releaseConnection(entry));
+  }
+
+  @Test(timeout = 15000)
+  public void testDestroyDuringConnectionCreation() {
+    SmtpConnectionPool pool = createDefaultSmtpConnectionPool();
+
+    Pair<IFuture<SmtpConnectionPoolEntry>, IBlockingCondition> request = leaseConnectionAsynchronouslyAndBlockUntilConnectionRequested(pool, createDefaultServerConfig(1));
+
+    pool.destroy();
+
+    request.getRight().setBlocking(false);
+    assertThrows(AssertionException.class, request.getLeft()::awaitDoneAndGet);
+  }
+
+  /**
+   * Lease a connection asynchronously and block until a connection is requested (actually
+   * {@link SmtpHelper#createSession(SmtpServerConfig)} is called).
+   */
+  protected Pair<IFuture<SmtpConnectionPoolEntry>, IBlockingCondition> leaseConnectionAsynchronouslyAndBlockUntilConnectionRequested(SmtpConnectionPool pool, SmtpServerConfig config) {
+    IBlockingCondition connectionRequestedBlockingCondition = Jobs.newBlockingCondition(true);
+    IBlockingCondition connectionRequestWaitBlockingCondition = Jobs.newBlockingCondition(true);
+
+    doAnswer((inv) -> {
+      connectionRequestedBlockingCondition.setBlocking(false);
+      connectionRequestWaitBlockingCondition.waitFor();
+      return mock(Session.class);
+    }).when(m_mockSmtpHelper).createSession(any());
+
+    IFuture<SmtpConnectionPoolEntry> future = Jobs.getJobManager().schedule(() -> {
+      SmtpConnectionPoolEntry entry = pool.leaseConnection(config);
+      assertNotNull(entry);
+      return entry;
+    }, Jobs.newInput());
+    connectionRequestedBlockingCondition.waitFor();
+
+    return new ImmutablePair<>(future, connectionRequestWaitBlockingCondition);
+  }
+
+  protected void assertPoolCount(SmtpConnectionPool pool, int leaseCount, int idleCount, int connectingCount) {
+    pool.runWithPoolLock(() -> {
+      assertEquals(leaseCount, pool.m_leasedEntries.size());
+      assertEquals(idleCount, pool.m_idleEntries.size());
+      int currentlyConnecting = pool.m_currentlyConnectingCounter.values().stream().mapToInt(Integer::intValue).sum();
+      assertEquals(connectingCount, currentlyConnecting);
+      if (currentlyConnecting == 0) {
+        assertTrue(pool.m_currentlyConnectingCounter.isEmpty());
+      }
+    });
+  }
+
+  protected SmtpServerConfig createDefaultServerConfig() {
+    int poolSize = 2;
+    return createDefaultServerConfig(poolSize);
+  }
+
+  protected SmtpServerConfig createDefaultServerConfig(int poolSize) {
+    return BEANS.get(SmtpServerConfig.class)
+        .withPoolSize(poolSize);
+  }
+
+  protected SmtpConnectionPool createDefaultSmtpConnectionPool() {
+    SmtpConnectionPool pool = new SmtpConnectionPool() {
+      @Override
+      protected void startCloseIdleConnectionsJob() {
+        // nop: do nothing during tests
+      }
+    };
+    pool.init();
+    return pool;
+  }
+}

--- a/org.eclipse.scout.rt.mail.test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/org.eclipse.scout.rt.mail.test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/smtp/SmtpConnectionPool.java
+++ b/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/smtp/SmtpConnectionPool.java
@@ -1,22 +1,32 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.mail.smtp;
 
+import static org.eclipse.scout.rt.platform.util.Assertions.*;
+
 import java.net.SocketException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -37,7 +47,7 @@ import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.job.FixedDelayScheduleBuilder;
 import org.eclipse.scout.rt.platform.job.Jobs;
-import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.concurrent.IRunnable;
 import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruptedError;
 import org.eclipse.scout.rt.platform.util.date.IDateProvider;
 import org.slf4j.Logger;
@@ -90,11 +100,50 @@ public class SmtpConnectionPool {
 
   protected static final String JOB_NAME_CLOSE_IDLE_CONNECTIONS = "smtp-close-idle-connections";
 
-  protected final Object m_poolLock = new Object();
+  /**
+   * Use {@link ReentrantLock} for synchronisation as monitor as it signals waiting threads in FIFO order (threads may
+   * wait if no connection is available), see {@link ReentrantLock#newCondition()}
+   */
+  protected final ReentrantLock m_poolLock = new ReentrantLock();
+
+  /**
+   * Only use synchronized within {@link #runWithPoolLock(IRunnable)} or {@link #callWithPoolLock(Callable)} otherwise
+   * multiple threads may access non thread-safe set at the same point of time.
+   */
   protected final Set<SmtpConnectionPoolEntry> m_idleEntries = new HashSet<>();
+
+  /**
+   * Only use synchronized within {@link #runWithPoolLock(IRunnable)} or {@link #callWithPoolLock(Callable)} otherwise
+   * multiple threads may access non thread-safe set at the same point of time.
+   */
   protected final Set<SmtpConnectionPoolEntry> m_leasedEntries = new HashSet<>();
-  protected final String m_jobExecutionHint = "smtp-connection-pool." + UUID.randomUUID().toString();
+  protected final String m_jobExecutionHint = "smtp-connection-pool." + UUID.randomUUID();
+
+  /**
+   * Only use synchronized within {@link #runWithPoolLock(IRunnable)} or {@link #callWithPoolLock(Callable)} otherwise
+   * multiple threads may access non thread-safe variable at the same point of time.
+   */
   protected long m_lastPoolEntryNo = 0;
+
+  /**
+   * This {@link Map} describes how many connections for the specific configuration are currently in the process of
+   * being established (these numbers count towards the pool size limit); before a connection is being established the
+   * number is increased by one; after successful/unsuccessful (in any case) it must be decreased again.
+   * <p>
+   * Only use synchronized within {@link #runWithPoolLock(IRunnable)} or {@link #callWithPoolLock(Callable)} otherwise
+   * multiple threads may access non thread-safe map at the same point of time.
+   * </p>
+   */
+  protected final Map<SmtpServerConfig, Integer> m_currentlyConnectingCounter = new HashMap<>();
+
+  /**
+   * Track {@link Condition}s per {@link SmtpServerConfig} for waiting threads.
+   * <p>
+   * Only use synchronized within {@link #runWithPoolLock(IRunnable)} or {@link #callWithPoolLock(Callable)} otherwise
+   * multiple threads may access non thread-safe set at the same point of time.
+   * </p>
+   */
+  protected final Map<SmtpServerConfig, Condition> m_conditionMap = new HashMap<>();
 
   protected long m_maxIdleTime;
   protected long m_maxConnectionLifetime;
@@ -106,7 +155,7 @@ public class SmtpConnectionPool {
   protected void init() {
     m_maxIdleTime = CONFIG.getPropertyValue(SmtpPoolMaxIdleTimeProperty.class) * 1000;
     m_maxConnectionLifetime = CONFIG.getPropertyValue(SmtpPoolMaxConnectionLifetimeProperty.class) * 1000;
-    m_waitForConnectionTimeout = CONFIG.getPropertyValue(SmtpPoolWaitForConnectionTimeoutProperty.class) * 1000;
+    m_waitForConnectionTimeout = CONFIG.getPropertyValue(SmtpPoolWaitForConnectionTimeoutProperty.class);
   }
 
   /**
@@ -157,100 +206,145 @@ public class SmtpConnectionPool {
    *          find a matching one in the pool.
    */
   protected SmtpConnectionPoolEntry leaseConnection(SmtpServerConfig smtpServerConfig) {
-    Assertions.assertGreater(smtpServerConfig.getPoolSize(), 0, "Pool size of provided SmtpServerConfig must be greater 0.");
-    synchronized (m_poolLock) {
-      Assertions.assertFalse(m_destroyed, "SmtpConnectionPool not available because it has already been destroyed.");
-      SmtpConnectionPoolEntry candidate = null;
-      while (candidate == null) {
+    assertGreater(smtpServerConfig.getPoolSize(), 0, "Pool size of provided SmtpServerConfig must be greater 0.");
+    while (true) { // loop is only repeated more than once if no idle connection has been found previously and also no new connection should be created (e.g. wait was called within loop and thread was now notified, createNewConnection in previous run was false)
+      AtomicBoolean createNewConnection = new AtomicBoolean();
+      SmtpConnectionPoolEntry candidate = callWithPoolLock(() -> {
+        checkAndThrowIfDestroyed();
         // try to find an idle connection or create a new connection if poolsize has not been reached yet.
         // candidate may be null as a result
+        SmtpConnectionPoolEntry entry = tryGetIdleConnection(smtpServerConfig);
+        if (entry != null) {
+          // we found a valid candidate. Remove it from the idle connection set, add it to the leased connection set and return it
+          m_idleEntries.remove(entry);
+          m_leasedEntries.add(entry);
+          LOG.debug("Leasing pooled idle SMTP connection {}", entry);
+          return entry;
+        }
+
+        Predicate<SmtpConnectionPoolEntry> poolFilter = getPoolFilter(smtpServerConfig);
+        // there was no idle connection so we create a new connection if the pool size has not been reached for this config
+        long idleEntryCount = m_idleEntries.stream()
+            .filter(poolFilter)
+            .count();
+        long leasedEntryCount = m_leasedEntries.stream()
+            .filter(poolFilter)
+            .count();
+        createNewConnection.set(idleEntryCount + leasedEntryCount + m_currentlyConnectingCounter.getOrDefault(smtpServerConfig, 0) < smtpServerConfig.getPoolSize());
+
+        // if we could not find an idle connection and the pool has already reached its limit in terms of connection count,
+        // we wait until someone releases a connection (@see #releaseConnection(SmtpConnectionPoolEntry))
+        if (!createNewConnection.get()) {
+          runWithConditionFor(smtpServerConfig, true, condition -> {
+            try {
+              if (m_waitForConnectionTimeout == 0) {
+                condition.await();
+              }
+              else if (m_waitForConnectionTimeout > 0 && !condition.await(m_waitForConnectionTimeout, TimeUnit.SECONDS)) {
+                // await(...) returned false, we did not get the lock and time-out has been reached
+                throw new ProcessingException("Wait for connection timeout of {}s exceeded while waiting for an SMTP connection.", m_waitForConnectionTimeout);
+              }
+            }
+            catch (InterruptedException e) {
+              runWithConditionFor(smtpServerConfig, true, Condition::signal); // InterruptedException may be thrown after this thread has awakened however there may be other waiting threads, signal them (they may not be interrupted)
+              Thread.currentThread().interrupt();
+              throw new ThreadInterruptedError("Interrupted while waiting for idle smtp connection");
+            }
+          });
+        }
+        // createNewConnection is true, reserve a spot for this thread as connection will be created outside of lock
+        else {
+          // following calls must be guarded by a try-finally block to ensure it is decremented again (also in case of exceptions)
+          incrementCurrentlyConnectingCounterSafe(smtpServerConfig);
+        }
+
+        return null;
+      });
+
+      if (candidate != null) { // safe: counter has not been incremented if null is returned, see above
+        return candidate;
+      }
+
+      if (createNewConnection.get()) { // safe: try-finally to decrement starts immediately in first line of createNewConnectionWithoutPoolLockAndLease, condition-check itself is safe as it is just a boolean check
         try {
-          candidate = tryGetIdleOrCreateNewConnection(smtpServerConfig);
+          // run outside synchronized/runWithPoolLock block as this operation may take longer (and would block whole pool, method however may use synchronisation itself)
+          candidate = createNewConnectionWithoutPoolLockAndLease(smtpServerConfig);
+          LOG.debug("Leased pooled new SMTP connection {}", candidate);
+          return candidate;
+        }
+        catch (AssertionException e) {
+          throw e; // keep AssertionException (do not catch it by catching RuntimeException)
         }
         catch (RuntimeException | MessagingException e) {
           throw new ProcessingException("MessagingException caught while trying to connect to smtp server.", e);
         }
-
-        // if we could not find an idle connection and the pool has already reached its limit in terms of connection count,
-        // we wait until someone releases a connection (@see #releaseConnection(SmtpConnectionPoolEntry))
-        if (candidate == null) {
-          try {
-            long startWaitMillis = System.currentTimeMillis();
-            m_poolLock.wait(m_waitForConnectionTimeout);
-            if (m_waitForConnectionTimeout > 0 &&
-                System.currentTimeMillis() >= startWaitMillis + m_waitForConnectionTimeout) {
-              // Object.wait(long) does not indicate why it returned (some form of notify called or timeout).
-              // So we check, if the current time is greater or equal our recorded starttime plus the configured
-              // wait for connection timeout and then assume, that we have been woken up by the timeout.
-              throw new ProcessingException("Wait for connection timeout of {}ms exceeded while waiting for an SMTP connection.", m_waitForConnectionTimeout);
-            }
-          }
-          catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new ThreadInterruptedError("Interrupted while waiting for idle smtp connection");
-          }
-        }
       }
-      // we found a valid candidate. Remove it from the idle connection set, add it to the leased connection set and return it
-      m_idleEntries.remove(candidate);
-      m_leasedEntries.add(candidate);
-      LOG.debug("Leasing pooled SMTP connection {}", candidate);
-      return candidate;
     }
   }
 
-  protected SmtpConnectionPoolEntry tryGetIdleOrCreateNewConnection(SmtpServerConfig smtpServerConfig) throws MessagingException {
-    Assertions.assertGreater(smtpServerConfig.getPoolSize(), 0, "Invalid pool size '{}'; must be greater 0", smtpServerConfig.getPoolSize());
-    synchronized (m_poolLock) {
+  protected int incrementCurrentlyConnectingCounterSafe(SmtpServerConfig smtpServerConfig) {
+    return callWithPoolLock(() -> m_currentlyConnectingCounter.compute(smtpServerConfig, (k, v) -> v == null ? 1 : (v + 1))); // increment
+  }
+
+  protected void decrementCurrentlyConnectingCounterSafe(SmtpServerConfig smtpServerConfig) {
+    runWithPoolLock(() -> {
+      m_currentlyConnectingCounter.compute(smtpServerConfig, (k, v) -> v == 1 ? null : (v - 1)); // decrement (remove if 0)
+      runWithConditionFor(smtpServerConfig, true, Condition::signal);
+    });
+  }
+
+  protected SmtpConnectionPoolEntry tryGetIdleConnection(SmtpServerConfig smtpServerConfig) {
+    assertGreater(smtpServerConfig.getPoolSize(), 0, "Invalid pool size '{}'; must be greater 0", smtpServerConfig.getPoolSize());
+    return callWithPoolLock(() -> {
       Predicate<SmtpConnectionPoolEntry> poolFilter = getPoolFilter(smtpServerConfig);
-      SmtpConnectionPoolEntry candidate = null;
-      candidate = m_idleEntries.stream()
+      return m_idleEntries.stream()
           .filter(poolFilter)
-          .sorted((pe1, pe2) -> {
+          .min((pe1, pe2) -> {
             // sort ascending by create time to favor younger connections when picking from the pool
             // as a result, older connections (which are less likely to be picked) are thus more likely to reach max idle time and are collected.
             return (int) (pe1.getCreateTime() - pe2.getCreateTime());
           })
-          .findFirst()
           .orElse(null);
-
-      if (candidate != null) {
-        return candidate;
-      }
-
-      return createNewConnection(smtpServerConfig);
-    }
+    });
   }
 
-  protected SmtpConnectionPoolEntry createNewConnection(SmtpServerConfig smtpServerConfig) throws MessagingException {
-    synchronized (m_poolLock) {
-      Predicate<SmtpConnectionPoolEntry> poolFilter = getPoolFilter(smtpServerConfig);
-      boolean firstConnection = m_idleEntries.isEmpty() && m_leasedEntries.isEmpty();
-      // there was no idle connection so we create a new connection if the pool size has not been reached for this config
-      long idleEntryCount = m_idleEntries.stream()
-          .filter(poolFilter)
-          .count();
-      long leasedEntryCount = m_leasedEntries.stream()
-          .filter(poolFilter)
-          .count();
-      SmtpConnectionPoolEntry poolEntry = null;
+  /**
+   * Creating a connection may take a while (network operations), consider running it outside synchronization (use
+   * {@link #m_currentlyConnectingCounter} to keep track of how many connections are currently being created).
+   * <p>
+   * This method will use a short runWithPoolLock block on itself after connection has been created to check whether
+   * pool has been destroyed in the meantime (in this case connection is closed again and exception is thrown), add
+   * connection to {@link #m_leasedEntries} and {@link #startCloseIdleConnectionsJob()} if its the first connection of
+   * this pool.
+   * </p>
+   */
+  protected SmtpConnectionPoolEntry createNewConnectionWithoutPoolLockAndLease(SmtpServerConfig smtpServerConfig) throws MessagingException {
+    try {
+      SmtpHelper smtpHelper = BEANS.get(SmtpHelper.class);
+      Session session = smtpHelper.createSession(smtpServerConfig);
+      @SuppressWarnings("resource") // suppress warning about resource leak, we are managing transports ourselves
+      Transport transport = session.getTransport();
+      smtpHelper.connect(session, transport, smtpServerConfig.getPassword());
+      IDateProvider dateProvider = BEANS.get(IDateProvider.class);
+      SmtpConnectionPoolEntry poolEntry = BEANS.get(SmtpConnectionPoolEntry.class)
+          .withName(getNextPoolEntryName())
+          .withSmtpServerConfig(smtpServerConfig)
+          .withSession(session)
+          .withTransport(transport)
+          .withCreateTime(dateProvider.currentMillis().getTime())
+          .withIdleSince(dateProvider.currentMillis().getTime());
 
-      if (idleEntryCount + leasedEntryCount < smtpServerConfig.getPoolSize()) {
-        Session session = BEANS.get(SmtpHelper.class).createSession(smtpServerConfig);
-        @SuppressWarnings("resource") // suppress warning about resource leak, we are managing transports ourselves
-        Transport transport = session.getTransport();
-        BEANS.get(SmtpHelper.class).connect(session, transport, smtpServerConfig.getPassword());
-        IDateProvider dateProvider = BEANS.get(IDateProvider.class);
-        poolEntry = BEANS.get(SmtpConnectionPoolEntry.class)
-            .withName(getNextPoolEntryName())
-            .withSmtpServerConfig(smtpServerConfig)
-            .withSession(session)
-            .withTransport(transport)
-            .withCreateTime(dateProvider.currentMillis().getTime())
-            .withIdleSince(dateProvider.currentMillis().getTime());
+      runWithPoolLock(() -> {
+        if (m_destroyed) {
+          // previously was not destroyed, now pool seems to be destroyed; safe close connection
+          safeCloseTransport(poolEntry);
+          checkAndThrowIfDestroyed();
+        }
+
+        boolean firstConnection = m_leasedEntries.isEmpty() && m_idleEntries.isEmpty();
 
         LOG.debug("Created new pooled SMTP connection {}", poolEntry);
-        m_idleEntries.add(poolEntry);
+        m_leasedEntries.add(poolEntry);
 
         if (firstConnection) {
           // if there were neither idle nor leased connections before, the first connection has just been created
@@ -258,8 +352,12 @@ public class SmtpConnectionPool {
           LOG.debug("First connection created, starting close-idle-connections job.");
           startCloseIdleConnectionsJob();
         }
-      }
+      });
+
       return poolEntry;
+    }
+    finally {
+      decrementCurrentlyConnectingCounterSafe(smtpServerConfig);
     }
   }
 
@@ -280,11 +378,14 @@ public class SmtpConnectionPool {
    * This method releases the provided {@link SmtpConnectionPoolEntry} and returns it back to the pool as idle
    * connection.<br>
    */
-  protected void releaseConnection(SmtpConnectionPoolEntry poolEntry) {
-    synchronized (m_poolLock) {
-      Assertions.assertFalse(m_destroyed, "SmtpConnectionPool not available because it has already been destroyed.");
+  protected void releaseConnection(SmtpConnectionPoolEntry poolEntry0) {
+    runWithPoolLock(() -> {
+      checkAndThrowIfDestroyed();
+
+      SmtpConnectionPoolEntry poolEntry = poolEntry0;
 
       m_leasedEntries.remove(poolEntry);
+      SmtpServerConfig config = poolEntry.m_smtpServerConfig;
 
       if (poolEntry.isFailed()) {
         LOG.debug("Releasing pooled SMTP connection {}; transport is broken, not returning to idle pool.", poolEntry);
@@ -304,8 +405,8 @@ public class SmtpConnectionPool {
           LOG.debug("Releasing pooled SMTP connection {}; {}, not returning to idle pool.", poolEntry, reuseCheckResult.getReuseDeniedReason());
         }
       }
-      m_poolLock.notifyAll();
-    }
+      runWithConditionFor(config, true, Condition::signal);
+    });
   }
 
   /**
@@ -320,18 +421,21 @@ public class SmtpConnectionPool {
    *         provided entry.
    */
   protected SmtpConnectionPoolEntry exchangeConnection(SmtpConnectionPoolEntry oldEntry) throws MessagingException {
-    synchronized (m_poolLock) {
+    SmtpServerConfig smtpServerConfig = oldEntry.getSmtpServerConfig();
+
+    runWithPoolLock(() -> {
+      checkAndThrowIfDestroyed();
 
       m_leasedEntries.remove(oldEntry);
       safeCloseTransport(oldEntry);
 
-      SmtpConnectionPoolEntry newEntry = createNewConnection(oldEntry.getSmtpServerConfig());
+      // stay in runWithPoolLock block as otherwise other threads may assume there is space for another connection as a leased one has just been removed
+      // however immediately after synchronized block ends start with a try-finally block to ensure decrement
+      incrementCurrentlyConnectingCounterSafe(smtpServerConfig);
+    });
 
-      m_idleEntries.remove(newEntry);
-      m_leasedEntries.add(newEntry);
-
-      return newEntry;
-    }
+    // run outside synchronized block as this operation may take longer (and would block whole pool), also includes try-finally block to decrement
+    return createNewConnectionWithoutPoolLockAndLease(smtpServerConfig);
   }
 
   protected P_ReuseCheckResult isReuseAllowed(SmtpConnectionPoolEntry smtpConnectionPoolEntry) {
@@ -347,9 +451,7 @@ public class SmtpConnectionPool {
   }
 
   protected String getNextPoolEntryName() {
-    synchronized (m_poolLock) {
-      return "pool-entry-" + ++m_lastPoolEntryNo;
-    }
+    return callWithPoolLock(() -> "pool-entry-" + ++m_lastPoolEntryNo);
   }
 
   protected boolean isConnectionFailure(MessagingException e) {
@@ -361,7 +463,7 @@ public class SmtpConnectionPool {
   }
 
   protected void closeIdleConnections() {
-    synchronized (m_poolLock) {
+    runWithPoolLock(() -> {
       try {
         for (Iterator<SmtpConnectionPoolEntry> it = m_idleEntries.iterator(); it.hasNext();) {
           SmtpConnectionPoolEntry idleEntry = it.next();
@@ -383,7 +485,7 @@ public class SmtpConnectionPool {
       catch (RuntimeException e) {
         LOG.warn("Caught RuntimeException while trying to close idle SMTP connections.", e);
       }
-    }
+    });
   }
 
   protected void safeCloseTransport(SmtpConnectionPoolEntry poolEntry) {
@@ -401,11 +503,8 @@ public class SmtpConnectionPool {
       return;
     }
 
-    synchronized (m_poolLock) {
-      if (m_destroyed) {
-        return;
-      }
-
+    if (m_poolLock.isHeldByCurrentThread()) {
+      // have the lock already, keep destroying
       Jobs.getJobManager().cancel(Jobs.newFutureFilterBuilder()
           .andMatchExecutionHint(m_jobExecutionHint)
           .toFilter(), true);
@@ -417,6 +516,62 @@ public class SmtpConnectionPool {
       m_idleEntries.clear();
       m_leasedEntries.clear();
       m_destroyed = true;
+    }
+    else {
+      // don't have the lock, acquire it and then destroy
+      runWithPoolLock(this::destroy);
+    }
+  }
+
+  protected void checkAndThrowIfDestroyed() {
+    callWithPoolLock(() -> assertFalse(m_destroyed, "SmtpConnectionPool not available because it has already been destroyed."));
+  }
+
+  protected void runWithConditionFor(SmtpServerConfig config, boolean optional, Consumer<Condition> conditionConsumer) {
+    runWithPoolLock(() -> {
+      try {
+        Condition condition = m_conditionMap.compute(config, (k, v) -> (v == null && !optional) ? m_poolLock.newCondition() : v);
+        if (condition == null) {
+          return;
+        }
+
+        // run the consumer
+        conditionConsumer.accept(condition);
+      }
+      finally {
+        if (m_poolLock.isHeldByCurrentThread()) {
+          // see lost lock explanation in callWithPoolLock
+          Optional.ofNullable(m_conditionMap.get(config))
+              .filter(c -> !m_poolLock.hasWaiters(c))
+              .ifPresent(c -> m_conditionMap.remove(config, c));
+        }
+      }
+    });
+  }
+
+  protected void runWithPoolLock(IRunnable runnable) {
+    callWithPoolLock(() -> {
+      runnable.run();
+      return null;
+    });
+  }
+
+  protected <T> T callWithPoolLock(Callable<T> callable) {
+    m_poolLock.lock();
+    try {
+      return callable.call();
+    }
+    catch (RuntimeException re) {
+      throw re;
+    }
+    catch (Exception e) {
+      throw new ProcessingException("Exception during callable", e);
+    }
+    finally {
+      if (m_poolLock.isHeldByCurrentThread()) {
+        // avoid lost lock, actually only case I know of then this may happen is if await exits with timeout
+        m_poolLock.unlock();
+      }
     }
   }
 

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/mock/RegisterBeanTestRule.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/mock/RegisterBeanTestRule.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.testing.platform.mock;
+
+import java.util.function.Supplier;
+
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Shortcut to replace a application scoped bean within a test.
+ */
+public class RegisterBeanTestRule<BEAN> implements TestRule {
+
+  private final Class<? super BEAN> m_beanClazz;
+  private final Supplier<BEAN> m_mockSupplier;
+
+  private IBean<?> m_temporaryBean;
+
+  public RegisterBeanTestRule(Class<? super BEAN> beanClazz, BEAN mock) {
+    this(beanClazz, () -> mock);
+  }
+
+  public RegisterBeanTestRule(Class<? super BEAN> beanClazz, Supplier<BEAN> mockSupplier) {
+    m_beanClazz = beanClazz;
+    m_mockSupplier = mockSupplier;
+  }
+
+  public void registerBean() {
+    m_temporaryBean = BeanTestingHelper.get().registerBean(
+        new BeanMetaData(m_beanClazz)
+            .withApplicationScoped(true)
+            .withInitialInstance(m_mockSupplier.get()));
+  }
+
+  public void unregisterBean() {
+    BeanTestingHelper.get().unregisterBean(m_temporaryBean);
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+
+      @Override
+      public void evaluate() throws Throwable {
+        try {
+          registerBean();
+          base.evaluate();
+        }
+        finally {
+          unregisterBean();
+        }
+      }
+    };
+  }
+}


### PR DESCRIPTION
Reason: Connection creation may take quite a while; if multiple connections are requested at the same time the connection establishment was previously run one after another; with this change multiple connections may be established at the same time (still limited by the pool size limits).

329715