### PR TITLE
Prevent focus change outside table control content on mouse down

### DIFF
--- a/eclipse-scout-core/src/focus/focusUtils.ts
+++ b/eclipse-scout-core/src/focus/focusUtils.ts
@@ -26,7 +26,7 @@ export const focusUtils = {
    */
   containsParentFocusableByMouse(element: HTMLElement | JQuery, entryPoint: JQuery): boolean {
     let $focusableParentElements = $(element)
-      .parents(':focusable')
+      .parentsUntil('.focus-boundary', ':focusable') // Stay inside focus boundaries (e.g. search forms should not consider parent table)
       .not(entryPoint) /* Exclude $entryPoint as all elements are its descendants. However, the $entryPoint is only focusable to provide Portlet support. */
       .filter(() => focusUtils.isFocusableByMouse(this));
     return $focusableParentElements.length > 0;

--- a/eclipse-scout-core/src/table/TableFooter.ts
+++ b/eclipse-scout-core/src/table/TableFooter.ts
@@ -100,7 +100,7 @@ export class TableFooter extends Widget implements TableFooterModel {
 
     // --- container for an open control ---
     this.$controlContainer = this.$container.appendDiv('table-control-container').hide();
-    this.$controlContent = this.$controlContainer.appendDiv('table-control-content');
+    this.$controlContent = this.$controlContainer.appendDiv('table-control-content focus-boundary');
 
     // --- table controls section ---
     this._$controls = this.$container.appendDiv('table-controls');

--- a/eclipse-scout-core/src/table/controls/FormTableControl.ts
+++ b/eclipse-scout-core/src/table/controls/FormTableControl.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AbstractLayout, Event, EventHandler, Form, FormTableControlEventMap, FormTableControlLayout, FormTableControlModel, GroupBox, InitModelOf, TabBox, TableControl} from '../../index';
+import {AbstractLayout, Event, EventHandler, Form, FormTableControlEventMap, FormTableControlLayout, FormTableControlModel, GroupBox, InitModelOf, ObjectOrChildModel, TabBox, TableControl} from '../../index';
 
 export class FormTableControl extends TableControl implements FormTableControlModel {
   declare model: FormTableControlModel;
@@ -67,6 +67,10 @@ export class FormTableControl extends TableControl implements FormTableControlMo
    */
   override isContentAvailable(): boolean {
     return !!this.form;
+  }
+
+  setForm(form: ObjectOrChildModel<Form>) {
+    this.setProperty('form', form);
   }
 
   protected _setForm(form: Form) {

--- a/eclipse-scout-core/src/testing/table/SpecTable.ts
+++ b/eclipse-scout-core/src/testing/table/SpecTable.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Column, DoubleClickSupport, EventListener, EventSupport, Range, Table, TableControl, TableFooter, TableRow} from '../../index';
+import {Column, DoubleClickSupport, EventListener, EventSupport, Range, Table, TableFooter, TableRow} from '../../index';
 
 export class SpecTable extends Table {
   declare _filteredRows: TableRow[];
@@ -22,10 +22,6 @@ export class SpecTable extends Table {
 
   override _calculateCurrentViewRange(): Range {
     return super._calculateCurrentViewRange();
-  }
-
-  override _setTableControls(controls: TableControl[]) {
-    super._setTableControls(controls);
   }
 
   override _calculateViewRangeForRowIndex(rowIndex: number): Range {

--- a/eclipse-scout-core/test/table/controls/AggregateTableControlSpec.ts
+++ b/eclipse-scout-core/test/table/controls/AggregateTableControlSpec.ts
@@ -71,7 +71,7 @@ describe('AggregateTableControl', () => {
         table: table
       });
       tableControl.selected = true;
-      table._setTableControls([tableControl]);
+      table.setTableControls([tableControl]);
 
       column0 = table.columns[0];
       column1 = table.columns[1] as NumberColumn;
@@ -282,7 +282,7 @@ describe('AggregateTableControl', () => {
         selected: true,
         table: table
       });
-      table._setTableControls([tableControl]);
+      table.setTableControls([tableControl]);
       table.render();
 
       expect(tableControl.enabled).toBe(false);
@@ -304,7 +304,7 @@ describe('AggregateTableControl', () => {
         selected: true,
         table: table
       });
-      table._setTableControls([tableControl]);
+      table.setTableControls([tableControl]);
       table.render();
 
       expect(tableControl.enabled).toBe(true);
@@ -326,7 +326,7 @@ describe('AggregateTableControl', () => {
         selected: false,
         table: table
       });
-      table._setTableControls([tableControl]);
+      table.setTableControls([tableControl]);
       table.render();
 
       expect(tableControl.enabled).toBe(false);

--- a/eclipse-scout-core/test/table/controls/TableControlSpec.ts
+++ b/eclipse-scout-core/test/table/controls/TableControlSpec.ts
@@ -7,8 +7,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {InitModelOf, RemoteEvent, scout, Session, TableControl, TableControlAdapter, Widget} from '../../../src/index';
-import {SpecTable, TableSpecHelper} from '../../../src/testing/index';
+import {focusUtils, FormTableControl, InitModelOf, RemoteEvent, scout, Session, TableControl, TableControlAdapter, Widget} from '../../../src/index';
+import {FormSpecHelper, SpecTable, TableSpecHelper} from '../../../src/testing/index';
 
 describe('TableControl', () => {
   let session: SandboxSession;
@@ -59,7 +59,7 @@ describe('TableControl', () => {
 
     it('opens and closes the control container', () => {
       let action = createAction(createModel());
-      table._setTableControls([action]);
+      table.setTableControls([action]);
       table.render();
       let $controlContainer = table.footer.$controlContainer;
       expect($controlContainer).toBeHidden();
@@ -75,7 +75,7 @@ describe('TableControl', () => {
     it('removes the content of the previous selected control without closing the container', () => {
       let action = createAction(createModel());
       let action2 = createAction(createModel());
-      table._setTableControls([action, action2]);
+      table.setTableControls([action, action2]);
 
       action.selected = true;
       table.render();
@@ -105,7 +105,7 @@ describe('TableControl', () => {
       let model2 = createModel();
       let adapter2 = createTableControlAdapter(model2);
       let action2 = adapter2.createWidget(model2, session.desktop) as TableControl;
-      table._setTableControls([action, action2]);
+      table.setTableControls([action, action2]);
 
       action.selected = true;
       table.render();
@@ -122,5 +122,21 @@ describe('TableControl', () => {
       ];
       expect(mostRecentJsonRequest()).toContainEvents(events);
     });
+  });
+
+  it('clicking in the control container does not focus the table', () => {
+    let table = createTable();
+    let action = scout.create(FormTableControl, {
+      parent: table,
+      selected: true
+    });
+    action.setForm(new FormSpecHelper(session).createFormWithOneField());
+    table.setTableControls([action]);
+    table.render();
+    jasmine.clock().tick(1); // Ensure animation complete function is executed (animation uses a 1ms delay)
+    expect(action.form.rootGroupBox.fields[0].isFocused()).toBeTrue();
+
+    // Focus must not leave the field when clicking outside (it cannot be simulated in a test -> test the function that causes the problem)
+    expect(focusUtils.containsParentFocusableByMouse(action.form.$container, session.desktop.$container)).toBe(false);
   });
 });


### PR DESCRIPTION
When a non-focusable element is clicked, the focus manager finds the nearest parent that is focusable and focuses it. For example, when clicking a table row, the table will receive the focus.

This logic sometimes fails. Search forms are rendered inside the table, thus clicking the "white space" on a search form (non-focusable) would cause the focus to be transferred to the table. In this case, the focus should remain on the form.

Stopping the element selector at focus boundaries like table control content fixes the issue.

333099