### PR TITLE
FormFieldTile: fix selection and border in dark mode for inverted tiles

### DIFF
--- a/eclipse-scout-core/src/index-dark.less
+++ b/eclipse-scout-core/src/index-dark.less
@@ -11,3 +11,4 @@
 @import "index";
 @import "style/colors-dark";
 @import "style/sizes-dark";
+@import "tile/fields/FormFieldTile-dark";

--- a/eclipse-scout-core/src/tile/fields/FormFieldTile-dark.less
+++ b/eclipse-scout-core/src/tile/fields/FormFieldTile-dark.less
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+.tile.dashboard {
+  &.inverted,
+  &.inverted.color-alternative {
+    #scout.double-drop-shadow(@spread1: 1px, @color1: @dashboard-tile-border-color, @y2: 0px, @blur2: 0px);
+  }
+
+  .dimmed-background &.inverted {
+    #scout.drop-shadow(@alpha: @dashboard-tile-drop-shadow-light-alpha);
+  }
+
+  &.inverted {
+    & ::-moz-selection {
+      #scout.text-selection();
+    }
+
+    & ::selection {
+      #scout.text-selection();
+    }
+  }
+}

--- a/eclipse-scout-core/src/tile/fields/FormFieldTile.less
+++ b/eclipse-scout-core/src/tile/fields/FormFieldTile.less
@@ -181,6 +181,22 @@
 
     &.disabled:not(.read-only) {
       --tile-background-color: @tile-default-border-color;
+
+      & ::-moz-selection {
+        #scout.text-selection();
+      }
+
+      & ::selection {
+        #scout.text-selection();
+      }
+    }
+
+    & ::-moz-selection {
+      background: darken(@text-selection-background-color, 10);
+    }
+
+    & ::selection {
+      background: darken(@text-selection-background-color, 10);
     }
 
     & > .form-field {
@@ -289,6 +305,14 @@
 
     &.disabled:not(.read-only) {
       --tile-background-color: @tile-default-border-color;
+    }
+
+    & ::-moz-selection {
+      #scout.text-selection();
+    }
+
+    & ::selection {
+      #scout.text-selection();
     }
 
     & > .form-field {


### PR DESCRIPTION
The background color of inverted tiles is the same as the standard selection color. Therefore, darken the selection color for these tiles in order to make text selection visible.
Fix borders for inverted tiles in dark mode.

338767