### PR TITLE
Desktop: adjust order of overlays when parent is no longer in foreground

### DIFF
--- a/eclipse-scout-core/src/datepicker/DatePickerPopup.js
+++ b/eclipse-scout-core/src/datepicker/DatePickerPopup.js
@@ -40,6 +40,7 @@ export default class DatePickerPopup extends Popup {
     this.htmlComp = HtmlComponent.install(this.$container, this.session);
     this.htmlComp.setLayout(this._createLayout());
     this.htmlComp.validateRoot = true;
+    this.findDesktop().adjustOverlayOrder(this);
     this.picker.render();
   }
 

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldPopup.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldPopup.js
@@ -51,6 +51,7 @@ export default class SmartFieldPopup extends Popup {
       .addClass(cssClass)
       .on('mousedown', this._onContainerMouseDown.bind(this));
     this.$container.toggleClass('alternative', this.smartField.fieldStyle === FormField.FieldStyle.ALTERNATIVE);
+    this.findDesktop().adjustOverlayOrder(this);
     this.proposalChooser.render();
   }
 

--- a/eclipse-scout-core/src/form/fields/tagfield/TagChooserPopup.js
+++ b/eclipse-scout-core/src/form/fields/tagfield/TagChooserPopup.js
@@ -54,6 +54,7 @@ export default class TagChooserPopup extends Popup {
     this.$container
       .addClass('tag-chooser-popup')
       .on('mousedown', this._onContainerMouseDown.bind(this));
+    this.findDesktop().adjustOverlayOrder(this);
     this._renderTable();
   }
 

--- a/eclipse-scout-core/src/timepicker/TimePickerPopup.js
+++ b/eclipse-scout-core/src/timepicker/TimePickerPopup.js
@@ -39,6 +39,7 @@ export default class TimePickerPopup extends Popup {
     this.htmlComp = HtmlComponent.install(this.$container, this.session);
     this.htmlComp.setLayout(this._createLayout());
     this.htmlComp.validateRoot = true;
+    this.findDesktop().adjustOverlayOrder(this);
     this.picker.render();
   }
 

--- a/eclipse-scout-core/src/tooltip/Tooltip.js
+++ b/eclipse-scout-core/src/tooltip/Tooltip.js
@@ -64,7 +64,7 @@ export default class Tooltip extends Widget {
     this.$container = this.$parent
       .appendDiv('tooltip')
       .data('tooltip', this);
-
+    this.findDesktop().adjustOverlayOrder(this);
     if (this.cssClass) {
       this.$container.addClass(this.cssClass);
     }
@@ -92,15 +92,7 @@ export default class Tooltip extends Widget {
     }
 
     // If the tooltip is rendered inside a (popup) dialog, get a reference to the dialog.
-    this.dialog = null;
-    let parent = this.parent;
-    while (parent) {
-      if (parent instanceof Form && parent.isDialog()) {
-        this.dialog = parent;
-        break;
-      }
-      parent = parent.parent;
-    }
+    this.dialog = this.findParent(p => p instanceof Form && p.isDialog());
 
     // If inside a dialog, attach a listener to reposition the tooltip when the dialog is moved
     if (this.dialog) {


### PR DESCRIPTION
- Prevent tooltips and popups from being rendered in front if its parent is no longer in foreground. This can happen if they are opened after an asynchronous process has been completed and the user switched to another non-modal dialog in the meantime.
- Overlays are always added to their "overlay context" (e.g. parent dialog or popup). Tooltips are rendered before other overlay types.

249643
252279
275990