### PR TITLE
ServletFilter: GzipServletFilter runs into OOM errors

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/filter/gzip/GzipServletOutputStream.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/filter/gzip/GzipServletOutputStream.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.commons.servlet.filter.gzip;
+
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.scout.rt.platform.util.Assertions;
+
+public class GzipServletOutputStream extends ServletOutputStream {
+
+  private final HttpServletResponse m_response;
+  private final ServletOutputStream m_servletOutputStream;
+
+  private GZIPOutputStream m_gzipOutputStream;
+  private byte[] m_buf;
+  private int m_bufCount = 0;
+
+  private volatile Object m_writeListener;
+
+  public GzipServletOutputStream(int compressThreshold, HttpServletResponse response) throws IOException {
+    super();
+    m_response = response;
+    m_servletOutputStream = response.getOutputStream();
+    m_buf = createBuffer(compressThreshold);
+  }
+
+  protected byte[] createBuffer(int size) {
+    return new byte[size];
+  }
+
+  @Override
+  public boolean isReady() {
+    return true;
+  }
+
+  @Override
+  public void setWriteListener(WriteListener writeListener) {
+    m_writeListener = Assertions.assertNotNull(writeListener);
+    try {
+      writeListener.onWritePossible();
+    }
+    catch (IOException e) {
+      writeListener.onError(e);
+    }
+  }
+
+  protected GZIPOutputStream ensureGzipOutStream() throws IOException {
+    if (m_gzipOutputStream == null) {
+      m_response.addHeader(GzipServletFilter.CONTENT_ENCODING, GzipServletFilter.GZIP);
+      m_gzipOutputStream = new GZIPOutputStream(m_servletOutputStream);
+    }
+    return m_gzipOutputStream;
+  }
+
+  protected void flushBufferToGzipOutputStream() throws IOException {
+    if (m_bufCount == 0) {
+      return;
+    }
+    writeToGzipOutputStream(m_buf, 0, m_bufCount);
+    m_bufCount = 0;
+  }
+
+  protected void writeToGzipOutputStream(byte[] buffer, int off, int len) throws IOException {
+    //noinspection resource
+    ensureGzipOutStream().write(buffer, off, len);
+  }
+
+  protected boolean fitsIntoBuffer(int len) {
+    return (m_buf.length - m_bufCount) >= len;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    if (m_gzipOutputStream == null && fitsIntoBuffer(1)) {
+      m_buf[m_bufCount] = (byte) b;
+      ++m_bufCount;
+      return;
+    }
+
+    try {
+      flushBufferToGzipOutputStream();
+      writeToGzipOutputStream(new byte[]{(byte) b}, 0, 1);
+    }
+    catch (IOException e) {
+      WriteListener listener = (WriteListener) m_writeListener;
+      if (listener != null) {
+        listener.onError(e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    write(b, 0, b.length);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    if (m_gzipOutputStream == null && fitsIntoBuffer(len)) { // enough space in buffer
+      System.arraycopy(b, off, m_buf, m_bufCount, len);
+      m_bufCount += len;
+      return;
+    }
+
+    try {
+      flushBufferToGzipOutputStream();
+      writeToGzipOutputStream(b, off, len);
+    }
+    catch (IOException e) {
+      WriteListener listener = (WriteListener) m_writeListener;
+      if (listener != null) {
+        listener.onError(e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (m_gzipOutputStream != null) {
+      m_gzipOutputStream.close();
+      m_gzipOutputStream = null;
+    }
+    else if (m_bufCount > 0) {
+      m_servletOutputStream.write(m_buf, 0, m_bufCount);
+      m_bufCount = 0;
+    }
+  }
+
+  /*
+   * In case where  m_gzipOutputStream is null and m_bufCount contains some written data, calling this method will not
+   * flush the data to the output stream. Data located in the memory buffer will be written to the output stream when
+   * close is called.
+   */
+  @Override
+  public void flush() throws IOException {
+    if (m_gzipOutputStream != null) {
+      m_gzipOutputStream.flush();
+    }
+  }
+}

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/filter/gzip/LegacyGzipServletFilter.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/filter/gzip/LegacyGzipServletFilter.java
@@ -10,7 +10,6 @@
 package org.eclipse.scout.rt.server.commons.servlet.filter.gzip;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Set;
 
 import javax.servlet.Filter;
@@ -25,38 +24,40 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.server.commons.servlet.UrlHints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Supports the following servlet init-params:
  * <ul>
- * <li><b>min_size:</b> minimum size in bytes that is compressed for GET or POST requests (default value =
+ * <li><b>get_min_size:</b> minimum size in bytes that is compressed for GET requests (default value = <code>256</code>)
+ * <li><b>post_min_size:</b> minimum size in bytes that is compressed for POST requests (default value =
  * <code>256</code>)
- * <li><b>content_types:</b> list of content types of the response that will be compressed (default value =
- * <code>text/html,text/css,text/xml,text/plain,application/json,application/javascript,image/svg+xml,text/vcard</code>)
- * <li><b>enable_empty_content_type_logging:</b> enables logging of empty content type of the response. (default value =
- * <code>true</code>)
+ * <li><b>get_pattern:</b> regex of pathInfo that is compressed for GET requests (default value =
+ * <code>.*\.(html|css|js|json|txt)</code>)
+ * <li><b>post_pattern:</b> regex of pathInfo that is compressed for POST requests (default value =
+ * <code>.{@literal *}/json</code>)
  * </ul>
  */
-public class GzipServletFilter implements Filter {
-  private static final Logger LOG = LoggerFactory.getLogger(GzipServletFilter.class);
+public class LegacyGzipServletFilter implements Filter {
+  private static final Logger LOG = LoggerFactory.getLogger(LegacyGzipServletFilter.class);
 
   public static final String ACCEPT_ENCODING = "Accept-Encoding";
   public static final String CONTENT_ENCODING = "Content-Encoding";
   public static final String GZIP = "gzip";
   public static final String CONTENT_TYPES = "text/html,text/css,text/xml,text/plain,application/json,application/javascript,image/svg+xml,text/vcard";
 
-  private int m_minSize;
+  private int m_getMinSize;
+  private int m_postMinSize;
   private Set<String> m_contentTypes;
-  private boolean m_enableEmptyContentTypeLogging;
 
   @Override
   public void init(FilterConfig config) throws ServletException {
     // read config
-    m_minSize = Integer.parseInt(ObjectUtility.nvl(config.getInitParameter("min_size"), "256"));
+    m_getMinSize = Integer.parseInt(ObjectUtility.nvl(config.getInitParameter("get_min_size"), "256"));
+    m_postMinSize = Integer.parseInt(ObjectUtility.nvl(config.getInitParameter("post_min_size"), "256"));
     m_contentTypes = CollectionUtility.hashSet(StringUtility.split(ObjectUtility.nvl(config.getInitParameter("content_types"), CONTENT_TYPES), ","));
-    m_enableEmptyContentTypeLogging = Boolean.parseBoolean(ObjectUtility.nvl(config.getInitParameter("enable_empty_content_type_logging"), "true"));
   }
 
   @Override
@@ -75,16 +76,27 @@ public class GzipServletFilter implements Filter {
             req.getPathInfo());
       }
     }
-
-    if (m_minSize >= 0 && requestAcceptsGzipEncoding(req)) {
-      resp = new GzipServletResponseWrapper(resp, req, m_minSize, Collections.unmodifiableSet(m_contentTypes), m_enableEmptyContentTypeLogging);
+    if (requestAcceptsGzipEncoding(req)) {
+      resp = new LegacyGzipServletResponseWrapper(resp);
     }
 
     chain.doFilter(req, resp);
 
-    if (resp instanceof GzipServletResponseWrapper) {
-      GzipServletResponseWrapper gzipResp = (GzipServletResponseWrapper) resp;
-      gzipResp.finish();
+    if (resp instanceof LegacyGzipServletResponseWrapper) {
+      LegacyGzipServletResponseWrapper gzipResp = (LegacyGzipServletResponseWrapper) resp;
+      int minLength = minimumLengthToCompress(req);
+      if (!responseNeedsGzipEncoding(req, resp)) {
+        // Disable compression
+        minLength = -1;
+      }
+      boolean compressed = gzipResp.finish(minLength);
+      if (compressed && LOG.isDebugEnabled()) {
+        LOG.debug("GZIP response[size {}%, uncompressed: {}, compressed: {}]: {}",
+            gzipResp.getCompressedLength() * 100 / gzipResp.getUncompressedLength(),
+            gzipResp.getUncompressedLength(),
+            gzipResp.getCompressedLength(),
+            req.getPathInfo());
+      }
     }
   }
 
@@ -96,6 +108,32 @@ public class GzipServletFilter implements Filter {
   protected boolean requestAcceptsGzipEncoding(HttpServletRequest req) {
     String h = req.getHeader(ACCEPT_ENCODING);
     return h != null && h.contains(GZIP);
+  }
+
+  protected boolean responseNeedsGzipEncoding(HttpServletRequest req, HttpServletResponse resp) {
+    if (!UrlHints.isCompressHint(req)) {
+      return false;
+    }
+    String contentType = resp.getContentType();
+    if (contentType == null) {
+      return false;
+    }
+    // Content type may contain the charset parameter separated by ; -> remove it
+    contentType = contentType.split(";")[0];
+    if (m_contentTypes.contains(contentType)) {
+      return true;
+    }
+    return false;
+  }
+
+  protected int minimumLengthToCompress(HttpServletRequest req) {
+    if ("GET".equals(req.getMethod())) {
+      return m_getMinSize;
+    }
+    if ("POST".equals(req.getMethod())) {
+      return m_postMinSize;
+    }
+    return -1;
   }
 
   @Override

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/filter/gzip/LegacyGzipServletResponseWrapper.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/filter/gzip/LegacyGzipServletResponseWrapper.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.commons.servlet.filter.gzip;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import org.eclipse.scout.rt.platform.util.IOUtility;
+import org.eclipse.scout.rt.server.commons.BufferedServletOutputStream;
+
+public class LegacyGzipServletResponseWrapper extends HttpServletResponseWrapper {
+
+  private BufferedServletOutputStream m_buf;
+  private int m_compressedLength = -1;
+  private int m_uncompressedLength = -1;
+  // one of these two is used
+  private ServletOutputStream m_servletOut;
+  private PrintWriter m_writer;
+
+  public LegacyGzipServletResponseWrapper(HttpServletResponse resp) {
+    super(resp);
+  }
+
+  protected BufferedServletOutputStream ensureBufferedStream() {
+    if (m_buf == null) {
+      m_buf = new BufferedServletOutputStream();
+    }
+    return m_buf;
+  }
+
+  /**
+   * only valid after {@link #finish(int)} was called
+   */
+  public int getCompressedLength() {
+    return m_compressedLength;
+  }
+
+  /**
+   * only valid after {@link #finish(int)} was called
+   */
+  public int getUncompressedLength() {
+    return m_uncompressedLength;
+  }
+
+  @Override
+  public ServletOutputStream getOutputStream() throws IOException {
+    if (m_writer != null) {
+      throw new IllegalStateException("getWriter was previsouly called, getOutputStream is not available");
+    }
+    if (m_servletOut == null) {
+      m_servletOut = ensureBufferedStream();
+    }
+    return m_servletOut;
+  }
+
+  @Override
+  public PrintWriter getWriter() throws IOException {
+    if (m_servletOut != null) {
+      throw new IllegalStateException("getOutputStream was previsouly called, getWriter is not available");
+    }
+    if (m_writer == null) {
+      m_writer = new PrintWriter(new OutputStreamWriter(ensureBufferedStream(), getResponse().getCharacterEncoding()));
+    }
+    return m_writer;
+  }
+
+  @Override
+  public void setContentLength(int len) {
+    // ignored
+  }
+
+  @Override
+  public void flushBuffer() throws IOException {
+    if (m_writer != null) {
+      m_writer.flush();
+    }
+    if (m_buf != null) {
+      m_buf.flush();
+    }
+    super.flushBuffer();
+  }
+
+  /**
+   * @param minimumLengthToCompress
+   *          is the minimum uncompressed size that is compressed, -1 disables compression
+   * @return true if the content was compressed
+   */
+  public boolean finish(int minimumLengthToCompress) throws IOException {
+    if (m_writer != null) {
+      m_writer.close();
+      m_writer = null;
+    }
+    boolean compressed = false;
+    if (m_buf != null) {
+      m_buf.close();
+      byte[] raw = m_buf.getContent();
+      m_uncompressedLength = raw.length;
+      m_buf = null;
+
+      HttpServletResponse res = (HttpServletResponse) getResponse();
+      byte[] gzipped;
+      if (minimumLengthToCompress >= 0 && m_uncompressedLength >= minimumLengthToCompress) {
+        gzipped = IOUtility.compressGzip(raw);
+        res.addHeader(GzipServletFilter.CONTENT_ENCODING, GzipServletFilter.GZIP);
+        compressed = true;
+      }
+      else {
+        gzipped = raw;
+      }
+      m_compressedLength = gzipped.length;
+      raw = null;
+      res.setContentLength(gzipped.length);
+      res.getOutputStream().write(gzipped);
+      super.flushBuffer();
+    }
+    return compressed;
+  }
+}


### PR DESCRIPTION
The current GzipServletFilter can run into OOM errors when large files are transferred. The GzipServletResponseWrapper uses a BufferedServletOutputStream that holds the large to be transferred file in memory. The content of the file will be zipped if the content type corresponds to a given content type list and if a certain size threshold is reached.

Solution: The new implementation uses an underlying GzipOutStream if a certain file size threshold is reached. In case where the file content is not zipped, the default output stream of the response is used.

Remark: The old implementation of the servlet filter and response wrappper are renamed to LegacyGzipServletFilter and LegacyGzipServletResponseWrapper and will be removed in a further Scout version.

339465