### PR TITLE
Support unzipping of filenames encoded in Cp437

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/IOUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/IOUtility.java
@@ -40,6 +40,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -289,6 +290,9 @@ public final class IOUtility {
   /**
    * Unzips the given ZIP archive as a collection of BinaryResources. Unzipping happens in-memory, no files are written.
    * The optional parameter <code>entryNameFilterPattern</code> allows to filter the ZIP for matching file entries.
+   * Unzipping will be performed with the UTF-8 charset. If this fails, unzipping with the legacy charset Cp437 will
+   * performed. If this fails again or Cp437 is not supported by the JVM used, an <code>IllegalArgumentException</code>
+   * is thrown.
    *
    * @return A collection of binary resources contained in the ZIP archive
    * @param zipArchive
@@ -297,7 +301,34 @@ public final class IOUtility {
    *          optional filter, may be null
    */
   public static Collection<BinaryResource> unzip(byte[] zipArchive, Pattern filterPattern) throws IOException {
-    try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipArchive))) {
+    try {
+      return unzip(zipArchive, filterPattern, StandardCharsets.UTF_8);
+    }
+    catch (IllegalArgumentException e) {
+      Charset charset;
+      try {
+        charset = Charset.forName("Cp437");
+      }
+      catch (UnsupportedCharsetException charsetException) { // NOSONAR
+        throw e;
+      }
+      return unzip(zipArchive, filterPattern, charset);
+    }
+  }
+
+  /**
+   * Unzips the given ZIP archive as a collection of BinaryResources. Unzipping happens in-memory, no files are written.
+   * The optional parameter <code>entryNameFilterPattern</code> allows to filter the ZIP for matching file entries.
+   *
+   * @return A collection of binary resources contained in the ZIP archive
+   * @param zipArchive
+   * @param charset
+   *          the charset to use for the unzipping
+   * @param filterPattern
+   *          optional filter, may be null
+   */
+  public static Collection<BinaryResource> unzip(byte[] zipArchive, Pattern filterPattern, Charset charset) throws IOException {
+    try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipArchive), charset)) {
       List<BinaryResource> list = new ArrayList<>();
       ZipEntry entry;
       while ((entry = zis.getNextEntry()) != null) {


### PR DESCRIPTION
Zipping a file in windows or with 7-Zip (without the cu parameter) will encode the filenames in charset Cp437. If one filename contains a special character (ex. ä,ö,ü), an unzipping operation must be done with the same charset or it will fail with an IllegalArgumentException. As this case may likely happen when zip files from users shall be unzipped, the default unzipping function has been extended.

If the unzipping function with charset UTF-8 fails with an IllegalArgumentException, the exception is catched and an unzipping with charset Cp437 will be performed. If this fails as well or Cp437 is not supported by the JVM, an IllegalArgumentException is thrown.

283162

Signed-off-by: Cyrill Wyss <cyrill.wyss@bsi-software.com>
Change-Id: I1998cdb0b20eda204664776edf4959ce03e019f6 Reviewed-on: https://git.eclipse.org/r/c/scout/org.eclipse.scout.rt/+/174372
Reviewed-by: Andre Wegmueller <awe@bsiag.com>
Tested-by: Scout Bot <scout-bot@eclipse.org>
(cherry picked from commit a1a12081212e02c7c6de265945f407e89877df08)
Reviewed-on: https://git.eclipse.org/r/c/scout/org.eclipse.scout.rt/+/179026