### PR TITLE
DoEntitySerializerAttributeNameComparator not @ApplicationScoped

### DIFF
--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializerAttributeNameComparatorTest.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializerAttributeNameComparatorTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -13,6 +13,7 @@ package org.eclipse.scout.rt.jackson.dataobject;
 import static org.junit.Assert.*;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.junit.Test;
 
 /**
@@ -28,6 +29,7 @@ public class DoEntitySerializerAttributeNameComparatorTest {
     DoEntitySerializerAttributeNameComparator comparator = BEANS.get(DoEntitySerializerAttributeNameComparator.class).init(context);
 
     // Equality
+    //noinspection EqualsWithItself
     assertEquals(0, comparator.compare("alfa", "alfa"));
     assertEquals(0, comparator.compare(context.getTypeAttributeName(), context.getTypeAttributeName()));
     assertEquals(0, comparator.compare(context.getTypeVersionAttributeName(), context.getTypeVersionAttributeName()));
@@ -41,5 +43,30 @@ public class DoEntitySerializerAttributeNameComparatorTest {
     assertTrue(comparator.compare(context.getTypeAttributeName(), context.getTypeVersionAttributeName()) < 0);
     assertTrue(comparator.compare(context.getTypeVersionAttributeName(), "alfa") < 0);
     assertTrue(comparator.compare("alfa", context.getContributionsAttributeName()) < 0);
+  }
+
+  @Test
+  public void testInitMayBeCalledOnlyOnce() {
+    ScoutDataObjectModuleContext context1 = BEANS.get(ScoutDataObjectModule.class).getModuleContext();
+    ScoutDataObjectModuleContext context2 = BEANS.get(ScoutDataObjectModule.class).getModuleContext();
+    DoEntitySerializerAttributeNameComparator comparator = BEANS.get(DoEntitySerializerAttributeNameComparator.class)
+        .init(context1);
+    assertThrows(AssertionException.class, () -> comparator.init(context2));
+  }
+
+  @Test
+  public void testDifferentConfigurations() {
+    ScoutDataObjectModuleContext contextWithDefaultConfig = BEANS.get(ScoutDataObjectModule.class).getModuleContext();
+    ScoutDataObjectModuleContext contextWithCustomTypeAttributeName = BEANS.get(ScoutDataObjectModule.class).getModuleContext()
+        .withTypeAttributeName("foo");
+
+    DoEntitySerializerAttributeNameComparator comparatorForDefaultConfig = BEANS.get(DoEntitySerializerAttributeNameComparator.class)
+        .init(contextWithDefaultConfig);
+    DoEntitySerializerAttributeNameComparator comparatorForCustomTypeAttributeName = BEANS.get(DoEntitySerializerAttributeNameComparator.class)
+        .init(contextWithCustomTypeAttributeName);
+
+    assertTrue(comparatorForDefaultConfig.compare("bar", "foo") < 0);
+    assertTrue(comparatorForCustomTypeAttributeName.compare("bar", "foo") > 0);
+    assertTrue(comparatorForCustomTypeAttributeName.compare("bar", "fun") < 0);
   }
 }

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -25,7 +25,6 @@ import org.eclipse.scout.rt.dataobject.DoNode;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.IDoEntityContribution;
-import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 import org.eclipse.scout.rt.platform.util.LazyValue;
 
@@ -47,12 +46,10 @@ public class DoEntitySerializer extends StdSerializer<IDoEntity> {
   protected final LazyValue<DataObjectInventory> m_dataObjectInventory = new LazyValue<>(DataObjectInventory.class);
 
   protected final ScoutDataObjectModuleContext m_context;
-  protected final DoEntitySerializerAttributeNameComparator m_comparator;
 
   public DoEntitySerializer(ScoutDataObjectModuleContext context, JavaType type) {
     super(type);
     m_context = context;
-    m_comparator = BEANS.get(DoEntitySerializerAttributeNameComparator.class).init(context);
   }
 
   @Override
@@ -74,7 +71,7 @@ public class DoEntitySerializer extends StdSerializer<IDoEntity> {
    */
   protected void serializeAttributes(IDoEntity entity, JsonGenerator gen, SerializerProvider provider) throws IOException {
     serializeTypeVersion(gen, entity);
-    TreeMap<String, DoNode<?>> sortedMap = new TreeMap<>(m_comparator);
+    TreeMap<String, DoNode<?>> sortedMap = new TreeMap<>(m_context.getComparator());
     sortedMap.putAll(entity.allNodes());
     for (Map.Entry<String, DoNode<?>> e : sortedMap.entrySet()) {
       gen.setCurrentValue(entity);

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializerAttributeNameComparator.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializerAttributeNameComparator.java
@@ -1,21 +1,23 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.jackson.dataobject;
 
+import static org.eclipse.scout.rt.platform.util.Assertions.assertTrue;
+
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.NumberUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
 
@@ -33,7 +35,7 @@ import org.eclipse.scout.rt.platform.util.ObjectUtility;
  * <li>Contributions attribute (unchanged order of contribution items)</li>
  * </ol>
  */
-@ApplicationScoped
+@Bean
 public class DoEntitySerializerAttributeNameComparator implements Comparator<String>, Serializable {
 
   private static final long serialVersionUID = 1L;
@@ -41,6 +43,7 @@ public class DoEntitySerializerAttributeNameComparator implements Comparator<Str
   protected Map<String, Integer> m_orders = new HashMap<>();
 
   public DoEntitySerializerAttributeNameComparator init(ScoutDataObjectModuleContext context) {
+    assertTrue(m_orders.isEmpty(), "Already initialized"); // avoid duplicate initialization as otherwise multiple different attribut names may be considered equal
     m_orders.put(context.getTypeAttributeName(), -2); // always first
     m_orders.put(context.getTypeVersionAttributeName(), -1); // always second
     m_orders.put(context.getContributionsAttributeName(), 1); // always last

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/ScoutDataObjectModuleContext.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/ScoutDataObjectModuleContext.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -14,9 +14,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.BooleanUtility;
+import org.eclipse.scout.rt.platform.util.LazyValue;
 
 /**
  * Context object used to carry properties for {@link ScoutDataObjectModule} and its components (e.g. serializers and
@@ -34,6 +36,8 @@ public class ScoutDataObjectModuleContext {
   protected static final String IGNORE_TYPE_ATTRIBUTE_KEY = "ignoreTypeAttributeKey";
 
   protected static final String CONTRIBUTIONS_ATTRIBUTE_NAME_KEY = "contributionsAttributeNameKey";
+
+  protected LazyValue<DoEntitySerializerAttributeNameComparator> m_comparator = new LazyValue<>(() -> BEANS.get(DoEntitySerializerAttributeNameComparator.class).init(this));
 
   protected final Map<String, Object> m_contextMap = new HashMap<>();
 
@@ -66,6 +70,10 @@ public class ScoutDataObjectModuleContext {
   public ScoutDataObjectModuleContext withDataObjectMapperClass(Class<? extends IDataObjectMapper> dataObjectMapperClass) {
     put(DATA_OBJECT_MAPPER_CLASS_KEY, dataObjectMapperClass);
     return this;
+  }
+
+  public DoEntitySerializerAttributeNameComparator getComparator() {
+    return m_comparator.get();
   }
 
   public String getTypeAttributeName() {


### PR DESCRIPTION
As DoEntitySerializerAttributeNameComparator is configuried using ScoutDataObjectModuleContext which may exist in multiple variations for multiple DoEntitySerializer also
DoEntitySerializerAttributeNameComparator must not be marked as @ApplicationScoped as both other classes are only configured as @Bean.

339105