### PR TITLE
Add knownType for QualifiedIIdDeserializer

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/id/AbstractIdCodecTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/id/AbstractIdCodecTest.java
@@ -173,6 +173,13 @@ public abstract class AbstractIdCodecTest {
   }
 
   @Test
+  public void testFromQualifiedRootId_2() {
+    FixtureUuId id1 = IIds.create(FixtureUuId.class, TEST_UUID);
+    IId id2 = getCodec().fromQualified("" + TEST_UUID);
+    assertEquals(id1, id2);
+  }
+
+  @Test
   public void testFromQualifiedRootId() {
     FixtureUuId id1 = IIds.create(FixtureUuId.class, TEST_UUID);
     IId id2 = getCodec().fromQualified("scout.FixtureUuId:" + TEST_UUID);

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/id/IdCodecTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/id/IdCodecTest.java
@@ -26,4 +26,9 @@ public class IdCodecTest extends AbstractIdCodecTest {
   protected IdCodec getCodec() {
     return m_idCodec;
   }
+
+  @Override
+  public void testFromQualifiedRootId_2() {
+    super.testFromQualifiedRootId_2();
+  }
 }

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/id/QualifiedIIdDeserializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/id/QualifiedIIdDeserializer.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 
 import org.eclipse.scout.rt.dataobject.id.IId;
 import org.eclipse.scout.rt.dataobject.id.IdCodec;
+import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.LazyValue;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -26,14 +27,22 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 public class QualifiedIIdDeserializer extends StdDeserializer<IId> {
   private static final long serialVersionUID = 1L;
 
-  protected final LazyValue<IdCodec> m_idExternalFormatter = new LazyValue<>(IdCodec.class);
+  protected final LazyValue<IdCodec> m_idCodec = new LazyValue<>(IdCodec.class);
+
+  protected final Class<? extends IId> m_concreteIdType;
 
   public QualifiedIIdDeserializer() {
     super(IId.class);
+    m_concreteIdType = null;
+  }
+
+  public QualifiedIIdDeserializer(Class<? extends IId> concreteIdType) {
+    super(Assertions.assertNotNull(concreteIdType));
+    m_concreteIdType = concreteIdType;
   }
 
   @Override
   public IId deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-    return m_idExternalFormatter.get().fromQualified(p.getText());
+    return m_idCodec.get().fromQualified(p.getText());
   }
 }


### PR DESCRIPTION
There may be cases where a qualified id is used however where the expected type is already known, allow supplying a known id type. If a qualified id the supplied type is checked again the known type. If an unqualified id is supplied and the type is known it will be used (instead of an error which would be thrown otherwise).

340504