### PR TITLE
IdCodec#fromQualified should look only at first ':' symbol

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/id/AbstractIdCodecTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/id/AbstractIdCodecTest.java
@@ -50,6 +50,14 @@ public abstract class AbstractIdCodecTest {
   }
 
   @Test
+  public void testToQualifiedStringId() {
+    String s = "scout.FixtureDateId:my-contain_special$characters{like:or}";
+    FixtureStringId id1 = FixtureStringId.of(s);
+    String ext1 = getCodec().toQualified(id1);
+    assertEquals("scout.FixtureStringId:scout.FixtureDateId:my-contain_special$characters{like:or}", ext1);
+  }
+
+  @Test
   public void testToQualifiedDateId() {
     Date date = new Date(123456789);
     FixtureDateId id1 = IIds.create(FixtureDateId.class, date);
@@ -176,6 +184,14 @@ public abstract class AbstractIdCodecTest {
   public void testFromQualifiedRootId() {
     FixtureUuId id1 = IIds.create(FixtureUuId.class, TEST_UUID);
     IId id2 = getCodec().fromQualified("scout.FixtureUuId:" + TEST_UUID);
+    assertEquals(id1, id2);
+  }
+
+  @Test
+  public void testFromQualifiedStringId() {
+    String s = "scout.FixtureDateId:my-contain_special$characters{like:or}";
+    FixtureStringId id1 = FixtureStringId.of(s);
+    IId id2 = getCodec().fromQualified("scout.FixtureStringId:" + s);
     assertEquals(id1, id2);
   }
 

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/id/IdCodec.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/id/IdCodec.java
@@ -193,8 +193,8 @@ public class IdCodec {
     if (StringUtility.isNullOrEmpty(qualifiedId)) {
       return null;
     }
-    String[] tmp = qualifiedId.split(":", -1 /* force empty string as second part */);
-    if (tmp.length == 0 || tmp.length > 2) {
+    String[] tmp = qualifiedId.split(":", 2); // split into at most two parts
+    if (tmp.length < 2) { // no ":" found
       if (lenient) {
         return null;
       }


### PR DESCRIPTION
 An IStringId might contain itself the ':' symbol.