### PR TITLE
Form: replace notificationCount by NotificationBadgeStatus

### DIFF
--- a/eclipse-scout-core/src/index.js
+++ b/eclipse-scout-core/src/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,6 +59,7 @@ export {default as promises} from './util/promises';
 export {default as Range} from './util/Range';
 export {default as Status} from './status/Status';
 export {default as DefaultStatus} from './status/DefaultStatus';
+export {default as NotificationBadgeStatus} from './status/NotificationBadgeStatus';
 export {default as ParsingFailedStatus} from './status/ParsingFailedStatus';
 export {default as ValidationFailedStatus} from './status/ValidationFailedStatus';
 export {default as CachedElement} from './encoder/CachedElement';

--- a/eclipse-scout-core/src/status/NotificationBadgeStatus.js
+++ b/eclipse-scout-core/src/status/NotificationBadgeStatus.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {Status, strings} from '../index';
+import $ from 'jquery';
+
+export default class NotificationBadgeStatus extends Status {
+
+  constructor(model) {
+    super($.extend(true, {severity: Status.Severity.INFO}, model));
+  }
+
+  cssClass() {
+    return strings.join(' ', Status.cssClassForSeverity(this.severity), 'notification-badge');
+  }
+
+  /**
+   * @return {NotificationBadgeStatus} a clone of this Status instance.
+   */
+  clone() {
+    let modelClone = $.extend({}, this);
+    return new NotificationBadgeStatus(modelClone);
+  }
+
+  equals(o) {
+    if (!(o instanceof NotificationBadgeStatus)) {
+      return false;
+    }
+    return super.equals(o);
+  }
+}

--- a/eclipse-scout-core/src/status/Status.js
+++ b/eclipse-scout-core/src/status/Status.js
@@ -1,14 +1,14 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {arrays, DefaultStatus, ObjectFactory, objects, ParsingFailedStatus, strings, ValidationFailedStatus} from '../index';
+import {arrays, DefaultStatus, NotificationBadgeStatus, ObjectFactory, objects, ParsingFailedStatus, strings, ValidationFailedStatus} from '../index';
 import $ from 'jquery';
 
 export default class Status {
@@ -318,6 +318,18 @@ export default class Status {
       status.children.forEach(childStatus => {
         arrays.pushAll(list, Status.asFlatList(childStatus));
       });
+      list.sort((s1, s2) => {
+        if (s1 instanceof NotificationBadgeStatus) {
+          if (s2 instanceof NotificationBadgeStatus) {
+            return 0;
+          }
+          return -1;
+        }
+        if (s2 instanceof NotificationBadgeStatus) {
+          return 1;
+        }
+        return 0;
+      });
     } else {
       list.push(status);
     }
@@ -340,6 +352,7 @@ export default class Status {
     return {
       Status: Status,
       DefaultStatus: DefaultStatus,
+      NotificationBadgeStatus: NotificationBadgeStatus,
       ParsingFailedStatus: ParsingFailedStatus,
       ValidationFailedStatus: ValidationFailedStatus
     }[className];

--- a/eclipse-scout-core/src/style/colors.less
+++ b/eclipse-scout-core/src/style/colors.less
@@ -539,8 +539,8 @@
 @simple-tab-selected-background-color: @background-color;
 @simple-tab-selected-color: @title-color;
 @simple-tab-background-color: @panel-background-color;
-@simple-tab-status-notification-count-background-color: @palette-red-4;
-@simple-tab-status-notification-count-color: @palette-white;
+@simple-tab-status-notification-badge-background-color: @palette-red-4;
+@simple-tab-status-notification-badge-color: @palette-white;
 @slider-thumb-color: @palette-gray-4;
 @slider-thumb-border-color: @palette-gray-7;
 @slider-track-color: @palette-gray-5;

--- a/eclipse-scout-core/src/tabbox/SimpleTab.less
+++ b/eclipse-scout-core/src/tabbox/SimpleTab.less
@@ -49,6 +49,7 @@
     & > .status-container {
       position: relative;
       display: inline-flex;
+      align-items: center;
       margin-left: 4px;
 
       flex: none;
@@ -63,29 +64,29 @@
         // do not grow or shrink icons
         &.save-needer,
         &.icon {
-          display: inline-flex;
-          align-items: center;
           flex: none;
         }
 
-        &.notification-count {
-          display: inline-block;
+        &.message {
+          display: none;
+        }
 
-          margin-top: auto;
-          margin-bottom: auto;
-          padding: 2px 4px;
-
-          min-width: calc(@font-size-small + 4px); // same as height, smallest possible badge is a circle
-          border-radius: calc(@font-size-small / 2 + 2px); // half of the height/min-width, smallest possible badge is a circle
-
-          text-align: center;
+        &.notification-badge {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 0 4px;
+          min-width: 16px;
+          min-height: 16px;
+          border-radius: 8px;
           font-weight: @font-weight-normal;
           font-size: @font-size-small;
-          line-height: @font-size-small;
-          #scout.overflow-ellipsis-nowrap();
+          background: @simple-tab-status-notification-badge-background-color;
+          color: @simple-tab-status-notification-badge-color;
 
-          background: @simple-tab-status-notification-count-background-color;
-          color: @simple-tab-status-notification-count-color;
+          & > .text {
+            #scout.overflow-ellipsis-nowrap();
+          }
         }
       }
     }

--- a/eclipse-scout-core/test/form/FormSpec.js
+++ b/eclipse-scout-core/test/form/FormSpec.js
@@ -9,7 +9,7 @@
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 import {FormSpecHelper, OutlineSpecHelper} from '../../src/testing/index';
-import {Dimension, fields, Form, NullWidget, Rectangle, scout, Status, webstorage} from '../../src/index';
+import {Dimension, fields, Form, NotificationBadgeStatus, NullWidget, Rectangle, scout, Status, webstorage} from '../../src/index';
 
 describe('Form', () => {
   let session, helper, outlineHelper;
@@ -1037,144 +1037,32 @@ describe('Form', () => {
     });
   });
 
-  describe('notificationCount', () => {
+  describe('notificationBadgeText', () => {
 
     it('is updated correctly', () => {
       const form = helper.createFormWithOneField();
-      expect(form.notificationCount).toBe(0);
+      expect(form.getNotificationBadgeText()).toBeUndefined();
 
-      form.incrementNotificationCount();
-      expect(form.notificationCount).toBe(1);
-      form.incrementNotificationCount();
-      expect(form.notificationCount).toBe(2);
-      form.incrementNotificationCount();
-      expect(form.notificationCount).toBe(3);
-      form.incrementNotificationCount();
-      expect(form.notificationCount).toBe(4);
+      form.setNotificationBadgeText('foo');
+      expect(form.getNotificationBadgeText()).toBe('foo');
+      form.setNotificationBadgeText('bar');
+      expect(form.getNotificationBadgeText()).toBe('bar');
+      form.setNotificationBadgeText(null);
+      expect(form.getNotificationBadgeText()).toBeUndefined();
 
-      form.addNotificationCount(38);
-      expect(form.notificationCount).toBe(42);
-      form.addNotificationCount(10);
-      expect(form.notificationCount).toBe(52);
-      form.addNotificationCount(-50);
-      expect(form.notificationCount).toBe(2);
-      form.addNotificationCount(-10);
-      expect(form.notificationCount).toBe(0);
-      form.addNotificationCount(10);
-      expect(form.notificationCount).toBe(10);
+      form.setNotificationBadgeText('foo');
+      expect(form.getNotificationBadgeText()).toBe('foo');
+      form.addStatus(new NotificationBadgeStatus('bar'));
+      expect(form.getNotificationBadgeText()).toBe('foo');
+      form.setNotificationBadgeText(null);
+      expect(form.getNotificationBadgeText()).toBeUndefined();
 
-      form.setNotificationCount(-13);
-      expect(form.notificationCount).toBe(0);
-      form.setNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-
-      form.resetNotificationCount();
-      expect(form.notificationCount).toBe(0);
-
-      form.setNotificationCount(3);
-      expect(form.notificationCount).toBe(3);
-
-      form.decrementNotificationCount();
-      expect(form.notificationCount).toBe(2);
-      form.decrementNotificationCount();
-      expect(form.notificationCount).toBe(1);
-      form.decrementNotificationCount();
-      expect(form.notificationCount).toBe(0);
-      form.decrementNotificationCount();
-      expect(form.notificationCount).toBe(0);
-    });
-
-    it('is not set to null, undefined or NaN', () => {
-      const form = helper.createFormWithOneField();
-      expect(form.notificationCount).toBe(0);
-
-      form.setNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount();
-      expect(form.notificationCount).toBe(0);
-      form.setNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount(null);
-      expect(form.notificationCount).toBe(0);
-      form.setNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount(undefined);
-      expect(form.notificationCount).toBe(0);
-      form.setNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount(1 + undefined);
-      expect(form.notificationCount).toBe(13);
-
-      form.resetNotificationCount();
-      expect(form.notificationCount).toBe(0);
-
-      form.addNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount();
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount(null);
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount(undefined);
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount(1 + undefined);
-      expect(form.notificationCount).toBe(13);
-    });
-
-    it('is only updated by finite numbers', () => {
-      const form = helper.createFormWithOneField();
-      expect(form.notificationCount).toBe(0);
-
-      form.setNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount(1 / 0);
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount(true);
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount({a: 42});
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount('42');
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount('foo');
-      expect(form.notificationCount).toBe(13);
-
-      form.resetNotificationCount();
-      expect(form.notificationCount).toBe(0);
-
-      form.addNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount(1 / 0);
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount(true);
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount({a: 42});
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount('42');
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount('foo');
-      expect(form.notificationCount).toBe(13);
-    });
-
-    it('is only updated to integer values', () => {
-      const form = helper.createFormWithOneField();
-      expect(form.notificationCount).toBe(0);
-
-      form.setNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.setNotificationCount(4.2);
-      expect(form.notificationCount).toBe(4);
-      form.setNotificationCount(9.7);
-      expect(form.notificationCount).toBe(10);
-      form.setNotificationCount(-2.1);
-      expect(form.notificationCount).toBe(0);
-
-      form.addNotificationCount(13);
-      expect(form.notificationCount).toBe(13);
-      form.addNotificationCount(4.2);
-      expect(form.notificationCount).toBe(17);
-      form.addNotificationCount(9.7);
-      expect(form.notificationCount).toBe(27);
-      form.addNotificationCount(-2.1);
-      expect(form.notificationCount).toBe(25);
+      form.addStatus(new NotificationBadgeStatus('bar'));
+      expect(form.getNotificationBadgeText()).toBeUndefined();
+      form.setNotificationBadgeText('foo');
+      expect(form.getNotificationBadgeText()).toBe('foo');
+      form.setNotificationBadgeText(null);
+      expect(form.getNotificationBadgeText()).toBeUndefined();
     });
   });
 });

--- a/eclipse-scout-core/test/util/StatusSpec.js
+++ b/eclipse-scout-core/test/util/StatusSpec.js
@@ -1,14 +1,14 @@
 /*
- * Copyright (c) 2010-2019 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {DefaultStatus, ParsingFailedStatus, Status} from '../../src/index';
+import {DefaultStatus, NotificationBadgeStatus, ParsingFailedStatus, Status} from '../../src/index';
 
 describe('scout.Status', () => {
 
@@ -179,4 +179,24 @@ describe('scout.Status', () => {
 
   });
 
+  describe('asFlatList', () => {
+    it('sorts NotificationBadgeStatus to the front', () => {
+      const numericNotificationBadgeStatus = new NotificationBadgeStatus({message: '42'}),
+        alphanumericNotificationBadgeStatus = new NotificationBadgeStatus({message: 'lorem ipsum dolor'}),
+        errorStatus = Status.error(),
+        ms = new Status({
+          children: [
+            numericNotificationBadgeStatus,
+            {
+              children: [
+                errorStatus,
+                alphanumericNotificationBadgeStatus
+              ]
+            }
+          ]
+        });
+
+      expect(ms.asFlatList()).toEqual([numericNotificationBadgeStatus, alphanumericNotificationBadgeStatus, errorStatus]);
+    });
+  });
 });

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/extension/ui/NotificationBadgeStatusTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/extension/ui/NotificationBadgeStatusTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.client.extension.ui;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.scout.rt.platform.status.IStatus;
+import org.eclipse.scout.rt.platform.status.Status;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NotificationBadgeStatusTest {
+
+  private NotificationBadgeStatus m_numericNotificationBadgeStatus;
+  private NotificationBadgeStatus m_alphanumericNotificationBadgeStatus;
+  private IStatus m_errorStatus;
+
+  @Before
+  public void setup() {
+    m_numericNotificationBadgeStatus = new NotificationBadgeStatus("42");
+    m_alphanumericNotificationBadgeStatus = new NotificationBadgeStatus("lorem ipsum dolor");
+    m_errorStatus = new Status(IStatus.ERROR);
+  }
+
+  @Test
+  public void testNotificationBadgeStatusCompare() {
+    assertTrue(m_numericNotificationBadgeStatus.compareTo(m_alphanumericNotificationBadgeStatus) < 0);
+    assertTrue(m_numericNotificationBadgeStatus.compareTo(m_errorStatus) < 0);
+    assertTrue(m_alphanumericNotificationBadgeStatus.compareTo(m_errorStatus) < 0);
+  }
+}

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/form/AbstractFormTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/form/AbstractFormTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.*;
 
 import java.beans.PropertyChangeListener;
 
+import org.eclipse.scout.rt.client.extension.ui.NotificationBadgeStatus;
 import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
 import org.eclipse.scout.rt.client.ui.form.AbstractFormTest.WrapperTestFormWithClassId.MainBox.EmbeddedField;
 import org.eclipse.scout.rt.client.ui.form.fields.IValidateContentDescriptor;
@@ -337,48 +338,29 @@ public class AbstractFormTest {
   }
 
   @Test
-  public void testNotificationStatus() {
+  public void testNotificationBadgeText() {
     final AbstractForm form = new TestForm(false);
-    assertEquals(0, form.getNotificationCount());
+    assertNull(form.getNotificationBadgeText());
 
-    form.incrementNotificationCount();
-    assertEquals(1, form.getNotificationCount());
-    form.incrementNotificationCount();
-    assertEquals(2, form.getNotificationCount());
-    form.incrementNotificationCount();
-    assertEquals(3, form.getNotificationCount());
-    form.incrementNotificationCount();
-    assertEquals(4, form.getNotificationCount());
+    form.setNotificationBadgeText("foo");
+    assertEquals("foo", form.getNotificationBadgeText());
+    form.setNotificationBadgeText("bar");
+    assertEquals("bar", form.getNotificationBadgeText());
+    form.setNotificationBadgeText(null);
+    assertNull(form.getNotificationBadgeText());
 
-    form.addNotificationCount(38);
-    assertEquals(42, form.getNotificationCount());
-    form.addNotificationCount(10);
-    assertEquals(52, form.getNotificationCount());
-    form.addNotificationCount(-50);
-    assertEquals(2, form.getNotificationCount());
-    form.addNotificationCount(-10);
-    assertEquals(0, form.getNotificationCount());
-    form.addNotificationCount(10);
-    assertEquals(10, form.getNotificationCount());
+    form.setNotificationBadgeText("foo");
+    assertEquals("foo", form.getNotificationBadgeText());
+    form.addStatus(new NotificationBadgeStatus("bar"));
+    assertEquals("foo", form.getNotificationBadgeText());
+    form.setNotificationBadgeText(null);
+    assertNull(form.getNotificationBadgeText());
 
-    form.setNotificationCount(-13);
-    assertEquals(0, form.getNotificationCount());
-    form.setNotificationCount(13);
-    assertEquals(13, form.getNotificationCount());
-
-    form.resetNotificationCount();
-    assertEquals(0, form.getNotificationCount());
-
-    form.setNotificationCount(3);
-    assertEquals(3, form.getNotificationCount());
-
-    form.decrementNotificationCount();
-    assertEquals(2, form.getNotificationCount());
-    form.decrementNotificationCount();
-    assertEquals(1, form.getNotificationCount());
-    form.decrementNotificationCount();
-    assertEquals(0, form.getNotificationCount());
-    form.decrementNotificationCount();
-    assertEquals(0, form.getNotificationCount());
+    form.addStatus(new NotificationBadgeStatus("bar"));
+    assertNull(form.getNotificationBadgeText());
+    form.setNotificationBadgeText("foo");
+    assertEquals("foo", form.getNotificationBadgeText());
+    form.setNotificationBadgeText(null);
+    assertNull(form.getNotificationBadgeText());
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/extension/ui/NotificationBadgeStatus.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/extension/ui/NotificationBadgeStatus.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.client.extension.ui;
+
+import org.eclipse.scout.rt.platform.status.IStatus;
+import org.eclipse.scout.rt.platform.status.Status;
+
+public class NotificationBadgeStatus extends Status {
+  private static final long serialVersionUID = 1L;
+
+  public NotificationBadgeStatus(String notificationBadgeText) {
+    super(notificationBadgeText, IStatus.INFO);
+  }
+
+  @Override
+  public int compareTo(IStatus o) {
+    if (o instanceof NotificationBadgeStatus) {
+      return super.compareTo(o);
+    }
+    return -1;
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/AbstractForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/AbstractForm.java
@@ -47,6 +47,7 @@ import org.eclipse.scout.rt.client.context.ClientRunContexts;
 import org.eclipse.scout.rt.client.dto.Data;
 import org.eclipse.scout.rt.client.dto.FormData;
 import org.eclipse.scout.rt.client.dto.FormData.SdkCommand;
+import org.eclipse.scout.rt.client.extension.ui.NotificationBadgeStatus;
 import org.eclipse.scout.rt.client.extension.ui.form.AbstractFormExtension;
 import org.eclipse.scout.rt.client.extension.ui.form.FormChains.FormAddSearchTermsChain;
 import org.eclipse.scout.rt.client.extension.ui.form.FormChains.FormCheckFieldsChain;
@@ -126,6 +127,7 @@ import org.eclipse.scout.rt.platform.resource.BinaryResource;
 import org.eclipse.scout.rt.platform.status.IMultiStatus;
 import org.eclipse.scout.rt.platform.status.IStatus;
 import org.eclipse.scout.rt.platform.status.MultiStatus;
+import org.eclipse.scout.rt.platform.status.Status;
 import org.eclipse.scout.rt.platform.text.TEXTS;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.BeanUtility;
@@ -167,6 +169,8 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
   private static final String FORM_STORED = "FORM_STORED";
   private static final String FORM_LOADING = "FORM_LOADING";
   private static final String FORM_STARTED = "FORM_STARTED";
+
+  protected static final int NOTIFICATION_BADGE_STATUS_CODE = 197821;
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractForm.class);
   private static final NamedBitMaskHelper FLAGS_BIT_HELPER = new NamedBitMaskHelper(CACHE_BOUNDS, ASK_IF_NEED_SAVE,
@@ -495,14 +499,14 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
   }
 
   /**
-   * If set, the count will be rendered as notification badge in the right upper corner of the view.
+   * If set, the text will be rendered as notification badge in the right upper corner of the view.
    *
-   * @return the number to be display in the notification badge of the form.
+   * @return the text to be display in the notification badge of the form.
    */
-  @ConfigProperty(ConfigProperty.INTEGER)
+  @ConfigProperty(ConfigProperty.TEXT)
   @Order(210)
-  protected int getConfiguredNotificationCount() {
-    return 0;
+  protected String getConfiguredNotificationBadgeText() {
+    return null;
   }
 
   /**
@@ -768,7 +772,7 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
     setDisplayViewId(getConfiguredDisplayViewId());
     setClosable(getConfiguredClosable());
     setSaveNeededVisible(getConfiguredSaveNeededVisible());
-    setNotificationCount(getConfiguredNotificationCount());
+    setNotificationBadgeText(getConfiguredNotificationBadgeText());
 
     // visit all system buttons and attach observer
     m_systemButtonListener = new P_SystemButtonListener();// is auto-detaching
@@ -919,33 +923,30 @@ public abstract class AbstractForm extends AbstractWidget implements IForm, IExt
   }
 
   @Override
-  public int getNotificationCount() {
-    return propertySupport.getPropertyInt(PROP_NOTIFICATION_COUNT);
+  public String getNotificationBadgeText() {
+    return getNotificationBadgeStatus()
+        .map(Status::getMessage)
+        .orElse(null);
   }
 
   @Override
-  public void setNotificationCount(int notificationCount) {
-    propertySupport.setPropertyInt(PROP_NOTIFICATION_COUNT, Math.max(notificationCount, 0));
+  public void setNotificationBadgeText(String notificationBadgeText) {
+    getNotificationBadgeStatus().ifPresent(this::removeStatus);
+    if (notificationBadgeText != null) {
+      addStatus(new NotificationBadgeStatus(notificationBadgeText)
+          .withCode(NOTIFICATION_BADGE_STATUS_CODE));
+    }
   }
 
-  @Override
-  public void incrementNotificationCount() {
-    setNotificationCount(getNotificationCount() + 1);
-  }
-
-  @Override
-  public void decrementNotificationCount() {
-    setNotificationCount(getNotificationCount() - 1);
-  }
-
-  @Override
-  public void addNotificationCount(int notificationCount) {
-    setNotificationCount(getNotificationCount() + notificationCount);
-  }
-
-  @Override
-  public void resetNotificationCount() {
-    setNotificationCount(0);
+  protected Optional<NotificationBadgeStatus> getNotificationBadgeStatus() {
+    final MultiStatus ms = getStatusInternal();
+    if (ms == null) {
+      return Optional.empty();
+    }
+    return ms.findChildStatuses(s -> NOTIFICATION_BADGE_STATUS_CODE == s.getCode()).stream()
+        .filter(NotificationBadgeStatus.class::isInstance)
+        .map(NotificationBadgeStatus.class::cast)
+        .findAny();
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/IForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/IForm.java
@@ -68,7 +68,6 @@ public interface IForm extends IWidget, ITypeWithSettableClassId, IStyleable, ID
   String PROP_CLOSABLE = "closable";
   String PROP_SAVE_NEEDED_VISIBLE = "saveNeededVisible";
   String PROP_STATUS = "status";
-  String PROP_NOTIFICATION_COUNT = "notificationCount";
 
   /**
    * Hint to render an {@link IForm} as dialog in a separate window. A dialog can be modal or non-modal.
@@ -203,21 +202,13 @@ public interface IForm extends IWidget, ITypeWithSettableClassId, IStyleable, ID
   void removeStatus(IStatus status);
 
   /**
-   * If set, the count will be rendered as notification badge in the right upper corner of the view.
+   * If set, the text will be rendered as notification badge in the right upper corner of the view.
    *
-   * @return the number to be display in the notification badge of the form.
+   * @return the text to be display in the notification badge of the form.
    */
-  int getNotificationCount();
+  String getNotificationBadgeText();
 
-  void setNotificationCount(int notificationCount);
-
-  void incrementNotificationCount();
-
-  void decrementNotificationCount();
-
-  void addNotificationCount(int notificationCount);
-
-  void resetNotificationCount();
+  void setNotificationBadgeText(String notificationBadgeText);
 
   /**
    * @return the {@link IWizard} that contains the step that started this form using startWizardStep

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/status/MultiStatusTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/status/MultiStatusTest.java
@@ -1,18 +1,20 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.platform.status;
 
+import static org.eclipse.scout.rt.platform.util.StringUtility.startsWith;
 import static org.junit.Assert.*;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
@@ -176,6 +178,72 @@ public class MultiStatusTest {
     sub.add(new TestStatus2());
     multiStatus.add(sub);
     assertFalse(multiStatus.containsStatus(TestStatus.class));
+  }
+
+  @Test
+  public void testFindChildStatuses() {
+    MultiStatus rootMs = new MultiStatus();
+    rootMs.add(new Status("Level 1 - OK", IStatus.OK));
+    rootMs.add(new Status("Level 1 - ERROR", IStatus.ERROR));
+    MultiStatus level1Ms = new MultiStatus();
+    rootMs.add(level1Ms);
+    level1Ms.add(new Status("Level 2 - INFO", IStatus.INFO));
+    level1Ms.add(new Status("Level 2 - WARNING", IStatus.WARNING));
+    MultiStatus level2Ms = new MultiStatus();
+    level1Ms.add(level2Ms);
+    level2Ms.add(new Status("Level 3 - OK", IStatus.OK));
+    level2Ms.add(new Status("Level 3 - ERROR", IStatus.ERROR));
+    level2Ms.add(new Status("Level 3 - WARNING", IStatus.WARNING));
+
+    Predicate<IStatus> okPredicate = s -> s.getSeverity() == IStatus.OK;
+    Predicate<IStatus> infoPredicate = s -> s.getSeverity() == IStatus.INFO;
+    Predicate<IStatus> warningPredicate = s -> s.getSeverity() == IStatus.WARNING;
+    Predicate<IStatus> errorPredicate = s -> s.getSeverity() == IStatus.ERROR;
+
+    Predicate<IStatus> level1Predicate = s -> startsWith(s.getMessage(), "Level 1");
+    Predicate<IStatus> level2Predicate = s -> startsWith(s.getMessage(), "Level 2");
+    Predicate<IStatus> level3Predicate = s -> startsWith(s.getMessage(), "Level 3");
+
+    // root of search is not considered a child
+
+    // rootMs
+    assertEquals(2, rootMs.findChildStatuses(okPredicate).size());
+    assertEquals(1, rootMs.findChildStatuses(infoPredicate).size());
+    assertEquals(3, rootMs.findChildStatuses(warningPredicate).size()); // level1Ms has severity WARNING
+    assertEquals(3, rootMs.findChildStatuses(errorPredicate).size()); // level2Ms has severity ERROR
+
+    assertEquals(2, rootMs.findChildStatuses(level1Predicate).size());
+    assertEquals(3, rootMs.findChildStatuses(level2Predicate).size()); // level1Ms has message Level 2 - WARNING
+    assertEquals(4, rootMs.findChildStatuses(level3Predicate).size()); // level2Ms has message Level 3 - ERROR
+
+    assertEquals(2, rootMs.findChildStatuses(level3Predicate.and(errorPredicate)).size());
+    assertEquals(5, rootMs.findChildStatuses(level2Predicate.or(okPredicate)).size());
+
+    // level1Ms
+    assertEquals(1, level1Ms.findChildStatuses(okPredicate).size());
+    assertEquals(1, level1Ms.findChildStatuses(infoPredicate).size());
+    assertEquals(2, level1Ms.findChildStatuses(warningPredicate).size()); // level1Ms is no longer a child
+    assertEquals(2, level1Ms.findChildStatuses(errorPredicate).size()); // level2Ms has severity ERROR
+
+    assertEquals(0, level1Ms.findChildStatuses(level1Predicate).size());
+    assertEquals(2, level1Ms.findChildStatuses(level2Predicate).size()); // level1Ms is no longer a child
+    assertEquals(4, level1Ms.findChildStatuses(level3Predicate).size()); // level2Ms has message Level 3 - ERROR
+
+    assertEquals(2, level1Ms.findChildStatuses(level3Predicate.and(errorPredicate)).size());
+    assertEquals(3, level1Ms.findChildStatuses(level2Predicate.or(okPredicate)).size());
+
+    // level2Ms
+    assertEquals(1, level2Ms.findChildStatuses(okPredicate).size());
+    assertEquals(0, level2Ms.findChildStatuses(infoPredicate).size());
+    assertEquals(1, level2Ms.findChildStatuses(warningPredicate).size()); // level1Ms is no longer a child
+    assertEquals(1, level2Ms.findChildStatuses(errorPredicate).size()); // level2Ms is no longer a child
+
+    assertEquals(0, level2Ms.findChildStatuses(level1Predicate).size());
+    assertEquals(0, level2Ms.findChildStatuses(level2Predicate).size()); // level1Ms is no longer a child
+    assertEquals(3, level2Ms.findChildStatuses(level3Predicate).size()); // level2Ms is no longer a child
+
+    assertEquals(1, level2Ms.findChildStatuses(level3Predicate.and(errorPredicate)).size());
+    assertEquals(1, level2Ms.findChildStatuses(level2Predicate.or(okPredicate)).size());
   }
 
   @Test(expected = AssertionException.class)

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/status/IMultiStatus.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/status/IMultiStatus.java
@@ -1,16 +1,18 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.platform.status;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.eclipse.scout.rt.platform.IOrdered;
 
@@ -65,6 +67,13 @@ public interface IMultiStatus extends IStatus {
    *         otherwise.
    */
   boolean containsStatus(Class<? extends IStatus> clazz);
+
+  /**
+   * @param childPredicate
+   *          not <code>null<code>
+   * @return all direct or indirect children for the given predicate
+   */
+  Collection<IStatus> findChildStatuses(Predicate<IStatus> childPredicate);
 
   /**
    * @return maximum severity of the children or {@link #OK}, if no children available

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/status/MultiStatus.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/status/MultiStatus.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -12,9 +12,11 @@ package org.eclipse.scout.rt.platform.status;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 
 import org.eclipse.scout.rt.platform.IOrdered;
 import org.eclipse.scout.rt.platform.util.Assertions;
@@ -182,6 +184,21 @@ public class MultiStatus extends Status implements IMultiStatus {
       }
     }
     return false;
+  }
+
+  @Override
+  public Collection<IStatus> findChildStatuses(Predicate<IStatus> childPredicate) {
+    Assertions.assertNotNull(childPredicate);
+    Collection<IStatus> result = new HashSet<>();
+    for (IStatus child : getChildren()) {
+      if (childPredicate.test(child)) {
+        result.add(child);
+      }
+      if (child instanceof IMultiStatus) {
+        result.addAll(((IMultiStatus) child).findChildStatuses(childPredicate));
+      }
+    }
+    return result;
   }
 
   @Override

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/JsonObjectFactory.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/JsonObjectFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import java.text.DecimalFormat;
 import java.util.Date;
 
 import org.eclipse.scout.rt.client.IClientSession;
+import org.eclipse.scout.rt.client.extension.ui.NotificationBadgeStatus;
 import org.eclipse.scout.rt.client.ui.accordion.IAccordion;
 import org.eclipse.scout.rt.client.ui.action.keystroke.IKeyStroke;
 import org.eclipse.scout.rt.client.ui.action.menu.IComboMenu;
@@ -124,6 +125,7 @@ import org.eclipse.scout.rt.ui.html.json.JsonByteArray;
 import org.eclipse.scout.rt.ui.html.json.JsonClientSession;
 import org.eclipse.scout.rt.ui.html.json.JsonDate;
 import org.eclipse.scout.rt.ui.html.json.JsonDecimalFormat;
+import org.eclipse.scout.rt.ui.html.json.JsonNotificationBadgeStatus;
 import org.eclipse.scout.rt.ui.html.json.JsonParsingFailedStatus;
 import org.eclipse.scout.rt.ui.html.json.JsonStatus;
 import org.eclipse.scout.rt.ui.html.json.JsonValidationFailedStatus;
@@ -519,6 +521,9 @@ public class JsonObjectFactory extends AbstractJsonObjectFactory {
     }
     if (object instanceof ValidationFailedStatus) {
       return new JsonValidationFailedStatus((ValidationFailedStatus) object);
+    }
+    if (object instanceof NotificationBadgeStatus) {
+      return new JsonNotificationBadgeStatus((NotificationBadgeStatus) object);
     }
     if (object instanceof IStatus) {
       return new JsonStatus((IStatus) object);

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonNotificationBadgeStatus.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonNotificationBadgeStatus.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.ui.html.json;
+
+import org.eclipse.scout.rt.client.extension.ui.NotificationBadgeStatus;
+
+public class JsonNotificationBadgeStatus extends JsonStatus {
+
+  public JsonNotificationBadgeStatus(NotificationBadgeStatus status) {
+    super(status);
+  }
+
+  @Override
+  public String getObjectType() {
+    return "NotificationBadgeStatus";
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/JsonForm.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/JsonForm.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * Copyright (c) 2014-2017 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -146,12 +146,6 @@ public class JsonForm<FORM extends IForm> extends AbstractJsonWidget<FORM> {
       @Override
       protected Boolean modelValue() {
         return getModel().isMaximized();
-      }
-    });
-    putJsonProperty(new JsonProperty<IForm>(IForm.PROP_NOTIFICATION_COUNT, model) {
-      @Override
-      protected Integer modelValue() {
-        return getModel().getNotificationCount();
       }
     });
   }


### PR DESCRIPTION
Add a NotificationBadgeStatus which replaces the notificationCount on the form. The notification badge is rendered in the status area of a SimpleTab if the form is displayed as view.

325085