### PR TITLE
StringUtility: make methods for prefix and suffix removal null-safe

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/StringUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/StringUtilityTest.java
@@ -760,4 +760,44 @@ public class StringUtilityTest {
     assertEquals(0, StringUtility.randomId(0).length());
     assertEquals(0, StringUtility.randomId(-123).length());
   }
+
+  @Test
+  public void testRemovePrefixes() {
+    assertEquals(null, StringUtility.removePrefixes(null, "prefix"));
+    assertEquals("", StringUtility.removePrefixes("", "prefix"));
+
+    assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData"));
+    assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData",null));
+    assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData",""));
+    assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData"," "));
+
+    assertEquals("CompanyFormData", StringUtility.removePrefixes(" CompanyFormData"," "));
+    assertEquals(".png", StringUtility.removePrefixes("image.png","image"));
+    assertEquals("FormData", StringUtility.removePrefixes("CompanyFormData","Company"));
+    assertEquals("FormData", StringUtility.removePrefixes("CompanyFormData","company"));
+    assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData","Form"));
+
+    assertEquals("Data", StringUtility.removePrefixes("CompanyFormData","Company", "Form"));
+    assertEquals("FormData", StringUtility.removePrefixes("CompanyFormData","Form", "Company"));
+  }
+
+  @Test
+  public void testRemoveSuffixes() {
+    assertEquals(null, StringUtility.removeSuffixes(null, "suffix"));
+    assertEquals("", StringUtility.removeSuffixes("", "suffix"));
+    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData"));
+    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData",null));
+    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData",""));
+    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData"," "));
+
+    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData "," "));
+    assertEquals("image", StringUtility.removeSuffixes("image.png",".png"));
+    assertEquals("CompanyForm", StringUtility.removeSuffixes("CompanyFormData","Data"));
+    assertEquals("CompanyForm", StringUtility.removeSuffixes("CompanyFormData","data"));
+    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData","Form"));
+
+    assertEquals("Company", StringUtility.removeSuffixes("CompanyFormData","Form", "Data"));
+    assertEquals("CompanyForm", StringUtility.removeSuffixes("CompanyFormData","Data", "Form"));
+  }
+
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/StringUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/StringUtility.java
@@ -1549,6 +1549,9 @@ public final class StringUtility {
    * but <code>removeSuffixes("CompanyFormData","Data","Form")</code> will result in "CompanyForm"
    */
   public static String removeSuffixes(String s, String... suffixes) {
+    if (isNullOrEmpty(s) || suffixes == null) {
+      return s;
+    }
     for (int i = suffixes.length - 1; i >= 0; i--) {
       if (suffixes[i] != null && s.toLowerCase().endsWith(suffixes[i].toLowerCase())) {
         s = s.substring(0, s.length() - suffixes[i].length());
@@ -1662,9 +1665,12 @@ public final class StringUtility {
    * but <code>removePrefixes("CompanyFormData","Form","Company")</code> will result in "FormData"
    */
   public static String removePrefixes(String s, String... prefixes) {
-    for (String prefixe : prefixes) {
-      if (prefixe != null && s.toLowerCase().startsWith(prefixe.toLowerCase())) {
-        s = s.substring(prefixe.length());
+    if (isNullOrEmpty(s) || prefixes == null) {
+      return s;
+    }
+    for (String prefix : prefixes) {
+      if (prefix != null && s.toLowerCase().startsWith(prefix.toLowerCase())) {
+        s = s.substring(prefix.length());
       }
     }
     return s;

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/StringUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/StringUtility.java
@@ -1549,6 +1549,9 @@ public final class StringUtility {
    * but <code>removeSuffixes("CompanyFormData","Data","Form")</code> will result in "CompanyForm"
    */
   public static String removeSuffixes(String s, String... suffixes) {
+    if (isNullOrEmpty(s)) {
+      return s;
+    }
     for (int i = suffixes.length - 1; i >= 0; i--) {
       if (suffixes[i] != null && s.toLowerCase().endsWith(suffixes[i].toLowerCase())) {
         s = s.substring(0, s.length() - suffixes[i].length());
@@ -1662,6 +1665,9 @@ public final class StringUtility {
    * but <code>removePrefixes("CompanyFormData","Form","Company")</code> will result in "FormData"
    */
   public static String removePrefixes(String s, String... prefixes) {
+    if (isNullOrEmpty(s)) {
+      return s;
+    }
     for (String prefixe : prefixes) {
       if (prefixe != null && s.toLowerCase().startsWith(prefixe.toLowerCase())) {
         s = s.substring(prefixe.length());


### PR DESCRIPTION
If a method for the removal of prefixes or suffixes is called on a String that is null or empty, said String is returned unchanged.

341727