### PR TITLE
TableEventBuffer: Adjust merger to support updated columns

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/TreeEventBuffer.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/TreeEventBuffer.java
@@ -498,7 +498,7 @@ public class TreeEventBuffer extends AbstractEventBuffer<TreeEvent> {
      */
     public void merge(TreeEvent event) {
       if (m_mergedNodes == null) {
-        throw new IllegalStateException("Invocations of merge is not allowed after complete has been invoked.");
+        throw new IllegalStateException("Invocation of merge is not allowed after complete() has been invoked.");
       }
       if (!event.hasNodes()) {
         return;


### PR DESCRIPTION
- Fixes the issue that when merging table events, the field updated columns of tables is ignored. Until now, the last event wins.
- Adds corresponding tests including a simple performance measure

339745