### PR TITLE
Data object migration: Add handler for non-root DO deletion

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/AbstractDoStructureMigrationHandlerCompletenessTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/AbstractDoStructureMigrationHandlerCompletenessTest.java
@@ -14,10 +14,12 @@ import static org.junit.Assert.fail;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoDeletionMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandlerTest;
 import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationHandler;
 import org.eclipse.scout.rt.platform.IgnoreBean;
@@ -95,6 +97,16 @@ public abstract class AbstractDoStructureMigrationHandlerCompletenessTest {
 
     if (ci.hasAnnotation(IgnoreBean.class)) {
       return false; // e.g. test migration handlers
+    }
+
+    Class<?> resolvedClass = ci.resolveClass();
+    Class<?> superclass = resolvedClass.getSuperclass();
+    while (superclass != null) {
+      // ignore deletion migrations
+      if (Objects.equals(superclass, AbstractDoDeletionMigrationHandler.class)) {
+        return false;
+      }
+      superclass = superclass.getSuperclass();
     }
 
     String className = ci.name();

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectDeletionMigrationTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectDeletionMigrationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.FloorFixtureDoStructureMigrationHandler_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.ScratchFixtureDeletionMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_4;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DataObjectDeletionMigrationTest {
+
+  private static final List<IBean<?>> TEST_BEANS = new ArrayList<>();
+
+  private static DataObjectMigrationContext s_migrationContext;
+  private static DataObjectMigrator s_migrator;
+
+  @BeforeClass
+  public static void beforeClass() {
+    DataObjectMigrationTestHelper testHelper = BEANS.get(DataObjectMigrationTestHelper.class);
+    TestDataObjectMigrationInventory inventory = new TestDataObjectMigrationInventory(
+        testHelper.getFixtureNamespaces(),
+        testHelper.getFixtureTypeVersions(),
+        testHelper.getFixtureContextDataClasses(),
+        Arrays.asList(new FloorFixtureDoStructureMigrationHandler_5(),
+            new ScratchFixtureDeletionMigrationHandler()),
+        Collections.emptyList());
+
+    TEST_BEANS.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(TestDataObjectMigrationInventory.class, inventory).withReplace(true)));
+    s_migrationContext = BEANS.get(DataObjectMigrationContext.class);
+    s_migrator = BEANS.get(DataObjectMigrator.class);
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    BEANS.get(BeanTestingHelper.class).unregisterBeans(TEST_BEANS);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testDeletionMigrationHandler() {
+    IDoEntity doWithDeletedFloorFixture = BEANS.get(DoEntityBuilder.class)
+        .put("_type", "charlieFixture.FloorFixture")
+        .put("_typeVersion", CharlieFixture_4.VERSION.unwrap())
+        .put("scratch", BEANS.get(DoEntityBuilder.class)
+            .put("_type", "bravoFixture.ScratchFixture")
+            .put("_typeVersion", BravoFixture_1.VERSION.unwrap())
+            .build())
+        .build();
+
+    s_migrator.applyStructureMigration(s_migrationContext, doWithDeletedFloorFixture, CharlieFixture_5.VERSION);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/FloorFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/FloorFixtureDo.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.TypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+
+/**
+ * Change history:
+ * <ul>
+ * <li>charlieFixture-5: removed scratches
+ * </ul>
+ *
+ * @since charlieFixture-4
+ */
+@TypeName("charlieFixture.FloorFixture")
+@TypeVersion(CharlieFixture_5.class)
+public class FloorFixtureDo extends DoEntity {
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/FloorFixtureDoStructureMigrationHandler_5.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/FloorFixtureDoStructureMigrationHandler_5.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import java.util.Set;
+
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoDeletionMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+
+/**
+ * Migration empty on purpose to test {@link AbstractDoDeletionMigrationHandler}.
+ */
+@IgnoreBean
+public class FloorFixtureDoStructureMigrationHandler_5 extends AbstractDoStructureMigrationHandler {
+
+  @Override
+  public Class<? extends ITypeVersion> toTypeVersionClass() {
+    return CharlieFixture_5.class;
+  }
+
+  @Override
+  public Set<String> getTypeNames() {
+    return CollectionUtility.hashSet("charlieFixture.FloorFixture");
+  }
+
+  @Override
+  protected boolean migrate(DataObjectMigrationContext ctx, IDoEntity doEntity) {
+    return true;
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/ScratchFixtureDeletionMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/ScratchFixtureDeletionMigrationHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.AbstractDoDeletionMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_2;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+
+@IgnoreBean
+public class ScratchFixtureDeletionMigrationHandler extends AbstractDoDeletionMigrationHandler {
+
+  @Override
+  public Class<? extends ITypeVersion> toTypeVersionClass() {
+    return BravoFixture_2.class;
+  }
+
+  @Override
+  public Set<String> getTypeNames() {
+    return Collections.singleton("bravoFixture.ScratchFixture");
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoDeletionMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoDeletionMigrationHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
+
+/**
+ * Handles the deletion of <i>non-root</i> {@link IDoEntity DO entitites}. Any other DOs referencing the deleted one
+ * need to migrate accordingly and remove it to ensure that an actual implementation of this migration is never called.
+ * Implementations do <i>not</i> need a unit test and are ignored by any migration handler completeness tests.
+ * <p>
+ * Abstract implementation of a {@link IDoStructureMigrationHandler} supporting {@link Class} of {@link ITypeVersion}
+ * instead of {@link NamespaceVersion} and auto-update of type version to {@link #toTypeVersion()}.
+ */
+public abstract class AbstractDoDeletionMigrationHandler implements IDoStructureMigrationHandler {
+
+  private final NamespaceVersion m_toTypeVersion;
+
+  public AbstractDoDeletionMigrationHandler() {
+    m_toTypeVersion = BEANS.get(toTypeVersionClass()).getVersion();
+  }
+
+  @Override
+  public NamespaceVersion toTypeVersion() {
+    return m_toTypeVersion;
+  }
+
+  public abstract Class<? extends ITypeVersion> toTypeVersionClass();
+
+  @Override
+  public boolean applyMigration(DataObjectMigrationContext ctx, IDoEntity doEntity) {
+    throw new UnsupportedOperationException(String.format("Unexpected DOs of types %s, all occurrences should have been deleted.", getTypeNames().toString()));
+  }
+}


### PR DESCRIPTION
Implements a DO migration handler for deletions. Any implementation throws an UnsupportedOperationException when applying a migration as no data object of this type is expected.

339239