### PR TITLE
Add severity to ErrorDo and use it along with ProcessingExceptions

### DIFF
--- a/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/error/ErrorDoTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/error/ErrorDoTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.rest.error;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.status.IStatus;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PlatformTestRunner.class)
+public class ErrorDoTest {
+
+  @Test
+  public void testSeverityAsInt() {
+    ErrorDo errorDo = BEANS.get(ErrorDo.class);
+    assertNull(errorDo.getSeverity());
+    assertEquals(IStatus.ERROR, errorDo.getSeverityAsInt());
+
+    errorDo.withSeverity("error");
+    assertEquals(IStatus.ERROR, errorDo.getSeverityAsInt());
+
+    errorDo.withSeverity("warning");
+    assertEquals(IStatus.WARNING, errorDo.getSeverityAsInt());
+
+    errorDo.withSeverity("info");
+    assertEquals(IStatus.INFO, errorDo.getSeverityAsInt());
+
+    errorDo.withSeverity("unknown severity");
+    assertEquals(IStatus.ERROR, errorDo.getSeverityAsInt());
+  }
+}

--- a/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/error/ErrorResponseBuilderTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/error/ErrorResponseBuilderTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.context.CorrelationId;
+import org.eclipse.scout.rt.platform.status.IStatus;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,12 +23,20 @@ public class ErrorResponseBuilderTest {
 
   @Test
   public void testBuild() {
-    ErrorDo error = BEANS.get(ErrorResponseBuilder.class).withErrorCode(42).withMessage("message").withTitle("title").withHttpStatus(10).buildError();
+    ErrorDo error = BEANS.get(ErrorResponseBuilder.class)
+        .withErrorCode(42)
+        .withMessage("message")
+        .withTitle("title")
+        .withHttpStatus(10)
+        .withSeverity(IStatus.INFO)
+        .buildError();
 
     assertEquals("message", error.getMessage());
     assertEquals("title", error.getTitle());
     assertEquals("42", error.getErrorCode());
     assertEquals(Integer.valueOf(10), error.getHttpStatus());
+    assertEquals("info", error.getSeverity());
+    assertEquals(IStatus.INFO, error.getSeverityAsInt());
     assertEquals(CorrelationId.CURRENT.get(), error.getCorrelationId());
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/proxy/ErrorDoRestClientExceptionTransformer.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/proxy/ErrorDoRestClientExceptionTransformer.java
@@ -53,7 +53,8 @@ public class ErrorDoRestClientExceptionTransformer extends AbstractEntityRestCli
       ErrorDo error = response.readEntity(ErrorResponse.class).getError();
       return vetoExceptionFactory.apply(error.getMessage(), e)
           .withTitle(error.getTitle())
-          .withCode(error.getErrorCodeAsInt());
+          .withCode(error.getErrorCodeAsInt())
+          .withSeverity(error.getSeverityAsInt());
     }, () -> {
       StatusType statusInfo = response.getStatusInfo();
       return vetoExceptionFactory.apply(statusInfo.getReasonPhrase(), e);
@@ -66,7 +67,8 @@ public class ErrorDoRestClientExceptionTransformer extends AbstractEntityRestCli
       ErrorDo error = response.readEntity(ErrorResponse.class).getError();
       return new ProcessingException(error.getMessage(), e)
           .withTitle(error.getTitle())
-          .withCode(error.getErrorCodeAsInt());
+          .withCode(error.getErrorCodeAsInt())
+          .withSeverity(error.getSeverityAsInt());
     }, () -> {
       StatusType statusInfo = response.getStatusInfo();
       return new ProcessingException("REST call failed: {} {}", statusInfo.getStatusCode(), statusInfo.getReasonPhrase(), e);

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/error/ErrorDo.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/error/ErrorDo.java
@@ -14,6 +14,7 @@ import javax.annotation.Generated;
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.platform.status.IStatus;
 import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 
 @TypeName("scout.Error")
@@ -46,6 +47,20 @@ public class ErrorDo extends DoEntity {
   }
 
   /**
+   * Error severity. Expecting one of:
+   * <ul>
+   * <li>ok</li>
+   * <li>info</li>
+   * <li>warning</li>
+   * <li>error</li>
+   * </ul>
+   * Assume <em>error</em> if {@code null}
+   */
+  public DoValue<String> severity() {
+    return doValue("severity");
+  }
+
+  /**
    * @return {@link #getErrorCode()} as int if it contains an integer else zero
    */
   @SuppressWarnings("squid:S1166")
@@ -55,6 +70,29 @@ public class ErrorDo extends DoEntity {
     }
     catch (RuntimeException e) {
       return 0;
+    }
+  }
+
+  /**
+   * Decodes the string-typed status into an int constant declared in {@link IStatus}:
+   * <ul>
+   * <li><em>info</em> to {@link IStatus#INFO}</li>
+   * <li><em>warning</em> to {@link IStatus#WARNING}</li>
+   * <li>anything else including {@code null} to {@link IStatus#ERROR}</li>
+   * </ul>
+   */
+  public int getSeverityAsInt() {
+    String s = getSeverity();
+    if (s == null) {
+      return IStatus.ERROR;
+    }
+    switch (s) {
+      case "info":
+        return IStatus.INFO;
+      case "warning":
+        return IStatus.WARNING;
+      default:
+        return IStatus.ERROR;
     }
   }
 
@@ -127,5 +165,16 @@ public class ErrorDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public String getCorrelationId() {
     return correlationId().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public ErrorDo withSeverity(String severity) {
+    severity().set(severity);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public String getSeverity() {
+    return severity().get();
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/error/ErrorResponseBuilder.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/error/ErrorResponseBuilder.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Response.Status;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.context.CorrelationId;
+import org.eclipse.scout.rt.platform.status.IStatus;
 
 /**
  * Builder for {@link ErrorDo} and {@link ErrorResponse} objects.
@@ -27,6 +28,7 @@ public class ErrorResponseBuilder {
   private String m_errorCode;
   private String m_title;
   private String m_message;
+  private String m_severity;
 
   public ErrorResponseBuilder withHttpStatus(int httpStatus) {
     m_httpStatus = httpStatus;
@@ -58,6 +60,25 @@ public class ErrorResponseBuilder {
     return this;
   }
 
+  public ErrorResponseBuilder withSeverity(int severity) {
+    switch (severity) {
+      case IStatus.INFO:
+        withSeverity("info");
+        break;
+      case IStatus.WARNING:
+        withSeverity("warning");
+        break;
+      case IStatus.ERROR:
+        withSeverity("error");
+    }
+    return this;
+  }
+
+  public ErrorResponseBuilder withSeverity(String severity) {
+    m_severity = severity;
+    return this;
+  }
+
   public Response build() {
     return Response.status(m_httpStatus)
         .entity(BEANS.get(ErrorResponse.class).withError(buildError()))
@@ -77,6 +98,9 @@ public class ErrorResponseBuilder {
     }
     if (m_message != null) {
       error.withMessage(m_message);
+    }
+    if (m_severity != null) {
+      error.withSeverity(m_severity);
     }
     return error;
   }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/AbstractVetoExceptionMapper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/AbstractVetoExceptionMapper.java
@@ -32,6 +32,7 @@ public abstract class AbstractVetoExceptionMapper<E extends VetoException> exten
         .withHttpStatus(Response.Status.BAD_REQUEST)
         .withTitle(exception.getStatus().getTitle())
         .withMessage(exception.getStatus().getBody())
-        .withErrorCode(exception.getStatus().getCode());
+        .withErrorCode(exception.getStatus().getCode())
+        .withSeverity(exception.getStatus().getSeverity());
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/ProcessingExceptionMapper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/ProcessingExceptionMapper.java
@@ -31,6 +31,7 @@ public class ProcessingExceptionMapper extends AbstractExceptionMapper<Processin
     return BEANS.get(ErrorResponseBuilder.class)
         .withHttpStatus(Response.Status.INTERNAL_SERVER_ERROR)
         .withErrorCode(exception.getStatus().getCode())
+        .withSeverity(exception.getStatus().getSeverity())
         .withMessage(defaultErrorMessage(exception))
         .build();
   }


### PR DESCRIPTION
The severity is used to control whether a ProcessingStatus is an INFO, WARNING or ERROR. Used to cancel an operation (i.e. throwing a VetoException) and informing the user with a non-error message.

(cherry picked from commit fc2ccc985dcd46f35cd406a95e78d30d14633e68)