### PR TITLE
Fix exception when control popup opens while a notification is shown

### DIFF
--- a/eclipse-scout-core/src/desktop/Desktop.ts
+++ b/eclipse-scout-core/src/desktop/Desktop.ts
@@ -1613,7 +1613,7 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
       let parentOverlay = null;
       $overlays.toArray().reverse().some(elem => {
         let overlayWidget = findWidget(elem);
-        if (overlayWidget && overlayWidget.has(widget)) {
+        if (overlayWidget && !(overlayWidget instanceof Desktop) && overlayWidget.has(widget)) {
           parentOverlay = overlayWidget;
           return true; // found
         }

--- a/eclipse-scout-core/test/desktop/DesktopSpec.ts
+++ b/eclipse-scout-core/test/desktop/DesktopSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {FormSpecHelper, OutlineSpecHelper} from '../../src/testing/index';
+import {DummyLookupCall, FormSpecHelper, OutlineSpecHelper} from '../../src/testing/index';
 import {
   arrays, BusyIndicator, Button, DateField, DatePickerPopup, Desktop, DesktopNotification, DesktopTab, Device, Event, FileChooser, Form, FormMenu, GroupBox, ListBox, MessageBox, MessageBoxes, Outline, Popup, RemoteEvent, scout, SmartField,
   SmartFieldPopup, Status, StringField, strings, Tooltip, UnsavedFormChangesForm, Widget, WidgetPopup, WrappedFormField
@@ -2249,7 +2249,7 @@ describe('Desktop', () => {
           fields: [
             {id: 'Field1', objectType: StringField, tooltipText: 'Tooltip V1-1'},
             {id: 'Field2', objectType: StringField, tooltipText: 'Tooltip V1-2'},
-            {id: 'Field3', objectType: SmartField, lookupCall: 'DummyLookupCall'}
+            {id: 'Field3', objectType: SmartField, lookupCall: DummyLookupCall}
           ]
         }
       });
@@ -2266,7 +2266,7 @@ describe('Desktop', () => {
           fields: [
             {id: 'Field1', objectType: StringField, tooltipText: 'Tooltip D1-1'},
             {id: 'Field2', objectType: StringField, tooltipText: 'Tooltip D1-2'},
-            {id: 'Field3', objectType: SmartField, lookupCall: 'DummyLookupCall'}
+            {id: 'Field3', objectType: SmartField, lookupCall: DummyLookupCall}
           ]
         }
       });
@@ -2289,7 +2289,7 @@ describe('Desktop', () => {
             fields: [
               {id: 'Field1', objectType: StringField, tooltipText: 'Tooltip P1-1'},
               {id: 'Field2', objectType: StringField, tooltipText: 'Tooltip P1-2'},
-              {id: 'Field3', objectType: SmartField, lookupCall: 'DummyLookupCall'}
+              {id: 'Field3', objectType: SmartField, lookupCall: DummyLookupCall}
             ]
           }
         }
@@ -2308,7 +2308,7 @@ describe('Desktop', () => {
           fields: [
             {id: 'Field1', objectType: StringField, tooltipText: 'Tooltip D2-1'},
             {id: 'Field2', objectType: StringField, tooltipText: 'Tooltip D2-2'},
-            {id: 'Field3', objectType: SmartField, lookupCall: 'DummyLookupCall'}
+            {id: 'Field3', objectType: SmartField, lookupCall: DummyLookupCall}
           ]
         }
       });
@@ -2357,7 +2357,7 @@ describe('Desktop', () => {
             fields: [
               {id: 'Field1', objectType: StringField, tooltipText: 'Tooltip P2-1'},
               {id: 'Field2', objectType: StringField, tooltipText: 'Tooltip P2-2'},
-              {id: 'Field3', objectType: SmartField, lookupCall: 'DummyLookupCall'}
+              {id: 'Field3', objectType: SmartField, lookupCall: DummyLookupCall}
             ]
           }
         }
@@ -2461,7 +2461,7 @@ describe('Desktop', () => {
           fields: [
             {id: 'Field1', objectType: StringField, tooltipText: 'Tooltip D1-1'},
             {id: 'Field2', objectType: StringField, tooltipText: 'Tooltip D1-2'},
-            {id: 'Field3', objectType: SmartField, lookupCall: 'DummyLookupCall'}
+            {id: 'Field3', objectType: SmartField, lookupCall: DummyLookupCall}
           ]
         }
       });
@@ -2477,7 +2477,7 @@ describe('Desktop', () => {
           fields: [
             {id: 'Field1', objectType: StringField, tooltipText: 'Tooltip D2-1'},
             {id: 'Field2', objectType: StringField, tooltipText: 'Tooltip D2-2'},
-            {id: 'Field3', objectType: SmartField, lookupCall: 'DummyLookupCall'}
+            {id: 'Field3', objectType: SmartField, lookupCall: DummyLookupCall}
           ]
         }
       });
@@ -2550,7 +2550,7 @@ describe('Desktop', () => {
           fields: [
             {id: 'Field1', objectType: StringField, tooltipText: 'Tooltip D1-1'},
             {id: 'Field2', objectType: StringField, tooltipText: 'Tooltip D1-2', errorStatus: Status.error('Invalid value')},
-            {id: 'Field3', objectType: SmartField, lookupCall: 'DummyLookupCall'}
+            {id: 'Field3', objectType: SmartField, lookupCall: DummyLookupCall}
           ]
         }
       });
@@ -2571,6 +2571,23 @@ describe('Desktop', () => {
       expect(overlayWidgets[1]).toBeInstanceOf(Tooltip);
       expect(overlayWidgets[1].text).toBe('Invalid value');
       expect(overlayWidgets.length).toBe(2);
+    });
+
+    it('never renders overlays outside desktop', () => {
+      let desktop = session.desktop;
+      desktop.render(session.$entryPoint);
+      desktop.addNotification(scout.create(DesktopNotification, {
+        parent: desktop
+      }));
+      let smartField = scout.create(SmartField, {
+        parent: desktop.bench, // Draw inside bench to not influence the overlays
+        lookupCall: DummyLookupCall
+      });
+      smartField.render();
+      smartField.activate();
+      jasmine.clock().tick(500);
+      smartField.popup.animateRemoval = false;
+      expect(smartField.popup.$container.parent()[0]).toBe(desktop.$container[0]);
     });
   });
 });


### PR DESCRIPTION
Clicking on a smart field or date field while a desktop notification is shown creates an error, because the popup will be drawn outside the desktop
-> the entry point (which should be the desktop container) cannot be determined anymore.

Bug has been introduced by
commit abcf27b02f252d389e5ee254507abb5ee3e393ea.

344377