### PR TITLE
Revert "Add dependency to eclipse-scout-core to fix IntelliJ code com…

### DIFF
--- a/org.eclipse.scout.rt.chart.ui.html/pom.xml
+++ b/org.eclipse.scout.rt.chart.ui.html/pom.xml
@@ -40,10 +40,5 @@
       <groupId>org.eclipse.scout.rt</groupId>
       <artifactId>org.eclipse.scout.rt.ui.html</artifactId>
     </dependency>
-    <!-- Necessary for JS code completion when Scout is in the same IntelliJ Project, see WEB-56592-->
-    <dependency>
-      <groupId>org.eclipse.scout.rt</groupId>
-      <artifactId>eclipse-scout-chart</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/org.eclipse.scout.rt.svg.ui.html/pom.xml
+++ b/org.eclipse.scout.rt.svg.ui.html/pom.xml
@@ -37,6 +37,12 @@
       <groupId>org.eclipse.scout.rt</groupId>
       <artifactId>org.eclipse.scout.rt.ui.html</artifactId>
     </dependency>
+    <!-- Necessary for JS code completion when Scout is in the same IntelliJ Project, see WEB-56592-->
+    <dependency>
+      <groupId>org.eclipse.scout.rt</groupId>
+      <artifactId>eclipse-scout-core</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <!-- primarily for license header generation -->

--- a/org.eclipse.scout.rt.ui.html/pom.xml
+++ b/org.eclipse.scout.rt.ui.html/pom.xml
@@ -44,11 +44,6 @@
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
     </dependency>
-    <!-- Necessary for JS code completion when Scout is in the same IntelliJ Project, see WEB-56592-->
-    <dependency>
-      <groupId>org.eclipse.scout.rt</groupId>
-      <artifactId>eclipse-scout-core</artifactId>
-    </dependency>
   </dependencies>
 
   <!-- primarily for license header generation -->


### PR DESCRIPTION
…pletion"

This reverts commit 631dc662266133c54ff169151c525c2c5aac9f29.

Reason: the new dependencies created a cycle.