### PR TITLE
Delegate calls from VirtualDesktop to the real Desktop when available

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/extension/ui/outline/desktop/DesktopMoveOutlinesTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/extension/ui/outline/desktop/DesktopMoveOutlinesTest.java
@@ -1,17 +1,16 @@
 /*
- * Copyright (c) 2010-2015 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.client.extension.ui.outline.desktop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.List;
 
@@ -63,7 +62,7 @@ public class DesktopMoveOutlinesTest extends AbstractLocalExtensionTestCase {
     List<IOutline> outlines = desktop.getAvailableOutlines();
     assertEquals(outlineClasses.length, outlines.size());
     for (int i = 0; i < outlineClasses.length; i++) {
-      assertTrue(outlineClasses[i] == outlines.get(i).getClass());
+      assertSame(outlineClasses[i], outlines.get(i).getClass());
     }
   }
 }

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/extension/ui/outline/pages/TablePageExtensionTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/extension/ui/outline/pages/TablePageExtensionTest.java
@@ -1,19 +1,16 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.client.extension.ui.outline.pages;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.eclipse.scout.extension.AbstractLocalExtensionTestCase;
 import org.eclipse.scout.rt.client.extension.ui.action.menu.IMenuExtension;
@@ -119,6 +116,7 @@ public class TablePageExtensionTest extends AbstractLocalExtensionTestCase {
     assertEquals(1, table.getMenuByClass(EditMenu.class).getAllExtensions().size());
   }
 
+  @SuppressWarnings("unchecked")
   protected void assertExtendedTablePage(AbstractPersonTablePage<?> page, Class<? extends AbstractMenu> expectedTestMenuClass, Class<? extends IMenuExtension> expectedMenuExtensionClass) {
     AbstractPersonTablePage<?>.Table table = page.getTable();
     assertEquals(2, table.getColumnCount());

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/services/common/bookmark/BookmarkServiceTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/services/common/bookmark/BookmarkServiceTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2015 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -34,19 +34,17 @@ import org.mockito.Mockito;
 @RunWithClientSession(TestEnvironmentClientSession.class)
 public class BookmarkServiceTest {
 
-  private IDesktop m_desktop;
   private IDesktop m_mockDesktop;
 
   @Before
   public void setUp() {
-    m_desktop = TestEnvironmentClientSession.get().getDesktop();
     m_mockDesktop = Mockito.mock(IDesktop.class);
     TestEnvironmentClientSession.get().replaceDesktop(m_mockDesktop);
   }
 
   @After
   public void tearDown() {
-    TestEnvironmentClientSession.get().replaceDesktop(m_desktop);
+    TestEnvironmentClientSession.get().replaceDesktop(null);
   }
 
   @Test

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/WidgetTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/WidgetTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -113,7 +113,7 @@ public class WidgetTest {
     assertTrue(widget.isDisposeDone());
 
     // Init may be called again after dispose
-    // The reason is: it has always been like this for forms and we don't want to break existing code
+    // The reason is: it has always been like this for forms, and we don't want to break existing code
     widget.init();
     assertEquals(2, widget.initCalls);
     assertTrue(widget.isInitDone());

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/internal/VirtualDesktopTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/internal/VirtualDesktopTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.client.ui.desktop.internal;
+
+import static org.junit.Assert.*;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.scout.rt.client.AbstractClientSession;
+import org.eclipse.scout.rt.client.context.ClientRunContexts;
+import org.eclipse.scout.rt.client.job.ModelJobs;
+import org.eclipse.scout.rt.client.session.ClientSessionProvider;
+import org.eclipse.scout.rt.client.ui.WidgetEvent;
+import org.eclipse.scout.rt.client.ui.WidgetListener;
+import org.eclipse.scout.rt.client.ui.desktop.AbstractDesktop;
+import org.eclipse.scout.rt.client.ui.desktop.DesktopEvent;
+import org.eclipse.scout.rt.client.ui.desktop.DesktopListener;
+import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
+import org.eclipse.scout.rt.client.ui.desktop.datachange.DataChangeEvent;
+import org.eclipse.scout.rt.client.ui.desktop.datachange.DataChangeManager;
+import org.eclipse.scout.rt.client.ui.desktop.datachange.IDataChangeListener;
+import org.eclipse.scout.rt.client.ui.desktop.internal.VirtualDesktopTest.VirtualDesktopForwardTestSession;
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.reflect.BasicPropertySupport;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that accessing the Desktop using IDesktop.CURRENT.get() in an async task that was scheduled while the Desktop
+ * on the Session was still the VirtualDesktop (e.g. if scheduled during Desktop creation):
+ * <ol>
+ * <li>Is called as it was scheduled: with the VirtualDesktop on the RunContext</li>
+ * <li>This virtual Desktop forwards all calls to the real Desktop which has been created in the meantime.</li>
+ * </ol>
+ */
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(VirtualDesktopForwardTestSession.class)
+public class VirtualDesktopTest {
+
+  @Test
+  public void testRealDesktopUsedAsSoonAsAvailable() throws Throwable {
+    VirtualDesktopForwardTestSession session = ClientSessionProvider.currentSession(VirtualDesktopForwardTestSession.class);
+    assertTrue(session.m_asyncJobFinished.await(10, TimeUnit.SECONDS));
+    if (session.m_exFromAsyncInDesktopConstructor != null) {
+      throw session.m_exFromAsyncInDesktopConstructor;
+    }
+    if (session.m_exFromAsyncInExecLoad != null) {
+      throw session.m_exFromAsyncInExecLoad;
+    }
+    if (session.m_exFromAsyncAfterDesktopSet1 != null) {
+      throw session.m_exFromAsyncAfterDesktopSet1;
+    }
+    if (session.m_exFromAsyncAfterDesktopSet2 != null) {
+      throw session.m_exFromAsyncAfterDesktopSet2;
+    }
+    AbstractDesktop realDesktop = (AbstractDesktop) session.getDesktop();
+    int numListenerExpected = 12;
+    assertEquals(numListenerExpected, realDesktop
+        .desktopListeners()
+        .list(DesktopEvent.TYPE_DESKTOP_CLOSED).stream()
+        .filter(l -> l instanceof VirtualDesktopForwardTestDesktopListener).count());
+    assertEquals(numListenerExpected, session.m_realDesktopPropertySupport
+        .getPropertyChangeListeners().stream()
+        .filter(l -> l instanceof VirtualDesktopForwardTestPropertyChangeListener).count());
+    DataChangeManager dataChangeManager = (DataChangeManager) realDesktop.dataChangeListeners();
+    assertEquals(numListenerExpected, dataChangeManager
+        .listAll().entrySet().stream()
+        .flatMap(e -> e.getValue().stream())
+        .filter(l -> l instanceof VirtualDesktopForwardTestDataChangeListener)
+        .distinct().count());
+    DataChangeManager dataChangeDesktopInForegroundListeners = (DataChangeManager) realDesktop.dataChangeDesktopInForegroundListeners();
+    assertEquals(numListenerExpected, dataChangeDesktopInForegroundListeners
+        .listAll().entrySet().stream()
+        .flatMap(e -> e.getValue().stream())
+        .filter(l -> l instanceof VirtualDesktopForwardTestDataChangeListener)
+        .distinct().count());
+    assertEquals(numListenerExpected, realDesktop
+        .widgetListeners()
+        .list(WidgetEvent.TYPE_SCROLL_TO_TOP).stream()
+        .filter(l -> l instanceof VirtualDesktopForwardTestWidgetListener).count());
+  }
+
+  public static class VirtualDesktopForwardTestSession extends AbstractClientSession {
+
+    private final CountDownLatch m_asyncJobFinished = new CountDownLatch(5);
+    private Throwable m_exFromAsyncInDesktopConstructor;
+    private Throwable m_exFromAsyncInExecLoad;
+    private Throwable m_exFromAsyncAfterDesktopSet1;
+    private Throwable m_exFromAsyncAfterDesktopSet2;
+    private BasicPropertySupport m_realDesktopPropertySupport;
+
+    public VirtualDesktopForwardTestSession() {
+      super(true);
+    }
+
+    @Override
+    protected void execLoadSession() {
+      IDesktop virtualDesktop = getDesktopElseVirtualDesktop();
+      assertTrue(virtualDesktop instanceof VirtualDesktop);
+      Throwable t = execWithCurrentDesktop(virtualDesktop, virtualDesktop, false /* cannot succeed here*/);
+      if (t != null) {
+        throw new ProcessingException("Error in execLoad", t);
+      }
+      ModelJobs.schedule(() -> {
+        m_exFromAsyncInExecLoad = execWithCurrentDesktop(getDesktop(), virtualDesktop, true);
+      }, ModelJobs.newInput(ClientRunContexts.copyCurrent()));
+
+      IDesktop realDesktop = new AbstractDesktop() {
+        @Override
+        protected void initInternal() {
+          m_realDesktopPropertySupport = propertySupport;
+          ModelJobs.schedule(() -> {
+            m_exFromAsyncInDesktopConstructor = execWithCurrentDesktop(this, virtualDesktop, true);
+          }, ModelJobs.newInput(ClientRunContexts.copyCurrent()));
+          super.initInternal();
+        }
+      };
+      ModelJobs.schedule(() -> {
+        m_exFromAsyncInExecLoad = execWithCurrentDesktop(realDesktop, virtualDesktop, true);
+      }, ModelJobs.newInput(ClientRunContexts.copyCurrent()));
+
+      setDesktop(realDesktop);
+
+      ModelJobs.schedule(() -> {
+        m_exFromAsyncAfterDesktopSet1 = execWithCurrentDesktop(realDesktop, virtualDesktop /* virtual because here the current thread-local is copied */, true);
+      }, ModelJobs.newInput(ClientRunContexts.copyCurrent()));
+      ModelJobs.schedule(() -> {
+        m_exFromAsyncAfterDesktopSet2 = execWithCurrentDesktop(realDesktop, realDesktop /* real desktop as withSession() re-applies the values from the session and overwrites the ones from the current thread-local */, true);
+      }, ModelJobs.newInput(ClientRunContexts.copyCurrent().withSession(this, true)));
+    }
+
+    private Throwable execWithCurrentDesktop(IDesktop expectedDesktopOnSession, IDesktop expectedDesktopOnThreadLocal, boolean callMethodOnDesktop) {
+      try {
+        IDesktop desktopFromSession = ClientSessionProvider.currentSession().getDesktopElseVirtualDesktop();
+        assertSame(expectedDesktopOnSession, desktopFromSession);
+        if (callMethodOnDesktop) {
+          desktopFromSession.dataChanged(); // would throw if the real desktop is not already known to the virtual one
+        }
+        desktopFromSession.desktopListeners().add(new VirtualDesktopForwardTestDesktopListener(), false, DesktopEvent.TYPE_DESKTOP_CLOSED);
+        desktopFromSession.addPropertyChangeListener(new VirtualDesktopForwardTestPropertyChangeListener());
+        desktopFromSession.dataChangeListeners().add(new VirtualDesktopForwardTestDataChangeListener(), false);
+        desktopFromSession.dataChangeDesktopInForegroundListeners().add(new VirtualDesktopForwardTestDataChangeListener(), false);
+        desktopFromSession.widgetListeners().add(new VirtualDesktopForwardTestWidgetListener(), false, WidgetEvent.TYPE_SCROLL_TO_TOP);
+
+        IDesktop desktopFromThreadLocal = IDesktop.CURRENT.get();
+        assertSame(expectedDesktopOnThreadLocal, desktopFromThreadLocal);
+        if (callMethodOnDesktop) {
+          desktopFromThreadLocal.dataChanged(); // would throw if the real desktop is not already known to the virtual one
+        }
+        desktopFromThreadLocal.desktopListeners().add(new VirtualDesktopForwardTestDesktopListener(), false, DesktopEvent.TYPE_DESKTOP_CLOSED);
+        desktopFromThreadLocal.addPropertyChangeListener(new VirtualDesktopForwardTestPropertyChangeListener());
+        desktopFromThreadLocal.dataChangeListeners().add(new VirtualDesktopForwardTestDataChangeListener(), false);
+        desktopFromThreadLocal.dataChangeDesktopInForegroundListeners().add(new VirtualDesktopForwardTestDataChangeListener(), false);
+        desktopFromThreadLocal.widgetListeners().add(new VirtualDesktopForwardTestWidgetListener(), false, WidgetEvent.TYPE_SCROLL_TO_TOP);
+      }
+      catch (Throwable e) {
+        return e;
+      }
+      finally {
+        m_asyncJobFinished.countDown();
+      }
+      return null;
+    }
+  }
+
+  private static class VirtualDesktopForwardTestWidgetListener implements WidgetListener {
+    @Override
+    public void widgetChanged(WidgetEvent event) {
+    }
+  }
+
+  private static class VirtualDesktopForwardTestDataChangeListener implements IDataChangeListener {
+    @Override
+    public void dataChanged(DataChangeEvent event) {
+    }
+  }
+
+  private static class VirtualDesktopForwardTestPropertyChangeListener implements PropertyChangeListener {
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+    }
+  }
+
+  private static class VirtualDesktopForwardTestDesktopListener implements DesktopListener {
+    @Override
+    public void desktopChanged(DesktopEvent e) {
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/AbstractClientSession.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/AbstractClientSession.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -325,26 +325,17 @@ public abstract class AbstractClientSession extends AbstractPropertyObserver imp
   @Override
   public void setDesktop(IDesktop desktop) {
     if (desktop == null) {
-      throw new IllegalArgumentException("argument must not be null");
+      throw new IllegalArgumentException("desktop must not be null");
+    }
+    if (desktop == m_desktop) {
+      return;
     }
     if (m_desktop != null) {
-      throw new IllegalStateException("desktop is active");
+      throw new IllegalStateException("desktop is already set and cannot be changed");
     }
     m_desktop = desktop;
     if (m_virtualDesktop != null) {
-      m_desktop.desktopListeners().addAll(m_virtualDesktop.desktopListeners());
-      m_virtualDesktop.getPropertyChangeListenerMap()
-          .forEach((propName, listeners) -> listeners
-              .forEach(listener -> {
-                if (propName == null) {
-                  m_desktop.addPropertyChangeListener(listener);
-                }
-                else {
-                  m_desktop.addPropertyChangeListener(propName, listener);
-                }
-              }));
-      m_desktop.dataChangeListeners().addAll(m_virtualDesktop.dataChangeListeners());
-      m_desktop.dataChangeDesktopInForegroundListeners().addAll(m_virtualDesktop.dataChangeDesktopInForegroundListeners());
+      m_virtualDesktop.setRealDesktop(desktop);
       m_virtualDesktop = null;
     }
     m_desktop.init();

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/IClientSession.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/IClientSession.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -21,7 +21,6 @@ import org.eclipse.scout.rt.platform.nls.NlsLocale;
 import org.eclipse.scout.rt.platform.reflect.IPropertyObserver;
 import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.services.common.context.SharedVariableMap;
-import org.eclipse.scout.rt.shared.servicetunnel.IServiceTunnel;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
 
 public interface IClientSession extends ISession, IPropertyObserver {
@@ -85,9 +84,6 @@ public interface IClientSession extends ISession, IPropertyObserver {
   /**
    * Consumers can query for the {@link Subject} of a {@link IClientSession}
    * <p>
-   * The {@link IServiceTunnel} used by {@link IClientSession#getServiceTunnel()} checks for the Subject under which the
-   * session is running and creates a WSSE security element.
-   * <p>
    * The subject is set when this object is created from {@link Subject#getSubject(java.security.AccessControlContext)}
    */
   Subject getSubject();
@@ -103,6 +99,13 @@ public interface IClientSession extends ISession, IPropertyObserver {
 
   /**
    * Sets the desktop model associated with this client session.
+   *
+   * @param desktop
+   *          Must not be null.
+   * @throws IllegalStateException
+   *           if this session already has a desktop set
+   * @throws IllegalArgumentException
+   *           if the given desktop is null
    */
   void setDesktop(IDesktop desktop);
 
@@ -116,9 +119,6 @@ public interface IClientSession extends ISession, IPropertyObserver {
    */
   void setMemoryPolicy(IMemoryPolicy memoryPolicy);
 
-  /**
-   * @param newMap
-   */
   void replaceSharedVariableMapInternal(SharedVariableMap newMap);
 
   /**

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -282,7 +282,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
   }
 
   /**
-   * @return <code>true</code> if UI key strokes to select view tabs are enabled, <code>false</code> otherwise. Default
+   * @return <code>true</code> if UI keystrokes to select view tabs are enabled, <code>false</code> otherwise. Default
    *         value is <code>true</code>.
    */
   @ConfigProperty(ConfigProperty.BOOLEAN)
@@ -292,7 +292,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
   }
 
   /**
-   * @return optional modifier to use for UI key strokes to select view tabs (only relevant when
+   * @return optional modifier to use for UI keystrokes to select view tabs (only relevant when
    *         {@link #isSelectViewTabsKeyStrokesEnabled()} is <code>true</code>). Default value is
    *         {@link IKeyStroke#CONTROL}.
    */
@@ -316,7 +316,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
   /**
    * Configures the logo id.
    * <p>
-   * If specified, the logo will be displayed on the top right corner of the desktop.
+   * If specified, the logo will be displayed in the top right corner of the desktop.
    * <p>
    * Subclasses can override this method. Default is {@code null}.
    *
@@ -472,7 +472,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
 
   /**
    * Called after a UI has been attached to this desktop. The desktop is opened at this point. This method may be called
-   * more than once. It is called immediately after the desktop has been opened and also in case of a reload, when a new
+   * more than once. It is called immediately after the desktop has been opened and also in case of reload, when a new
    * UiSession has been created.
    * <p>
    * Subclasses can override this method. The default does nothing.
@@ -1398,7 +1398,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
   }
 
   /**
-   * @return the internal key stroke list. May be {@code null}.
+   * @return the internal keystroke list. May be {@code null}.
    */
   protected Set<IKeyStroke> getKeyStrokesInternal() {
     return propertySupport.getPropertySet(PROP_KEY_STROKES);
@@ -2163,7 +2163,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
   /**
    * How many times the attachGui() method has been called. Some behavior like URL or deep-link handling may be
    * different the first time a desktop is attached. If the attached count is 1 it means the desktop has been created.
-   * If attached count is > 1 it means an existing desktop is re-used (probably by a reload with Ctrl + R in the
+   * If attached count is > 1 it means an existing desktop is re-used (probably by reloading with Ctrl + R in the
    * browser).
    */
   protected int getAttachedCount() {
@@ -2284,7 +2284,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
       }
     }
     else {
-      // non empty deepLinkPath provided but no handler found, throw exception to let user know
+      // non-empty deepLinkPath provided but no handler found, throw exception to let user know
       throw new DeepLinkException("No deep-link handler found. deepLinkPath={" + deepLinkPath + " }");
     }
     return handled;

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/ClientSessionWithBlockingConditionInterruptionTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/ClientSessionWithBlockingConditionInterruptionTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
 package org.eclipse.scout.rt.ui.html;
 
 import static org.junit.Assert.assertEquals;
@@ -27,6 +37,7 @@ import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.IBeanInstanceProducer;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.classid.ClassId;
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.job.IFuture;
 import org.eclipse.scout.rt.platform.job.JobState;
 import org.eclipse.scout.rt.platform.job.Jobs;
@@ -216,17 +227,12 @@ public class ClientSessionWithBlockingConditionInterruptionTest {
     assertEquals(expectedProtocol, m_protocol);
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test(expected = ProcessingException.class)
   public void testSessionWithBlockingFormInLoad() {
     m_sessionBehaviour = SessionBehaviour.OPEN_FORM_IN_LOAD;
     m_desktopBehaviour = DesktopBehaviour.DO_NOTHING;
-    try {
-      IUiSession uiSession = JsonTestUtility.createAndInitializeUiSession();
-      uiSession.getClientSession();
-    }
-    catch (Exception ex) {
-      throw ex;
-    }
+    IUiSession uiSession = JsonTestUtility.createAndInitializeUiSession();
+    uiSession.getClientSession();
   }
 
   @Test

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonDesktopTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonDesktopTest.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -94,6 +94,7 @@ public class JsonDesktopTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testFormAddedAndRemoved() {
     DesktopWithOneOutline desktop = new DesktopWithOneOutline();
     desktop.init();
@@ -159,6 +160,7 @@ public class JsonDesktopTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testFormClosedBeforeRemovedInDifferentRequests() {
     DesktopWithOneOutline desktop = new DesktopWithOneOutline();
     desktop.init();
@@ -200,6 +202,7 @@ public class JsonDesktopTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testFormClosedBeforeRemovedInSameRequest() throws JSONException {
     DesktopWithOneOutline desktop = new DesktopWithOneOutline();
     desktop.init();
@@ -233,7 +236,7 @@ public class JsonDesktopTest {
   }
 
   /**
-   * Tests whether non displayable menus are sent.
+   * Tests whether non-displayable menus are sent.
    * <p>
    * This reduces response size and also leverages security because the menus are never visible to the user, not even
    * with the dev tools of the browser
@@ -265,7 +268,7 @@ public class JsonDesktopTest {
   }
 
   /**
-   * Tests whether non displayable view buttons are sent.
+   * Tests whether non-displayable view buttons are sent.
    * <p>
    * This reduces response size and also leverages security because the menus are never visible to the user, not even
    * with the dev tools of the browser
@@ -290,7 +293,7 @@ public class JsonDesktopTest {
   }
 
   /**
-   * Tests whether non displayable outline is sent.
+   * Tests whether non-displayable outline is sent.
    * <p>
    * This reduces response size and also leverages security because the menus are never visible to the user, not even
    * with the dev tools of the browser


### PR DESCRIPTION
If a ClientRunContext is created (e.g. by using copyCurrent) the values
from the currently active context are copied. The values are the ones
from the moment of the RunContext creation.

E.g. if an async task is scheduled while the Desktop is constructing,
the VirtualDesktop is on the RunContext (as no other Desktop has been
created yet). This means the async task is executed with the
VirtualDesktop as well, even if it is actually executed after the real
Desktop has been created.

This means that the second task uses the VirtualDesktop which has
already been removed from the Session and has been replaced with the
real one. As the VirtualDesktop throws Exceptions for most of the
methods, this may lead to unexpected behavior.

Now the VirtualDesktop gets the real Desktop as soon as it is set to the
session and delegates all calls to it. Older RunContexts still having
the VirtualDesktop will then start to use the real one transparently and
immediately after it is available on the session and without changing
the RunContext or re-scheduling anything. After the real Desktop has
been set to the virtual one, the VirtualDesktop acts like a proxy
delegating all calls to the real one.

As calling methods on the Desktop requires to be in a ModelJob, the
Desktop cannot change during a single execution.

320004