### PR TITLE
Fix invalid Content-Length on GzipServletResponseWrapper responses

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/filter/gzip/GzipServletResponseWrapper.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/filter/gzip/GzipServletResponseWrapper.java
@@ -19,6 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
+import org.apache.http.protocol.HTTP;
 import org.eclipse.scout.rt.server.commons.servlet.UrlHints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,6 +91,24 @@ public class GzipServletResponseWrapper extends HttpServletResponseWrapper {
   @Override
   public void setContentLength(int len) {
     // ignored: content length zipped content != content length unzipped content
+  }
+
+  @Override
+  public void setHeader(String name, String value) {
+    if (HTTP.CONTENT_LEN.equalsIgnoreCase(name)) {
+      // see setContentLength
+      return;
+    }
+    super.setHeader(name, value);
+  }
+
+  @Override
+  public void addHeader(String name, String value) {
+    if (HTTP.CONTENT_LEN.equalsIgnoreCase(name)) {
+      // see setContentLength
+      return;
+    }
+    super.addHeader(name, value);
   }
 
   @Override


### PR DESCRIPTION
Ignore Content-Length header in setHeader and addHeader methods (same as in setContentLength method) on GzipServletResponseWrapper to ensure the size is either correctly calculated after compressing the response or the response is transmitted in chunks without Content-Length header.

343547