### PR TITLE
Form.ts: modal should depend on display hint

### DIFF
--- a/eclipse-scout-chart/test-build/global/hello.js
+++ b/eclipse-scout-chart/test-build/global/hello.js
@@ -26,7 +26,6 @@ class Desktop extends scout.Desktop {
         {
           objectType: 'Form',
           displayHint: 'view',
-          modal: false,
           rootGroupBox: {
             objectType: 'GroupBox',
             borderDecoration: scout.GroupBox.BorderDecoration.EMPTY,

--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -90,7 +90,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
     this.displayParent = null; // only relevant if form is opened, not relevant if form is just rendered into another widget (not managed by a form controller)
     this.maximized = false;
     this.headerVisible = null;
-    this.modal = true;
+    this.modal = null;
     this.logicalGrid = scout.create(FormGrid);
     this.dialogs = [];
     this.views = [];
@@ -258,10 +258,11 @@ export class Form extends Widget implements FormModel, DisplayParent {
     if (this.parent instanceof WrappedFormField) {
       return;
     }
-    if (this.modal && !this._glassPaneRenderer) {
+    let modal = this.modal === null ? this.isDialog() : this.modal;
+    if (modal && !this._glassPaneRenderer) {
       this._glassPaneRenderer = new GlassPaneRenderer(this);
       this._glassPaneRenderer.renderGlassPanes();
-    } else if (!this.modal && this._glassPaneRenderer) {
+    } else if (!modal && this._glassPaneRenderer) {
       this._glassPaneRenderer.removeGlassPanes();
       this._glassPaneRenderer = null;
     }

--- a/eclipse-scout-core/src/form/FormModel.ts
+++ b/eclipse-scout-core/src/form/FormModel.ts
@@ -71,21 +71,25 @@ export interface FormModel extends WidgetModel, DisplayParentModel {
    */
   maximized?: boolean;
   /**
-   * The header contains the {@link title}, {@link subtitle}, {@link icon}, {@link saveNeeded} status and close action (controlled by {@link closable}.
+   * The header contains the {@link title}, {@link subtitle}, {@link icon}, {@link saveNeeded} status and close action (controlled by {@link closable}).
    *
-   * Set it to true, to show a header, false to not show a header. Null, to let the UI decide what to do, which means: show a header if it is a dialog, otherwise don't show one.
+   * - If set to true, a header will be shown.
+   * - If set to false, no header will be shown.
+   * - If set to null, the UI will decide what to do, which means: show a header if {@link displayHint} is set to {@link DisplayHint.DIALOG}, otherwise don't show one.
    *
    * Default is null (= header is visible if the form is a dialog).
    */
   headerVisible?: boolean;
   /**
-   * Controls whether the user is allowed to interact with the user interface on the back of the dialog.
+   * Controls whether the user is allowed to interact with the user interface outside the form.
    *
-   * If set to true, the user can only interact with the dialog.
+   * - If set to true, the user can only interact with the form and the rest is blocked.
+   * - If set to false, the interaction is not limited to the form.
+   * - If set to null, the UI decides whether to use true or false, which means: modal will be true if {@link displayHint} is set to {@link DisplayHint.DIALOG}, otherwise it will be false.
    *
-   * What parts of the desktop will be blocked dependends on the used {@link displayParent}.
+   * What parts of the desktop will be blocked depends on the used {@link displayParent}.
    *
-   * Default is true.
+   * Default is null (= form is modal if it is a dialog).
    */
   modal?: boolean;
   /**

--- a/eclipse-scout-core/test-build/global/hello.js
+++ b/eclipse-scout-core/test-build/global/hello.js
@@ -26,7 +26,6 @@ class Desktop extends scout.Desktop {
         {
           objectType: 'Form',
           displayHint: 'view',
-          modal: false,
           rootGroupBox: {
             objectType: 'GroupBox',
             borderDecoration: scout.GroupBox.BorderDecoration.EMPTY,

--- a/eclipse-scout-core/test/desktop/DesktopSpec.ts
+++ b/eclipse-scout-core/test/desktop/DesktopSpec.ts
@@ -2175,7 +2175,6 @@ describe('Desktop', () => {
   describe('views', () => {
     let formModel = {
       objectType: Form,
-      modal: false,
       displayHint: Form.DisplayHint.VIEW,
       rootGroupBox: {
         objectType: GroupBox
@@ -2243,7 +2242,6 @@ describe('Desktop', () => {
   describe('selectedViewTabs', () => {
     let formModel: ObjectOrChildModel<Form> = {
       objectType: Form,
-      modal: false,
       displayHint: Form.DisplayHint.VIEW,
       displayViewId: 'E',
       rootGroupBox: {
@@ -2459,7 +2457,6 @@ describe('Desktop', () => {
       let view = scout.create(Form, {
         parent: desktop,
         displayHint: Form.DisplayHint.VIEW,
-        modal: false,
         rootGroupBox: {
           objectType: GroupBox,
           fields: [
@@ -2511,7 +2508,6 @@ describe('Desktop', () => {
         id: 'View1',
         parent: desktop,
         displayHint: Form.DisplayHint.VIEW,
-        modal: false,
         rootGroupBox: {
           objectType: GroupBox,
           fields: [
@@ -2551,7 +2547,6 @@ describe('Desktop', () => {
           id: 'Popup1Form',
           objectType: Form,
           displayHint: Form.DisplayHint.VIEW,
-          modal: false,
           rootGroupBox: {
             objectType: GroupBox,
             fields: [
@@ -2619,7 +2614,6 @@ describe('Desktop', () => {
           id: 'Popup2Form',
           objectType: Form,
           displayHint: Form.DisplayHint.VIEW,
-          modal: false,
           rootGroupBox: {
             objectType: GroupBox,
             fields: [

--- a/eclipse-scout-core/test/form/FormSpec.ts
+++ b/eclipse-scout-core/test/form/FormSpec.ts
@@ -450,30 +450,50 @@ describe('Form', () => {
       let form = helper.createFormWithOneField({
         modal: true
       });
-      form.open()
-        .then(() => {
-          expect($('.glasspane').length).toBe(3);
-          form.close();
-          expect($('.glasspane').length).toBe(0);
-        })
-        .catch(fail)
-        .always(done);
+      openFormAndExpectGlassPane(form, true, done);
+    });
+
+    it('creates a glass pane if true also for views', done => {
+      let form = helper.createFormWithOneField({
+        modal: true,
+        displayHint: Form.DisplayHint.VIEW
+      });
+      openFormAndExpectGlassPane(form, true, done);
     });
 
     it('does not create a glass pane if false', done => {
       let form = helper.createFormWithOneField({
         modal: false
       });
+      openFormAndExpectGlassPane(form, false, done);
+    });
+
+    it('is true for dialogs if not explicitly set', done => {
+      let form = helper.createFormWithOneField({
+        displayHint: Form.DisplayHint.DIALOG
+      });
+      expect(form.modal).toBe(null);
+      openFormAndExpectGlassPane(form, true, done);
+    });
+
+    it('is false for views if not explicitly set', done => {
+      let form = helper.createFormWithOneField({
+        displayHint: Form.DisplayHint.VIEW
+      });
+      expect(form.modal).toBe(null);
+      openFormAndExpectGlassPane(form, false, done);
+    });
+
+    function openFormAndExpectGlassPane(form: Form, expectGlasspane: boolean, done: DoneFn) {
       form.open()
         .then(() => {
-          expect($('.glasspane').length).toBe(0);
+          expect($('.glasspane').length).toBe(expectGlasspane ? form.displayHint === 'dialog' ? 3 : 2 : 0);
           form.close();
           expect($('.glasspane').length).toBe(0);
         })
         .catch(fail)
         .always(done);
-    });
-
+    }
   });
 
   describe('displayParent', () => {

--- a/eclipse-scout-core/test/popup/WidgetPopupSpec.ts
+++ b/eclipse-scout-core/test/popup/WidgetPopupSpec.ts
@@ -24,7 +24,6 @@ describe('WidgetPopup', () => {
       content: {
         objectType: Form,
         displayHint: Form.DisplayHint.VIEW,
-        modal: false,
         initialFocus: initialFocus,
         rootGroupBox: {
           objectType: GroupBox,


### PR DESCRIPTION
Mostly, a view should not be modal -> make the flag depend on the display hint, so it will only be true for dialogs. This is the same behavior as for Scout Classic.

326196