### PR TITLE
Decrease memory footprint of ObjectExtensions

### DIFF
--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/extension/ObjectExtensions.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/extension/ObjectExtensions.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -117,6 +117,9 @@ public class ObjectExtensions<OWNER, EXTENSION extends IExtension<? extends OWNE
 
   private List<EXTENSION> loadExtensions(EXTENSION localExtension) {
     List<EXTENSION> extensions = BEANS.get(IInternalExtensionRegistry.class).createExtensionsFor(m_owner);
+    if (extensions.isEmpty()) {
+      return Collections.singletonList(localExtension);
+    }
     extensions.add(localExtension);
     return Collections.unmodifiableList(extensions);
   }


### PR DESCRIPTION
Use SingletonList if only one extension exists