### PR TITLE
Decrease memory footprint of ObjectExtensions

### DIFF
--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/extension/ObjectExtensions.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/extension/ObjectExtensions.java
@@ -116,6 +116,9 @@ public class ObjectExtensions<OWNER, EXTENSION extends IExtension<? extends OWNE
 
   private List<EXTENSION> loadExtensions(EXTENSION localExtension) {
     List<EXTENSION> extensions = BEANS.get(IInternalExtensionRegistry.class).createExtensionsFor(m_owner);
+    if (extensions.isEmpty()) {
+      return Collections.singletonList(localExtension);
+    }
     extensions.add(localExtension);
     return Collections.unmodifiableList(extensions);
   }


### PR DESCRIPTION
Use SingletonList if only one extension exists