### PR TITLE
DoEntitySerializerAttributeNameComparator not @ApplicationScoped

### DIFF
--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
@@ -24,7 +24,6 @@ import org.eclipse.scout.rt.dataobject.DoNode;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.IDoEntityContribution;
-import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 import org.eclipse.scout.rt.platform.util.LazyValue;
 
@@ -46,12 +45,10 @@ public class DoEntitySerializer extends StdSerializer<IDoEntity> {
   protected final LazyValue<DataObjectInventory> m_dataObjectInventory = new LazyValue<>(DataObjectInventory.class);
 
   protected final ScoutDataObjectModuleContext m_context;
-  protected final DoEntitySerializerAttributeNameComparator m_comparator;
 
   public DoEntitySerializer(ScoutDataObjectModuleContext context, JavaType type) {
     super(type);
     m_context = context;
-    m_comparator = BEANS.get(DoEntitySerializerAttributeNameComparator.class).init(context);
   }
 
   @Override
@@ -73,7 +70,7 @@ public class DoEntitySerializer extends StdSerializer<IDoEntity> {
    */
   protected void serializeAttributes(IDoEntity entity, JsonGenerator gen, SerializerProvider provider) throws IOException {
     serializeTypeVersion(gen, entity);
-    TreeMap<String, DoNode<?>> sortedMap = new TreeMap<>(m_comparator);
+    TreeMap<String, DoNode<?>> sortedMap = new TreeMap<>(m_context.getComparator());
     sortedMap.putAll(entity.allNodes());
     for (Map.Entry<String, DoNode<?>> e : sortedMap.entrySet()) {
       gen.setCurrentValue(entity);

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializerAttributeNameComparator.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializerAttributeNameComparator.java
@@ -9,12 +9,14 @@
  */
 package org.eclipse.scout.rt.jackson.dataobject;
 
+import static org.eclipse.scout.rt.platform.util.Assertions.assertTrue;
+
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.NumberUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
 
@@ -32,7 +34,7 @@ import org.eclipse.scout.rt.platform.util.ObjectUtility;
  * <li>Contributions attribute (unchanged order of contribution items)</li>
  * </ol>
  */
-@ApplicationScoped
+@Bean
 public class DoEntitySerializerAttributeNameComparator implements Comparator<String>, Serializable {
 
   private static final long serialVersionUID = 1L;
@@ -40,6 +42,7 @@ public class DoEntitySerializerAttributeNameComparator implements Comparator<Str
   protected Map<String, Integer> m_orders = new HashMap<>();
 
   public DoEntitySerializerAttributeNameComparator init(ScoutDataObjectModuleContext context) {
+    assertTrue(m_orders.isEmpty(), "Already initialized"); // avoid duplicate initialization as otherwise multiple different attribut names may be considered equal
     m_orders.put(context.getTypeAttributeName(), -2); // always first
     m_orders.put(context.getTypeVersionAttributeName(), -1); // always second
     m_orders.put(context.getContributionsAttributeName(), 1); // always last

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/ScoutDataObjectModuleContext.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/ScoutDataObjectModuleContext.java
@@ -13,9 +13,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.BooleanUtility;
+import org.eclipse.scout.rt.platform.util.LazyValue;
 
 /**
  * Context object used to carry properties for {@link ScoutDataObjectModule} and its components (e.g. serializers and
@@ -33,6 +35,8 @@ public class ScoutDataObjectModuleContext {
   protected static final String IGNORE_TYPE_ATTRIBUTE_KEY = "ignoreTypeAttributeKey";
 
   protected static final String CONTRIBUTIONS_ATTRIBUTE_NAME_KEY = "contributionsAttributeNameKey";
+
+  protected LazyValue<DoEntitySerializerAttributeNameComparator> m_comparator = new LazyValue<>(() -> BEANS.get(DoEntitySerializerAttributeNameComparator.class).init(this));
 
   protected final Map<String, Object> m_contextMap = new HashMap<>();
 
@@ -65,6 +69,10 @@ public class ScoutDataObjectModuleContext {
   public ScoutDataObjectModuleContext withDataObjectMapperClass(Class<? extends IDataObjectMapper> dataObjectMapperClass) {
     put(DATA_OBJECT_MAPPER_CLASS_KEY, dataObjectMapperClass);
     return this;
+  }
+
+  public DoEntitySerializerAttributeNameComparator getComparator() {
+    return m_comparator.get();
   }
 
   public String getTypeAttributeName() {


### PR DESCRIPTION
As DoEntitySerializerAttributeNameComparator is configuried using ScoutDataObjectModuleContext which may exist in multiple variations for multiple DoEntitySerializer also
DoEntitySerializerAttributeNameComparator must not be marked as @ApplicationScoped as both other classes are only configured as @Bean.

339105