### PR TITLE
DoValueMigrationDataObjectVisitor: Do not ignore result from super call

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeCompositeFixture.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeCompositeFixture.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.assertNotNull;
+
+import java.util.Objects;
+
+/**
+ * Immutable composite object used as value in {@link RoomTypeCompositeFixtureDo}.
+ *
+ * @see RoomTypeCompositeFixtureDataObjectVisitorExtension
+ */
+public class RoomTypeCompositeFixture {
+
+  private final RoomTypeFixtureStringId m_primaryRoomType;
+  private final RoomTypeFixtureStringId m_secondaryRoomType;
+
+  public RoomTypeCompositeFixture(RoomTypeFixtureStringId primaryRoomType, RoomTypeFixtureStringId secondaryRoomType) {
+    m_primaryRoomType = assertNotNull(primaryRoomType);
+    m_secondaryRoomType = assertNotNull(secondaryRoomType);
+  }
+
+  public RoomTypeFixtureStringId getPrimaryRoomType() {
+    return m_primaryRoomType;
+  }
+
+  public RoomTypeFixtureStringId getSecondaryRoomType() {
+    return m_secondaryRoomType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RoomTypeCompositeFixture that = (RoomTypeCompositeFixture) o;
+    return m_primaryRoomType.equals(that.m_primaryRoomType) && m_secondaryRoomType.equals(that.m_secondaryRoomType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_primaryRoomType, m_secondaryRoomType);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeCompositeFixtureDataObjectVisitorExtension.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeCompositeFixtureDataObjectVisitorExtension.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+import org.eclipse.scout.rt.dataobject.AbstractDataObjectVisitorExtension;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
+
+/**
+ * Handles the components within a {@link RoomTypeCompositeFixture}.
+ */
+public class RoomTypeCompositeFixtureDataObjectVisitorExtension extends AbstractDataObjectVisitorExtension<RoomTypeCompositeFixture> {
+
+  @Override
+  public void visit(RoomTypeCompositeFixture value, Consumer<Object> chain) {
+    chain.accept(value.getPrimaryRoomType());
+    chain.accept(value.getSecondaryRoomType());
+  }
+
+  @Override
+  public RoomTypeCompositeFixture replaceOrVisit(RoomTypeCompositeFixture value, UnaryOperator<Object> chain) {
+    RoomTypeFixtureStringId migratedPrimaryRoomType = (RoomTypeFixtureStringId) chain.apply(value.getPrimaryRoomType());
+    RoomTypeFixtureStringId migratedSecondaryRoomType = (RoomTypeFixtureStringId) chain.apply(value.getSecondaryRoomType());
+
+    if (ObjectUtility.equals(migratedPrimaryRoomType, value.getPrimaryRoomType()) && ObjectUtility.equals(migratedSecondaryRoomType, value.getSecondaryRoomType())) {
+      // no changes detected: return value itself
+      return value;
+    }
+
+    // create a new instance of the immutable composite object with the migrated components
+    return new RoomTypeCompositeFixture(migratedPrimaryRoomType, migratedSecondaryRoomType);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeCompositeFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeCompositeFixtureDo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.dataobject.migration.fixture.house;
+
+import javax.annotation.Generated;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.TypeVersion;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
+
+/**
+ * Used for value migration tests for composite objects handled by
+ * {@link RoomTypeCompositeFixtureDataObjectVisitorExtension}.
+ */
+@TypeName("charlieFixture.RoomTypeCompositeFixture")
+@TypeVersion(CharlieFixture_1.class)
+public class RoomTypeCompositeFixtureDo extends DoEntity {
+
+  public DoValue<RoomTypeCompositeFixture> roomTypeComposite() {
+    return doValue("roomTypeComposite");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public RoomTypeCompositeFixtureDo withRoomTypeComposite(RoomTypeCompositeFixture roomTypeComposite) {
+    roomTypeComposite().set(roomTypeComposite);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public RoomTypeCompositeFixture getRoomTypeComposite() {
+    return roomTypeComposite().get();
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationDataObjectVisitor.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DoValueMigrationDataObjectVisitor.java
@@ -74,7 +74,6 @@ public class DoValueMigrationDataObjectVisitor extends AbstractReplacingDataObje
       }
     }
     // recursively visit migrated value
-    super.replaceOrVisit(currentValue);
-    return currentValue;
+    return super.replaceOrVisit(currentValue);
   }
 }


### PR DESCRIPTION
Method replaceOrVisit must not ignore the result from the super call, if values are replaced by the super call, e.g. through a DataObjectVisitorExtension, the replaced value must not be ignored.

346741