### PR TITLE
Abstract Type version: add support for optional suffix

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/AbstractTypeVersionTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/AbstractTypeVersionTest.java
@@ -15,6 +15,11 @@ import static org.eclipse.scout.rt.platform.util.Assertions.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_002__suffix;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_0__123456;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_0__loremIpsumDolor_3;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_0__lorem_ipsum;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_0__suffix;
 import org.eclipse.scout.rt.dataobject.fixture.DataObjectProjectFixtureTypeVersions.DataObjectProjectFixture_1_2_3_004;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 import org.junit.Assert;
@@ -32,5 +37,12 @@ public class AbstractTypeVersionTest {
 
     assertEquals(NamespaceVersion.of("dataObjectFixture", "1.0.0"), fromClassName(DataObjectFixture_1_0_0.class));
     assertEquals(NamespaceVersion.of("dataObjectProjectFixture", "1.2.3.004"), fromClassName(DataObjectProjectFixture_1_2_3_004.class));
+
+    // with suffix
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(DataObjectFixture_1_3_0__suffix.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(DataObjectFixture_1_3_0__123456.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(DataObjectFixture_1_3_0__lorem_ipsum.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(DataObjectFixture_1_3_0__loremIpsumDolor_3.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.002"), fromClassName(DataObjectFixture_1_3_002__suffix.class));
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/DataObjectFixtureTypeVersions.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/DataObjectFixtureTypeVersions.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.eclipse.scout.rt.dataobject.AbstractTypeVersion;
+import org.eclipse.scout.rt.dataobject.AbstractTypeVersionTest;
 import org.eclipse.scout.rt.dataobject.DataObjectInventoryTest;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.platform.IgnoreBean;
@@ -90,5 +91,40 @@ public final class DataObjectFixtureTypeVersions {
     public Collection<NamespaceVersion> getDependencies() {
       return Collections.emptyList();
     }
+  }
+
+  /**
+   * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
+   */
+  @IgnoreBean
+  public static final class DataObjectFixture_1_3_0__suffix extends AbstractTypeVersion {
+  }
+
+  /**
+   * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
+   */
+  @IgnoreBean
+  public static final class DataObjectFixture_1_3_0__123456 extends AbstractTypeVersion {
+  }
+
+  /**
+   * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
+   */
+  @IgnoreBean
+  public static final class DataObjectFixture_1_3_0__lorem_ipsum extends AbstractTypeVersion {
+  }
+
+  /**
+   * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
+   */
+  @IgnoreBean
+  public static final class DataObjectFixture_1_3_0__loremIpsumDolor_3 extends AbstractTypeVersion {
+  }
+
+  /**
+   * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
+   */
+  @IgnoreBean
+  public static final class DataObjectFixture_1_3_002__suffix extends AbstractTypeVersion {
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractTypeVersion.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractTypeVersion.java
@@ -78,7 +78,10 @@ public abstract class AbstractTypeVersion implements ITypeVersion {
     return Collections.emptyList();
   }
 
-  private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("(\\w+?)_(\\d+(?:_\\d+)*)");
+  /**
+   * Optional suffix (class name only) starting with __ followed by any word characters.
+   */
+  private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("(\\w+?)_(\\d+(?:_\\d+)*)(?:__\\w+)?");
 
   static NamespaceVersion fromClassName(Class<? extends ITypeVersion> typeVersionClass) {
     if (typeVersionClass == null) {
@@ -92,6 +95,6 @@ public abstract class AbstractTypeVersion implements ITypeVersion {
   }
 
   static List<NamespaceVersion> resolveDependencies(Collection<Class<? extends ITypeVersion>> dependencyClasses) {
-    return Collections.unmodifiableList(dependencyClasses.stream().map(dependencyClass -> BEANS.get(dependencyClass).getVersion()).collect(Collectors.toList()));
+    return dependencyClasses.stream().map(dependencyClass -> BEANS.get(dependencyClass).getVersion()).collect(Collectors.toUnmodifiableList());
   }
 }


### PR DESCRIPTION
Optional suffix starts with __ followed by any word characters. The suffix is only part of the class name, but not the resulting NamespaceVersion.

Examples:
- Scout_22_0_0__lorem
- Scout_22_0_0__ipsum_dolor

346252