### PR TITLE
ESLint: don't mark format violations as errors

### DIFF
--- a/eslint-config/src/common.js
+++ b/eslint-config/src/common.js
@@ -52,7 +52,7 @@ module.exports = {
     'no-else-return': 'error',
     'max-len': ['warn', 240, 2, {ignoreUrls: true, ignorePattern: '^import .*'}],
     'semi': ['error', 'always'],
-    'quotes': ['error', 'single'],
+    'quotes': ['warn', 'single'],
     'comma-dangle': ['error', 'never'],
     'object-curly-spacing': ['error', 'never'],
     'operator-linebreak': 'off',

--- a/eslint-config/src/index.js
+++ b/eslint-config/src/index.js
@@ -39,7 +39,7 @@ module.exports = {
       '@typescript-eslint/member-delimiter-style': 'warn', // Enforce semicolon for interface members for consistency,
       '@typescript-eslint/no-this-alias': 'off', // Allow assigment of this to a variable, e.g. for better readability. 'That' and 'self' are not used often anymore.
       'indent': 'off', // Disable because it will be replaced by the following ts rule
-      '@typescript-eslint/indent': ['error', 2, {'SwitchCase': 1, 'ignoredNodes': ['PropertyDefinition[decorators]']}], // Workarounds bug https://github.com/typescript-eslint/typescript-eslint/issues/1824. See also https://github.com/eslint/eslint/issues/15299#issuecomment-967762181
+      '@typescript-eslint/indent': ['warn', 2, {'SwitchCase': 1, 'ignoredNodes': ['PropertyDefinition[decorators]']}], // Workarounds bug https://github.com/typescript-eslint/typescript-eslint/issues/1824. See also https://github.com/eslint/eslint/issues/15299#issuecomment-967762181. Also change to warn because indent errors are not critical.
       'linebreak-style': 'off',
       '@typescript-eslint/prefer-ts-expect-error': 'warn',
       '@typescript-eslint/no-empty-function': 'off'


### PR DESCRIPTION
With the use of TypeScript, the developer now gets real errors that must be solved before the code can be run. Format violations that look like compile errors are distracting.

If the build should fail when there are eslint violations we could add --max-warnings 0 to the eslint check in the future.