### PR TITLE
JsonAdapter: ignore events for disposed adapters

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/AbstractJsonAdapter.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/AbstractJsonAdapter.java
@@ -347,7 +347,12 @@ public abstract class AbstractJsonAdapter<T> implements IJsonAdapter<T> {
 
   protected final JsonEvent addActionEvent(String eventName, IJsonAdapter<?> referenceAdapter, JSONObject eventData) {
     JsonEvent event;
-    if (referenceAdapter == null) {
+    if (isDisposed()) {
+      // Create dummy event to prevent NPEs
+      event = new JsonEvent(getId(), eventName, new JSONObject());
+      LOG.debug("Adding action event ignored '{}' for disposed {} with id {}. Model: {}", eventName, getObjectType(), getId(), getModel());
+    }
+    else if (referenceAdapter == null) {
       event = getUiSession().currentJsonResponse().addActionEvent(getId(), eventName, eventData);
       LOG.debug("Added action event '{}' for {} with id {}. Model: {}", eventName, getObjectType(), getId(), getModel());
     }
@@ -375,6 +380,11 @@ public abstract class AbstractJsonAdapter<T> implements IJsonAdapter<T> {
   }
 
   protected JsonEvent addPropertyChangeEvent(String propertyName, Object newValue) {
+    if (isDisposed()) {
+      LOG.debug("Adding property change event ignored '{}' for disposed {} with id {}. Model: {}", propertyName, getObjectType(), getId(), getModel());
+      // Create dummy event to prevent NPEs
+      return new JsonPropertyChangeEvent(getId());
+    }
     if (newValue instanceof IJsonAdapter<?>) {
       throw new IllegalArgumentException("Cannot pass an adapter instance to a JSON response");
     }


### PR DESCRIPTION
Use case:
Changing a value in a smartfield causes the form to be replaced which also changes the errorStatus of the SmartField.
handleUiAcceptInput in JsonSmartField listens for error status changes and wants to send them to the UI.
Because accept input triggered the disposal of the form, the field will be disposed as well and the error status change must not be sent to the UI because it won't exist on the UI anymore. The minimal solution would be to guard the addPropertyChangeEvent in acceptInput of JsonSmartField. But actually, I don't see any reason to allow events to be sent for disposed adapters at all, beside the disposeAdapter event which is sent by the UiSession.

Stacktrace:
Could not resolve event targets: ["target: 1194, type: property, properties: errorStatus"]
    at Session._processEvents (webpack:///org.eclipse.scout.rt/eclipse-scout-core/src/session/Session.js:1445:12)
    at _processEvents (webpack:///org.eclipse.scout.rt/eclipse-scout-core/src/session/Session.js:928:13)
    at _processSuccessResponse (webpack:///org.eclipse.scout.rt/eclipse-scout-core/src/session/Session.js:915:11)
    at processJsonResponseInternal (webpack:///org.eclipse.scout.rt/eclipse-scout-core/src/session/ResponseQueue.js:96:33)
    at process (webpack:///org.eclipse.scout.rt/eclipse-scout-core/src/session/Session.js:728:37)
    at apply (webpack:///node_modules/.pnpm/jquery@3.6.0/node_modules/jquery/dist/jquery.js:3500:30)
    at fire (webpack:///node_modules/.pnpm/jquery@3.6.0/node_modules/jquery/dist/jquery.js:3630:6)
    at deferred.<computed> (webpack:///node_modules/.pnpm/jquery@3.6.0/node_modules/jquery/dist/jquery.js:3968:37)
    at resolve (webpack:///org.eclipse.scout.rt/eclipse-scout-core/src/util/Call.js:80:18)
    at _resolve (webpack:///org.eclipse.scout.rt/eclipse-scout-core/src/util/Call.js:182:9)

Returned an empty event to ensure there won't be any NPEs in case anyone checked the return value.

348319