### PR TITLE
NumberField & NumberColumn: add fractionDigits

### DIFF
--- a/eclipse-scout-core/src/form/fields/integerfield/IntegerField.ts
+++ b/eclipse-scout-core/src/form/fields/integerfield/IntegerField.ts
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {DecimalFormat, Locale, NumberField, objects} from '../../../index';
+import {DecimalFormat, Locale, NumberField} from '../../../index';
 
 export class IntegerField extends NumberField {
+
+  declare fractionDigits: 0;
 
   static MIN_VALUE = Number.MIN_SAFE_INTEGER;
   static MAX_VALUE = Number.MAX_SAFE_INTEGER;
@@ -18,17 +20,14 @@ export class IntegerField extends NumberField {
     super();
     this.minValue = IntegerField.MIN_VALUE;
     this.maxValue = IntegerField.MAX_VALUE;
+    this.fractionDigits = 0;
   }
 
   protected override _getDefaultFormat(locale: Locale): string | DecimalFormat {
     return '#,##0';
   }
 
-  protected override _parseValue(displayText: string): number {
-    let result = super._parseValue(displayText);
-    if (objects.isNullOrUndefined(result)) {
-      return null;
-    }
-    return this.decimalFormat.round(result, false);
+  protected override _setFractionDigits(fractionDigits: number) {
+    super._setFractionDigits(0);
   }
 }

--- a/eclipse-scout-core/src/form/fields/numberfield/NumberField.ts
+++ b/eclipse-scout-core/src/form/fields/numberfield/NumberField.ts
@@ -18,6 +18,7 @@ export class NumberField extends BasicField<number, number | string> implements 
   minValue: number;
   maxValue: number;
   decimalFormat: DecimalFormat;
+  fractionDigits: number;
 
   constructor() {
     super();
@@ -25,6 +26,7 @@ export class NumberField extends BasicField<number, number | string> implements 
     this.minValue = null;
     this.maxValue = null;
     this.decimalFormat = null;
+    this.fractionDigits = null;
     this.invalidValueMessageKey = 'InvalidNumberMessageX';
     this.gridDataHints.horizontalAlignment = 1; // number fields are right aligned by default.
   }
@@ -33,15 +35,15 @@ export class NumberField extends BasicField<number, number | string> implements 
     super._init(model);
     this._setMinValue(this.minValue);
     this._setMaxValue(this.maxValue);
-    this._setDecimalFormat(this.decimalFormat);
   }
 
   /**
-   * Initializes the decimal format before calling set value.
+   * Initializes the decimal format and the fraction digits before calling set value.
    * This cannot be done in _init because the value field would call _setValue first
    */
   protected override _initValue(value: number) {
     this._setDecimalFormat(this.decimalFormat);
+    this._setFractionDigits(this.fractionDigits);
     super._initValue(value);
   }
 
@@ -88,8 +90,19 @@ export class NumberField extends BasicField<number, number | string> implements 
     this._setProperty('decimalFormat', decimalFormat);
 
     if (this.initialized) {
-      // if format changes on the fly, just update the display text
-      this._updateDisplayText();
+      this.setValue(this.value);
+    }
+  }
+
+  setFractionDigits(fractionDigits: number) {
+    this.setProperty('fractionDigits', fractionDigits);
+  }
+
+  protected _setFractionDigits(fractionDigits: number) {
+    this._setProperty('fractionDigits', fractionDigits);
+
+    if (this.initialized) {
+      this.setValue(this.value);
     }
   }
 
@@ -126,6 +139,9 @@ export class NumberField extends BasicField<number, number | string> implements 
     if (!numbers.isNumber(typedValue)) {
       // might be NaN if the string is no valid number
       throw this.session.text(this.invalidValueMessageKey, value);
+    }
+    if (numbers.isNumber(this.fractionDigits)) {
+      typedValue = numbers.round(typedValue, this.decimalFormat.roundingMode, this.fractionDigits);
     }
     return typedValue;
   }

--- a/eclipse-scout-core/src/form/fields/numberfield/NumberFieldEventMap.ts
+++ b/eclipse-scout-core/src/form/fields/numberfield/NumberFieldEventMap.ts
@@ -11,6 +11,7 @@ import {BasicFieldEventMap, DecimalFormat, PropertyChangeEvent} from '../../../i
 
 export interface NumberFieldEventMap extends BasicFieldEventMap<number> {
   'propertyChange:decimalFormat': PropertyChangeEvent<DecimalFormat>;
+  'propertyChange:fractionDigits': PropertyChangeEvent<number>;
   'propertyChange:maxValue': PropertyChangeEvent<number>;
   'propertyChange:minValue': PropertyChangeEvent<number>;
 }

--- a/eclipse-scout-core/src/form/fields/numberfield/NumberFieldModel.ts
+++ b/eclipse-scout-core/src/form/fields/numberfield/NumberFieldModel.ts
@@ -10,7 +10,37 @@
 import {BasicFieldModel, DecimalFormat, DecimalFormatOptions} from '../../../index';
 
 export interface NumberFieldModel extends BasicFieldModel<number, number | string> {
+  /**
+   * Specifies the minimum value. Value <code>null</code> means no limitation.
+   *
+   * If value is bigger than {@link maxValue}, the current maxValue is set to the same new value.
+   *
+   * Default is null.
+   */
   minValue?: number;
+  /**
+   * Specifies the maximum value. Value <code>null</code> means no limitation.
+   *
+   * If value is smaller than {@link minValue}, the current minValue is set to the same new value.
+   *
+   * Default is null.
+   */
   maxValue?: number;
+  /**
+   * Specifies the decimalFormat used to format the displayText and to parse user input.
+   * @see DecimalFormat
+   *
+   * Default is {@link Locale.decimalFormatPatternDefault} of the current locale.
+   */
   decimalFormat?: string | DecimalFormat | DecimalFormatOptions;
+  /**
+   * Specifies the number of fraction digits the value is rounded to. If not set, the value will not be rounded.
+   * This will always be applied to the value even if the decimalFormat has a multiplier.
+   *
+   * Example: decimalFormat with multiplier 100, fractionDigits 1.
+   * User input 42 will result in a value 0.4 and a displayText 40.
+   *
+   * Default is null.
+   */
+  fractionDigits?: number;
 }

--- a/eclipse-scout-core/src/table/TableAdapter.ts
+++ b/eclipse-scout-core/src/table/TableAdapter.ts
@@ -754,13 +754,13 @@ export class TableAdapter extends ModelAdapter {
         let model;
         if (objects.isPlainObject(vararg)) {
           model = vararg;
-          model.value = this._parseValue(model.value);
+          model.value = this._ensureValue(model.value);
           // Parse the value if a text but no value is provided. The server does only set the text if value and text are equal.
           // It is also necessary for custom columns which don't have a UI representation and never send the value.
           // Do not parse the value if there is an error status.
           // If editing fails, the display text will be the user input, the value unchanged, and the server will set the error status.
           if (model.text && model.value === undefined && !model.errorStatus) {
-            model.value = this._parseValue(model.text);
+            model.value = this._ensureValue(model.text);
           }
           // use null instead of undefined
           if (model.value === undefined) {
@@ -768,7 +768,7 @@ export class TableAdapter extends ModelAdapter {
           }
         } else {
           model = {
-            value: this._parseValue(vararg)
+            value: this._ensureValue(vararg)
           };
         }
         defaultValues.applyTo(model, 'Cell');

--- a/eclipse-scout-core/src/table/columns/Column.ts
+++ b/eclipse-scout-core/src/table/columns/Column.ts
@@ -230,12 +230,12 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
       cell = vararg;
 
       // value may be set but may have the wrong type (e.g. text instead of date) -> ensure type
-      cell.value = this._parseValue(cell.value);
+      cell.value = this._ensureValue(cell.value);
     } else {
       // in this case 'vararg' is only a scalar value, typically a string
       let cellType = Cell<TValue>;
       cell = scout.create(cellType, {
-        value: this._parseValue(vararg)
+        value: this._ensureValue(vararg)
       });
     }
 
@@ -245,8 +245,8 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
   /**
    * Override this method to create a value based on the given scalar value.
    */
-  protected _parseValue(scalar: TValue): TValue {
-    return scalar;
+  protected _ensureValue(scalar: TValue | string): TValue {
+    return scalar as TValue;
   }
 
   protected _updateCellText(row: TableRow, cell: Cell<TValue>) {
@@ -625,7 +625,7 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
 
   protected _setCellValue(row: TableRow, value: TValue, cell: Cell<TValue>) {
     // value may have the wrong type (e.g. text instead of date) -> ensure type
-    value = this._parseValue(value);
+    value = this._ensureValue(value);
 
     // Only update row status when value changed.
     // Cell text needs to be updated even if value did not change

--- a/eclipse-scout-core/src/table/columns/DateColumn.ts
+++ b/eclipse-scout-core/src/table/columns/DateColumn.ts
@@ -73,7 +73,7 @@ export class DateColumn extends Column<Date> implements DateColumnModel {
     return this.format.format(value);
   }
 
-  protected override _parseValue(text: Date): Date {
+  protected override _ensureValue(text: Date | string): Date {
     return dates.ensure(text);
   }
 

--- a/eclipse-scout-core/src/table/columns/NumberColumn.ts
+++ b/eclipse-scout-core/src/table/columns/NumberColumn.ts
@@ -25,6 +25,7 @@ export class NumberColumn extends Column<number> implements NumberColumnModel {
   aggregationFunction: NumberColumnAggregationFunction;
   backgroundEffect: NumberColumnBackgroundEffect;
   decimalFormat: DecimalFormat;
+  fractionDigits: number;
   minValue: number;
   maxValue: number;
 
@@ -47,6 +48,7 @@ export class NumberColumn extends Column<number> implements NumberColumnModel {
     this.aggregationFunction = 'sum';
     this.backgroundEffect = null;
     this.decimalFormat = null;
+    this.fractionDigits = null;
     this.minValue = null;
     this.maxValue = null;
     this.calcMinValue = null;
@@ -61,6 +63,7 @@ export class NumberColumn extends Column<number> implements NumberColumnModel {
   protected override _init(model: InitModelOf<this>) {
     super._init(model);
     this._setDecimalFormat(this.decimalFormat);
+    this._setFractionDigits(this.fractionDigits);
     this._setAggregationFunction(this.aggregationFunction);
   }
 
@@ -88,7 +91,15 @@ export class NumberColumn extends Column<number> implements NumberColumnModel {
     return this.decimalFormat.format(value);
   }
 
-  protected override _parseValue(value: number | string): number {
+  setFractionDigits(fractionDigits: number) {
+    this.setProperty('fractionDigits', fractionDigits);
+  }
+
+  protected _setFractionDigits(fractionDigits: number) {
+    this._setProperty('fractionDigits', fractionDigits);
+  }
+
+  protected override _ensureValue(value: number | string): number {
     // server sends cell.value only if it differs from text -> make sure cell.value is set and has the right type
     return numbers.ensure(value);
   }
@@ -278,7 +289,7 @@ export class NumberColumn extends Column<number> implements NumberColumnModel {
       b = Math.ceil(startColor.blue - level * (startColor.blue - endColor.blue));
 
     return {
-      backgroundColor: 'rgb(' + r + ',' + g + ', ' + b + ')'
+      backgroundColor: 'rgb(' + r + ', ' + g + ', ' + b + ')'
     };
   }
 
@@ -295,7 +306,8 @@ export class NumberColumn extends Column<number> implements NumberColumnModel {
       parent: this.table,
       maxValue: this.maxValue,
       minValue: this.minValue,
-      decimalFormat: this.decimalFormat
+      decimalFormat: this.decimalFormat,
+      fractionDigits: this.fractionDigits
     });
   }
 

--- a/eclipse-scout-core/src/table/columns/NumberColumnEventMap.ts
+++ b/eclipse-scout-core/src/table/columns/NumberColumnEventMap.ts
@@ -13,4 +13,5 @@ export interface NumberColumnEventMap extends ColumnEventMap {
   'propertyChange:aggregationFunction': PropertyChangeEvent<NumberColumnAggregationFunction>;
   'propertyChange:backgroundEffect': PropertyChangeEvent<NumberColumnBackgroundEffect>;
   'propertyChange:decimalFormat': PropertyChangeEvent<DecimalFormat>;
+  'propertyChange:fractionDigits': PropertyChangeEvent<number>;
 }

--- a/eclipse-scout-core/src/table/columns/NumberColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/NumberColumnModel.ts
@@ -13,6 +13,12 @@ export interface NumberColumnModel extends ColumnModel<number> {
   aggregationFunction?: NumberColumnAggregationFunction;
   backgroundEffect?: 'colorGradient1' | 'colorGradient2' | 'barChart';
   decimalFormat?: DecimalFormat | string | DecimalFormatOptions;
+  /**
+   * Has no effect on the column itself, but is passed to the cell editor if the column is editable.
+   *
+   * @see NumberField.fractionDigits
+   */
+  fractionDigits?: number;
   minValue?: number;
   maxValue?: number;
 }

--- a/eclipse-scout-core/src/text/DecimalFormat.ts
+++ b/eclipse-scout-core/src/text/DecimalFormat.ts
@@ -11,13 +11,10 @@ import {Locale, numbers, RoundingMode, scout, strings} from '../index';
 
 /**
  * Provides formatting of numbers using java format pattern.
- * <p>
+ *
  * Compared to the java DecimalFormat the following pattern characters are not considered:
- * <ul>
- *   <li>prefix and suffix</li>
- *   <li>E</li>
- *   <li>%</li>
- * </ul>
+ * - E
+ * - %
  */
 export class DecimalFormat {
   positivePrefix: string;
@@ -243,16 +240,35 @@ export class DecimalFormat {
   }
 
   /**
-   * Convert to JS number format (remove groupingChar, replace decimalSeparatorChar with '.')
+   * Convert to JS number format:
+   * - remove groupingChar and lenientGroupingChars
+   * - replace decimalSeparatorChar with '.'
+   * - remove positiveSuffix and negativeSuffix
+   * - replace positivePrefix with '+'
+   * - replace negativePrefix with '-'
    */
   normalize(numberString: string): string {
     if (!numberString) {
       return numberString;
     }
-    return numberString
+    let result = numberString
       .replace(new RegExp('[' + this.groupingChar + this.lenientGroupingChars + ']', 'g'), '')
-      .replace(new RegExp('[' + this.decimalSeparatorChar + ']', 'g'), '.')
-      .replace(/\s/g, '');
+      .replace(new RegExp('[' + this.decimalSeparatorChar + ']', 'g'), '.');
+
+    if (strings.hasText(this.positivePrefix)) {
+      result = result.replace(new RegExp(this.positivePrefix, 'g'), '+');
+    }
+    if (strings.hasText(this.positiveSuffix)) {
+      result = result.replace(new RegExp(this.positiveSuffix, 'g'), '');
+    }
+    if (strings.hasText(this.negativePrefix)) {
+      result = result.replace(new RegExp(this.negativePrefix, 'g'), '-');
+    }
+    if (strings.hasText(this.negativeSuffix)) {
+      result = result.replace(new RegExp(this.negativeSuffix, 'g'), '');
+    }
+
+    return result.replace(/\s/g, '');
   }
 
   /* --- STATIC HELPERS ------------------------------------------------------------- */

--- a/eclipse-scout-core/src/util/numbers.ts
+++ b/eclipse-scout-core/src/util/numbers.ts
@@ -83,25 +83,25 @@ export const numbers = {
   },
 
   /**
-   * Rounds a number to the given number of decimal places.
+   * Rounds a number to the given number of fraction digits.
    *
    * Numbers should not be rounded with the built-in Number.toFixed() method, since it
    * behaves differently on different browsers. However, it is safe to apply toFixed()
-   * to the result of this method to ensure a fixed number of decimal places (filled up
+   * to the result of this method to ensure a fixed number of fraction digits (filled up
    * with 0's) because this operation does not involve any rounding anymore.
    * <p>
-   * If decimalPlaces is omitted, the number will be rounded to integer by default.
+   * If fractionDigits is omitted, the number will be rounded to integer by default.
    * Rounding mode {@link RoundingMode.HALF_UP} is used as default.
    */
-  round(number: number, roundingMode?: RoundingMode, decimalPlaces?: number): number {
+  round(number: number, roundingMode?: RoundingMode, fractionDigits?: number): number {
     if (number === null || number === undefined) {
       return number;
     }
-    decimalPlaces = decimalPlaces || 0;
+    fractionDigits = fractionDigits || 0;
 
     // Do _not_ multiply with powers of 10 here, because that might cause rounding errors!
-    // Example: 1.005 with 2 decimal places would result in 100.49999999999999
-    number = numbers.shiftDecimalPoint(number, decimalPlaces);
+    // Example: 1.005 with 2 fraction digits would result in 100.49999999999999
+    number = numbers.shiftDecimalPoint(number, fractionDigits);
 
     switch (roundingMode) {
       case RoundingMode.UP:
@@ -143,7 +143,7 @@ export const numbers = {
         }
     }
 
-    return numbers.shiftDecimalPoint(number, -decimalPlaces);
+    return numbers.shiftDecimalPoint(number, -fractionDigits);
   },
 
   /**

--- a/eclipse-scout-core/test/form/fields/numberfield/NumberFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/numberfield/NumberFieldSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {FormSpecHelper, JQueryTesting, LocaleSpecHelper} from '../../../../src/testing/index';
-import {DecimalFormat, Locale, NumberField, scout, Status} from '../../../../src/index';
+import {DecimalFormat, Locale, NumberField, RoundingMode, scout, Status} from '../../../../src/index';
 
 describe('NumberField', () => {
   let session: SandboxSession;
@@ -251,6 +251,143 @@ describe('NumberField', () => {
       expect(field.decimalFormat.multiplier).toBe(1);
     });
 
+  });
+
+  describe('fractionDigits', () => {
+    let field;
+
+    beforeEach(() => {
+      field = helper.createField(NumberField);
+    });
+
+    it('is applied on setValue', () => {
+      field.setValue(123.456789);
+      expect(field.value).toBe(123.456789);
+
+      field.setFractionDigits(3);
+      field.setValue(123.456789);
+      expect(field.value).toBe(123.457);
+
+      field.setFractionDigits(5);
+      field.setValue(123.456789);
+      expect(field.value).toBe(123.45679);
+
+      field.setFractionDigits(1);
+      field.setValue(123.456789);
+      expect(field.value).toBe(123.5);
+    });
+
+    it('is applied on user input', () => {
+      field.render();
+
+      field.$field.val('123.456789');
+      field.acceptInput();
+      expect(field.value).toBe(123.456789);
+
+      field.setFractionDigits(3);
+      field.$field.val('123.456789');
+      field.acceptInput();
+      expect(field.value).toBe(123.457);
+
+      field.setFractionDigits(5);
+      field.$field.val('123.456789');
+      field.acceptInput();
+      expect(field.value).toBe(123.45679);
+
+      field.setFractionDigits(1);
+      field.$field.val('123.456789');
+      field.acceptInput();
+      expect(field.value).toBe(123.5);
+    });
+
+    it('updates the value if it changes', () => {
+      field.setValue(123.456789);
+
+      field.setDecimalFormat('###0.#');
+      expect(field.value).toBe(123.456789);
+      expect(field.displayText).toBe('123.5');
+
+      field.setDecimalFormat('###0.##');
+      expect(field.value).toBe(123.456789);
+      expect(field.displayText).toBe('123.46');
+
+      field.setFractionDigits(3);
+      expect(field.value).toBe(123.457);
+      expect(field.displayText).toBe('123.46');
+
+      field.setFractionDigits(1);
+      expect(field.value).toBe(123.5);
+      expect(field.displayText).toBe('123.5');
+
+      field.setDecimalFormat('###0.000');
+      expect(field.value).toBe(123.5);
+      expect(field.displayText).toBe('123.500');
+
+      field.setFractionDigits(3);
+      expect(field.value).toBe(123.5);
+      expect(field.displayText).toBe('123.500');
+    });
+
+    it('updates the value if it changes (decimalFormat with multiplier)', () => {
+      field.setValue(123.456789);
+
+      field.setDecimalFormat({
+        pattern: '###0.#',
+        multiplier: 100
+      });
+      expect(field.value).toBe(123.456789);
+      expect(field.displayText).toBe('12345.7');
+
+      field.setFractionDigits(3);
+      expect(field.value).toBe(123.457);
+      expect(field.displayText).toBe('12345.7');
+
+      field.setFractionDigits(1);
+      expect(field.value).toBe(123.5);
+      expect(field.displayText).toBe('12350');
+
+      field.setFractionDigits(3);
+      expect(field.value).toBe(123.5);
+      expect(field.displayText).toBe('12350');
+    });
+
+    it('updates the value using the roundingMode of the format', () => {
+      field.setFractionDigits(1);
+      field.setDecimalFormat('###0.0');
+      field.setValue(12.3456789);
+      expect(field.value).toBe(12.3);
+      expect(field.displayText).toBe('12.3');
+
+      field.setFractionDigits(3);
+      expect(field.value).toBe(12.3);
+      expect(field.displayText).toBe('12.3');
+
+      field.setValue(12.3456789);
+      expect(field.value).toBe(12.346);
+      expect(field.displayText).toBe('12.3');
+
+      field.setDecimalFormat({
+        pattern: '###0.0',
+        roundingMode: RoundingMode.FLOOR
+      });
+      expect(field.value).toBe(12.346);
+      expect(field.displayText).toBe('12.3');
+
+      field.setValue(12.3456789);
+      expect(field.value).toBe(12.345);
+      expect(field.displayText).toBe('12.3');
+
+      field.setDecimalFormat({
+        pattern: '###0.0',
+        roundingMode: RoundingMode.CEILING
+      });
+      expect(field.value).toBe(12.345);
+      expect(field.displayText).toBe('12.4');
+
+      field.setValue(12.3456789);
+      expect(field.value).toBe(12.346);
+      expect(field.displayText).toBe('12.4');
+    });
   });
 
   describe('calculates value', () => {

--- a/eclipse-scout-core/test/text/DecimalFormatSpec.ts
+++ b/eclipse-scout-core/test/text/DecimalFormatSpec.ts
@@ -349,4 +349,25 @@ describe('DecimalFormat', () => {
       expect(decimalFormat.round(-12345.6789)).toBe(-12345.67);
     });
   });
+
+  describe('normalize', () => {
+    it('can handle prefix and suffix', () => {
+      let decimalFormat = new DecimalFormat(locale, {
+        pattern: 'plus###0%;minus###0§'
+      });
+
+      expect(decimalFormat.normalize('42')).toBe('42');
+      expect(decimalFormat.normalize('42%')).toBe('42');
+      expect(decimalFormat.normalize('42§')).toBe('42');
+      expect(decimalFormat.normalize('plus42')).toBe('+42');
+      expect(decimalFormat.normalize('plus42%')).toBe('+42');
+      expect(decimalFormat.normalize('plus42§')).toBe('+42');
+      expect(decimalFormat.normalize('minus42')).toBe('-42');
+      expect(decimalFormat.normalize('minus42%')).toBe('-42');
+      expect(decimalFormat.normalize('minus42§')).toBe('-42');
+
+      expect(decimalFormat.normalize('plus42&')).toBe('+42&');
+      expect(decimalFormat.normalize('MiNuS42§')).toBe('MiNuS42');
+    });
+  });
 });


### PR DESCRIPTION
Add a new property to round the value to a given number of fraction
digits. This gives the possibility to round the value to e.g. 5 fraction
digits while the format has only 3 fraction digits. In this example a
user input "12.3456789" will give the value "12.34568" and the
displayText "12.346".

333348