### PR TITLE
Add connection error / exception detector for remote file servlet, Ui…

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/ConnectionErrorDetectorTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/ConnectionErrorDetectorTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.util;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.lang.reflect.Field;
+import java.net.SocketException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.testing.platform.runner.parameterized.AbstractScoutTestParameter;
+import org.eclipse.scout.rt.testing.platform.runner.parameterized.IScoutTestParameter;
+import org.eclipse.scout.rt.testing.platform.runner.parameterized.ParameterizedPlatformTestRunner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(ParameterizedPlatformTestRunner.class)
+public class ConnectionErrorDetectorTest {
+
+  private static final String CONNECTION_RESET_MESSAGE = "connection reset by peer";
+  private static final String BROKEN_PIPE_MESSAGE = "broken pipe";
+
+  @Parameters
+  public static List<IScoutTestParameter> getParameters() {
+    List<IScoutTestParameter> parametersList = new LinkedList<>();
+    parametersList.add(new ExceptionTestParameter(new SocketException(CONNECTION_RESET_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new SocketException(BROKEN_PIPE_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new SocketException("unknown error"), false));
+
+    parametersList.add(new ExceptionTestParameter(new EofException(CONNECTION_RESET_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new EofException(BROKEN_PIPE_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new EofException("unknown error"), false));
+
+    parametersList.add(new ExceptionTestParameter(new ClientAbortException(CONNECTION_RESET_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new ClientAbortException(BROKEN_PIPE_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new ClientAbortException("unknown error"), false));
+
+    parametersList.add(new ExceptionTestParameter(new InterruptedIOException(CONNECTION_RESET_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new InterruptedIOException(BROKEN_PIPE_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new InterruptedIOException("unknown error"), false));
+
+    parametersList.add(new ExceptionTestParameter(new IOException(CONNECTION_RESET_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new IOException(BROKEN_PIPE_MESSAGE), true));
+    parametersList.add(new ExceptionTestParameter(new IOException("unknown error"), false));
+
+    parametersList.add(new ExceptionTestParameter(new CustomException(CONNECTION_RESET_MESSAGE), false));
+    parametersList.add(new ExceptionTestParameter(new CustomException(BROKEN_PIPE_MESSAGE), false));
+    parametersList.add(new ExceptionTestParameter(new CustomException("unknown error"), false));
+
+    parametersList.add(new ExceptionTestParameter(createDetectedNestedException(), true));
+    parametersList.add(new ExceptionTestParameter(createUndetectedNestedException(), false));
+
+    parametersList.add(new ExceptionTestParameter(createUndetectedCycledCauseException(), false));
+
+    return parametersList;
+  }
+
+  private static Exception createDetectedNestedException() {
+    IOException detectedIOException = new IOException(BROKEN_PIPE_MESSAGE);
+    CustomException customException = new CustomException("custom exception", detectedIOException);
+    IOException ioException = new IOException("some IO exception", customException);
+    return new Exception("detected nested exception", ioException);
+  }
+
+  private static Exception createUndetectedNestedException() {
+    IOException undetectedIOException = new IOException("unknown IO exception");
+    CustomException customException = new CustomException("custom exception", undetectedIOException);
+    IOException ioException = new IOException("some IO exception", customException);
+    return new Exception("undetected nested exception", ioException);
+  }
+
+  private static CycledCauseException createUndetectedCycledCauseException() {
+    CycledCauseException cycledCauseException = new CycledCauseException("cycled cause exception");
+    Assert.assertSame(cycledCauseException, cycledCauseException.getCause());
+
+    return cycledCauseException;
+  }
+
+  private final ExceptionTestParameter m_testParameter;
+
+  public ConnectionErrorDetectorTest(ExceptionTestParameter testParameter) {
+    m_testParameter = testParameter;
+  }
+
+  @Test
+  public void testIsConnectionError() {
+    ConnectionErrorDetector connectionErrorDetector = BEANS.get(ConnectionErrorDetector.class);
+    if (m_testParameter.isDetectable()) {
+      Assert.assertTrue(connectionErrorDetector.isConnectionError(m_testParameter.getException()));
+    }
+    else {
+      Assert.assertFalse(connectionErrorDetector.isConnectionError(m_testParameter.getException()));
+    }
+  }
+
+  private static class ClientAbortException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ClientAbortException(String message) {
+      super(message);
+    }
+  }
+
+  private static class EofException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public EofException(String message) {
+      super(message);
+    }
+  }
+
+  private static class CustomException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public CustomException(String message) {
+      super(message);
+    }
+
+    public CustomException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  private static class CycledCauseException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public CycledCauseException(String message) {
+      super(message);
+    }
+
+    @Override
+    public synchronized Throwable getCause() {
+      Throwable t = null;
+      try {
+        Field causeField = Throwable.class.getDeclaredField("cause");
+        causeField.setAccessible(true);
+        t = (Throwable) causeField.get(this);
+      }
+      catch (NoSuchFieldException | IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+      return t;
+    }
+  }
+
+  private static class ExceptionTestParameter extends AbstractScoutTestParameter {
+
+    private Exception m_exception;
+    private boolean m_isDetectable;
+
+    public ExceptionTestParameter(Exception exception, boolean isDetectable) {
+      super(exception.getClass().getSimpleName() + ":" + exception.getMessage());
+      m_exception = exception;
+      m_isDetectable = isDetectable;
+    }
+
+    public Exception getException() {
+      return m_exception;
+    }
+
+    public boolean isDetectable() {
+      return m_isDetectable;
+    }
+  }
+}

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/ConnectionErrorDetectorTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/ConnectionErrorDetectorTest.java
@@ -11,7 +11,6 @@ package org.eclipse.scout.rt.platform.util;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.lang.reflect.Field;
 import java.net.SocketException;
 import java.util.LinkedList;
 import java.util.List;
@@ -145,16 +144,7 @@ public class ConnectionErrorDetectorTest {
 
     @Override
     public synchronized Throwable getCause() {
-      Throwable t = null;
-      try {
-        Field causeField = Throwable.class.getDeclaredField("cause");
-        causeField.setAccessible(true);
-        t = (Throwable) causeField.get(this);
-      }
-      catch (NoSuchFieldException | IllegalAccessException e) {
-        throw new RuntimeException(e);
-      }
-      return t;
+      return ObjectUtility.nvl(super.getCause(), this);
     }
   }
 

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/ConnectionErrorDetector.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/ConnectionErrorDetector.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.util;
+
+import java.io.InterruptedIOException;
+import java.net.SocketException;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+@ApplicationScoped
+public class ConnectionErrorDetector {
+
+  public boolean isConnectionError(Throwable e) {
+    Throwable cause = e;
+    Throwable previousCause = null;
+    while (cause != null && cause != previousCause) { // second check avoids endless loops
+      String simpleName = cause.getClass().getSimpleName();
+      String message = cause.getMessage();
+      if ((cause instanceof SocketException
+          || "EofException".equalsIgnoreCase(simpleName)
+          || "ClientAbortException".equalsIgnoreCase(simpleName)
+          || cause instanceof InterruptedIOException
+          || "IOException".equalsIgnoreCase(simpleName))
+          && (StringUtility.containsStringIgnoreCase(message, "Connection reset by peer")
+           || StringUtility.containsStringIgnoreCase(message, "Broken pipe"))) {
+        return true;
+      }
+      // set previous cause
+      previousCause = cause;
+      // set next cause
+      cause = cause.getCause();
+    }
+    return false;
+  }
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/RemoteFileServlet.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/RemoteFileServlet.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.ConnectionErrorDetector;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.server.commons.servlet.HttpServletControl;
 import org.eclipse.scout.rt.server.commons.servlet.cache.HttpCacheControl;
@@ -120,8 +121,9 @@ public class RemoteFileServlet extends HttpServlet {
       }
     }
     catch (Exception ex) {
-      if (("" + ex.toString()).contains("Connection reset by peer: socket write error")) {
-        // ignore it
+      if (BEANS.get(ConnectionErrorDetector.class).isConnectionError(ex)) {
+        // Ignore disconnect errors: we do not want to throw an exception, if the client closed the connection.
+        LOG.debug("Connection error detected: exception class={}, message={}.", ex.getClass().getSimpleName(), ex.getMessage(), ex);
       }
       else {
         LOG.warn("Failed to get remotefile {}.", pathInfo, ex);


### PR DESCRIPTION
…Servlet and GzipServletOutputStream

Connections aborted or reset by the browser may lead to IOException in the backend application. These exception can be ignored. The detector can be used be identify these exception types and messabges. In general, those exceptions can be ignored and should only be logged in level debug.

345358