### PR TITLE
TS: add some more types to adapters

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
@@ -166,17 +166,14 @@ export class OutlineAdapter extends TreeAdapter {
   }
 
   /**
-   * Replacement for Outline#_computeDetailContent(). 'This' points to the outline.
+   * Replacement for {@link Outline._computeDetailContent}.
    */
-  protected static _computeDetailContentRemote() {
-    // @ts-expect-error
+  protected static _computeDetailContentRemote(this: Outline & { _computeDetailContentOrig }) {
     if (!this.modelAdapter) {
-      // @ts-expect-error
       return this._computeDetailContentOrig();
     }
 
-    // @ts-expect-error
-    let selectedPage = this.selectedNode();
+    let selectedPage: Page & { detailFormResolved?: boolean } = this.selectedNode();
     if (!selectedPage) {
       // Detail content is shown for the selected node only
       return null;
@@ -186,21 +183,17 @@ export class OutlineAdapter extends TreeAdapter {
     if (selectedPage.detailForm || selectedPage.detailFormResolved) {
       // If there is a detail form -> return (and set flag to true to make updateDetailMenusRemote work)
       selectedPage.detailFormResolved = true;
-      // @ts-expect-error
       return this._computeDetailContentOrig();
     }
 
     // It is not known yet whether there is a detail form -> wait for the requests to be processed before showing the table row detail
-    // @ts-expect-error
     if (!this.session.areRequestsPending() && !this.session.areEventsQueued()) {
       // There are no requests pending -> return (and set flag to true to make updateDetailMenusRemote work)
       selectedPage.detailFormResolved = true;
-      // @ts-expect-error
       return this._computeDetailContentOrig();
     }
 
     // Wait for the requests to complete
-    // @ts-expect-error
     this.session.listen().done(function(selectedPage) {
       if (selectedPage.detailFormResolved) {
         // No need to update detail content again if resolved is true
@@ -213,17 +206,14 @@ export class OutlineAdapter extends TreeAdapter {
   }
 
   /**
-   * Replacement for Outline#updateDetailMenusRemote(). 'This' points to the outline.
+   * Replacement for {@link Outline.updateDetailMenus}.
    */
-  static updateDetailMenusRemote() {
-    // @ts-expect-error
+  static updateDetailMenusRemote(this: Outline & { updateDetailMenusOrig: typeof Outline.prototype.updateDetailMenus }) {
     if (!this.modelAdapter) {
-      // @ts-expect-error
       return this.updateDetailMenusOrig();
     }
-    // @ts-expect-error
-    if (this.selectedNode() && this.selectedNode().detailFormResolved) {
-      // @ts-expect-error
+    let selectedPage: Page & { detailFormResolved?: boolean } = this.selectedNode();
+    if (selectedPage && selectedPage.detailFormResolved) {
       return this.updateDetailMenusOrig();
     }
   }
@@ -233,22 +223,17 @@ export class OutlineAdapter extends TreeAdapter {
    * This cannot be done using pageInit event because the page needs to be initialized during the outline initialization
    * and the event listener can only be attached afterwards.
    */
-  protected static _initTreeNodeInternalRemote(page: Page, parentNode: Page) {
-    // @ts-expect-error
+  protected static _initTreeNodeInternalRemote(this: Outline & { modelAdapter: OutlineAdapter; _initTreeNodeInternalOrig }, page: Page, parentNode: Page) {
     this._initTreeNodeInternalOrig(page, parentNode);
-    // @ts-expect-error
     if (!this.modelAdapter) {
       return;
     }
     // The current method may be called during init of the Outline
     // -> widget is not set yet but the following methods need it
-    // @ts-expect-error
     this.modelAdapter.widget = this;
     if (page.detailTable) {
-      // @ts-expect-error
       this.modelAdapter._initDetailTable(page);
     }
-    // @ts-expect-error
     this.modelAdapter._linkNodeWithRowLater(page);
   }
 }

--- a/eclipse-scout-core/src/form/fields/FormFieldAdapter.ts
+++ b/eclipse-scout-core/src/form/fields/FormFieldAdapter.ts
@@ -67,16 +67,14 @@ export class FormFieldAdapter extends ModelAdapter {
       return;
     }
 
-    objects.replacePrototypeFunction(FormField, 'getCurrentMenuTypes', FormFieldAdapter.getCurrentMenuTypes, true);
+    objects.replacePrototypeFunction(FormField, FormField.prototype.getCurrentMenuTypes, FormFieldAdapter.getCurrentMenuTypes, true);
   }
 
-  static getCurrentMenuTypes(): string[] {
-    // @ts-expect-error
+  static getCurrentMenuTypes(this: FormField & { getCurrentMenuTypesOrig: typeof FormField.prototype.getCurrentMenuTypes }): string[] {
     let modelAdapter = this.modelAdapter as FormFieldAdapter;
     if (modelAdapter) {
       return modelAdapter._currentMenuTypes;
     }
-    // @ts-expect-error
     return this.getCurrentMenuTypesOrig();
   }
 }

--- a/eclipse-scout-core/src/form/fields/datefield/DateFieldAdapter.ts
+++ b/eclipse-scout-core/src/form/fields/datefield/DateFieldAdapter.ts
@@ -47,10 +47,8 @@ export class DateFieldAdapter extends ValueFieldAdapter {
     return Object.keys(newProperties).sort(this._createPropertySortFunc(DateFieldAdapter.PROPERTIES_ORDER));
   }
 
-  static isDateAllowedRemote(date: Date): boolean {
-    // @ts-expect-error
+  static isDateAllowedRemote(this: DateField & { isDateAllowedOrig: typeof DateField.prototype.isDateAllowed }, date: Date): boolean {
     if (!this.modelAdapter) {
-      // @ts-expect-error
       return this.isDateAllowedOrig(date);
     }
     // Server will take care of it
@@ -62,7 +60,7 @@ export class DateFieldAdapter extends ValueFieldAdapter {
       return;
     }
 
-    objects.replacePrototypeFunction(DateField, 'isDateAllowed', DateFieldAdapter.isDateAllowedRemote, true);
+    objects.replacePrototypeFunction(DateField, DateField.prototype.isDateAllowed, DateFieldAdapter.isDateAllowedRemote, true);
   }
 }
 

--- a/eclipse-scout-core/src/form/fields/numberfield/NumberFieldAdapter.ts
+++ b/eclipse-scout-core/src/form/fields/numberfield/NumberFieldAdapter.ts
@@ -29,7 +29,7 @@ export class NumberFieldAdapter extends BasicFieldAdapter {
       return;
     }
 
-    objects.replacePrototypeFunction(NumberField, 'clearErrorStatus', function() {
+    objects.replacePrototypeFunction(NumberField, NumberField.prototype.clearErrorStatus, function() {
       if (this.modelAdapter) {
         // Don't do anything -> let server handle it
 

--- a/eclipse-scout-core/src/planner/PlannerAdapter.ts
+++ b/eclipse-scout-core/src/planner/PlannerAdapter.ts
@@ -112,21 +112,17 @@ export class PlannerAdapter extends ModelAdapter {
     }
   }
 
-  protected static _initResourceRemote(resource: PlannerResource) {
-    // @ts-expect-error
+  protected static _initResourceRemote(this: Planner & { _initResourceOrig }, resource: PlannerResource) {
     if (this.modelAdapter) {
       defaultValues.applyTo(resource, 'Resource');
     }
-    // @ts-expect-error
     return this._initResourceOrig(resource);
   }
 
-  protected static _initActivityRemote(activity: PlannerActivity) {
-    // @ts-expect-error
+  protected static _initActivityRemote(this: Planner & { _initActivityOrig }, activity: PlannerActivity) {
     if (this.modelAdapter) {
       defaultValues.applyTo(activity, 'Activity');
     }
-    // @ts-expect-error
     return this._initActivityOrig(activity);
   }
 

--- a/eclipse-scout-core/src/session/ModelAdapter.ts
+++ b/eclipse-scout-core/src/session/ModelAdapter.ts
@@ -457,7 +457,7 @@ export class ModelAdapter extends EventEmitter implements ModelAdapterModel, Mod
     }
 
     // _createChild
-    objects.replacePrototypeFunction(Widget, '_createChild', function(model) {
+    objects.replacePrototypeFunction(Widget, '_createChild', function(this: Widget & { _createChildOrig }, model) {
       if (model instanceof Widget) {
         return model;
       }

--- a/eclipse-scout-core/src/table/TableTileGridMediatorAdapter.ts
+++ b/eclipse-scout-core/src/table/TableTileGridMediatorAdapter.ts
@@ -19,7 +19,7 @@ export class TableTileGridMediatorAdapter extends ModelAdapter {
     }
 
     // tiles are already provided by the backend in classic mode
-    objects.replacePrototypeFunction(TableTileGridMediator, 'loadTiles', function() {
+    objects.replacePrototypeFunction(TableTileGridMediator, 'loadTiles', function(this: TableTileGridMediator & { loadTilesOrig }) {
       if (this.modelAdapter) {
         // nop in classic mode
         return;
@@ -28,7 +28,7 @@ export class TableTileGridMediatorAdapter extends ModelAdapter {
     }, true);
 
     // handled by the java mediator
-    objects.replacePrototypeFunction(TableTileGridMediator, '_onTableRowsInserted', function(event) {
+    objects.replacePrototypeFunction(TableTileGridMediator, '_onTableRowsInserted', function(this: TableTileGridMediator & { _onTableRowsInsertedOrig }, event) {
       if (this.modelAdapter) {
         // nop in classic mode
         return;
@@ -37,7 +37,7 @@ export class TableTileGridMediatorAdapter extends ModelAdapter {
     }, true);
 
     // handled by the java mediator
-    objects.replacePrototypeFunction(TableTileGridMediator, '_onTableRowsDeleted', function(event) {
+    objects.replacePrototypeFunction(TableTileGridMediator, '_onTableRowsDeleted', function(this: TableTileGridMediator & { _onTableRowsDeletedOrig }, event) {
       if (this.modelAdapter) {
         // nop in classic mode
         return;
@@ -46,7 +46,7 @@ export class TableTileGridMediatorAdapter extends ModelAdapter {
     }, true);
 
     // handled by the java mediator
-    objects.replacePrototypeFunction(TableTileGridMediator, '_onTableAllRowsDeleted', function(event) {
+    objects.replacePrototypeFunction(TableTileGridMediator, '_onTableAllRowsDeleted', function(this: TableTileGridMediator & { _onTableAllRowsDeletedOrig }, event) {
       if (this.modelAdapter) {
         // nop in classic mode
         return;

--- a/eclipse-scout-core/src/table/controls/AggregateTableControlAdapter.ts
+++ b/eclipse-scout-core/src/table/controls/AggregateTableControlAdapter.ts
@@ -16,7 +16,7 @@ export class AggregateTableControlAdapter extends TableControlAdapter {
     }
 
     // _onTableColumnStructureChanged
-    objects.replacePrototypeFunction(AggregateTableControl, '_onTableColumnStructureChanged', function(vararg) {
+    objects.replacePrototypeFunction(AggregateTableControl, '_onTableColumnStructureChanged', function(this: AggregateTableControl & { _onTableColumnStructureChangedOrig; _updateEnabledAndSelectedState }, vararg) {
       if (this.modelAdapter) {
         this._updateEnabledAndSelectedState();
       } else {

--- a/eclipse-scout-core/src/tile/TileGridAdapter.ts
+++ b/eclipse-scout-core/src/tile/TileGridAdapter.ts
@@ -91,7 +91,7 @@ export class TileGridAdapter extends ModelAdapter {
     }
 
     // _sortWhileInit
-    objects.replacePrototypeFunction(TileGrid, '_sortWhileInit', function() {
+    objects.replacePrototypeFunction(TileGrid, '_sortWhileInit', function(this: TileGrid & { _sortWhileInitOrig }) {
       if (this.modelAdapter) {
         return; // Do nothing. Was sorted in Java UI already.
       }

--- a/eclipse-scout-core/src/tree/TreeAdapter.ts
+++ b/eclipse-scout-core/src/tree/TreeAdapter.ts
@@ -276,13 +276,10 @@ export class TreeAdapter extends ModelAdapter {
   /**
    * 'this' in this function refers to the Tree
    */
-  protected static _createTreeNodeRemote(nodeModel: TreeNodeModel) {
-    // @ts-expect-error
+  protected static _createTreeNodeRemote(this: Tree & { modelAdapter: TreeAdapter; _createTreeNodeOrig }, nodeModel: TreeNodeModel) {
     if (this.modelAdapter) {
-      // @ts-expect-error
       nodeModel = this.modelAdapter._initNodeModel(nodeModel);
     }
-    // @ts-expect-error
     return this._createTreeNodeOrig(nodeModel);
   }
 


### PR DESCRIPTION
Specifying 'this' allows us to remove some @ts-expect-error. Referencing the prototype methods instead of using strings would be nice to get compile errors if the methods were renamed. Unfortunately many methods are protected and making them internal only for the adapters seems to be wrong.