### PR TITLE
Increase default timeout in Selenium tests

### DIFF
--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/AbstractSeleniumTest.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/AbstractSeleniumTest.java
@@ -41,7 +41,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 public abstract class AbstractSeleniumTest {
 
-  public static final int DEFAULT_WAIT_UNTIL_TIMEOUT = 10; // seconds
+  public static final int DEFAULT_WAIT_UNTIL_TIMEOUT = 20; // seconds
 
   private static WebDriver s_driver;
 


### PR DESCRIPTION
Test agents can be busy with other tasks and lead to spurious timeouts in Selenium tests which are tedious to sort out.