### PR TITLE
ScoutJS: add menus from parent table page to detailForm/detailTable

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.ts
+++ b/eclipse-scout-core/src/desktop/outline/Outline.ts
@@ -453,6 +453,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
 
   protected override _setSelectedNodes(nodes: Page[], debounceSend?: boolean) {
     super._setSelectedNodes(nodes, debounceSend);
+    this.mediator.onPageSelected(this.selectedNode());
     // Needs to be done here so that tree.selectNodes() can restore scroll position correctly after the content has been updated
     this.updateDetailContent();
   }

--- a/eclipse-scout-core/src/desktop/outline/Outline.ts
+++ b/eclipse-scout-core/src/desktop/outline/Outline.ts
@@ -432,6 +432,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
 
   override selectNodes(nodes: Page | Page[], debounceSend?: boolean) {
     nodes = arrays.ensure(nodes);
+    nodes.splice(1);
     if (nodes.length > 0 && this.isNodeSelected(nodes[0])) {
       // Already selected, do nothing
       return;

--- a/eclipse-scout-core/src/desktop/outline/OutlineMediator.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineMediator.ts
@@ -70,4 +70,17 @@ export class OutlineMediator {
   onTableFilter(event: Event<Table>, page: Page) {
     page.getOutline().filter();
   }
+
+  onPageSelected(selectedPage: Page) {
+    if (!selectedPage || !selectedPage.parentNode) {
+      return;
+    }
+
+    const table = selectedPage.parentNode.detailTable;
+    const row = selectedPage.row;
+    if (!table || !row || table !== row.getTable()) {
+      return;
+    }
+    table.selectRow(row);
+  }
 }

--- a/eclipse-scout-core/src/desktop/outline/pages/PageModel.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageModel.ts
@@ -28,4 +28,10 @@ export interface PageModel extends TreeNodeModel {
    */
   overviewIconId?: string;
   showTileOverview?: boolean;
+  /**
+   * True to inherit all menus (single selection) from the parent table page, false to inherit none.
+   *
+   * Default is true
+   */
+  inheritMenusFromParentTablePage?: boolean;
 }

--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -29,6 +29,7 @@ export class PageWithTable extends Page implements PageWithTableModel {
     super();
 
     this.nodeType = Page.NodeType.TABLE;
+    this.inheritMenusFromParentTablePage = false;
     this.alwaysCreateChildPage = false;
 
     this._tableRowDeleteHandler = this._onTableRowsDeleted.bind(this);

--- a/eclipse-scout-core/src/form/js/JsFormAdapter.ts
+++ b/eclipse-scout-core/src/form/js/JsFormAdapter.ts
@@ -22,6 +22,7 @@ export class JsFormAdapter extends FormAdapter {
       parent: model.parent,
       owner: model.owner,
       objectType: model.jsFormObjectType,
+      modelAdapter: model.modelAdapter,
       displayParent: model.displayParent,
       displayHint: model.displayHint,
       data: model.inputData

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -1872,7 +1872,8 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
       clone: clone,
       originalToClone: EventDelegator.create(this, clone, {
         delegateProperties: options.delegatePropertiesToClone,
-        delegateAllProperties: options.delegateAllPropertiesToClone
+        delegateAllProperties: options.delegateAllPropertiesToClone,
+        excludeProperties: options.excludePropertiesToClone
       }),
       cloneToOriginal: EventDelegator.create(clone, this, {
         delegateProperties: options.delegatePropertiesToOriginal,
@@ -2392,14 +2393,17 @@ export type TreeVisitor<T> = (element: T) => boolean | TreeVisitResult | void;
 export interface CloneOptions {
   /** An array of all properties to be delegated from the original to the clone when changed on the original widget. Default is []. */
   delegatePropertiesToClone?: string[];
+  /** An array of all properties to be excluded from delegating from the original to the clone in any cases. Default is []. */
+  excludePropertiesToClone?: string[];
+  /** True to delegate all property changes from the original to the clone. Default is false. */
+  delegateAllPropertiesToClone?: boolean;
+
   /** An array of all properties to be delegated from the clone to the original when changed on the clone widget. Default is []. */
   delegatePropertiesToOriginal?: string[];
   /** An array of all properties to be excluded from delegating from the clone to the original in any cases. Default is []. */
   excludePropertiesToOriginal?: string[];
   /** An array of all events to be delegated from the clone to the original when fired on the clone widget. Default is []. */
   delegateEventsToOriginal?: string[];
-  /** True to delegate all property changes from the original to the clone. Default is false. */
-  delegateAllPropertiesToClone?: boolean;
   /** True to delegate all property changes from the clone to the original. Default is false. */
   delegateAllPropertiesToOriginal?: boolean;
 }

--- a/eclipse-scout-core/test/desktop/outline/OutlineMediatorSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineMediatorSpec.ts
@@ -121,4 +121,29 @@ describe('OutlineMediator', () => {
     expect(page.childNodes[1].filterAccepted).toBe(true); // filter is accepted for 'Bar'
   });
 
+
+  it('onPageSelected', () => {
+    const modelRows = [
+      tableHelper.createModelRow('0', ['Foo']),
+      tableHelper.createModelRow('1', ['Bar'])
+    ];
+
+    detailTable.insertRows(modelRows);
+
+    const row0 = detailTable.rows[0];
+    const row1 = detailTable.rows[1];
+    const page0 = row0.page;
+    const page1 = row1.page;
+
+    expect(detailTable.selectedRows).toEqual([]);
+
+    outline.selectNodes(page1);
+    expect(detailTable.selectedRows).toEqual([row1]);
+
+    outline.selectNodes(page0);
+    expect(detailTable.selectedRows).toEqual([row0]);
+
+    outline.selectNodes(null);
+    expect(detailTable.selectedRows).toEqual([row0]);
+  });
 });

--- a/eclipse-scout-core/test/desktop/outline/OutlineSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineSpec.ts
@@ -180,6 +180,26 @@ describe('Outline', () => {
       expect(node.detailFormVisibleByUi).toBe(true);
     });
 
+    it('can only select 1 node', () => {
+      const node1 = outline.nodes[1];
+
+      expect(outline.selectedNodes).toEqual([]);
+
+      outline.selectNodes([node]);
+      expect(outline.selectedNodes).toEqual([node]);
+
+      outline.selectNodes([node1]);
+      expect(outline.selectedNodes).toEqual([node1]);
+
+      outline.selectNodes([node, node1]);
+      expect(outline.selectedNodes).toEqual([node]);
+
+      outline.selectNodes([node1, node]);
+      expect(outline.selectedNodes).toEqual([node1]);
+
+      outline.selectNodes();
+      expect(outline.selectedNodes).toEqual([]);
+    });
   });
 
   describe('updateDetailMenus', () => {

--- a/eclipse-scout-core/test/widget/WidgetSpec.ts
+++ b/eclipse-scout-core/test/widget/WidgetSpec.ts
@@ -613,6 +613,29 @@ describe('Widget', () => {
       expect(widgetClone.text).toBe('foo');
     });
 
+    it('considers excludePropertiesToClone', () => {
+      widget._addCloneProperties(['notExcluded', 'excluded']);
+      widget.setProperty('notExcluded', 'foo');
+      widget.setProperty('excluded', 'foo');
+
+      const widgetClone = widget.clone(
+        {
+          parent: widget.parent
+        }, {
+          excludePropertiesToClone: ['excluded'],
+          delegateAllPropertiesToClone: true
+        }
+      );
+
+      expect(widgetClone.notExcluded).toBe('foo');
+      expect(widgetClone.excluded).toBe('foo');
+
+      widget.setProperty('notExcluded', 'bar');
+      widget.setProperty('excluded', 'bar');
+
+      expect(widgetClone.notExcluded).toBe('bar');
+      expect(widgetClone.excluded).toBe('foo');
+    });
   });
 
   describe('init', () => {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithNodes.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithNodes.java
@@ -154,7 +154,7 @@ public abstract class AbstractPageWithNodes extends AbstractPage<ITable> impleme
   protected void updateParentTableRow(ICell cell) {
     IPage<?> parent = getParentPage();
     if (parent instanceof IPageWithNodes) {
-      ITableRow row = ((IPageWithNodes) parent).getTableRowFor(this);
+      ITableRow row = parent.getTableRowFor(this);
       if (row != null) {
         row.getCellForUpdate(0).setText(cell.getText());
       }


### PR DESCRIPTION
Add single selection menus from the parent table page to the detailForm and detailTable of the current page.
Select corresponding row in parent table page when a page is selected.
Add excludePropertiesToClone to Widget.clone.
Add modelAdapter to JsForm.

330431