### PR TITLE
Cache invalidate during resolve should not compromise cache

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/cache/ClientCacheBuilder.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/cache/ClientCacheBuilder.java
@@ -33,7 +33,7 @@ public class ClientCacheBuilder<K, V> extends CacheBuilder<K, V> {
     if (isSharedAndRemoteAvailable() && isRemoteValueResolverEnabled()) {
       valueResolver = new RemoteCacheValueResolver<>(getCacheId());
     }
-    return new BasicCache<>(getCacheId(), valueResolver, cacheMap, isAtomicInsertion());
+    return new BasicCache<>(getCacheId(), valueResolver, cacheMap);
   }
 
   @Override

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/cache/BasicCacheTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/cache/BasicCacheTest.java
@@ -12,10 +12,19 @@ package org.eclipse.scout.rt.platform.cache;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.junit.Test;
 
@@ -27,6 +36,7 @@ public class BasicCacheTest {
   protected ICache<Integer, String> createCache(String id) {
     return createCache(id, new ICacheValueResolver<Integer, String>() {
       private int m_counter;
+
       @Override
       public String resolve(Integer key) {
         if (13 == key) {
@@ -118,9 +128,348 @@ public class BasicCacheTest {
   }
 
   @Test(expected = ProcessingException.class)
-  public void testCacheExceptionDuringCreation() {
+  public void testCacheExceptionDuringResolve() {
     ICache<Integer, String> cache = createCache("BasicCacheTestCacheId_testCacheExceptionDuringCreation");
     cache.get(1337);
   }
 
+  @Test
+  public void testCacheTransactional() {
+    testCacheTransactional(true);
+    testCacheTransactional(false);
+  }
+
+  protected void testCacheTransactional(boolean transactionalFastForward) {
+    @SuppressWarnings("unchecked")
+    ICache<Integer, String> cache = BEANS.get(ICacheBuilder.class)
+        .withCacheId("BasicCacheTestCacheId#testInvalidateDuringResolve")
+        .withValueResolver((ICacheValueResolver<Integer, String>) key -> "value_" + key)
+        .withReplaceIfExists(true)
+        .withTransactional(true)
+        .withTransactionalFastForward(transactionalFastForward)
+        .build();
+
+    assertEquals("value_1", RunContexts.empty().call(() -> cache.get(1)));
+
+    Map<Integer, String> expectedMap = new HashMap<>();
+    expectedMap.put(1, "value_1");
+    expectedMap.put(2, "value_2");
+    expectedMap.put(3, "value_3");
+    assertEquals(expectedMap, RunContexts.empty().call(() -> cache.getAll(Arrays.asList(1, 2, 3))));
+
+    RunContexts.empty().run(() -> cache.invalidate(new KeyCacheEntryFilter<>(Arrays.asList(1)), true));
+    expectedMap.remove(1);
+    assertEquals(expectedMap, RunContexts.empty().call(() -> cache.getUnmodifiableMap()));
+
+    RunContexts.empty().run(() -> cache.invalidate(new KeyCacheEntryFilter<>(Arrays.asList(1, 2)), true));
+    expectedMap.remove(2);
+    assertEquals(expectedMap, RunContexts.empty().call(() -> cache.getUnmodifiableMap()));
+
+    assertEquals("value_2", RunContexts.empty().call(() -> cache.get(2)));
+
+    RunContexts.empty().run(() -> cache.invalidate(new AllCacheEntryFilter<>(), true));
+    assertEquals(Collections.emptyMap(), RunContexts.empty().call(() -> cache.getUnmodifiableMap()));
+  }
+
+  @Test
+  public void testNoFastForwardOfDirty() {
+    AtomicReference<Function<Integer, String>> valueResolver = new AtomicReference<>();
+
+    @SuppressWarnings("unchecked")
+    ICache<Integer, String> cache = BEANS.get(ICacheBuilder.class)
+        .withCacheId("BasicCacheTestCacheId#testInvalidateDuringResolve")
+        .withValueResolver((ICacheValueResolver<Integer, String>) key -> {
+          Function<Integer, String> internalResolver = valueResolver.get();
+          return internalResolver.apply(key);
+        })
+        .withReplaceIfExists(true)
+        .withTransactional(true)
+        .withTransactionalFastForward(true)
+        .build();
+
+    valueResolver.set(key -> "val_A_" + key);
+    assertEquals("val_A_1", RunContexts.empty().call(() -> cache.get(1)));
+
+    RunContexts.empty().run(() -> {
+      valueResolver.set(key -> "val_AA_" + key); // change value "in local transaction"
+      cache.invalidate(new AllCacheEntryFilter<>(), true);
+      assertEquals("val_AA_1", cache.get(1));
+    });
+
+    assertEquals("val_AA_1", RunContexts.empty().call(() -> cache.get(1)));
+    // remove all cache values -> fast-forward in local transaction
+    RunContexts.empty().run(() -> cache.invalidate(new AllCacheEntryFilter<>(), true));
+
+    RunContexts.empty().run(() -> {
+      valueResolver.set(key -> "val_B_" + key); // change value "in local transaction"
+      cache.invalidate(new AllCacheEntryFilter<>(), true);
+      assertEquals("val_B_1", cache.get(1));
+    });
+
+    assertEquals("val_B_1", RunContexts.empty().call(() -> cache.getCachedValue(1))); // fast-forward success
+    assertEquals("val_B_1", RunContexts.empty().call(() -> cache.get(1))); // see new value
+
+    try {
+      RunContexts.empty().run(() -> {
+        Function<Integer, String> oldResolver = valueResolver.getAndSet(key -> "val_C_" + key); // change value "in local transaction"
+        cache.invalidate(new AllCacheEntryFilter<>(), true);
+        assertEquals("val_C_1", cache.get(1));
+
+        // transaction rollback
+        valueResolver.set(oldResolver); // change value back
+        throw new ProcessingException("rollback");
+      });
+    }
+    catch (ProcessingException e) {
+      // nop
+    }
+
+    assertEquals("val_B_1", RunContexts.empty().call(() -> cache.get(1)));
+
+    // remove all cache values -> fast-forward in local, rolled back transaction
+    RunContexts.empty().run(() -> cache.invalidate(new AllCacheEntryFilter<>(), true));
+
+    try {
+      RunContexts.empty().run(() -> {
+        Function<Integer, String> oldResolver = valueResolver.getAndSet(key -> "val_CC_" + key); // change value "in local transaction"
+        cache.invalidate(new AllCacheEntryFilter<>(), true);
+        assertEquals("val_CC_1", cache.get(1));
+
+        // transaction rollback
+        valueResolver.set(oldResolver); // change value back
+        throw new ProcessingException("rollback");
+      });
+    }
+    catch (ProcessingException e) {
+      // nop
+    }
+
+    assertTrue(RunContexts.empty().call(() -> cache.getUnmodifiableMap().isEmpty()));
+    assertEquals("val_B_1", RunContexts.empty().call(() -> cache.get(1)));
+  }
+
+  @Test
+  public void testInvalidateDuringResolve() throws InterruptedException {
+    testInvalidateDuringResolve(true, false, false, false);
+    testInvalidateDuringResolve(true, false, false, true);
+    testInvalidateDuringResolve(false, false, false, false);
+    testInvalidateDuringResolve(false, false, false, true);
+  }
+
+  @Test
+  public void testInvalidateDuringResolve_secondLoad() throws InterruptedException {
+    testInvalidateDuringResolve(true, true, false, false);
+    testInvalidateDuringResolve(true, true, false, true);
+    testInvalidateDuringResolve(false, true, false, false);
+    testInvalidateDuringResolve(false, true, false, true);
+  }
+
+  @Test
+  public void testInvalidateDuringResolve_allKeyInvalidate() throws InterruptedException {
+    testInvalidateDuringResolve(true, false, true, false);
+    testInvalidateDuringResolve(true, false, true, true);
+    testInvalidateDuringResolve(false, false, true, false);
+    testInvalidateDuringResolve(false, false, true, true);
+  }
+
+  @Test
+  public void testInvalidateDuringResolve_secondLoad_allKeyInvalidate() throws InterruptedException {
+    testInvalidateDuringResolve(true, true, true, false);
+    testInvalidateDuringResolve(true, true, true, true);
+    testInvalidateDuringResolve(false, true, true, false);
+    testInvalidateDuringResolve(false, true, true, true);
+  }
+
+  /**
+   * Tests what happens if resolve is slow and an invalidate happens during resolve
+   */
+  protected void testInvalidateDuringResolve(boolean transactionalFastForward, boolean secondCacheLoadAfterInvalidate, boolean allKeyInvalidate, boolean getAll) throws InterruptedException {
+    AtomicReference<Function<Integer, String>> valueResolver = new AtomicReference<>();
+
+    @SuppressWarnings("unchecked")
+    ICache<Integer, String> cache = BEANS.get(ICacheBuilder.class)
+        .withCacheId("BasicCacheTestCacheId#testInvalidateDuringResolve")
+        .withValueResolver((ICacheValueResolver<Integer, String>) key -> {
+          Function<Integer, String> internalResolver = valueResolver.get();
+          return internalResolver.apply(key);
+        })
+        .withReplaceIfExists(true)
+        .withTransactional(true)
+        .withTransactionalFastForward(transactionalFastForward)
+        .build();
+
+    CountDownLatch resolvingLatch = new CountDownLatch(1);
+    CountDownLatch resolvingBlockingLatch = new CountDownLatch(1);
+    valueResolver.set(key -> {
+      resolvingLatch.countDown();
+      try {
+        resolvingBlockingLatch.await();
+      }
+      catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      return "oldValue_" + key;
+    });
+    IFuture<String> future = Jobs.schedule(() -> {
+      if (getAll) {
+        return cache.getAll(Arrays.asList(1, 3, 5)).get(1);
+      }
+      else {
+        return cache.get(1);
+      }
+    }, Jobs.newInput().withRunContext(RunContexts.empty()));
+    resolvingLatch.await();
+
+    valueResolver.set(key -> "newValue_" + key); // value is "changed" in source
+    // this value change will call invalidate (e.g. in a transaction value is changed on database and then 'invalidate' on cache is called)
+    ICacheEntryFilter<Integer, String> invalidateEntryFilter = allKeyInvalidate ? new AllCacheEntryFilter<>() : new KeyCacheEntryFilter<>(Collections.singleton(1));
+    RunContexts.empty().run(() -> cache.invalidate(invalidateEntryFilter, true));
+
+    if (secondCacheLoadAfterInvalidate) {
+      // new transaction accesses cache
+      assertEquals("newValue_1", RunContexts.empty().call(() -> {
+        if (getAll) {
+          return cache.getAll(Arrays.asList(1, 2, 3)).get(1);
+        }
+        else {
+          return cache.get(1);
+        }
+      }));
+    }
+
+    // release first transaction in job
+    resolvingBlockingLatch.countDown();
+    future.awaitDone();
+
+    // access cache value again - expected to be still "newValue"
+    String value2 = RunContexts.empty().call(() -> {
+      if (getAll) {
+        return cache.getAll(Arrays.asList(1, 4, 5)).get(1);
+      }
+      else {
+        return cache.get(1);
+      }
+    });
+    assertEquals("newValue_1", value2);
+    assertEquals("newValue_2", RunContexts.empty().call(() -> cache.get(2)));
+    assertEquals("newValue_3", RunContexts.empty().call(() -> cache.get(3)));
+    assertEquals("newValue_4", RunContexts.empty().call(() -> cache.get(4)));
+    assertEquals("newValue_5", RunContexts.empty().call(() -> cache.get(5)));
+  }
+
+  @Test
+  public void testInvalidateBeforeAndDuringResolve() throws InterruptedException {
+    testInvalidateBeforeAndDuringResolve(true, false, false, false);
+    testInvalidateBeforeAndDuringResolve(true, false, false, true);
+    testInvalidateBeforeAndDuringResolve(false, false, false, false);
+    testInvalidateBeforeAndDuringResolve(false, false, false, true);
+  }
+
+  @Test
+  public void testInvalidateBeforeAndDuringResolve_secondLoad() throws InterruptedException {
+    testInvalidateBeforeAndDuringResolve(true, true, false, false);
+    testInvalidateBeforeAndDuringResolve(true, true, false, true);
+    testInvalidateBeforeAndDuringResolve(false, true, false, false);
+    testInvalidateBeforeAndDuringResolve(false, true, false, true);
+  }
+
+  @Test
+  public void testInvalidateBeforeAndDuringResolve_allKeyInvalidate() throws InterruptedException {
+    testInvalidateBeforeAndDuringResolve(true, false, true, false);
+    testInvalidateBeforeAndDuringResolve(true, false, true, true);
+    testInvalidateBeforeAndDuringResolve(false, false, true, false);
+    testInvalidateBeforeAndDuringResolve(false, false, true, true);
+  }
+
+  @Test
+  public void testInvalidateBeforeAndDuringResolve_secondLoad_allKeyInvalidate() throws InterruptedException {
+    testInvalidateBeforeAndDuringResolve(true, true, true, false);
+    testInvalidateBeforeAndDuringResolve(true, true, true, true);
+    testInvalidateBeforeAndDuringResolve(false, true, true, false);
+    testInvalidateBeforeAndDuringResolve(false, true, true, true);
+  }
+
+  /**
+   * Tests what happens if resolve is slow and an invalidate happens during resolve
+   */
+  protected void testInvalidateBeforeAndDuringResolve(boolean transactionalFastForward, boolean secondCacheLoadAfterInvalidate, boolean allKeyInvalidate, boolean getAll) throws InterruptedException {
+    AtomicReference<Function<Integer, String>> valueResolver = new AtomicReference<>();
+
+    @SuppressWarnings("unchecked")
+    ICache<Integer, String> cache = BEANS.get(ICacheBuilder.class)
+        .withCacheId("BasicCacheTestCacheId#testInvalidateDuringResolve")
+        .withValueResolver((ICacheValueResolver<Integer, String>) key -> {
+          Function<Integer, String> internalResolver = valueResolver.get();
+          return internalResolver.apply(key);
+        })
+        .withReplaceIfExists(true)
+        .withTransactional(true)
+        .withTransactionalFastForward(transactionalFastForward)
+        .build();
+
+    CountDownLatch invalidateBlockingLatch = new CountDownLatch(1);
+    ICacheEntryFilter<Integer, String> invalidateEntryFilter = allKeyInvalidate ? new AllCacheEntryFilter<>() : new KeyCacheEntryFilter<>(Collections.singleton(1));
+    IFuture<Void> invalidateFuture = Jobs.schedule(() -> {
+      cache.invalidate(invalidateEntryFilter, true);
+      invalidateBlockingLatch.await();
+    }, Jobs.newInput().withRunContext(RunContexts.empty()));
+
+    CountDownLatch resolvingLatch = new CountDownLatch(1);
+    CountDownLatch resolvingBlockingLatch = new CountDownLatch(1);
+    valueResolver.set(key -> {
+      resolvingLatch.countDown();
+      try {
+        resolvingBlockingLatch.await();
+      }
+      catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      return "oldValue_" + key;
+    });
+    IFuture<String> future = Jobs.schedule(() -> {
+      if (getAll) {
+        return cache.getAll(Arrays.asList(1, 3, 5)).get(1);
+      }
+      else {
+        return cache.get(1);
+      }
+    }, Jobs.newInput().withRunContext(RunContexts.empty()));
+    resolvingLatch.await();
+
+    valueResolver.set(key -> "newValue_" + key); // value is "changed" in source
+    // invalidate by already started invalidation job
+    invalidateBlockingLatch.countDown();
+    invalidateFuture.awaitDone();
+
+    if (secondCacheLoadAfterInvalidate) {
+      // new transaction accesses cache
+      assertEquals("newValue_1", RunContexts.empty().call(() -> {
+        if (getAll) {
+          return cache.getAll(Arrays.asList(1, 2, 3)).get(1);
+        }
+        else {
+          return cache.get(1);
+        }
+      }));
+    }
+
+    // release first transaction in job
+    resolvingBlockingLatch.countDown();
+    future.awaitDone();
+
+    // access cache value again - expected to be still "newValue"
+    String value2 = RunContexts.empty().call(() -> {
+      if (getAll) {
+        return cache.getAll(Arrays.asList(1, 4, 5)).get(1);
+      }
+      else {
+        return cache.get(1);
+      }
+    });
+    assertEquals("newValue_1", value2);
+    assertEquals("newValue_2", RunContexts.empty().call(() -> cache.get(2)));
+    assertEquals("newValue_3", RunContexts.empty().call(() -> cache.get(3)));
+    assertEquals("newValue_4", RunContexts.empty().call(() -> cache.get(4)));
+    assertEquals("newValue_5", RunContexts.empty().call(() -> cache.get(5)));
+  }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/AbstractCacheWrapper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/AbstractCacheWrapper.java
@@ -35,6 +35,16 @@ public abstract class AbstractCacheWrapper<K, V> implements ICache<K, V> {
   }
 
   @Override
+  public Map<K, V> getCacheMap() {
+    return m_delegate.getCacheMap();
+  }
+
+  @Override
+  public V getCachedValue(K key) {
+    return m_delegate.getCachedValue(key);
+  }
+
+  @Override
   public Map<K, V> getUnmodifiableMap() {
     return m_delegate.getUnmodifiableMap();
   }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/BasicCache.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/BasicCache.java
@@ -17,10 +17,11 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.collection.AbstractTransactionalMap;
+import org.eclipse.scout.rt.platform.util.collection.ConcurrentExpiringMap;
 
 /**
  * Basic implementation of {@link ICache}.
@@ -36,32 +37,49 @@ import org.eclipse.scout.rt.platform.util.CollectionUtility;
  */
 public class BasicCache<K, V> implements ICache<K, V> {
 
-  private final String m_cacheId;
-  private final ICacheValueResolver<K, V> m_resolver;
-  private final Map<K, V> m_cacheMap;
-  private final boolean m_atomicInsertion;
+  protected final String m_cacheId;
+  protected final ICacheValueResolver<K, V> m_resolver;
+  protected final Map<K, V> m_cacheMap;
 
-  public BasicCache(String cacheId, ICacheValueResolver<K, V> resolver, Map<K, V> cacheMap, boolean atomicInsertion) {
+  protected final AbstractTransactionalMap<K, ?> m_transactionalMap; // is null if not transactional cache
+
+  public BasicCache(String cacheId, ICacheValueResolver<K, V> resolver, Map<K, V> cacheMap) {
+    this(cacheId, resolver, cacheMap, findTransactionalMap(cacheMap));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <K, V> AbstractTransactionalMap<K, ?> findTransactionalMap(Map<K, V> cacheMap) {
+    Map<K, ?> innerMap = cacheMap;
+    if (cacheMap instanceof ConcurrentExpiringMap) {
+      innerMap = ((ConcurrentExpiringMap<K, Object>) cacheMap).getElementMap();
+    }
+    if (innerMap instanceof AbstractTransactionalMap) {
+      return (AbstractTransactionalMap<K, ?>) innerMap;
+    }
+    return null;
+  }
+
+  public BasicCache(String cacheId, ICacheValueResolver<K, V> resolver, Map<K, V> cacheMap, AbstractTransactionalMap<K, ?> transactionalMap) {
     m_cacheId = Assertions.assertNotNullOrEmpty(cacheId);
     m_resolver = Assertions.assertNotNull(resolver);
     m_cacheMap = Assertions.assertNotNull(cacheMap);
-    m_atomicInsertion = atomicInsertion;
-    if (m_atomicInsertion && !(cacheMap instanceof ConcurrentMap)) {
-      throw new IllegalArgumentException("To use atomic insertions cacheMap must implement ConcurrentMap interface");
-    }
-  }
 
-  protected ICacheValueResolver<K, V> getResolver() {
-    return m_resolver;
-  }
-
-  protected Map<K, V> getCacheMap() {
-    return m_cacheMap;
+    m_transactionalMap = transactionalMap;
   }
 
   @Override
   public String getCacheId() {
     return m_cacheId;
+  }
+
+  @Override
+  public V getCachedValue(K key) {
+    return m_cacheMap.get(key);
+  }
+
+  @Override
+  public Map<K, V> getCacheMap() {
+    return new HashMap<>(m_cacheMap);
   }
 
   @Override
@@ -76,15 +94,13 @@ public class BasicCache<K, V> implements ICache<K, V> {
     }
     V value = m_cacheMap.get(key);
     if (value == null) {
+      if (m_transactionalMap != null) {
+        m_transactionalMap.getTransactionMember(true); // enforce creation of transaction member before resolve
+      }
       value = m_resolver.resolve(key);
       if (value != null) {
-        if (m_atomicInsertion) {
-          V alreadySetValue = m_cacheMap.putIfAbsent(key, value);
-          value = alreadySetValue != null ? alreadySetValue : value;
-        }
-        else {
-          m_cacheMap.put(key, value);
-        }
+        V alreadySetValue = m_cacheMap.putIfAbsent(key, value);
+        value = alreadySetValue != null ? alreadySetValue : value;
       }
     }
     return value;
@@ -109,6 +125,10 @@ public class BasicCache<K, V> implements ICache<K, V> {
       // all keys could be resolved with cache
       return result;
     }
+
+    if (m_transactionalMap != null) {
+      m_transactionalMap.getTransactionMember(true); // enforce creation of transaction member before resolve
+    }
     Map<K, V> resolvedValues = m_resolver.resolveAll(keys);
     for (Iterator<Entry<K, V>> iterator = resolvedValues.entrySet().iterator(); iterator.hasNext();) {
       Entry<K, V> entry = iterator.next();
@@ -116,15 +136,12 @@ public class BasicCache<K, V> implements ICache<K, V> {
       if (entry.getKey() == null || entry.getValue() == null) {
         iterator.remove();
       }
-      else if (m_atomicInsertion) {
+      else {
         V alreadySetValue = m_cacheMap.putIfAbsent(entry.getKey(), entry.getValue());
         if (alreadySetValue != null) {
           entry.setValue(alreadySetValue);
         }
       }
-    }
-    if (!m_atomicInsertion) {
-      m_cacheMap.putAll(resolvedValues);
     }
     result.putAll(resolvedValues);
     return result;
@@ -132,17 +149,25 @@ public class BasicCache<K, V> implements ICache<K, V> {
 
   @Override
   public void invalidate(ICacheEntryFilter<K, V> filter, boolean propagate) {
+    boolean markInsertsDirty = true;
+
     if (filter instanceof AllCacheEntryFilter) {
       m_cacheMap.clear();
     }
     else if (filter instanceof KeyCacheEntryFilter) {
+      markInsertsDirty = false; // if all remove operations find a previous value, we do not need to mark inserts of other transactions as dirty
       KeyCacheEntryFilter<K, V> keyCacheEntryFilter = (KeyCacheEntryFilter<K, V>) filter;
       for (K key : keyCacheEntryFilter.getKeys()) {
-        m_cacheMap.remove(key);
+        boolean valueNotRemoved = m_cacheMap.remove(key) == null;
+        markInsertsDirty = markInsertsDirty | valueNotRemoved;
       }
     }
     else if (filter != null) {
       m_cacheMap.entrySet().removeIf(entry -> filter.accept(entry.getKey(), entry.getValue()));
+    }
+
+    if (markInsertsDirty && m_transactionalMap != null) {
+      m_transactionalMap.markInsertsDirty();
     }
   }
 

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/BoundedResolveCacheWrapper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/BoundedResolveCacheWrapper.java
@@ -35,7 +35,7 @@ public class BoundedResolveCacheWrapper<K, V> extends AbstractCacheWrapper<K, V>
 
   @Override
   public V get(K key) {
-    V value = getUnmodifiableMap().get(key);
+    V value = getCachedValue(key);
     if (value != null) {
       return value;
     }
@@ -57,15 +57,14 @@ public class BoundedResolveCacheWrapper<K, V> extends AbstractCacheWrapper<K, V>
 
   @Override
   public Map<K, V> getAll(Collection<? extends K> keys) {
-    Map<K, V> cacheMap = getUnmodifiableMap();
     Map<K, V> result = new HashMap<>();
     for (K key : keys) {
-      V value = cacheMap.get(key);
+      V value = getCachedValue(key);
       if (value == null) {
         // not all keys can be looked up without resolve. call super anyway
         break;
       }
-      result.put(key, cacheMap.get(key));
+      result.put(key, value);
     }
     if (result.size() == keys.size()) {
       return result;

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/CacheBuilder.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/CacheBuilder.java
@@ -94,14 +94,14 @@ public class CacheBuilder<K, V> implements ICacheBuilder<K, V> {
   }
 
   protected Map<K, V> createCacheMap() {
-    if (!isCreateExpiringMap() && isTransactional() && !isAtomicInsertion() && (isSingleton() || !isTransactionalFastForward())) {
+    if (!isCreateExpiringMap() && isTransactional() && (isSingleton() || !isTransactionalFastForward())) {
       return new CopyOnWriteTransactionalMap<>(getCacheId(), isTransactionalFastForward());
     }
     else if (isCreateExpiringMap()) {
       boolean touchOnGet = isTouchOnGet() || getSizeBound() != null;
       long timeToLive = NumberUtility.nvl(getTimeToLive(), -1L);
       int targetSize = NumberUtility.nvl(getSizeBound(), -1);
-      return new ConcurrentExpiringMap<>(this.createConcurrentMap(), timeToLive, touchOnGet, targetSize);
+      return new ConcurrentExpiringMap<>(createConcurrentMap(), timeToLive, touchOnGet, targetSize);
     }
     else if (isThreadSafe() || isTransactional()) {
       return createConcurrentMap();
@@ -123,7 +123,7 @@ public class CacheBuilder<K, V> implements ICacheBuilder<K, V> {
   }
 
   protected ICache<K, V> createBasicCache(Map<K, V> cacheMap) {
-    return new BasicCache<>(getCacheId(), getValueResolver(), cacheMap, isAtomicInsertion());
+    return new BasicCache<>(getCacheId(), getValueResolver(), cacheMap);
   }
 
   protected ICache<K, V> addBeforeCustomWrappers(ICache<K, V> cache) {
@@ -233,6 +233,10 @@ public class CacheBuilder<K, V> implements ICacheBuilder<K, V> {
     return this;
   }
 
+  /**
+   * @deprecated not used anymore; will be removed in scout 23.2
+   */
+  @Deprecated
   public boolean isAtomicInsertion() {
     return m_atomicInsertion && m_threadSafe;
   }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/ICache.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/ICache.java
@@ -21,7 +21,7 @@ import org.eclipse.scout.rt.platform.util.IAdaptable;
  * Interface to model a cache. In case of a cache miss, the functional interface
  * {@link ICacheValueResolver#resolve(Object)} is called to fetch or recompute the value.
  * <p>
- * If one need to reload one ore multiple keys, simply invalidate first the keys and then call {@link #get(Object)} or
+ * If one needs to reload one or multiple keys, simply invalidate first the keys and then call {@link #get(Object)} or
  * {@link #getAll(Collection)}
  * <p>
  * Any null key or values are <em>not</em> allowed. They are ignored.
@@ -76,6 +76,16 @@ public interface ICache<K, V> extends IAdaptable {
    *          cluster nodes. Note that a server propagates invalidations always to its connected clients.
    */
   void invalidate(ICacheEntryFilter<K, V> filter, boolean propagate);
+
+  /**
+   * @return cached value for given key if or null if not yet in cache
+   */
+  V getCachedValue(K key);
+
+  /**
+   * @return new map with the current content of the cache
+   */
+  Map<K, V> getCacheMap();
 
   /**
    * @return an unmodifiable view of the map on which this cache is based on. Never null.

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/ICacheBuilder.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/ICacheBuilder.java
@@ -19,7 +19,7 @@ import org.eclipse.scout.rt.platform.util.BeanUtility;
 
 /**
  * All caches should be build through this builder. After building a cache, <b>do not</b> surround it with another
- * cache-wrapper. Instead use {@link #withAdditionalCustomWrapper(Class, Object...)} to add additional behavior.
+ * cache-wrapper. Instead, use {@link #withAdditionalCustomWrapper(Class, Object...)} to add additional behavior.
  *
  * @param <K>
  *          the type of keys maintained by this cache
@@ -94,7 +94,7 @@ public interface ICacheBuilder<K, V> {
   /**
    * @param remoteValueResolverEnabled
    *          Usually an application client of a shared cache uses the remote cache to resolve a cache value. With this
-   *          property, this behavior can be disabled and the client uses too the local value resolver. This may be
+   *          property, this behavior can be disabled and the client uses the local value resolver too. This may be
    *          useful if a cache value is not {@link Serializable}. (Default true)
    * @return this builder
    */
@@ -108,10 +108,12 @@ public interface ICacheBuilder<K, V> {
   ICacheBuilder<K, V> withThreadSafe(boolean threadSafe);
 
   /**
+   * This property has no effect anymore and will be deprecated in scout 23.2
+   *
    * @param atomicInsertion
    *          if set to true, a cache might concurrently resolve a key, but the get operations that issued these
-   *          resolves will return the same value. This option is only valid if threadSafe is set to true. Typically set
-   *          this option to true if the cache value is modifiable. (Default false)
+   *          resolves will return the same value. This option is only valid if threadSafe is set to true. Typically,
+   *          set this option to true if the cache value is modifiable. (Default false)
    * @return this builder
    */
   ICacheBuilder<K, V> withAtomicInsertion(boolean atomicInsertion);
@@ -162,7 +164,7 @@ public interface ICacheBuilder<K, V> {
    * @param timeToLiveUnit
    *          time to live unit
    * @param touchOnGet
-   *          if true getting an value will reset the time to live of a cache entry
+   *          if true getting a value will reset the time to live of a cache entry
    * @return this builder
    * @throws IllegalArgumentException
    *           if readTimeToLive is negative
@@ -170,7 +172,7 @@ public interface ICacheBuilder<K, V> {
   ICacheBuilder<K, V> withTimeToLive(Long timeToLiveDuration, TimeUnit timeToLiveUnit, boolean touchOnGet);
 
   /**
-   * If set to a non null value, the maximum number of cached values is bounded. The provided size bound is <em>not</em>
+   * If set to a non-null value, the maximum number of cached values is bounded. The provided size bound is <em>not</em>
    * enforced and is just a guidance value.
    * <p>
    * The current policy that is used to evict elements is least recently used (LRU).
@@ -196,10 +198,10 @@ public interface ICacheBuilder<K, V> {
   ICacheBuilder<K, V> withMaxConcurrentResolve(Integer maxConcurrentResolve);
 
   /**
-   * Adds an additional cache wrapper to the constructed cache instance. In the cache instance these additional wrappers
-   * are ordered in the same sequence as they were added. The cache wrapper is created always through a constructor that
-   * takes as first argument an {@link ICache}. See also {@link BeanUtility#createInstance(Class, Object...)} for
-   * creation details.
+   * Adds a cache wrapper to the constructed cache instance. In the cache instance these additional wrappers are ordered
+   * in the same sequence as they were added. The cache wrapper is created always through a constructor that takes as
+   * first argument an {@link ICache}. See also {@link BeanUtility#createInstance(Class, Object...)} for creation
+   * details.
    *
    * @param arguments
    *          any additional arguments (beside the first {@link ICache} argument) used to create the cache wrapper

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/collection/AbstractTransactionalMap.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/collection/AbstractTransactionalMap.java
@@ -12,14 +12,17 @@ package org.eclipse.scout.rt.platform.util.collection;
 
 import java.util.AbstractMap;
 import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.scout.rt.platform.cache.ICache;
 import org.eclipse.scout.rt.platform.transaction.ITransaction;
@@ -38,13 +41,13 @@ import org.eclipse.scout.rt.platform.transaction.ITransactionMember;
  * <p>
  * If there were concurrent modifications on the same key in different transactions only the first transaction will be
  * able to commit the change to the shared map. As a default, if a commit fails on a key, the entry is completely
- * removed from the shared map ({@link AbstractMapTransactionMember#changesCommited(Collection, Collection)}).
+ * removed from the shared map ({@link AbstractMapTransactionMember#changesCommitted}).
  * <p>
  * In order to use this map safely one must conform to the following behavior: <b>If the current transaction changed the
  * value of a key in the transactional source, this maps {@link #remove(Object)} to that key must be called
  * <em>before</em> the value is fetched from that source again.</b> If one fails doing so, there are no guarantees, that
  * values in the shared map reflect values in the transactional source. Note that this behavior is given when using
- * {@link ICache}. See also {@link AbstractMapTransactionMember#changesCommited(Collection, Collection)}.
+ * {@link ICache}. See also {@link AbstractMapTransactionMember#changesCommitted}.
  * <p>
  * If the <tt>fastForward</tt> property is set to true, a newly inserted value is directly committed to the shared map
  * if it is consider as a save commit.
@@ -65,8 +68,15 @@ import org.eclipse.scout.rt.platform.transaction.ITransactionMember;
  * @since 5.2
  */
 public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
-  private final String m_transactionMemberId;
-  private final boolean m_fastForward;
+  protected final String m_transactionMemberId;
+  /**
+   * If set to true, before a put operation the shared map is checked if there is already an entry for the given key. If
+   * there is no such entry, the new entry is directly put in the shared map.
+   */
+  protected final boolean m_fastForward;
+
+  protected final AtomicInteger m_insertVersion = new AtomicInteger();
+  protected final AtomicInteger m_removeVersion = new AtomicInteger();
 
   public AbstractTransactionalMap(String transactionMemberId) {
     this(transactionMemberId, true);
@@ -83,8 +93,8 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
   }
 
   /**
-   * This method is call when no scout transaction can be found as a fallback. Implementers are allowed to return a full
-   * featured map, a read only map view or throw an {@link IllegalStateException}. Null is not allowed.
+   * This method is call when no scout transaction can be found as a fallback. Implementers are allowed to return a
+   * full-featured map, a read only map view or throw an {@link IllegalStateException}. Null is not allowed.
    */
   protected abstract Map<K, V> getSharedMap();
 
@@ -92,8 +102,30 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
     return m_fastForward;
   }
 
+  /**
+   * Any inserts in concurrent transactions must be handled as invalid and will not be committed to the shared map (does
+   * not apply to inserts from this transaction).
+   */
+  public void markInsertsDirty() {
+    AbstractMapTransactionMember transactionMember = getTransactionMember(true);
+    if (transactionMember != null) { // if not transaction, then no transaction member
+      transactionMember.markInsertsDirty();
+    }
+  }
+
+  /**
+   * Any removes in concurrent transactions must be handled as invalid and will not be committed to the shared map (does
+   * not apply to removes from this transaction).
+   */
+  public void markRemovesDirty() {
+    AbstractMapTransactionMember transactionMember = getTransactionMember(true);
+    if (transactionMember != null) { // if not transaction, then no transaction member
+      transactionMember.markRemovesDirty();
+    }
+  }
+
   protected Map<K, V> getTransactionMap(boolean onlyReadOperation) {
-    Map<K, V> m = getTransaction(!onlyReadOperation);
+    Map<K, V> m = getTransactionMember(!onlyReadOperation);
     if (m == null) {
       // no transaction, return shared map
       return getSharedMap();
@@ -101,13 +133,13 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
     return m;
   }
 
-  @SuppressWarnings("unchecked")
-  protected <TM extends Map<K, V> & ITransactionMember> TM getTransaction(boolean createIfNotExist) {
+  public AbstractMapTransactionMember getTransactionMember(boolean createIfNotExist) {
     ITransaction t = ITransaction.CURRENT.get();
     if (t == null) {
       return null;
     }
-    TM m = (TM) t.getMember(getTransactionMemberId());
+    @SuppressWarnings("unchecked")
+    AbstractMapTransactionMember m = (AbstractMapTransactionMember) t.getMember(getTransactionMemberId());
     if (m == null && createIfNotExist) {
       m = createMapTransactionMember();
       t.registerMember(m);
@@ -178,8 +210,7 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
   }
 
   @SuppressWarnings("squid:S2160")
-  public abstract static class AbstractMapTransactionMember<K, V> extends AbstractMap<K, V> implements ITransactionMember {
-    private final String m_memberId;
+  public abstract class AbstractMapTransactionMember extends AbstractMap<K, V> implements ITransactionMember {
 
     /**
      * Map containing an entry for removes that were done within this transaction, containing the old value from the
@@ -188,22 +219,23 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
      */
     protected final Map<K, V> m_removedMap;
     /**
-     * Map containing entry for each inserted value. Before an value is inserted, any previous value has to be removed.
+     * Map containing entry for each inserted value. Before a value is inserted, any previous value has to be removed.
      * In other words, an entry was added to the removedMap.
      */
     protected final Map<K, V> m_insertedMap;
-    /**
-     * If set to true, before a put operation the shared map is checked if there is already an entry for the given key.
-     * If there is no such entry, the new entry is directly put in the shared map.
-     */
-    protected final boolean m_fastForward;
 
-    public AbstractMapTransactionMember(String transactionId, Map<K, V> removedMap, Map<K, V> insertedMap, boolean fastForward) {
+    protected final int m_insertVersion;
+    protected final int m_removeVersion;
+
+    private boolean m_insertsDirty;
+    private boolean m_removesDirty;
+
+    public AbstractMapTransactionMember(Map<K, V> removedMap, Map<K, V> insertedMap) {
       super();
-      m_memberId = transactionId;
       m_removedMap = removedMap;
       m_insertedMap = insertedMap;
-      m_fastForward = fastForward;
+      m_insertVersion = AbstractTransactionalMap.this.m_insertVersion.get();
+      m_removeVersion = AbstractTransactionalMap.this.m_removeVersion.get();
     }
 
     /**
@@ -219,23 +251,113 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
       return m_removedMap;
     }
 
-    protected boolean isFastForward() {
-      return m_fastForward;
+    public void markInsertsDirty() {
+      m_insertsDirty = true;
+    }
+
+    public void markRemovesDirty() {
+      m_removesDirty = true;
     }
 
     @Override
     public String getMemberId() {
-      return m_memberId;
+      return m_transactionMemberId;
     }
 
     @Override
     public boolean needsCommit() {
-      return !m_removedMap.isEmpty() || !m_insertedMap.isEmpty();
+      return !m_removedMap.isEmpty() || !m_insertedMap.isEmpty() || m_insertsDirty || m_removesDirty;
     }
 
     @Override
     public boolean commitPhase1() {
       return true;
+    }
+
+    protected void commitChanges(Map<K, V> sharedMap) {
+      List<K> successfulCommittedChanges = new ArrayList<>();
+      List<K> failedCommittedChanges = new ArrayList<>();
+
+      int sharedRemoveVersion;
+      if (m_removesDirty) {
+        sharedRemoveVersion = AbstractTransactionalMap.this.m_removeVersion.getAndIncrement();
+      }
+      else {
+        sharedRemoveVersion = AbstractTransactionalMap.this.m_removeVersion.get();
+      }
+      boolean removesValid = sharedRemoveVersion == m_removeVersion;
+
+      int sharedInsertVersion;
+      if (m_insertsDirty) {
+        sharedInsertVersion = AbstractTransactionalMap.this.m_insertVersion.getAndIncrement();
+      }
+      else {
+        sharedInsertVersion = AbstractTransactionalMap.this.m_insertVersion.get();
+      }
+      boolean insertsValid = sharedInsertVersion == m_insertVersion;
+
+      if (removesValid) {
+        for (Entry<K, V> entry : m_removedMap.entrySet()) {
+          K key = entry.getKey();
+          V oldValue = entry.getValue();
+          if (oldValue != null) {
+            V insertedValue = m_insertedMap.remove(key);
+            if (!insertsValid) {
+              failedCommittedChanges.add(key);
+            }
+            else if (insertedValue != null) {
+              if (sharedMap.replace(key, oldValue, insertedValue)) {
+                successfulCommittedChanges.add(key);
+              }
+              else {
+                failedCommittedChanges.add(key);
+              }
+            }
+            else {
+              if (sharedMap.remove(key, oldValue)) {
+                successfulCommittedChanges.add(key);
+              }
+              else {
+                failedCommittedChanges.add(key);
+              }
+            }
+          }
+          else {
+            // if there must be a value inserted, the loop over insertedMap will handle this
+            if (sharedMap.containsKey(key)) {
+              // remove entry, and there was no previous value in sharedMap but now there is one. Commit failed.
+              failedCommittedChanges.add(key);
+            }
+          }
+        }
+      }
+      else {
+        for (Entry<K, V> entry : m_removedMap.entrySet()) {
+          if (entry.getValue() != null) {
+            m_insertedMap.remove(entry.getKey());
+          }
+        }
+        failedCommittedChanges.addAll(m_removedMap.keySet());
+      }
+
+      if (insertsValid) {
+        for (Entry<K, V> entry : m_insertedMap.entrySet()) {
+          K key = entry.getKey();
+          V newValue = entry.getValue();
+          V previousValue = sharedMap.putIfAbsent(key, newValue);
+          if (previousValue != null && !previousValue.equals(newValue)) {
+            failedCommittedChanges.add(key);
+          }
+          else {
+            successfulCommittedChanges.add(key);
+          }
+        }
+      }
+      else {
+        failedCommittedChanges.addAll(m_insertedMap.keySet());
+      }
+
+      changesCommitted(sharedMap, successfulCommittedChanges, failedCommittedChanges);
     }
 
     /**
@@ -244,13 +366,9 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
      * <p>
      * As a default, entries from the shared map are removed for any failed commit. Therefore, if map is used as a lazy
      * loaded shared cache, the item will be reloaded.
-     *
-     * @param successfulCommitedChanges
-     * @param failedCommitedChanges
-     * @param sharedMap
      */
-    protected void changesCommited(Map<K, V> newSharedMap, Collection<K> successfulCommitedChanges, Collection<K> failedCommitedChanges) {
-      for (K key : failedCommitedChanges) {
+    protected void changesCommitted(Map<K, V> newSharedMap, Collection<K> successfulCommittedChanges, Collection<K> failedCommittedChanges) {
+      for (K key : failedCommittedChanges) {
         newSharedMap.remove(key);
       }
     }
@@ -267,6 +385,7 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
     public void release() {
     }
 
+    @SuppressWarnings("SuspiciousMethodCalls")
     @Override
     public V get(Object key) {
       V value = m_insertedMap.get(key);
@@ -284,9 +403,9 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
       }
       V sharedValue = getReadSharedMap().get(key);
       boolean hasRemoveEntry = m_removedMap.containsKey(key);
-      if (m_fastForward && !hasRemoveEntry && sharedValue == null && fastForward(key, value)) {
+      if (m_fastForward && !hasRemoveEntry && sharedValue == null && !m_insertsDirty && fastForward(key, value)) {
         // fastForward success; value was directly put in shared map
-        return null;
+        sharedValue = value; // do not return but add to inserted/removed map; this will ensure that dirty marked transactions will roll back this fast-forward action
       }
       V oldValue = m_insertedMap.put(key, value);
       if (!hasRemoveEntry && sharedValue != null) {
@@ -300,13 +419,13 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
     /**
      * Tries to commit a new value directly into the shared map
      *
-     * @return true if fast forward succeeded
+     * @return true if fast-forward succeeded
      */
     protected boolean fastForward(K key, V value) {
       return false;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"SuspiciousMethodCalls", "unchecked"})
     @Override
     public V remove(Object key) {
       V insertedValue = m_insertedMap.remove(key);
@@ -336,7 +455,7 @@ public abstract class AbstractTransactionalMap<K, V> implements Map<K, V> {
     public int size() {
       if (m_removedMap.containsValue(null)) {
         // If a value in the removed map is null, then there was no entry in the shared map, at the time when remove was called.
-        // Now there could be an entry in the shared map. Therefore we have now to carefully compute the sizes.
+        // Now there could be an entry in the shared map. Therefore, we have now to carefully compute the sizes.
         Set<K> keys = new HashSet<>(getReadSharedMap().keySet());
         keys.removeAll(m_removedMap.keySet());
         keys.addAll(m_insertedMap.keySet());

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/code/CodeServiceInvalidateTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/code/CodeServiceInvalidateTest.java
@@ -18,6 +18,7 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.server.TestServerSession;
 import org.eclipse.scout.rt.server.context.ServerRunContexts;
 import org.eclipse.scout.rt.shared.services.common.code.AbstractCodeType;
@@ -58,7 +59,7 @@ public class CodeServiceInvalidateTest {
 
   @Test
   public void testInvalidateInsideSubTransaction() {
-    CODES.invalidateCodeTypes(new ArrayList<>(CODES.getAllCodeTypeClasses("")));
+    RunContexts.copyCurrent().run(() -> CODES.invalidateCodeTypes(new ArrayList<>(CODES.getAllCodeTypeClasses(""))));
 
     readCodeType(1);
     invalidateCodeType();
@@ -78,7 +79,7 @@ public class CodeServiceInvalidateTest {
 
   @Test
   public void testReloadInsideSubTransaction() {
-    CODES.invalidateCodeTypes(new ArrayList<>(CODES.getAllCodeTypeClasses("")));
+    RunContexts.copyCurrent().run(() -> CODES.invalidateCodeTypes(new ArrayList<>(CODES.getAllCodeTypeClasses(""))));
 
     readCodeType(1);
     invalidateCodeType();
@@ -101,7 +102,6 @@ public class CodeServiceInvalidateTest {
 
   private static TestCodeType readCodeType(int expectedInstanceId) {
     TestCodeType codeType = BEANS.get(TestCodeType.class);
-    System.out.println("" + codeType.instanceId);
     Assert.assertEquals("TestCodeType.instanceId", expectedInstanceId, codeType.instanceId);
     return codeType;
   }

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/cache/CacheRegistryServiceTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/cache/CacheRegistryServiceTest.java
@@ -33,7 +33,7 @@ public class CacheRegistryServiceTest {
   public void testRegistry() {
     CacheRegistryService s = new CacheRegistryService();
     String testKey = "testkey";
-    BasicCache<String, String> testCache = new BasicCache<String, String>(testKey, mock(ICacheValueResolver.class), new HashMap<>(), false);
+    BasicCache<String, String> testCache = new BasicCache<>(testKey, mock(ICacheValueResolver.class), new HashMap<>());
     s.register(testCache);
     assertEquals(testCache, s.get(testKey));
   }
@@ -43,7 +43,7 @@ public class CacheRegistryServiceTest {
   public void testRegistryIfAbsent() {
     CacheRegistryService s = new CacheRegistryService();
     String testKey = "testkey";
-    BasicCache<String, String> testCache = new BasicCache<String, String>(testKey, mock(ICacheValueResolver.class), new HashMap<>(), false);
+    BasicCache<String, String> testCache = new BasicCache<>(testKey, mock(ICacheValueResolver.class), new HashMap<>());
     s.registerIfAbsent(testCache);
     assertEquals(testCache, s.get(testKey));
   }
@@ -64,9 +64,9 @@ public class CacheRegistryServiceTest {
   public void testDuplicateCreate() {
     CacheRegistryService s = new CacheRegistryService();
     String cacheId = "testcacheid";
-    BasicCache<String, String> cache1 = new BasicCache<String, String>(cacheId, key -> "Valuf of " + key, new HashMap<>(), false);
+    BasicCache<String, String> cache1 = new BasicCache<>(cacheId, key -> "Valuf of " + key, new HashMap<>());
     s.register(cache1);
-    BasicCache<String, String> cache2 = new BasicCache<String, String>(cacheId, key -> "Valuf of " + key, new HashMap<>(), false);
+    BasicCache<String, String> cache2 = new BasicCache<>(cacheId, key -> "Valuf of " + key, new HashMap<>());
     s.register(cache2);
   }
 
@@ -74,9 +74,9 @@ public class CacheRegistryServiceTest {
   public void testDuplicateCreateIfAbsent() {
     CacheRegistryService s = new CacheRegistryService();
     String cacheId = "testcacheid";
-    ICache<String, String> cache1 = new BasicCache<String, String>(cacheId, key -> "Valuf of " + key, new HashMap<>(), false);
+    ICache<String, String> cache1 = new BasicCache<>(cacheId, key -> "Valuf of " + key, new HashMap<>());
     s.registerIfAbsent(cache1);
-    ICache<String, String> cache2 = new BasicCache<String, String>(cacheId, key -> "Valuf of " + key, new HashMap<>(), false);
+    ICache<String, String> cache2 = new BasicCache<>(cacheId, key -> "Valuf of " + key, new HashMap<>());
     ICache<String, String> cache = s.registerIfAbsent(cache2);
     assertSame(cache1, cache);
   }


### PR DESCRIPTION
Before this change, an invalidate operation on a cache entry was ignored by a concurrent running resolve of this same cache entry.

347248