### PR TITLE
Table: Allow to directly open the cell edit popup when focusing a cell

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -2205,10 +2205,10 @@ export class Table extends Widget implements TableModel {
    * Starts cell editing for the cell at the given column and row, but only if editing is allowed.
    * @see prepareCellEdit
    */
-  focusCell(column: Column<any>, row: TableRow) {
+  focusCell(column: Column<any>, row: TableRow, openFieldPopupOnCellEdit = false) {
     let cell = this.cell(column, row);
     if (this.enabledComputed && row.enabled && cell.editable) {
-      this.prepareCellEdit(column, row);
+      this.prepareCellEdit(column, row, openFieldPopupOnCellEdit);
     }
   }
 


### PR DESCRIPTION
The Table#focusCell method is the entry point for a possible cell edit lifecycle. This change adds the possibility to directly open the cell edit popup if requested. The default value ensures backward compatibility.