### PR TITLE
Calendar: fix multiple full day components

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.less
+++ b/eclipse-scout-core/src/calendar/Calendar.less
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -220,7 +220,7 @@
     background-color: @palette-blue-1; /* Default colors used when component has no specific class */
   }
 
-   /* Default colors used when component has no specific class */
+  /* Default colors used when component has no specific class */
   background-color: @palette-blue-0;
 
   &:hover {
@@ -347,11 +347,28 @@
   display: inline-block;
   vertical-align: top;
   overflow: hidden;
+
+  --min-full-day-components: 2;
+  --max-full-day-components: 4;
+  --full-day-components: 0;
+  --day-of-month-height: 30px; // CalendarComponent.DAY_OF_MONTH_HEIGHT
+  --component-height: 24px; // CalendarComponent.COMPONENT_HEIGHT
+  --component-vgap: 2px; // CalendarComponent.COMPONENT_VGAP
+  --component-height-with-gap: calc(var(--component-height) + var(--component-vgap));
+  --top-grid-height: calc(@calendar-title-height
+  + var(--day-of-month-height)
+  + (max(min(var(--full-day-components), var(--max-full-day-components)), var(--min-full-day-components)) * var(--component-height-with-gap))// number of full day components, bounded by min and max
+  - (min(max(var(--full-day-components), var(--min-full-day-components)), 1) * var(--component-vgap))// remove additional gap after the last full day component if there is one
+  + 1px); // border
+
+  &.calendar-grids-month {
+    --top-grid-height: @calendar-title-height + 1px;
+  }
 }
 
 .calendar-grid {
   display: block;
-  height: calc(~'100% - 25px');
+  height: calc(~'100% - ' var(--top-grid-height));
   padding-right: @root-group-box-padding-right;
 
   & + .scroll-shadow {
@@ -367,20 +384,12 @@
   }
 }
 
-.calendar-grid.calendar-grid-short {
-  height: calc(~'100% - 105px');
-}
-
 .calendar-top-grid {
   display: block;
   overflow: hidden;
   border-bottom: 1px solid @border-color;
-  height: 105px;
+  height: var(--top-grid-height);
   margin-right: @root-group-box-padding-right;
-
-  &.calendar-top-grid-short {
-    height: 25px;
-  }
 
   &.mobile {
     margin-right: @calendar-padding-right-mobile;
@@ -394,9 +403,12 @@
   white-space: nowrap;
 }
 
-.calendar-week-allday-container,
+.calendar-week-allday-container {
+  height: calc(~'100% - ' @calendar-title-height);
+}
+
 .calendar-week-allday-container > .calendar-week-name {
-  height: 80px;
+  height: calc(~'100% - ' @calendar-title-height - 9px);
 }
 
 .calendar-week-allday-container > .calendar-day {

--- a/eclipse-scout-core/src/calendar/CalendarComponent.js
+++ b/eclipse-scout-core/src/calendar/CalendarComponent.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2019 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -21,6 +21,7 @@ export default class CalendarComponent extends Widget {
      */
     this.selected = false;
     this.fullDay = false;
+    this.fullDayIndex = -1;
     this.item = null;
     this._$parts = [];
   }
@@ -29,6 +30,10 @@ export default class CalendarComponent extends Widget {
    * If day of a month is smaller than 100px, the components get the class compact
    */
   static MONTH_COMPACT_THRESHOLD = 100;
+
+  static DAY_OF_MONTH_HEIGHT = 30;
+  static COMPONENT_HEIGHT = 24;
+  static COMPONENT_VGAP = 2;
 
   _init(model) {
     super._init(model);
@@ -129,10 +134,9 @@ export default class CalendarComponent extends Widget {
       } else {
         if (this.fullDay) {
           // Full day tasks are rendered in the topGrid
-          let alreadyExistingTasks = $('.component-task', $day).length;
-          // Offset of initial task: 30px for the day-of-month number
-          // Offset of following tasks: 26px * preceding number of tasks. 26px: Task 23px high, 1px border. Spaced by 2px
-          this._arrangeTask(30 + 26 * alreadyExistingTasks);
+          // Offset of initial task: CalendarComponent.DAY_OF_MONTH_HEIGHT
+          // Offset of following tasks: (CalendarComponent.COMPONENT_HEIGHT + CalendarComponent.COMPONENT_VGAP) * preceding number of tasks
+          this._arrangeTask(CalendarComponent.DAY_OF_MONTH_HEIGHT + (CalendarComponent.COMPONENT_HEIGHT + CalendarComponent.COMPONENT_VGAP) * Math.max(this.fullDayIndex, 0));
           $part.addClass('component-task');
         } else {
           let


### PR DESCRIPTION
Add fullDayIndex to arrange full day components correct. One component needs to be on the same line for each day in its range. The height of the topGrid now depends on its content, it grows if there are more full day components to fit a maximum of 4 components without scrolling.

348235