### PR TITLE
Table: add columnById overload

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.ts
+++ b/eclipse-scout-core/src/desktop/outline/Outline.ts
@@ -379,7 +379,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
     return menus;
   }
 
-  protected _getMenu(menus: Menu[], menuClass: new() => Menu): Menu {
+  protected _getMenu(menus: Menu[], menuClass: abstract new() => Menu): Menu {
     for (let i = 0; i < menus.length; i++) {
       if (menus[i] instanceof menuClass) {
         return menus[i];
@@ -388,7 +388,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
     return null;
   }
 
-  protected _hasMenu(menus: Menu[], menuClass: new() => Menu): boolean {
+  protected _hasMenu(menus: Menu[], menuClass: abstract new() => Menu): boolean {
     return this._getMenu(menus, menuClass) !== null;
   }
 

--- a/eclipse-scout-core/src/form/fields/FormField.ts
+++ b/eclipse-scout-core/src/form/fields/FormField.ts
@@ -399,9 +399,9 @@ export class FormField extends Widget implements FormFieldModel {
   }
 
   /**
-   * Whether or not the error status is or has the given status type.
+   * Whether the error status is or has the given status type.
    */
-  containsStatus(statusType: new() => Status): boolean {
+  containsStatus(statusType: abstract new() => Status): boolean {
     if (!this.errorStatus) {
       return false;
     }

--- a/eclipse-scout-core/src/scout.ts
+++ b/eclipse-scout-core/src/scout.ts
@@ -87,7 +87,7 @@ function widget(widgetIdOrElement: string | number | HTMLElement | JQuery, partI
 
 /**
  * Resolves the widget using the given widget id or HTML element.
- * <p>
+ *
  * If the argument is a string or a number, it will search the widget hierarchy for the given id using {@link Widget.widget}.
  * If the argument is a {@link HTMLElement} or {@link JQuery} element, it will use {@link widgets.get(elem)} to get the widget which belongs to the given element.
  *
@@ -259,8 +259,8 @@ export const scout = {
    * for that element is prevented, we set an 'active' CSS class instead. This means in the
    * CSS we must deal with :active and with .active, where we need same behavior for the
    * active state across all browsers.
-   * <p>
-   * Typically you'd write something like this in your CSS:
+   *
+   * Typically, you'd write something like this in your CSS:
    *   button:active, button.active { ... }
    */
   installSyntheticActiveStateHandler(myDocument: Document) {

--- a/eclipse-scout-core/src/status/Status.ts
+++ b/eclipse-scout-core/src/status/Status.ts
@@ -110,7 +110,7 @@ export class Status implements StatusModel, ObjectWithType {
    *
    * @returns whether or not this status contains a child with the give type
    */
-  containsStatus(statusType: new() => Status): boolean {
+  containsStatus(statusType: abstract new() => Status): boolean {
     return this.containsStatusByPredicate(status => status instanceof statusType);
   }
 
@@ -130,7 +130,7 @@ export class Status implements StatusModel, ObjectWithType {
   /**
    * Removes all children of the given type from this status. The type is checked by inheritance.
    */
-  removeAllStatus(statusType: new() => Status) {
+  removeAllStatus(statusType: abstract new() => Status) {
     this.removeAllStatusByPredicate(status => status instanceof statusType);
   }
 

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -3580,7 +3580,25 @@ export class Table extends Widget implements TableModel {
     return $row.children('.table-cell').eq(columnIndex);
   }
 
-  columnById<TId extends string & keyof ColumnMapOf<this>>(columnId: TId): ColumnMapOf<this>[TId] {
+  /**
+   * Searches for a column with the given ID.
+   *
+   * @param columnId the ID of the column to look for
+   * @param type the type of the column to look for. The return value will be cast to that type. This parameter has no effect at runtime.
+   * @returns the column for the requested ID or null if no column has been found.
+   */
+  columnById<TColumn extends Column>(columnId: string, type: abstract new() => TColumn): TColumn;
+  /**
+   * Searches for a column with the given ID.
+   *
+   * If this table has a {@link columnMap}, its type has to contain a mapping for the given ID so the found column can be cast to the correct type.
+   * If there is no concrete {@link columnMap}, the return type will be {@link Column}.
+   *
+   * @param columnId the ID of the column to look for
+   * @returns the column for the requested ID or null if no column has been found.
+   */
+  columnById<TId extends string & keyof ColumnMapOf<this>>(columnId: TId): ColumnMapOf<this>[TId];
+  columnById<TId extends string & keyof ColumnMapOf<this>, TColumn extends Column>(columnId: TId, type?: abstract new() => TColumn): ColumnMapOf<this>[TId] | TColumn {
     return arrays.find(this.columns, column => column.id === columnId) as ColumnMapOf<this>[TId];
   }
 
@@ -3596,7 +3614,7 @@ export class Table extends Widget implements TableModel {
   }
 
   columnsByIds<TId extends string & keyof ColumnMapOf<this>>(columnIds: TId[]): ColumnMapOf<this>[TId][] {
-    return columnIds.map(this.columnById.bind(this));
+    return columnIds.map(id => this.columnById(id));
   }
 
   getVisibleRows(): TableRow[] {

--- a/eclipse-scout-core/src/util/objects.ts
+++ b/eclipse-scout-core/src/util/objects.ts
@@ -744,7 +744,7 @@ export const objects = {
   /**
    * @returns true if the first parameter is the same or a subclass of the second parameter.
    */
-  isSameOrExtendsClass<TClass2>(class1: any, class2: new() => TClass2): class1 is new() => TClass2 {
+  isSameOrExtendsClass<TClass2>(class1: any, class2: abstract new() => TClass2): class1 is new() => TClass2 {
     if (typeof class1 !== 'function' || typeof class2 !== 'function') {
       return false;
     }

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -1920,16 +1920,25 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
     this.setParent(this.owner);
   }
 
-  widget<T extends Widget>(widgetId: string, type: new() => T): T;
-  widget<TId extends string & keyof WidgetMapOf<this>>(widgetId: TId): WidgetMapOf<this>[TId];
-
   /**
-   * Traverses the object-tree (children) of this widget and searches for a widget with the given ID.
-   * Returns the widget with the requested ID or null if no widget has been found.
-   * @param widgetId the id of the widget to look for
-   * @param type the type of the widget to look for. When specified, the return value will be cast to that type. This parameter has no effect at runtime.
+   * Traverses the widget tree starting from this widget and searches for a child widget with the given ID.
+   *
+   * @param widgetId the ID of the widget to look for
+   * @param type the type of the widget to look for. The return value will be cast to that type. This parameter has no effect at runtime.
+   * @returns the widget for the requested ID or null if no widget has been found.
    */
-  widget<TId extends string & keyof WidgetMapOf<this>, T extends Widget>(widgetId: TId, type?: new() => T): WidgetMapOf<this>[TId] | T {
+  widget<T extends Widget>(widgetId: string, type: abstract new() => T): T;
+  /**
+   * Traverses the widget tree starting from this widget and searches for a child widget with the given ID.
+   *
+   * If this widget has a {@link widgetMap}, its type has to contain a mapping for the given ID so the found widget can be cast to the correct type.
+   * If there is no concrete {@link widgetMap}, the return type will be {@link Widget}.
+   *
+   * @param widgetId the ID of the widget to look for
+   * @returns the widget for the requested ID or null if no widget has been found.
+   */
+  widget<TId extends string & keyof WidgetMapOf<this>>(widgetId: TId): WidgetMapOf<this>[TId];
+  widget<TId extends string & keyof WidgetMapOf<this>, T extends Widget>(widgetId: TId, type?: abstract new() => T): WidgetMapOf<this>[TId] | T {
     if (predicate(this)) {
       return this as unknown as T;
     }
@@ -1941,7 +1950,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
   }
 
   /**
-   * Similar to widget(), but uses "breadth-first" strategy, i.e. it checks all children of the
+   * Similar to {@link widget}, but uses "breadth-first" strategy, i.e. it checks all children of the
    * same depth (level) before it advances to the next level. If multiple widgets with the same
    * ID exist, the one with the smallest distance to this widget is returned.
    *
@@ -2005,7 +2014,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
    * @param predicateOrClass may be a {@link Predicate} or a sub-class of {@link Widget}.
    * @returns the first ancestor for which the given predicate returns true or that matches the given widget type if a subclass of {@link Widget} is provided.
    */
-  findParent<T extends Widget>(predicateOrClass: Predicate<Widget> | (new() => T)): T {
+  findParent<T extends Widget>(predicateOrClass: Predicate<Widget> | (abstract new() => T)): T {
     let predicate;
     if (objects.isSameOrExtendsClass(predicateOrClass, Widget)) {
       predicate = widget => widget instanceof predicateOrClass;


### PR DESCRIPTION
Can be used to search for a column in a table with a created columnMap and dynamic columns.

Also added abstract key word to some constructor type parameters, so that abstract classes can be passed as well.