### PR TITLE
Calendar: fix multiple full day components

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.less
+++ b/eclipse-scout-core/src/calendar/Calendar.less
@@ -429,11 +429,28 @@
   display: inline-block;
   vertical-align: top;
   overflow: hidden;
+
+  --min-full-day-components: 2;
+  --max-full-day-components: 4;
+  --full-day-components: 0;
+  --day-of-month-height: 30px; // CalendarComponent.DAY_OF_MONTH_HEIGHT
+  --component-height: 24px; // CalendarComponent.COMPONENT_HEIGHT
+  --component-vgap: 2px; // CalendarComponent.COMPONENT_VGAP
+  --component-height-with-gap: calc(var(--component-height) + var(--component-vgap));
+  --top-grid-height: calc(@calendar-title-height
+  + var(--day-of-month-height)
+  + (max(min(var(--full-day-components), var(--max-full-day-components)), var(--min-full-day-components)) * var(--component-height-with-gap))// number of full day components, bounded by min and max
+  - (min(max(var(--full-day-components), var(--min-full-day-components)), 1) * var(--component-vgap))// remove additional gap after the last full day component if there is one
+  + 1px); // border
+
+  &.calendar-grids-month {
+    --top-grid-height: @calendar-title-height + 1px;
+  }
 }
 
 .calendar-grid {
   display: block;
-  height: calc(~'100% - 25px');
+  height: calc(~'100% - ' var(--top-grid-height));
   padding-right: @root-group-box-padding-right;
 
   & + .scroll-shadow {
@@ -449,20 +466,12 @@
   }
 }
 
-.calendar-grid.calendar-grid-short {
-  height: calc(~'100% - 105px');
-}
-
 .calendar-top-grid {
   display: block;
   overflow: hidden;
   border-bottom: 1px solid @border-color;
-  height: 105px;
+  height: var(--top-grid-height);
   margin-right: @root-group-box-padding-right;
-
-  &.calendar-top-grid-short {
-    height: 25px;
-  }
 
   &.mobile {
     margin-right: @calendar-padding-right-mobile;
@@ -476,9 +485,12 @@
   white-space: nowrap;
 }
 
-.calendar-week-allday-container,
+.calendar-week-allday-container {
+  height: calc(~'100% - ' @calendar-title-height);
+}
+
 .calendar-week-allday-container > .calendar-week-name {
-  height: 80px;
+  height: calc(~'100% - ' @calendar-title-height - 9px);
 }
 
 .calendar-week-allday-container > .calendar-day {

--- a/eclipse-scout-core/src/calendar/CalendarComponent.ts
+++ b/eclipse-scout-core/src/calendar/CalendarComponent.ts
@@ -20,6 +20,7 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
   toDate: string;
   selected: boolean;
   fullDay: boolean;
+  fullDayIndex: number;
   draggable: boolean;
   item: CalendarItem;
   stack: Record<string, { x?: number; w?: number }>;
@@ -32,6 +33,7 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
     super();
     this.selected = false;
     this.fullDay = false;
+    this.fullDayIndex = -1;
     this.item = null;
     this._$parts = [];
   }
@@ -40,6 +42,10 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
    * If day of a month is smaller than 100px, the components get the class compact
    */
   static MONTH_COMPACT_THRESHOLD = 100;
+
+  static DAY_OF_MONTH_HEIGHT = 30;
+  static COMPONENT_HEIGHT = 24;
+  static COMPONENT_VGAP = 2;
 
   protected override _init(model: InitModelOf<this>) {
     super._init(model);
@@ -142,10 +148,9 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
       } else {
         if (this.fullDay) {
           // Full day tasks are rendered in the topGrid
-          let alreadyExistingTasks = $('.component-task', $day).length;
-          // Offset of initial task: 30px for the day-of-month number
-          // Offset of following tasks: 26px * preceding number of tasks. 26px: Task 23px high, 1px border. Spaced by 2px
-          this._arrangeTask(30 + 26 * alreadyExistingTasks);
+          // Offset of initial task: CalendarComponent.DAY_OF_MONTH_HEIGHT
+          // Offset of following tasks: (CalendarComponent.COMPONENT_HEIGHT + CalendarComponent.COMPONENT_VGAP) * preceding number of tasks
+          this._arrangeTask(CalendarComponent.DAY_OF_MONTH_HEIGHT + (CalendarComponent.COMPONENT_HEIGHT + CalendarComponent.COMPONENT_VGAP) * Math.max(this.fullDayIndex, 0));
           $part.addClass('component-task');
         } else {
           let

--- a/eclipse-scout-core/src/calendar/CalendarComponentModel.ts
+++ b/eclipse-scout-core/src/calendar/CalendarComponentModel.ts
@@ -18,6 +18,7 @@ export interface CalendarComponentModel extends WidgetModel {
    */
   selected?: boolean;
   fullDay?: boolean;
+  fullDayIndex?: number;
   item?: CalendarItem;
   coveredDaysRange?: DateRange | JsonDateRange;
 }


### PR DESCRIPTION
Add fullDayIndex to arrange full day components correct. One component needs to be on the same line for each day in its range. The height of the topGrid now depends on its content, it grows if there are more full day components to fit a maximum of 4 components without scrolling.

348235