### PR TITLE
Add busy handling to Scout JS

### DIFF
--- a/eclipse-scout-core/src/ErrorHandler.ts
+++ b/eclipse-scout-core/src/ErrorHandler.ts
@@ -261,6 +261,7 @@ export class ErrorHandler implements ErrorHandlerModel, ObjectWithType {
   protected _analyzeRegularError(errorInfo: ErrorInfo) {
     let error = errorInfo.error as Error;
     errorInfo.code = this.getJsErrorCode(error);
+    errorInfo.showAsFatalError = true;
     errorInfo.message = String(error.message || error);
     if (error.stack) {
       errorInfo.stack = String(error.stack);

--- a/eclipse-scout-core/src/desktop/Desktop.ts
+++ b/eclipse-scout-core/src/desktop/Desktop.ts
@@ -8,11 +8,11 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AbstractLayout, Action, arrays, BenchColumnLayoutData, cookies, DeferredGlassPaneTarget, DesktopBench, DesktopBenchViewActivateEvent, DesktopEventMap, DesktopFormController, DesktopHeader, DesktopLayout, DesktopModel, DesktopNavigation,
-  DesktopNotification, Device, DisableBrowserF5ReloadKeyStroke, DisableBrowserTabSwitchingKeyStroke, DisplayParent, DisplayViewId, EnumObject, Event, EventEmitter, EventHandler, FileChooser, FileChooserController, Form, GlassPaneTarget,
-  HtmlComponent, HtmlEnvironment, InitModelOf, KeyStrokeContext, Menu, MessageBox, MessageBoxController, NativeNotificationVisibility, ObjectOrChildModel, ObjectOrModel, objects, OfflineDesktopNotification, OpenUriHandler, Outline,
-  OutlineContent, OutlineViewButton, Popup, ReloadPageOptions, ResponsiveHandler, scout, SimpleTabArea, SimpleTabBox, Splitter, SplitterMoveEndEvent, SplitterMoveEvent, SplitterPositionChangeEvent, strings, styles, Tooltip, Tree,
-  TreeDisplayStyle, UnsavedFormChangesForm, URL, ViewButton, webstorage, Widget, widgets
+  AbstractLayout, Action, arrays, BenchColumnLayoutData, BusyIndicatorOptions, BusySupport, cookies, DeferredGlassPaneTarget, DesktopBench, DesktopBenchViewActivateEvent, DesktopEventMap, DesktopFormController, DesktopHeader, DesktopLayout,
+  DesktopModel, DesktopNavigation, DesktopNotification, Device, DisableBrowserF5ReloadKeyStroke, DisableBrowserTabSwitchingKeyStroke, DisplayParent, DisplayViewId, EnumObject, Event, EventEmitter, EventHandler, FileChooser,
+  FileChooserController, Form, GlassPaneTarget, HtmlComponent, HtmlEnvironment, InitModelOf, KeyStrokeContext, Menu, MessageBox, MessageBoxController, NativeNotificationVisibility, ObjectOrChildModel, ObjectOrModel, objects,
+  OfflineDesktopNotification, OpenUriHandler, Outline, OutlineContent, OutlineViewButton, Popup, ReloadPageOptions, ResponsiveHandler, scout, SimpleTabArea, SimpleTabBox, Splitter, SplitterMoveEndEvent, SplitterMoveEvent,
+  SplitterPositionChangeEvent, strings, styles, Tooltip, Tree, TreeDisplayStyle, UnsavedFormChangesForm, URL, ViewButton, webstorage, Widget, widgets
 } from '../index';
 import $ from 'jquery';
 
@@ -67,6 +67,7 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
   animateLayoutChange: boolean;
   url: URL;
   responsiveHandler: ResponsiveHandler;
+  busySupport: BusySupport;
 
   $notifications: JQuery;
   $overlaySeparator: JQuery;
@@ -125,6 +126,7 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
     this.theme = null;
     this.dense = false;
     this.url = null;
+    this.busySupport = scout.create(BusySupport, {parent: this});
     this.$notifications = null;
 
     this._addWidgetProperties(['viewButtons', 'menus', 'views', 'selectedViewTabs', 'dialogs', 'outline', 'messageBoxes', 'notifications', 'fileChoosers', 'addOns', 'keyStrokes', 'activeForm', 'focusedElement']);
@@ -364,6 +366,18 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
       this.outline.setCompact(compact);
       this.outline.setEmbedDetailContent(compact);
     }
+  }
+
+  /** @see BusySupport.setBusy */
+  setBusy(busy: boolean | BusyIndicatorOptions) {
+    this.busySupport.setBusy(busy);
+  }
+
+  /**
+   * @return true if the desktop has a busy indicator active.
+   */
+  get busy(): boolean {
+    return this.busySupport.isBusy();
   }
 
   /** @see DesktopModel.dense */

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -134,6 +134,8 @@ export * from './session/BackgroundJobPollingStatus';
 export * from './session/BackgroundJobPollingSupport';
 export * from './session/BusyIndicator';
 export * from './session/BusyIndicatorEventMap';
+export * from './session/BusySupport';
+export * from './session/BusySupportModel';
 export * from './session/RemoteEvent';
 export * from './session/Locale';
 export * from './session/LocaleModel';

--- a/eclipse-scout-core/src/session/BusyIndicator.ts
+++ b/eclipse-scout-core/src/session/BusyIndicator.ts
@@ -10,9 +10,34 @@
 import {Action, BoxButtons, BusyIndicatorEventMap, ClickActiveElementKeyStroke, CloseKeyStroke, Event, FocusRule, GlassPaneRenderer, InitModelOf, keys, KeyStrokeContext, scout, strings, Widget, WidgetModel} from '../index';
 
 export interface BusyIndicatorModel extends WidgetModel {
+  /**
+   * Specifies if the {@link BusyIndicator} is cancellable.
+   *
+   * If true, a cancel button is visible and the 'cancel' event may be fired on click.
+   *
+   * Default is true.
+   */
   cancellable?: boolean;
+  /**
+   * The time in milliseconds from the moment the {@link BusyIndicator} is rendered until the popup becomes visible.
+   * Before this timeout the glasspanes are rendered and the cursors is displayed as busy.
+   * As soon as the timeout elapsed, the busy indicator popup is shown as well.
+   * Only after the popup is shown it is possible to cancel the indicator.
+   *
+   * Default is 2.5s.
+   */
   showTimeout?: number;
+  /**
+   * The text to show in the busy indicator popup.
+   *
+   * Default is 'Please wait'.
+   */
   label?: string;
+  /**
+   * An additional text shown in the busy indicator popup below the label.
+   *
+   * Default is no details text.
+   */
   details?: string;
 }
 
@@ -151,6 +176,7 @@ export class BusyIndicator extends Widget implements BusyIndicatorModel {
     super._remove();
   }
 
+  /** @see BusyIndicatorModel.label */
   setLabel(label: string) {
     this.setProperty('label', label);
   }
@@ -159,6 +185,7 @@ export class BusyIndicator extends Widget implements BusyIndicatorModel {
     this.$label.text(this.label || '');
   }
 
+  /** @see BusyIndicatorModel.details */
   setDetails(details: string) {
     this.setProperty('details', details);
   }
@@ -174,7 +201,7 @@ export class BusyIndicator extends Widget implements BusyIndicatorModel {
   }
 
   /**
-   * Used by CloseKeyStroke.js
+   * Used by CloseKeyStroke
    */
   close() {
     if (this.cancelButton && this.cancelButton.$container && this.session.focusManager.requestFocus(this.cancelButton.$container)) {

--- a/eclipse-scout-core/src/session/BusySupport.ts
+++ b/eclipse-scout-core/src/session/BusySupport.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {arrays, BusyIndicator, BusyIndicatorModel, BusySupportModel, Event, EventHandler, InitModelOf, objects, ObjectWithType, scout, SomeRequired} from '../index';
+import $ from 'jquery';
+
+export class BusySupport implements ObjectWithType {
+  declare model: BusySupportModel;
+  declare initModel: SomeRequired<this['model'], 'parent'>;
+  declare self: BusySupport;
+
+  objectType: string;
+  defaultBusyIndicatorModel: InitModelOf<BusyIndicator>;
+  defaultRenderDelay: number;
+  busyIndicator: BusyIndicator;
+
+  protected _busyCounter: number;
+  protected _busyIndicatorTimeoutId: number;
+  protected _cancellationCallbacks: EventHandler<Event<BusyIndicator>>[];
+
+  constructor() {
+    this.objectType = null;
+    this.defaultBusyIndicatorModel = null;
+    this.defaultRenderDelay = 50;
+    this.busyIndicator = null;
+    this._busyCounter = 0;
+    this._busyIndicatorTimeoutId = null;
+    this._cancellationCallbacks = [];
+  }
+
+  init(model: InitModelOf<this>) {
+    scout.assertParameter('model', model);
+    const defaultIndicatorParent = scout.assertParameter('parent', model.parent);
+    this.defaultBusyIndicatorModel = $.extend({
+      cancellable: false,
+      parent: defaultIndicatorParent
+    }, model.busyIndicatorModel);
+    this.defaultRenderDelay = scout.nvl(model.renderDelay, this.defaultRenderDelay);
+  }
+
+  /** @see BusySupportModel.renderDelay */
+  setDefaultRenderDelay(delay: number) {
+    this.defaultRenderDelay = delay;
+  }
+
+  /** @see BusySupportModel.busyIndicatorModel */
+  setDefaultBusyIndicatorModel(model: InitModelOf<BusyIndicator>) {
+    this.defaultBusyIndicatorModel = model;
+  }
+
+  isBusy(): boolean {
+    return this._busyCounter > 0;
+  }
+
+  /**
+   * Changes the busy state
+   *
+   * @param options A boolean indicating if busy or not to show the busy indicator with the default settings (as passed when creating this instance) and without a cancellation callback.
+   * Or a {@link BusyIndicatorOptions} object which allows to customize the behavior and style of the indicator and to pass a cancellation callback.
+   */
+  setBusy(options: boolean | BusyIndicatorOptions) {
+    let optionsObj: BusyIndicatorOptions;
+    if (objects.isPlainObject(options)) {
+      optionsObj = options;
+    } else {
+      optionsObj = {
+        busy: !!options
+      };
+    }
+    optionsObj.renderDelay = scout.nvl(optionsObj.renderDelay, this.defaultRenderDelay);
+
+    if (optionsObj.busy) {
+      this._busyCounter++;
+      if (optionsObj.onCancel && !arrays.contains(this._cancellationCallbacks, optionsObj.onCancel)) {
+        this._cancellationCallbacks.push(optionsObj.onCancel);
+      }
+      if (this._busyCounter === 1) {
+        this._startBusy(optionsObj);
+      }
+    } else {
+      if (this._busyCounter > 0) {
+        if (optionsObj.force) {
+          this._busyCounter = 0;
+        } else {
+          this._busyCounter--;
+        }
+      }
+      if (this._busyCounter === 0) {
+        this._cancellationCallbacks = []; // reset callback list for next busy round
+        this._stopBusy();
+      }
+    }
+  }
+
+  protected _startBusy(options: BusyIndicatorOptions) {
+    if (this.busyIndicator) {
+      return; // already busy
+    }
+    const model = $.extend({}, this.defaultBusyIndicatorModel, options.busyIndicatorModel, {parent: options.parent});
+    this.busyIndicator = scout.create(BusyIndicator, model);
+    this.busyIndicator.one('cancel', this._onBusyIndicatorCancel.bind(this));
+    if (options.renderDelay > 0) {
+      // Don't show the busy indicator immediately
+      this._busyIndicatorTimeoutId = setTimeout(() => {
+        this._busyIndicatorTimeoutId = null;
+        this._renderBusy();
+      }, options.renderDelay);
+    } else {
+      this._renderBusy();
+    }
+  }
+
+  protected _renderBusy() {
+    if (!this.busyIndicator?.parent?.rendered) {
+      return;
+    }
+    this.busyIndicator.render();
+  }
+
+  protected _stopBusy() {
+    if (this.busyIndicator) {
+      this.busyIndicator.destroy();
+      this.busyIndicator = null;
+    }
+    if (this._busyIndicatorTimeoutId) {
+      clearTimeout(this._busyIndicatorTimeoutId);
+      this._busyIndicatorTimeoutId = null;
+    }
+  }
+
+  protected _onBusyIndicatorCancel(event: Event<BusyIndicator>) {
+    // Set "canceling" state in busy indicator (after 100ms, would not look good otherwise)
+    setTimeout(() => this.busyIndicator?.cancelled(), 100);
+    this._cancellationCallbacks.forEach(callback => callback(event));
+  }
+}
+
+export interface BusyIndicatorOptions extends BusySupportModel {
+  /**
+   * Specifies if the {@link BusySupport} should be set to busy or not.
+   * The default is false.
+   */
+  busy: boolean;
+  /**
+   * If set to true and {@link BusyIndicatorOptions.busy} is false, the {@link BusyIndicator} is removed even if there have been fewer calls with busy=false than with busy=true (asymmetric).
+   * The default is false.
+   */
+  force?: boolean;
+  /**
+   * Adds a callback to be executed when the {@link BusyIndicator} is cancelled. Only executed if {@link BusyIndicatorModel.cancellable} is true.
+   * Every callback is only executed once when the {@link BusyIndicator} is removed.
+   * Only used if {@link BusyIndicatorOptions.busy} is true.
+   */
+  onCancel?: EventHandler<Event<BusyIndicator>>;
+}

--- a/eclipse-scout-core/src/session/BusySupportModel.ts
+++ b/eclipse-scout-core/src/session/BusySupportModel.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {BusyIndicator, BusyIndicatorModel, BusyIndicatorOptions, BusySupport, ModelOf, ObjectModel, Widget} from '../index';
+
+export interface BusySupportModel extends ObjectModel<BusySupport> {
+  /**
+   * The default parent {@link Widget} to use for the {@link BusyIndicator}.
+   * This property is mandatory.
+   * The default parent specified by this property may be overwritten using {@link BusyIndicatorOptions.busyIndicatorModel} in {@link BusySupport.setBusy}.
+   */
+  parent?: Widget;
+  /**
+   * The default model to use for the {@link BusyIndicator}.
+   * It may be overwritten using {@link BusyIndicatorOptions.busyIndicatorModel} in {@link BusySupport.setBusy}.
+   * By default it sets {@link busyIndicatorModel.cancellable} to false.
+   */
+  busyIndicatorModel?: ModelOf<BusyIndicator>;
+  /**
+   * The default timeout in milliseconds between the call to {@link BusyIndicator.setBusy} and the rendering of the {@link BusyIndicator}.
+   * This is not the timeout until the busy indicator popup is shown (for this use {@link BusyIndicatorModel.showTimeout}) but the timeout until the glasspanes are rendered.
+   * The default is 50ms. It is not recommended to set this value to zero because this may lead to flickering of the mouse cursor.
+   */
+  renderDelay?: number;
+}

--- a/eclipse-scout-core/test/desktop/DesktopSpec.ts
+++ b/eclipse-scout-core/test/desktop/DesktopSpec.ts
@@ -1845,8 +1845,7 @@ describe('Desktop', () => {
 
       desktop.cancelViews([view1, view2]);
 
-      // UnsavedFormChangesForm should be the last child
-      let unsavedFormChangesForm = arrays.last(desktop.children) as UnsavedFormChangesForm;
+      let unsavedFormChangesForm = arrays.find(desktop.children, child => child instanceof UnsavedFormChangesForm) as UnsavedFormChangesForm;
       expect(unsavedFormChangesForm instanceof UnsavedFormChangesForm).toBe(true);
       let openFormsField = (unsavedFormChangesForm.rootGroupBox.fields[0] as GroupBox).fields[0] as ListBox<Form>;
       expect(openFormsField.id).toBe('OpenFormsField');
@@ -1871,7 +1870,7 @@ describe('Desktop', () => {
 
       desktop.cancelViews([view1, view2]);
       // UnsavedFormChangesForm should be the last child
-      let unsavedFormChangesForm = arrays.last(desktop.children) as UnsavedFormChangesForm;
+      let unsavedFormChangesForm = arrays.find(desktop.children, child => child instanceof UnsavedFormChangesForm) as UnsavedFormChangesForm;
       expect(unsavedFormChangesForm instanceof UnsavedFormChangesForm).toBe(true);
       unsavedFormChangesForm.whenPostLoad().then(() => {
         unsavedFormChangesForm.close();
@@ -1893,7 +1892,7 @@ describe('Desktop', () => {
       desktop.cancelViews([view1, view2]);
 
       // UnsavedFormChangesForm should be the last child
-      let unsavedFormChangesForm = arrays.last(desktop.children) as UnsavedFormChangesForm;
+      let unsavedFormChangesForm = arrays.find(desktop.children, child => child instanceof UnsavedFormChangesForm) as UnsavedFormChangesForm;
       expect(unsavedFormChangesForm instanceof UnsavedFormChangesForm).toBe(true);
       let openFormsField = (unsavedFormChangesForm.rootGroupBox.fields[0] as GroupBox).fields[0] as ListBox<Form>;
       expect(openFormsField.id).toBe('OpenFormsField');
@@ -1956,7 +1955,7 @@ describe('Desktop', () => {
       desktop.cancelViews([view1, view2]);
 
       // UnsavedFormChangesForm should be the last child
-      let unsavedFormChangesForm = arrays.last(desktop.children) as UnsavedFormChangesForm;
+      let unsavedFormChangesForm = arrays.find(desktop.children, child => child instanceof UnsavedFormChangesForm) as UnsavedFormChangesForm;
       expect(unsavedFormChangesForm instanceof UnsavedFormChangesForm).toBe(true);
       let openFormsField = (unsavedFormChangesForm.rootGroupBox.fields[0] as GroupBox).fields[0] as ListBox<Form>;
       expect(openFormsField.id).toBe('OpenFormsField');
@@ -2000,7 +1999,7 @@ describe('Desktop', () => {
       desktop.cancelViews([view1, view2]);
 
       // UnsavedFormChangesForm should be the last child
-      let unsavedFormChangesForm = arrays.last(desktop.children) as UnsavedFormChangesForm;
+      let unsavedFormChangesForm = arrays.find(desktop.children, child => child instanceof UnsavedFormChangesForm) as UnsavedFormChangesForm;
       expect(unsavedFormChangesForm instanceof UnsavedFormChangesForm).toBe(true);
       let openFormsField = (unsavedFormChangesForm.rootGroupBox.fields[0] as GroupBox).fields[0] as ListBox<Form>;
       expect(openFormsField.id).toBe('OpenFormsField');
@@ -2067,7 +2066,7 @@ describe('Desktop', () => {
       desktop.cancelViews([view1, view2]);
 
       // UnsavedFormChangesForm should be the last child
-      let unsavedFormChangesForm = arrays.last(desktop.children) as UnsavedFormChangesForm;
+      let unsavedFormChangesForm = arrays.find(desktop.children, child => child instanceof UnsavedFormChangesForm) as UnsavedFormChangesForm;
       expect(unsavedFormChangesForm instanceof UnsavedFormChangesForm).toBe(true);
       let openFormsField = (unsavedFormChangesForm.rootGroupBox.fields[0] as GroupBox).fields[0] as ListBox<Form>;
       expect(openFormsField.id).toBe('OpenFormsField');
@@ -2123,7 +2122,7 @@ describe('Desktop', () => {
       jasmine.clock().install();
       desktop.cancelViews([view1, view2]);
       // UnsavedFormChangesForm should be the last child
-      let unsavedFormChangesForm = arrays.last(desktop.children) as UnsavedFormChangesForm;
+      let unsavedFormChangesForm = arrays.find(desktop.children, child => child instanceof UnsavedFormChangesForm) as UnsavedFormChangesForm;
       expect(unsavedFormChangesForm instanceof UnsavedFormChangesForm).toBe(true);
       let openFormsField = (unsavedFormChangesForm.rootGroupBox.fields[0] as GroupBox).fields[0] as ListBox<Form>;
       expect(openFormsField.id).toBe('OpenFormsField');

--- a/eclipse-scout-core/test/form/FormSpec.ts
+++ b/eclipse-scout-core/test/form/FormSpec.ts
@@ -255,13 +255,13 @@ describe('Form', () => {
         return $.resolvedPromise();
       };
 
-      expect(form.formStored).toBe(false);
+      expect(form.formSaved).toBe(false);
       form.touch();
-      expect(form.formStored).toBe(false);
+      expect(form.formSaved).toBe(false);
       form.save()
         .then(() => {
           expect(saveCalled).toBe(true);
-          expect(form.formStored).toBe(true);
+          expect(form.formSaved).toBe(true);
         })
         .catch(fail)
         .always(done);
@@ -1842,6 +1842,7 @@ describe('Form', () => {
       throwInSave = false;
 
       protected override _load(): JQuery.Promise<object> {
+        expect(this.session.desktop.busy).toBe(true);
         if (this.throwInLoad) {
           return $.rejectedPromise('load');
         }
@@ -1849,6 +1850,7 @@ describe('Form', () => {
       }
 
       protected override _postLoad(): JQuery.Promise<void> {
+        expect(this.session.desktop.busy).toBe(true);
         if (this.throwInPostLoad) {
           return $.rejectedPromise('postLoad');
         }
@@ -1856,6 +1858,7 @@ describe('Form', () => {
       }
 
       protected override _save(data: object): JQuery.Promise<void> {
+        expect(this.session.desktop.busy).toBe(true);
         if (this.throwInSave) {
           return $.rejectedPromise('save');
         }
@@ -1920,7 +1923,7 @@ describe('Form', () => {
             })
             .always(() => {
               expect(catchCalled).toBe(true);
-              expect(form.formStored).toBe(false); // save failed: do not mark as stored
+              expect(form.formSaved).toBe(false); // save failed: do not mark as stored
               expect(App.get().errorHandler.handleErrorInfo).toHaveBeenCalledTimes(1);
               done();
             });
@@ -1940,6 +1943,7 @@ describe('Form', () => {
         .then(fail)
         .catch(e => {
           catchCalled = true;
+          expect(form.session.desktop.busy).toBe(false);
           expect(e).toBe('load');
           expect(numHandled).toBe(1);
         })
@@ -1966,6 +1970,7 @@ describe('Form', () => {
             .then(fail)
             .catch(e => {
               catchCalled = true;
+              expect(form.session.desktop.busy).toBe(false);
               expect(e).toEqual('save');
               expect(numHandled).toBe(1);
             })

--- a/eclipse-scout-core/test/session/BusySupportSpec.ts
+++ b/eclipse-scout-core/test/session/BusySupportSpec.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {BusyIndicator, BusySupport, Event, EventHandler, scout} from '../../src/index';
+
+describe('BusySupport', () => {
+  let session: SandboxSession;
+
+  class SpecBusySupport extends BusySupport {
+    declare _busyCounter: number;
+    declare _cancellationCallbacks: EventHandler<Event<BusyIndicator>>[];
+
+    override _renderBusy() {
+      // NOP
+    }
+  }
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+  });
+
+  describe('indicator', () => {
+    it('model can be customized', () => {
+      let support = scout.create(SpecBusySupport, {
+        parent: session.desktop,
+        busyIndicatorModel: {
+          cancellable: true,
+          label: 'test'
+        },
+        renderDelay: 10
+      });
+      expect(support.defaultBusyIndicatorModel.label).toEqual('test');
+      expect(support.defaultBusyIndicatorModel.cancellable).toBe(true);
+      expect(support.defaultBusyIndicatorModel.parent).toBe(session.desktop);
+      expect(support.defaultRenderDelay).toBe(10);
+      expect(support._cancellationCallbacks.length).toBe(0);
+      expect(support.isBusy()).toBe(false);
+
+      support.setBusy({
+        busy: true,
+        busyIndicatorModel: {
+          cancellable: false,
+          label: 'test2'
+        },
+        onCancel: () => {
+        }
+      });
+      expect(support.isBusy()).toBe(true);
+      expect(support.busyIndicator.cancellable).toBe(false); // overwritten by setBusy
+      expect(support.busyIndicator.label).toBe('test2'); // overwritten by setBusy
+      expect(support._cancellationCallbacks.length).toBe(1);
+
+      support.setBusy({
+        busy: true,
+        busyIndicatorModel: {
+          cancellable: true,
+          label: 'test3'
+        },
+        onCancel: () => {
+        }
+      });
+      expect(support.isBusy()).toBe(true); // still true
+      expect(support.busyIndicator.cancellable).toBe(false); // overwritten by first setBusy, no effect in second
+      expect(support.busyIndicator.label).toBe('test2'); // overwritten by first setBusy, no effect in second
+      expect(support._cancellationCallbacks.length).toBe(2);
+
+      support.setBusy(false);
+      support.setBusy(false);
+      expect(support.isBusy()).toBe(false);
+      expect(support._cancellationCallbacks.length).toBe(0); // has been reset
+    });
+
+    it('is not cancellable by default', () => {
+      let support = scout.create(SpecBusySupport, {
+        parent: session.desktop
+      });
+      expect(support.defaultBusyIndicatorModel.cancellable).toBe(false);
+    });
+  });
+
+  describe('callback', () => {
+    it('is executed on cancel', () => {
+      let support = scout.create(SpecBusySupport, {
+        parent: session.desktop
+      });
+      let isCancelled = false;
+      support.setBusy({
+        busy: true,
+        onCancel: e => {
+          isCancelled = true;
+        }
+      });
+      support.busyIndicator.trigger('cancel');
+      expect(isCancelled).toBe(true);
+    });
+
+    it('has no duplicates', () => {
+      let support = scout.create(SpecBusySupport, {
+        parent: session.desktop
+      });
+      let cancelCounter = 0;
+      support.setBusy({
+        busy: true,
+        onCancel: e => {
+          cancelCounter++;
+        }
+      });
+      expect(support._cancellationCallbacks.length).toBe(1);
+      let handler = e => {
+        cancelCounter++;
+      };
+      support.setBusy({
+        busy: true,
+        onCancel: handler
+      });
+      support.setBusy({
+        busy: true,
+        onCancel: handler
+      });
+      expect(support._cancellationCallbacks.length).toBe(2);
+      support.busyIndicator.trigger('cancel');
+      expect(cancelCounter).toBe(2);
+    });
+  });
+
+  describe('counter', () => {
+    it('can be reset with "force"', () => {
+      let support = scout.create(SpecBusySupport, {
+        parent: session.desktop
+      });
+      support.setBusy(true);
+      support.setBusy(true);
+      expect(support._busyCounter).toBe(2);
+      support.setBusy({
+        busy: false,
+        force: true
+      });
+      expect(support._busyCounter).toBe(0);
+    });
+
+    it('cannot fall below zero', () => {
+      let support = scout.create(SpecBusySupport, {
+        parent: session.desktop
+      });
+      expect(support._busyCounter).toBe(0);
+      support.setBusy(false);
+      expect(support._busyCounter).toBe(0);
+      expect(support.busyIndicator).toBeFalsy();
+      support.setBusy(true);
+      expect(support._busyCounter).toBe(1);
+      let busyIndicator = support.busyIndicator;
+      expect(busyIndicator).toBeTruthy();
+      support.setBusy(true);
+      expect(support._busyCounter).toBe(2);
+      expect(support.busyIndicator).toBe(busyIndicator); // still the same
+      support.setBusy(false);
+      expect(support._busyCounter).toBe(1);
+      expect(support.busyIndicator).toBe(busyIndicator); // still the same
+      support.setBusy(false);
+      support.setBusy(false);
+      support.setBusy(false);
+      expect(support._busyCounter).toBe(0);
+      expect(support.busyIndicator).toBeFalsy();
+    });
+  });
+});

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/cancellation/RestRequestCancellationClientRequestFilter.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/cancellation/RestRequestCancellationClientRequestFilter.java
@@ -75,7 +75,7 @@ public class RestRequestCancellationClientRequestFilter implements ClientRequest
       }
 
       RunContexts.copyCurrent()
-          .withRunMonitor(BEANS.get(RunMonitor.class)) // execute with a new RunMontior
+          .withRunMonitor(BEANS.get(RunMonitor.class)) // execute with a new RunMonitor
           .run(() -> m_requestCanceller.accept(m_requestId));
 
       return true;

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceUtility.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceUtility.java
@@ -21,7 +21,7 @@ import org.eclipse.scout.rt.platform.util.Assertions;
 public class ServiceUtility {
 
   /**
-   * @return the reflective service operation that can be called using {@link #invoke(Method,Object,Object[])}
+   * @return the reflective service operation that can be called using {@link #invoke(Object, Method, Object[])}
    */
   public Method getServiceOperation(Class<?> serviceClass, String operation, Class<?>[] paramTypes) {
     Assertions.assertNotNull(serviceClass, "service class is null");


### PR DESCRIPTION
- Move the old busy handling for Scout classic from Session to Desktop
- Introduce BusySupport which cares about:
  - multiple nested busy calls
  - cancellation callbacks
  - delayed rendering
- Add automatic busy handling to form load and save

326179