### PR TITLE
Introduce object-type and headerIconId for column-descriptor

### DIFF
--- a/eclipse-scout-core/src/form/fields/lookupfield/lookupField.ts
+++ b/eclipse-scout-core/src/form/fields/lookupfield/lookupField.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Cell, LookupRow, scout, TableRowModel} from '../../../index';
+import {Cell, ColumnDescriptor, LookupRow, scout, TableRowModel} from '../../../index';
 
 export const lookupField = {
   /**
@@ -40,7 +40,7 @@ export const lookupField = {
   /**
    * Creates a table cell for a descriptor. If no descriptor is provided, the default lookupRow cell is created.
    */
-  createTableCell<T>(lookupRow: LookupRow<T>, desc?: { propertyName?: string }, tableRowData?: object): Cell<T> {
+  createTableCell<T>(lookupRow: LookupRow<T>, desc?: ColumnDescriptor, tableRowData?: object): Cell<T> {
     let cell = scout.create(Cell);
 
     // default column descriptor (first column) has propertyName null
@@ -62,7 +62,7 @@ export const lookupField = {
         cell.setFont(lookupRow.font);
       }
     } else {
-      cell.setText(tableRowData[desc.propertyName]);
+      cell.setValue(tableRowData[desc.propertyName]);
     }
 
     return cell;

--- a/eclipse-scout-core/src/form/fields/smartfield/TableProposalChooser.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/TableProposalChooser.ts
@@ -48,7 +48,7 @@ export class TableProposalChooser<TValue> extends ProposalChooser<TValue, Table,
     if (descriptor.width && descriptor.width > 0) { // 0 = default
       width = descriptor.width;
     }
-    return scout.create(Column, {
+    return scout.create(scout.nvl(descriptor.objectType, Column), {
       session: this.session,
       text: descriptor.text,
       cssClass: scout.nvl(descriptor.cssClass, null),
@@ -58,7 +58,8 @@ export class TableProposalChooser<TValue> extends ProposalChooser<TValue, Table,
       fixedPosition: scout.nvl(descriptor.fixedPosition, false),
       horizontalAlignment: scout.nvl(descriptor.horizontalAlignment, this.smartField.gridData.horizontalAlignment),
       visible: scout.nvl(descriptor.visible, true),
-      htmlEnabled: scout.nvl(descriptor.htmlEnabled, false)
+      htmlEnabled: scout.nvl(descriptor.htmlEnabled, false),
+      headerIconId: scout.nvl(descriptor.headerIconId, null)
     });
   }
 

--- a/eclipse-scout-core/src/table/columns/ColumnDescriptor.ts
+++ b/eclipse-scout-core/src/table/columns/ColumnDescriptor.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Alignment} from '../../index';
+import {Alignment, Column, ObjectType} from '../../index';
 
 /**
  * The ColumnDescriptor is used to define texts, widths and order of columns.
@@ -18,7 +18,9 @@ export interface ColumnDescriptor {
    * Name of the corresponding property in the "additional table row data" or <code>null</code> if this descriptor describes the first (default) column.
    */
   propertyName?: string;
+  objectType?: ObjectType<Column>;
   text?: string;
+  headerIconId?: string;
   cssClass?: string;
   width?: number;
   fixedWidth?: boolean;

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/ColumnDescriptor.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/ColumnDescriptor.java
@@ -18,7 +18,9 @@ import org.eclipse.scout.rt.shared.data.basic.table.AbstractTableRowData;
 public class ColumnDescriptor {
 
   private String m_propertyName;
+  private String m_objectType;
   private String m_text;
+  private String m_headerIconId;
   private String m_cssClass;
   private int m_width;
   private boolean m_fixedWidth;
@@ -61,6 +63,22 @@ public class ColumnDescriptor {
   }
 
   /**
+   * @return Object type of this column.
+   */
+  public String getObjectType() {
+    return m_objectType;
+  }
+
+  /**
+   * @param objectType
+   *          Object type of this column (e.g. 'BooleanColumn').
+   */
+  public ColumnDescriptor withObjectType(String objectType) {
+    m_objectType = objectType;
+    return this;
+  }
+
+  /**
    * @return Header text of this column.
    */
   public String getText() {
@@ -73,6 +91,22 @@ public class ColumnDescriptor {
    */
   public ColumnDescriptor withText(String text) {
     m_text = text;
+    return this;
+  }
+
+  /**
+   * @return Header icon-id of this column.
+   */
+  public String getHeaderIconId() {
+    return m_headerIconId;
+  }
+
+  /**
+   * @param headerIconId
+   *          Header icon-id of this column.
+   */
+  public ColumnDescriptor withHeaderIconId(String headerIconId) {
+    m_headerIconId = headerIconId;
     return this;
   }
 

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/smartfield/JsonSmartField.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/smartfield/JsonSmartField.java
@@ -452,7 +452,9 @@ public class JsonSmartField<VALUE, MODEL extends ISmartField<VALUE>> extends Jso
     }
     JSONObject json = new JSONObject();
     json.put("propertyName", descriptor.getPropertyName());
+    json.put("objectType", descriptor.getObjectType());
     json.put("text", descriptor.getText());
+    json.put("headerIconId", descriptor.getHeaderIconId());
     json.put("cssClass", descriptor.getCssClass());
     json.put("width", descriptor.getWidth());
     json.put("fixedWidth", descriptor.isFixedWidth());


### PR DESCRIPTION
Allows the definition of the object-type (e.g. BooleanColumn or IconColumn) in the column-descriptor. Additionally adds ability to use an icon as column-header instead of text.