### PR TITLE
Restore flushJobScheduled flag in case of an exception

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/concurrent/DeferredOperationQueue.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/concurrent/DeferredOperationQueue.java
@@ -92,7 +92,14 @@ public class DeferredOperationQueue<E> {
         }
       });
       if (m_flushJobScheduled.compareAndSet(false, true)) {
-        scheduleFlushJob();
+        try {
+          scheduleFlushJob();
+        }
+        catch (RuntimeException | Error e) {
+          // restore flushJobScheduled flag so that successive invocations schedule another job
+          m_flushJobScheduled.set(false);
+          throw e;
+        }
       }
     }
     finally {


### PR DESCRIPTION
Otherwise, deferred operations are not executed anymore.

352932

(cherry picked from commit b9a225afd7cd9b10b505a271ab1760a8f2bf86eb)