### PR TITLE
Call: fix retry intervals

### DIFF
--- a/eclipse-scout-core/src/util/Call.ts
+++ b/eclipse-scout-core/src/util/Call.ts
@@ -38,7 +38,7 @@ export abstract class Call implements CallModel, ObjectWithType {
   constructor() {
     this.initialized = false;
     this.retryIntervals = [];
-    this.maxRetries = 0;
+    this.maxRetries = null; // automatically set to the length of retryInternals in init(), unless specified explicitly
     this.minCallDuration = 500;
     /**
      * Counts how many times this call was actually performed (normally, only 1 try is expected)

--- a/eclipse-scout-core/test/util/CallSpec.ts
+++ b/eclipse-scout-core/test/util/CallSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {Call} from '../../src/index';
-import {InitModelOf} from '../../src/scout';
+import {InitModelOf, scout} from '../../src/scout';
 
 describe('scout.Call', () => {
 
@@ -119,4 +119,21 @@ describe('scout.Call', () => {
     expect(call.callCounter).toBe(2);
   });
 
+  it('correctly initializes retry internals', () => {
+    let call1 = scout.create(SuccessCall);
+    expect(call1.retryIntervals).toEqual([]);
+    expect(call1.maxRetries).toBe(0);
+
+    let call2 = scout.create(SuccessCall, {retryIntervals: [100, 200, 300]});
+    expect(call2.retryIntervals).toEqual([100, 200, 300]);
+    expect(call2.maxRetries).toBe(3);
+
+    let call3 = scout.create(SuccessCall, {maxRetries: 2});
+    expect(call3.retryIntervals).toEqual([0, 0]);
+    expect(call3.maxRetries).toBe(2);
+
+    let call4 = scout.create(SuccessCall, {retryIntervals: [100, 200, 300], maxRetries: 2}); // maxRetries takes precedence
+    expect(call4.retryIntervals).toEqual([0, 0]);
+    expect(call4.maxRetries).toBe(2);
+  });
 });


### PR DESCRIPTION
During TypeScript migration, maxRetries was accidentally initialized with 0, which caused the retryIntervals specified by AjaxCall to be overridden with an empty array.

353195