### PR TITLE
Chart: add support for multiple color hex values

### DIFF
--- a/eclipse-scout-chart/src/chart/AbstractChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/AbstractChartRenderer.js
@@ -1,13 +1,15 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
+
+import {arrays} from '@eclipse-scout/core';
 
 export default class AbstractChartRenderer {
 
@@ -58,7 +60,7 @@ export default class AbstractChartRenderer {
         }
       }
       // color should have been set.
-      if (!this.chart.config.options.autoColor && !chartValueGroup.colorHexValue && !chartValueGroup.cssClass) {
+      if (!this.chart.config.options.autoColor && !arrays.ensure(chartValueGroup.colorHexValue).length && !chartValueGroup.cssClass) {
         return false;
       }
     }

--- a/eclipse-scout-chart/src/chart/Chart.js
+++ b/eclipse-scout-chart/src/chart/Chart.js
@@ -14,7 +14,9 @@ import $ from 'jquery';
 
 /**
  * @typedef ChartValueGroup
+ * @property {*[]} values
  * @property {string} type
+ * @property {string | string[]} colorHexValue
  */
 
 /**

--- a/eclipse-scout-chart/src/chart/FulfillmentChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/FulfillmentChartRenderer.js
@@ -1,14 +1,14 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {objects, scout} from '@eclipse-scout/core';
+import {arrays, objects, scout} from '@eclipse-scout/core';
 import {AbstractSvgChartRenderer} from '../index';
 import $ from 'jquery';
 
@@ -58,7 +58,7 @@ export default class FulfillmentChartRenderer extends AbstractSvgChartRenderer {
   _renderPercentage(value, total) {
     // arc segment
     let arcClass = 'fulfillment-chart',
-      color = this.chart.data.chartValueGroups[0].colorHexValue,
+      color = arrays.ensure(this.chart.data.chartValueGroups[0].colorHexValue)[0],
       chartGroupCss = this.chart.data.chartValueGroups[0].cssClass;
 
     if (this.chart.config.options.autoColor) {
@@ -140,7 +140,7 @@ export default class FulfillmentChartRenderer extends AbstractSvgChartRenderer {
 
   _renderCirclePath(cssClass, id, radius) {
     let chartGroupCss = this.chart.data.chartValueGroups[0].cssClass;
-    let color = this.chart.data.chartValueGroups[1].colorHexValue;
+    let color = arrays.ensure(this.chart.data.chartValueGroups[1].colorHexValue)[0];
 
     if (this.chart.config.options.autoColor) {
       cssClass += ' auto-color';

--- a/eclipse-scout-chart/src/chart/SalesfunnelChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/SalesfunnelChartRenderer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {objects, strings} from '@eclipse-scout/core';
+import {arrays, objects, strings} from '@eclipse-scout/core';
 import {AbstractSvgChartRenderer} from '../index';
 import $ from 'jquery';
 
@@ -106,7 +106,7 @@ export default class SalesfunnelChartRenderer extends AbstractSvgChartRenderer {
         width: width,
         widthBottom: widthBottom,
         cssClass: 'salesfunnel-chart-bar',
-        fill: chartValueGroups[i].colorHexValue,
+        fill: arrays.ensure(chartValueGroups[i].colorHexValue)[0],
         label: chartValueGroups[i].groupName,
         clickObject: this._createClickObject(null, i)
       };
@@ -302,7 +302,7 @@ export default class SalesfunnelChartRenderer extends AbstractSvgChartRenderer {
         width: width,
         widthBottom: width,
         cssClass: 'salesfunnel-chart-bar',
-        fill: chartValueGroups[i].colorHexValue,
+        fill: arrays.ensure(chartValueGroups[i].colorHexValue)[0],
         label: chartValueGroups[i].groupName,
         clickObject: this._createClickObject(null, i)
       };

--- a/eclipse-scout-chart/src/chart/VennChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/VennChartRenderer.js
@@ -1,15 +1,16 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 import {AbstractSvgChartRenderer, VennAsync3Calculator, VennCircle, VennCircleHelper} from '../index';
 import $ from 'jquery';
+import {arrays} from '@eclipse-scout/core';
 
 export default class VennChartRenderer extends AbstractSvgChartRenderer {
 
@@ -63,17 +64,17 @@ export default class VennChartRenderer extends AbstractSvgChartRenderer {
 
     // create svg elements and venns
     if (this.numberOfCircles > 0) {
-      this.$v1 = this._createCircle(0, this.data[0].colorHexValue, this.data[0].cssClass);
+      this.$v1 = this._createCircle(0, arrays.ensure(this.data[0].colorHexValue)[0], this.data[0].cssClass);
       this.vennNumber1 = new VennCircle(this.$v1);
       this.vennReal1 = new VennCircle(this.$v1);
     }
     if (this.numberOfCircles > 1) {
-      this.$v2 = this._createCircle(1, this.data[1].colorHexValue, this.data[1].cssClass);
+      this.$v2 = this._createCircle(1, arrays.ensure(this.data[1].colorHexValue)[0], this.data[1].cssClass);
       this.vennNumber2 = new VennCircle(this.$v2);
       this.vennReal2 = new VennCircle(this.$v2);
     }
     if (this.numberOfCircles > 2) {
-      this.$v3 = this._createCircle(2, this.data[2].colorHexValue, this.data[2].cssClass);
+      this.$v3 = this._createCircle(2, arrays.ensure(this.data[2].colorHexValue)[0], this.data[2].cssClass);
       this.vennNumber3 = new VennCircle(this.$v3);
       this.vennReal3 = new VennCircle(this.$v3);
     }

--- a/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/AbstractChartValueGroupBean.java
+++ b/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/AbstractChartValueGroupBean.java
@@ -1,16 +1,20 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.chart.shared.data.basic.chart;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.scout.rt.platform.annotations.IgnoreProperty;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
 public abstract class AbstractChartValueGroupBean implements IChartValueGroupBean {
   private static final long serialVersionUID = 1L;
@@ -18,8 +22,7 @@ public abstract class AbstractChartValueGroupBean implements IChartValueGroupBea
   private String m_type;
   private Object m_groupKey;
   private String m_groupName;
-  private String m_colorHexValue;
-  private String m_cssClass;
+  private List<String> m_colorHexValue = CollectionUtility.emptyArrayList();
   private boolean m_clickable = true;
 
   @Override
@@ -55,13 +58,36 @@ public abstract class AbstractChartValueGroupBean implements IChartValueGroupBea
   }
 
   @Override
-  public String getColorHexValue() {
+  public List<String> getColorHexValue() {
+    return Collections.unmodifiableList(getColorHexValueInternal());
+  }
+
+  protected List<String> getColorHexValueInternal() {
     return m_colorHexValue;
   }
 
   @Override
-  public void setColorHexValue(String colorHexValue) {
+  public void setColorHexValue(String... colorHexValue) {
+    setColorHexValue(CollectionUtility.arrayList(colorHexValue));
+  }
+
+  @Override
+  public void setColorHexValue(List<String> colorHexValue) {
+    setColorHexValueInternal(CollectionUtility.arrayList(colorHexValue));
+  }
+
+  protected void setColorHexValueInternal(List<String> colorHexValue) {
     m_colorHexValue = colorHexValue;
+  }
+
+  @Override
+  public void addColorHexValue(String colorHexValue) {
+    getColorHexValueInternal().add(colorHexValue);
+  }
+
+  @Override
+  public void clearColorHexValue() {
+    getColorHexValueInternal().clear();
   }
 
   @Override

--- a/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/IChartValueGroupBean.java
+++ b/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/IChartValueGroupBean.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -11,6 +11,7 @@
 package org.eclipse.scout.rt.chart.shared.data.basic.chart;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * @since 5.2
@@ -29,9 +30,15 @@ public interface IChartValueGroupBean extends Serializable {
 
   void setGroupName(String groupName);
 
-  String getColorHexValue();
+  List<String> getColorHexValue();
 
-  void setColorHexValue(String colorHexValue);
+  void setColorHexValue(String... colorHexValue);
+
+  void setColorHexValue(List<String> colorHexValue);
+
+  void addColorHexValue(String colorHexValue);
+
+  void clearColorHexValue();
 
   boolean isClickable();
 


### PR DESCRIPTION
The colorHexValue property of a IChartValueGroupBean can now hold more
than one hex value. These values are used to color the corresponding
dataset in a ChartJS chart (bar, line, pie, bubble, etc.), if autoColor
is turned off. The given colors are repeated for the whole dataset, e.g.
if there are two colors given (blue and yellow) and the dataset contains
7 values, the elements are colored alternately in blue and yellow
(starting and ending with blue). These colors are also used by the
tooltip and the legend. If there are multiple colors for one legend
label the first one will be used.

307024