### PR TITLE
PropertyEventEmitter: fix getAliasForPropertyDimension()

### DIFF
--- a/eclipse-scout-core/src/events/PropertyEventEmitter.ts
+++ b/eclipse-scout-core/src/events/PropertyEventEmitter.ts
@@ -416,7 +416,7 @@ export class PropertyEventEmitter extends EventEmitter {
     let changed = false;
     for (const [dimension, value] of Object.entries(dimensions)) {
       let internalPropertyName = propertyName + '-' + dimension;
-      let alias = this.getAliasForPropertyDimension(dimension);
+      let alias = this.getAliasForPropertyDimension(propertyName, dimension);
       if (alias) {
         internalPropertyName = alias;
       }
@@ -477,9 +477,9 @@ export class PropertyEventEmitter extends EventEmitter {
   /**
    * @returns the alias for a property dimension, if there is an alias registered for that dimension
    */
-  getAliasForPropertyDimension(dimension: string): string {
+  getAliasForPropertyDimension(propertyName: string, dimension: string): string {
     for (const [alias, config] of Object.entries(this._propertyDimensionAliases)) {
-      if (config.dimension === dimension) {
+      if (config.propertyName === propertyName && config.dimension === dimension) {
         return alias;
       }
     }

--- a/eclipse-scout-core/test/events/PropertyEventEmitterSpec.ts
+++ b/eclipse-scout-core/test/events/PropertyEventEmitterSpec.ts
@@ -59,6 +59,46 @@ describe('PropertyEventEmitter', () => {
     }
   }
 
+  class DimensionMultiPropertyAliasEventEmitter extends PropertyEventEmitter {
+
+    foo: boolean;
+    bar: boolean;
+
+    constructor() {
+      super();
+      this.foo = true;
+      this.bar = true;
+      this._addMultiDimensionalProperty('foo', true);
+      this._addMultiDimensionalProperty('bar', true);
+      this._addPropertyDimensionAlias('foo', 'fooDim', {dimension: 'dim'});
+      this._addPropertyDimensionAlias('bar', 'barDim', {dimension: 'dim'});
+    }
+
+    setFoo(foo: boolean) {
+      this.setProperty('foo', foo);
+    }
+
+    setFooDim(fooDim: boolean) {
+      this.setProperty('fooDim', fooDim);
+    }
+
+    get fooDim(): boolean {
+      return this.getProperty('fooDim');
+    }
+
+    setBar(bar: boolean) {
+      this.setProperty('bar', bar);
+    }
+
+    setBarDim(barDim: boolean) {
+      this.setProperty('barDim', barDim);
+    }
+
+    get barDim(): boolean {
+      return this.getProperty('barDim');
+    }
+  }
+
   describe('init', () => {
     describe('multidimensional property', () => {
       it('default dimension can be passed as boolean or object', () => {
@@ -137,6 +177,49 @@ describe('PropertyEventEmitter', () => {
         emitter.setProperty('alias', false);
         expect(emitter.getProperty('multiProp')).toBe(false);
         expect(emitter.getProperty('alias')).toBe(false);
+      });
+
+      it('updates the correct dimension if multiple properties use the same alias', () => {
+        let emitter = scout.create(DimensionMultiPropertyAliasEventEmitter);
+        expect(emitter.isMultiDimensionalProperty('foo')).toBe(true);
+        expect(emitter.isMultiDimensionalProperty('bar')).toBe(true);
+        expect(emitter.isPropertyDimensionAlias('fooDim')).toBe(true);
+        expect(emitter.isPropertyDimensionAlias('barDim')).toBe(true);
+
+        expect(emitter.getProperty('foo')).toBe(true);
+        expect(emitter.getProperty('fooDim')).toBe(true);
+        expect(emitter.getProperty('foo-dim')).toBe(true);
+        expect(emitter.foo).toBe(true);
+        expect(emitter.fooDim).toBe(true);
+        expect(emitter.getProperty('bar')).toBe(true);
+        expect(emitter.getProperty('barDim')).toBe(true);
+        expect(emitter.getProperty('bar-dim')).toBe(true);
+        expect(emitter.bar).toBe(true);
+        expect(emitter.barDim).toBe(true);
+
+        emitter.setBarDim(false);
+        expect(emitter.getProperty('foo')).toBe(true);
+        expect(emitter.getProperty('fooDim')).toBe(true);
+        expect(emitter.getProperty('foo-dim')).toBe(true);
+        expect(emitter.foo).toBe(true);
+        expect(emitter.fooDim).toBe(true);
+        expect(emitter.getProperty('bar')).toBe(false);
+        expect(emitter.getProperty('barDim')).toBe(false);
+        expect(emitter.getProperty('bar-dim')).toBe(false);
+        expect(emitter.bar).toBe(false);
+        expect(emitter.barDim).toBe(false);
+
+        emitter.setFoo(false);
+        expect(emitter.getProperty('foo')).toBe(false);
+        expect(emitter.getProperty('fooDim')).toBe(true);
+        expect(emitter.getProperty('foo-dim')).toBe(true);
+        expect(emitter.foo).toBe(false);
+        expect(emitter.fooDim).toBe(true);
+        expect(emitter.getProperty('bar')).toBe(false);
+        expect(emitter.getProperty('barDim')).toBe(false);
+        expect(emitter.getProperty('bar-dim')).toBe(false);
+        expect(emitter.bar).toBe(false);
+        expect(emitter.barDim).toBe(false);
       });
 
       it('supports inverted aliases', () => {


### PR DESCRIPTION
When looking for the dimension-specific alias for a propertyName, both the propertyName and the dimension values have to match. This is relevant if multiple properties use the same dimension, for example "visibleGranted" and "enabledGranted". If only the dimension part is checked when retrieving the alias for "visible", the result might be "enabled-granted" instead of "visible-granted".