### PR TITLE
CLI: ignore warnings from esbuild minifier

### DIFF
--- a/eclipse-scout-cli/bin/scout-scripts.js
+++ b/eclipse-scout-cli/bin/scout-scripts.js
@@ -251,7 +251,7 @@ function logWebpack(err, stats, statsConfig) {
     console.error(info.errors);
     process.exitCode = 1; // let the webpack build fail on errors
   }
-  if (stats.hasWarnings()) {
+  if (info.warnings && info.warnings.length > 0) {
     console.warn(info.warnings);
   }
   statsConfig = statsConfig || {};

--- a/eclipse-scout-cli/scripts/webpack-defaults.js
+++ b/eclipse-scout-cli/scripts/webpack-defaults.js
@@ -490,14 +490,13 @@ function nvl(arg, defaultValue) {
 }
 
 function isWarningIgnored(devMode, webpackError) {
-  if (webpackError && webpackError.message === '[object Object]') {
-    return true; // esbuild warnings are not correctly passed to webpack. ignore them. The actual message is printed with the esbuild flag 'logLevel' (see below)
-  }
-
-  if (devMode || !webpackError || !webpackError.warning || !webpackError.warning.message) {
+  if (devMode || !webpackError) {
     return false;
   }
-  return webpackError.warning.message.startsWith('Failed to parse source map');
+  // Ignore warnings from esbuild minifier.
+  // One warning is 'Converting "require" to "esm" is currently not supported' which is not of interest.
+  // Others may be created by third party libs which are not of interest as well.
+  return webpackError.name === 'Warning';
 }
 
 /**


### PR DESCRIPTION
5.3.7 from terser-webpack-plugin fixed esbuild warning output: https://github.com/webpack-contrib/terser-webpack-plugin/releases/tag/v5.3.7

-> the check for [object Object] can be removed.
-> since the warnings from esbuild are not of interest they need to be
 ignored now

Also don't print empty warning objects.
hasWarnings() may return true even if info.warnings is empty. Maybe happens because some warnings are ignored.