### PR TITLE
Scout JS: rename menuType constants and types

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -14,7 +14,7 @@ import {
 import $ from 'jquery';
 
 export type CalendarDisplayMode = EnumObject<typeof Calendar.DisplayMode>;
-export type CalendarMenuTypes = EnumObject<typeof Calendar.MenuTypes>;
+export type CalendarMenuType = EnumObject<typeof Calendar.MenuType>;
 export type CalendarDirection = EnumObject<typeof Calendar.Direction>;
 export type CalendarMoveData = {
   event?: JQuery.MouseEventBase;
@@ -147,7 +147,7 @@ export class Calendar extends Widget implements CalendarModel {
     this.viewRange = null;
     this.calendarToggleListWidth = 270;
     this.calendarToggleYearWidth = 215;
-    this.defaultMenuTypes = [Calendar.MenuTypes.EmptySpace];
+    this.defaultMenuTypes = [Calendar.MenuType.EmptySpace];
 
     // main elements
     this.$container = null;
@@ -204,7 +204,7 @@ export class Calendar extends Widget implements CalendarModel {
     FORWARD: 1
   } as const;
 
-  static MenuTypes = {
+  static MenuType = {
     EmptySpace: 'Calendar.EmptySpace',
     CalendarComponent: 'Calendar.CalendarComponent'
   } as const;
@@ -1301,7 +1301,7 @@ export class Calendar extends Widget implements CalendarModel {
   }
 
   protected _onDayContextMenu(event: JQuery.ContextMenuEvent) {
-    this._showContextMenu(event, Calendar.MenuTypes.EmptySpace);
+    this._showContextMenu(event, Calendar.MenuType.EmptySpace);
   }
 
   /** @internal */

--- a/eclipse-scout-core/src/calendar/CalendarComponent.ts
+++ b/eclipse-scout-core/src/calendar/CalendarComponent.ts
@@ -324,7 +324,7 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
 
   /** @internal */
   _onContextMenu(event: JQuery.ContextMenuEvent) {
-    this.parent._showContextMenu(event, Calendar.MenuTypes.CalendarComponent);
+    this.parent._showContextMenu(event, Calendar.MenuType.CalendarComponent);
   }
 
   protected _format(date: Date, pattern: string): string {

--- a/eclipse-scout-core/src/desktop/outline/Outline.ts
+++ b/eclipse-scout-core/src/desktop/outline/Outline.ts
@@ -908,7 +908,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
       // DetailContent can be null, or it is the tableRowDetail. Don't show menus on OutlineOverview.
       if (selectedPage.detailTable) {
         detailTable = selectedPage.detailTable;
-        menuItems = menuUtil.filter(detailTable.menus, [Table.MenuTypes.EmptySpace], {
+        menuItems = menuUtil.filter(detailTable.menus, [Table.MenuType.EmptySpace], {
           onlyVisible: false,
           enableDisableKeyStrokes: true,
           defaultMenuTypes: detailTable.defaultMenuTypes
@@ -921,7 +921,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
       let parentPage = selectedPage.parentNode;
       if (parentPage && parentPage.detailTable) {
         detailTable = parentPage.detailTable;
-        menuItems = menuItems.concat(menuUtil.filter(detailTable.menus, [Table.MenuTypes.SingleSelection], {
+        menuItems = menuItems.concat(menuUtil.filter(detailTable.menus, [Table.MenuType.SingleSelection], {
           onlyVisible: false,
           enableDisableKeyStrokes: true,
           defaultMenuTypes: detailTable.defaultMenuTypes
@@ -1185,7 +1185,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
     this.updateKeyStrokes(menus, oldMenus);
     this._setProperty('menus', menus);
     if (this.titleMenuBar) { // _setMenus is called by parent class Tree.js, at this time titleMenuBar is not yet initialized
-      let menuItems = menuUtil.filter(this.menus, [Tree.MenuTypes.Header], {defaultMenuTypes: this.defaultMenuTypes});
+      let menuItems = menuUtil.filter(this.menus, [Tree.MenuType.Header], {defaultMenuTypes: this.defaultMenuTypes});
       this.titleMenuBar.setMenuItems(menuItems);
     }
   }

--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -283,7 +283,7 @@ export class Page extends TreeNode implements PageModel {
       return [];
     }
 
-    return menus.filter(table.menus, Table.MenuTypes.SingleSelection)
+    return menus.filter(table.menus, Table.MenuType.SingleSelection)
       .filter(this._isMenuInheritedFromParentTablePage.bind(this));
   }
 

--- a/eclipse-scout-core/src/form/fields/ValueField.ts
+++ b/eclipse-scout-core/src/form/fields/ValueField.ts
@@ -34,7 +34,7 @@ export class ValueField<TValue extends TModelValue, TModelValue = TValue> extend
   constructor() {
     super();
 
-    this.defaultMenuTypes = [...this.defaultMenuTypes, ValueField.MenuTypes.NotNull, ValueField.MenuTypes.Null];
+    this.defaultMenuTypes = [...this.defaultMenuTypes, ValueField.MenuType.NotNull, ValueField.MenuType.Null];
     this.clearable = ValueField.Clearable.FOCUSED;
     this.displayText = null;
     this.formatter = this._formatValue.bind(this);
@@ -66,7 +66,7 @@ export class ValueField<TValue extends TModelValue, TModelValue = TValue> extend
     NEVER: 'never'
   } as const;
 
-  static MenuTypes = {
+  static MenuType = {
     Null: 'ValueField.Null',
     NotNull: 'ValueField.NotNull'
   } as const;
@@ -423,9 +423,9 @@ export class ValueField<TValue extends TModelValue, TModelValue = TValue> extend
 
   protected override _getCurrentMenuTypes(): string[] {
     if (objects.isNullOrUndefined(this.value)) {
-      return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.Null];
+      return [...super._getCurrentMenuTypes(), ValueField.MenuType.Null];
     }
-    return [...super._getCurrentMenuTypes(), ValueField.MenuTypes.NotNull];
+    return [...super._getCurrentMenuTypes(), ValueField.MenuType.NotNull];
   }
 
   /**
@@ -697,7 +697,7 @@ export class ValueField<TValue extends TModelValue, TModelValue = TValue> extend
 }
 
 export type ValueFieldClearable = EnumObject<typeof ValueField.Clearable>;
-export type ValueFieldMenuTypes = EnumObject<typeof ValueField.MenuTypes>;
+export type ValueFieldMenuType = EnumObject<typeof ValueField.MenuType>;
 export type ValueFieldValidator<TValue> = (value: TValue, defaultValidator?: ValueFieldValidator<TValue>) => TValue;
 export type ValueFieldFormatter<TValue> = (value: TValue, defaultFormatter?: ValueFieldFormatter<TValue>) => string | JQuery.Promise<string>;
 export type ValueFieldParser<TValue> = (displayText: string, defaultParser?: ValueFieldParser<TValue>) => TValue;

--- a/eclipse-scout-core/src/form/fields/imagefield/ImageField.ts
+++ b/eclipse-scout-core/src/form/fields/imagefield/ImageField.ts
@@ -31,7 +31,7 @@ export class ImageField extends FormField implements ImageFieldModel {
   constructor() {
     super();
 
-    this.defaultMenuTypes = [...this.defaultMenuTypes, ImageField.MenuTypes.ImageUrl, ImageField.MenuTypes.Null];
+    this.defaultMenuTypes = [...this.defaultMenuTypes, ImageField.MenuType.ImageUrl, ImageField.MenuType.Null];
     this.autoFit = false;
     this.imageUrl = null;
     this.scrollBarEnabled = false;
@@ -42,7 +42,7 @@ export class ImageField extends FormField implements ImageFieldModel {
     this._clickHandler = null;
   }
 
-  static MenuTypes = {
+  static MenuType = {
     Null: 'ImageField.Null',
     ImageUrl: 'ImageField.ImageUrl'
   } as const;
@@ -210,9 +210,9 @@ export class ImageField extends FormField implements ImageFieldModel {
 
   protected override _getCurrentMenuTypes(): string[] {
     if (this.imageUrl) {
-      return [...super._getCurrentMenuTypes(), ImageField.MenuTypes.ImageUrl];
+      return [...super._getCurrentMenuTypes(), ImageField.MenuType.ImageUrl];
     }
-    return [...super._getCurrentMenuTypes(), ImageField.MenuTypes.Null];
+    return [...super._getCurrentMenuTypes(), ImageField.MenuType.Null];
   }
 
   /**
@@ -253,4 +253,4 @@ export class ImageField extends FormField implements ImageFieldModel {
   }
 }
 
-export type ImageFieldMenuTypes = EnumObject<typeof ImageField.MenuTypes>;
+export type ImageFieldMenuType = EnumObject<typeof ImageField.MenuType>;

--- a/eclipse-scout-core/src/form/fields/tabbox/TabBox.ts
+++ b/eclipse-scout-core/src/form/fields/tabbox/TabBox.ts
@@ -51,7 +51,7 @@ export class TabBox extends CompositeField implements TabBoxModel {
     this._tabBoxHeaderPropertyChangeHandler = this._onTabBoxHeaderPropertyChange.bind(this);
   }
 
-  static MenuTypes = {
+  static MenuType = {
     /**
      * In most cases, it is not necessary to set this menu type for a tab box menu because it does not affect the
      * visibility of the menu unless the menu is used for widgets other than the tab box. In this case, the menu type can
@@ -307,4 +307,4 @@ export class TabBox extends CompositeField implements TabBoxModel {
   }
 }
 
-export type TabBoxMenuTypes = EnumObject<typeof TabBox.MenuTypes>;
+export type TabBoxMenuType = EnumObject<typeof TabBox.MenuType>;

--- a/eclipse-scout-core/src/planner/Planner.ts
+++ b/eclipse-scout-core/src/planner/Planner.ts
@@ -87,7 +87,7 @@ export class Planner extends Widget implements PlannerModel {
     this.selectedActivity = null;
     this.startRow = null;
     this.lastRow = null;
-    this.defaultMenuTypes = [Planner.MenuTypes.EmptySpace];
+    this.defaultMenuTypes = [Planner.MenuType.EmptySpace];
 
     this._resourceTitleWidth = 20;
     this._rangeSelectionStarted = false;
@@ -131,7 +131,7 @@ export class Planner extends Widget implements PlannerModel {
 
   static RANGE_SELECTION_MOVE_THRESHOLD = 10;
 
-  static MenuTypes = {
+  static MenuType = {
     Activity: 'Planner.Activity',
     EmptySpace: 'Planner.EmptySpace',
     Range: 'Planner.Range',
@@ -333,15 +333,15 @@ export class Planner extends Widget implements PlannerModel {
   }
 
   protected _onResourceTitleContextMenu(event: JQuery.ContextMenuEvent) {
-    this._showContextMenu(event, Planner.MenuTypes.Resource);
+    this._showContextMenu(event, Planner.MenuType.Resource);
   }
 
   protected _onRangeSelectorContextMenu(event: JQuery.ContextMenuEvent) {
-    this._showContextMenu(event, Planner.MenuTypes.Range);
+    this._showContextMenu(event, Planner.MenuType.Range);
   }
 
   protected _onActivityContextMenu(event: JQuery.ContextMenuEvent) {
-    this._showContextMenu(event, Planner.MenuTypes.Activity);
+    this._showContextMenu(event, Planner.MenuType.Activity);
   }
 
   protected _showContextMenu(event: JQuery.ContextMenuEvent, allowedType: string) {
@@ -1282,20 +1282,20 @@ export class Planner extends Widget implements PlannerModel {
   }
 
   protected _updateMenuBar() {
-    let menuItems = this._filterMenus([Planner.MenuTypes.EmptySpace, Planner.MenuTypes.Resource, Planner.MenuTypes.Activity, Planner.MenuTypes.Range], false, true);
+    let menuItems = this._filterMenus([Planner.MenuType.EmptySpace, Planner.MenuType.Resource, Planner.MenuType.Activity, Planner.MenuType.Range], false, true);
     this.menuBar.setMenuItems(menuItems);
   }
 
   protected _filterMenus(allowedTypes: string[], onlyVisible: boolean, enableDisableKeyStrokes?: boolean): Menu[] {
     allowedTypes = allowedTypes || [];
-    if (allowedTypes.indexOf(Planner.MenuTypes.Resource) > -1 && this.selectedResources.length === 0) {
-      arrays.remove(allowedTypes, Planner.MenuTypes.Resource);
+    if (allowedTypes.indexOf(Planner.MenuType.Resource) > -1 && this.selectedResources.length === 0) {
+      arrays.remove(allowedTypes, Planner.MenuType.Resource);
     }
-    if (allowedTypes.indexOf(Planner.MenuTypes.Activity) > -1 && !this.selectedActivity) {
-      arrays.remove(allowedTypes, Planner.MenuTypes.Activity);
+    if (allowedTypes.indexOf(Planner.MenuType.Activity) > -1 && !this.selectedActivity) {
+      arrays.remove(allowedTypes, Planner.MenuType.Activity);
     }
-    if (allowedTypes.indexOf(Planner.MenuTypes.Range) > -1 && !this.selectionRange.from && !this.selectionRange.to) {
-      arrays.remove(allowedTypes, Planner.MenuTypes.Range);
+    if (allowedTypes.indexOf(Planner.MenuType.Range) > -1 && !this.selectionRange.from && !this.selectionRange.to) {
+      arrays.remove(allowedTypes, Planner.MenuType.Range);
     }
     return menuUtil.filter(this.menus, allowedTypes, {onlyVisible, enableDisableKeyStrokes, defaultMenuTypes: this.defaultMenuTypes});
   }
@@ -1667,7 +1667,7 @@ export class Planner extends Widget implements PlannerModel {
 export type PlannerDisplayMode = EnumObject<typeof Planner.DisplayMode>;
 export type PlannerDirection = EnumObject<typeof Planner.Direction>;
 export type PlannerSelectionMode = EnumObject<typeof Planner.SelectionMode>;
-export type PlannerMenuTypes = EnumObject<typeof Planner.MenuTypes>;
+export type PlannerMenuType = EnumObject<typeof Planner.MenuType>;
 
 export interface PlannerActivity {
   id: string;

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -232,7 +232,7 @@ export class Table extends Widget implements TableModel {
     this.textFilterEnabled = true;
     this.filterSupport = this._createFilterSupport();
     this.filteredElementsDirty = false;
-    this.defaultMenuTypes = [Table.MenuTypes.EmptySpace];
+    this.defaultMenuTypes = [Table.MenuType.EmptySpace];
 
     this._doubleClickSupport = new DoubleClickSupport();
     this._permanentHeadSortColumns = [];
@@ -254,7 +254,7 @@ export class Table extends Widget implements TableModel {
 
   // TODO [7.0] cgu create StringColumn.js incl. defaultValues from defaultValues.json
 
-  static MenuTypes = {
+  static MenuType = {
     /**
      * The menu is always visible and displayed first in the {@link MenuBar}.
      * The menu won't be displayed in the context menu.
@@ -5658,7 +5658,7 @@ export class Table extends Widget implements TableModel {
   }
 }
 
-export type TableMenuTypes = EnumObject<typeof Table.MenuTypes>;
+export type TableMenuType = EnumObject<typeof Table.MenuType>;
 export type TableHierarchicalStyle = EnumObject<typeof Table.HierarchicalStyle>;
 export type TableCheckableStyle = EnumObject<typeof Table.CheckableStyle>;
 export type TableGroupingStyle = EnumObject<typeof Table.GroupingStyle>;

--- a/eclipse-scout-core/src/table/TableModel.ts
+++ b/eclipse-scout-core/src/table/TableModel.ts
@@ -109,7 +109,7 @@ export interface TableModel extends WidgetModel {
   /**
    * Configures the menus to be displayed in the {@link MenuBar} of the table.
    *
-   * The visibility of the {@link Menu} and where it should appear depends on the used {@link Table.MenuTypes} configured in {@link Menu.menuTypes}.
+   * The visibility of the {@link Menu} and where it should appear depends on the used {@link Table.MenuType} configured in {@link Menu.menuTypes}.
    */
   menus?: ObjectOrChildModel<Menu>[];
   menuBarVisible?: boolean;

--- a/eclipse-scout-core/src/testing/table/TableSpecHelper.ts
+++ b/eclipse-scout-core/src/testing/table/TableSpecHelper.ts
@@ -102,11 +102,11 @@ export class TableSpecHelper {
   }
 
   createMenuModel(text?: string, icon?: string): MenuModel {
-    return this.menuHelper.createModel(text, icon, [Table.MenuTypes.SingleSelection]);
+    return this.menuHelper.createModel(text, icon, [Table.MenuType.SingleSelection]);
   }
 
   createMenuModelWithSingleAndHeader(text: string, icon?: string): MenuModel {
-    return this.menuHelper.createModel(text, icon, [Table.MenuTypes.SingleSelection, Table.MenuTypes.Header]);
+    return this.menuHelper.createModel(text, icon, [Table.MenuType.SingleSelection, Table.MenuType.Header]);
   }
 
   createModelColumns(count: number, columnType?: ObjectType): ChildModelOf<Column<any>>[] {

--- a/eclipse-scout-core/src/tile/TileGrid.ts
+++ b/eclipse-scout-core/src/tile/TileGrid.ts
@@ -110,7 +110,7 @@ export class TileGrid extends Widget implements TileGridModel {
     this.createTextFilter = null;
     this.updateTextFilterText = null;
 
-    this.defaultMenuTypes = [TileGrid.MenuTypes.EmptySpace];
+    this.defaultMenuTypes = [TileGrid.MenuType.EmptySpace];
 
     this._filterMenusHandler = this._filterMenus.bind(this);
     this._renderViewPortAfterAttach = false;
@@ -122,7 +122,7 @@ export class TileGrid extends Widget implements TileGridModel {
     this.$fillAfter = null;
   }
 
-  static MenuTypes = {
+  static MenuType = {
     EmptySpace: 'TileGrid.EmptySpace',
     SingleSelection: 'TileGrid.SingleSelection',
     MultiSelection: 'TileGrid.MultiSelection'
@@ -1594,4 +1594,4 @@ export class TileGrid extends Widget implements TileGridModel {
   }
 }
 
-export type TileGridMenuTypes = EnumObject<typeof TileGrid.MenuTypes>;
+export type TileGridMenuType = EnumObject<typeof TileGrid.MenuType>;

--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -170,7 +170,7 @@ export class Tree extends Widget implements TreeModel {
     this.$data = null;
     this._scrollDirections = 'both';
     this.requestFocusOnNodeControlMouseDown = true;
-    this.defaultMenuTypes = [Tree.MenuTypes.EmptySpace];
+    this.defaultMenuTypes = [Tree.MenuType.EmptySpace];
     this._$mouseDownNode = null;
   }
 
@@ -190,7 +190,7 @@ export class Tree extends Widget implements TreeModel {
     CHECKBOX_TREE_NODE: 'checkbox_tree_node'
   } as const;
 
-  static MenuTypes = {
+  static MenuType = {
     EmptySpace: 'Tree.EmptySpace',
     SingleSelection: 'Tree.SingleSelection',
     MultiSelection: 'Tree.MultiSelection',
@@ -3371,7 +3371,7 @@ export class Tree extends Widget implements TreeModel {
 
 export type TreeDisplayStyle = EnumObject<typeof Tree.DisplayStyle>;
 export type TreeCheckableStyle = EnumObject<typeof Tree.CheckableStyle>;
-export type TreeMenuTypes = EnumObject<typeof Tree.MenuTypes>;
+export type TreeMenuType = EnumObject<typeof Tree.MenuType>;
 export type TreeNodeExpandOptions = {
   /**
    * Default is derived from {@link TreeNode.expandedLazy} and {@link TreeNode.lazyExpandingEnabled} if the node is expanded and false otherwise.

--- a/eclipse-scout-core/src/tree/TreeModel.ts
+++ b/eclipse-scout-core/src/tree/TreeModel.ts
@@ -54,7 +54,7 @@ export interface TreeModel extends WidgetModel {
   /**
    * Configures the menus to be displayed in the {@link MenuBar} of the tree.
    *
-   * The visibility of the {@link Menu} and where it should appear depends on the used {@link Tree.MenuTypes} configured in {@link Menu.menuTypes}.
+   * The visibility of the {@link Menu} and where it should appear depends on the used {@link Tree.MenuType} configured in {@link Menu.menuTypes}.
    */
   menus?: ObjectOrChildModel<Menu>[];
   /**

--- a/eclipse-scout-core/test/desktop/outline/OutlineSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineSpec.ts
@@ -210,7 +210,7 @@ describe('Outline', () => {
       let node0 = outline.nodes[0];
       node0.detailTable.setMenus([
         menuHelper.createMenu({
-          menuTypes: [Table.MenuTypes.SingleSelection]
+          menuTypes: [Table.MenuType.SingleSelection]
         }), menuHelper.createMenu()
       ]);
       expect(outline.detailMenuBarVisible).toBe(false);
@@ -228,7 +228,7 @@ describe('Outline', () => {
       let node0 = outline.nodes[0];
       node0.detailTable.setMenus([
         menuHelper.createMenu({
-          menuTypes: [Table.MenuTypes.SingleSelection]
+          menuTypes: [Table.MenuType.SingleSelection]
         }), menuHelper.createMenu()
       ]);
       expect(outline.detailMenuBarVisible).toBe(false);
@@ -325,10 +325,10 @@ describe('Outline', () => {
       expect(outline.detailMenuBar.menuItems.length).toBe(0);
 
       let singleSelectionMenu = menuHelper.createMenu({
-        menuTypes: [Table.MenuTypes.SingleSelection]
+        menuTypes: [Table.MenuType.SingleSelection]
       });
       let singleSelectionMenu2 = menuHelper.createMenu({
-        menuTypes: [Table.MenuTypes.SingleSelection]
+        menuTypes: [Table.MenuType.SingleSelection]
       });
       node0.detailTable.setMenus([singleSelectionMenu, singleSelectionMenu2]);
       expect(outline.detailMenuBar.menuItems.length).toBe(2);

--- a/eclipse-scout-core/test/desktop/outline/pages/PageSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageSpec.ts
@@ -80,16 +80,16 @@ describe('Page', () => {
       objectType: Table,
       menus: [
         menuHelper.createModel('EmptySpaceMenu'),
-        menuHelper.createModel('SingleSelectionMenu', null, [Table.MenuTypes.SingleSelection]),
-        menuHelper.createModel('MultiSelectionMenu', null, [Table.MenuTypes.MultiSelection]),
-        menuHelper.createModel('SingleMultiSelectionMenu', null, [Table.MenuTypes.SingleSelection, Table.MenuTypes.MultiSelection])
+        menuHelper.createModel('SingleSelectionMenu', null, [Table.MenuType.SingleSelection]),
+        menuHelper.createModel('MultiSelectionMenu', null, [Table.MenuType.MultiSelection]),
+        menuHelper.createModel('SingleMultiSelectionMenu', null, [Table.MenuType.SingleSelection, Table.MenuType.MultiSelection])
       ]
     }, null);
     parentPage.createChildPage = row => scout.create(Page, {
       parent: outline,
       detailTable: {
         objectType: Table,
-        menus: [menuHelper.createModel('DetailTableSingleSelectionMenu', null, [Table.MenuTypes.SingleSelection])]
+        menus: [menuHelper.createModel('DetailTableSingleSelectionMenu', null, [Table.MenuType.SingleSelection])]
       },
       detailForm: {
         objectType: Form,
@@ -130,13 +130,13 @@ describe('Page', () => {
 
     expect(detailTable.menus.map(extractTextAndMenuTypes)).toEqual([...expectedParentTablePageMenus, {
       text: 'DetailTableSingleSelectionMenu',
-      menuTypes: [Table.MenuTypes.SingleSelection]
+      menuTypes: [Table.MenuType.SingleSelection]
     }]);
 
-    detailTable.setMenus([menuHelper.createModel('DetailTableMultiSelectionMenu', null, [Table.MenuTypes.MultiSelection])]);
+    detailTable.setMenus([menuHelper.createModel('DetailTableMultiSelectionMenu', null, [Table.MenuType.MultiSelection])]);
     expect(detailTable.menus.map(extractTextAndMenuTypes)).toEqual([...expectedParentTablePageMenus, {
       text: 'DetailTableMultiSelectionMenu',
-      menuTypes: [Table.MenuTypes.MultiSelection]
+      menuTypes: [Table.MenuType.MultiSelection]
     }]);
   });
 

--- a/eclipse-scout-core/test/form/fields/ValueFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/ValueFieldSpec.ts
@@ -824,8 +824,8 @@ describe('ValueField', () => {
     });
 
     it('context menu only shows menus of specific type', () => {
-      let menu1 = menuHelper.createMenu(menuHelper.createModel('menu', null, [ValueField.MenuTypes.Null, ValueField.MenuTypes.NotNull])),
-        menu2 = menuHelper.createMenu(menuHelper.createModel('menu', null, [ValueField.MenuTypes.Null]));
+      let menu1 = menuHelper.createMenu(menuHelper.createModel('menu', null, [ValueField.MenuType.Null, ValueField.MenuType.NotNull])),
+        menu2 = menuHelper.createMenu(menuHelper.createModel('menu', null, [ValueField.MenuType.Null]));
       formField.setMenus([menu1, menu2]);
       formField.render();
 

--- a/eclipse-scout-core/test/form/fields/imagefield/ImageFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/imagefield/ImageFieldSpec.ts
@@ -41,8 +41,8 @@ describe('ImageField', () => {
     });
 
     it('context menu only shows menus of specific type', () => {
-      let menu1 = menuHelper.createMenu(menuHelper.createModel('menu', null, [ImageField.MenuTypes.Null, ImageField.MenuTypes.ImageUrl])),
-        menu2 = menuHelper.createMenu(menuHelper.createModel('menu', null, [ImageField.MenuTypes.Null]));
+      let menu1 = menuHelper.createMenu(menuHelper.createModel('menu', null, [ImageField.MenuType.Null, ImageField.MenuType.ImageUrl])),
+        menu2 = menuHelper.createMenu(menuHelper.createModel('menu', null, [ImageField.MenuType.Null]));
       imageField.setMenus([menu1, menu2]);
       imageField.render();
 

--- a/eclipse-scout-core/test/menu/MenuBarSpec.ts
+++ b/eclipse-scout-core/test/menu/MenuBarSpec.ts
@@ -35,7 +35,7 @@ describe('MenuBar', () => {
   function createMenuBar(menuOrder?: MenuOrder): SpecMenuBar {
     return scout.create(SpecMenuBar, {
       parent: session.desktop,
-      menuOrder: scout.nvl(menuOrder, new MenuItemsOrder(session, 'Table', [Table.MenuTypes.EmptySpace]))
+      menuOrder: scout.nvl(menuOrder, new MenuItemsOrder(session, 'Table', [Table.MenuType.EmptySpace]))
     });
   }
 
@@ -51,8 +51,8 @@ describe('MenuBar', () => {
         menuBar = createMenuBar(),
         menus = [menu2, menu1];
 
-      menu1.setMenuTypes([Table.MenuTypes.EmptySpace, Table.MenuTypes.SingleSelection]);
-      menu2.setMenuTypes([Table.MenuTypes.SingleSelection]);
+      menu1.setMenuTypes([Table.MenuType.EmptySpace, Table.MenuType.SingleSelection]);
+      menu2.setMenuTypes([Table.MenuType.SingleSelection]);
 
       menuBar.render();
       menuBar.setMenuItems(menus);
@@ -70,8 +70,8 @@ describe('MenuBar', () => {
     it('must add/destroy dynamically created separators', () => {
       let separator,
         menu1 = helper.createMenu(createModel('empty')),
-        menu2 = helper.createMenu(createModel('selection-1', null, [Table.MenuTypes.SingleSelection])),
-        menu3 = helper.createMenu(createModel('selection-2', null, [Table.MenuTypes.SingleSelection])),
+        menu2 = helper.createMenu(createModel('selection-1', null, [Table.MenuType.SingleSelection])),
+        menu3 = helper.createMenu(createModel('selection-2', null, [Table.MenuType.SingleSelection])),
         menuBar = createMenuBar(),
         menus = [menu1, menu2];
 
@@ -143,10 +143,10 @@ describe('MenuBar', () => {
       let sep1b = helper.createMenu($.extend({}, menuModel, {id: 'test.sep1b', separator: true}));
       let menu1 = helper.createMenu($.extend({}, menuModel, {id: 'test.menu1', text: 'Menu 1 (L)'}));
       let sep12a = helper.createMenu($.extend({}, menuModel, {id: 'test.sep12a', separator: true}));
-      let sep12b = helper.createMenu($.extend({}, menuModel, {id: 'test.sep12b', separator: true, menuTypes: [Table.MenuTypes.SingleSelection]})); // <-- will generate an additional artificial separator menu
-      let menu2 = helper.createMenu($.extend({}, menuModel, {id: 'test.menu2', text: 'Menu 2 (L)', menuTypes: [Table.MenuTypes.SingleSelection]}));
-      let sep2a = helper.createMenu($.extend({}, menuModel, {id: 'test.sep2a', separator: true, menuTypes: [Table.MenuTypes.SingleSelection]}));
-      let sep2b = helper.createMenu($.extend({}, menuModel, {id: 'test.sep2b', separator: true, menuTypes: [Table.MenuTypes.SingleSelection]}));
+      let sep12b = helper.createMenu($.extend({}, menuModel, {id: 'test.sep12b', separator: true, menuTypes: [Table.MenuType.SingleSelection]})); // <-- will generate an additional artificial separator menu
+      let menu2 = helper.createMenu($.extend({}, menuModel, {id: 'test.menu2', text: 'Menu 2 (L)', menuTypes: [Table.MenuType.SingleSelection]}));
+      let sep2a = helper.createMenu($.extend({}, menuModel, {id: 'test.sep2a', separator: true, menuTypes: [Table.MenuType.SingleSelection]}));
+      let sep2b = helper.createMenu($.extend({}, menuModel, {id: 'test.sep2b', separator: true, menuTypes: [Table.MenuType.SingleSelection]}));
 
       let sep3a = helper.createMenu($.extend({}, menuModel, {id: 'test.sep3a', horizontalAlignment: 1, separator: true}));
       let sep3b = helper.createMenu($.extend({}, menuModel, {id: 'test.sep3b', horizontalAlignment: 1, separator: true}));

--- a/eclipse-scout-core/test/menu/MenuItemsOrderSpec.ts
+++ b/eclipse-scout-core/test/menu/MenuItemsOrderSpec.ts
@@ -28,7 +28,7 @@ describe('MenuItemsOrder', () => {
     setFixtures(sandbox());
     session = sandboxSession();
     menuHelper = new MenuSpecHelper(session);
-    menuItemsOrder = new SpecMenuItemsOrder(session, 'Table', [Table.MenuTypes.EmptySpace]);
+    menuItemsOrder = new SpecMenuItemsOrder(session, 'Table', [Table.MenuType.EmptySpace]);
     let nullWidget = new NullWidget();
     nullWidget.session = session;
     // @ts-expect-error
@@ -57,11 +57,11 @@ describe('MenuItemsOrder', () => {
 
   it('order', () => {
     let emptySpaceImplicit = menuHelper.createMenu(),
-      emptySpace = menuHelper.createMenu({menuTypes: [Table.MenuTypes.EmptySpace]}),
-      singleSelection = menuHelper.createMenu({menuTypes: [Table.MenuTypes.SingleSelection]}),
-      multiSelection = menuHelper.createMenu({menuTypes: [Table.MenuTypes.MultiSelection]}),
-      header1 = menuHelper.createMenu({menuTypes: [Table.MenuTypes.Header]}),
-      header2 = menuHelper.createMenu({menuTypes: [Table.MenuTypes.Header]}),
+      emptySpace = menuHelper.createMenu({menuTypes: [Table.MenuType.EmptySpace]}),
+      singleSelection = menuHelper.createMenu({menuTypes: [Table.MenuType.SingleSelection]}),
+      multiSelection = menuHelper.createMenu({menuTypes: [Table.MenuType.MultiSelection]}),
+      header1 = menuHelper.createMenu({menuTypes: [Table.MenuType.Header]}),
+      header2 = menuHelper.createMenu({menuTypes: [Table.MenuType.Header]}),
       separator = menuItemsOrder._createSeparator();
 
     menuItemsOrder._createSeparator = () => separator;

--- a/eclipse-scout-core/test/table/TableHeaderSpec.ts
+++ b/eclipse-scout-core/test/table/TableHeaderSpec.ts
@@ -51,7 +51,7 @@ describe('TableHeaderSpec', () => {
     table.setMenus([scout.create(Menu, { // fake header menu required to properly calculate visibility
       parent: table,
       text: 'Foo',
-      menuTypes: [Table.MenuTypes.Header]
+      menuTypes: [Table.MenuType.Header]
     })]);
     table.render();
 

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -1791,14 +1791,14 @@ describe('Table', () => {
     beforeEach(() => {
       let model = helper.createModelFixture(2, 2);
       singleSelMenu = helper.menuHelper.createMenu({
-        menuTypes: [Table.MenuTypes.SingleSelection]
+        menuTypes: [Table.MenuType.SingleSelection]
       });
       multiSelMenu = helper.menuHelper.createMenu({
-        menuTypes: [Table.MenuTypes.MultiSelection]
+        menuTypes: [Table.MenuType.MultiSelection]
       });
       emptySpaceMenu = helper.menuHelper.createMenu();
       headerMenu = helper.menuHelper.createMenu({
-        menuTypes: [Table.MenuTypes.Header]
+        menuTypes: [Table.MenuType.Header]
       });
       table = helper.createTable(model);
       table.menus = [singleSelMenu, multiSelMenu, emptySpaceMenu, headerMenu];
@@ -1825,7 +1825,7 @@ describe('Table', () => {
 
     it('returns menus with single- and multi selection set for contextMenu if one or more rows are selected', () => {
       bothSelMenu = helper.menuHelper.createMenu({
-        menuTypes: [Table.MenuTypes.SingleSelection, Table.MenuTypes.MultiSelection]
+        menuTypes: [Table.MenuType.SingleSelection, Table.MenuType.MultiSelection]
       });
       table.menus = [singleSelMenu, multiSelMenu, bothSelMenu];
       table.selectRows(table.rows[0]);
@@ -1862,7 +1862,7 @@ describe('Table', () => {
 
     it('returns menus with empty space, single- and multi selection set if one or more rows are selected', () => {
       bothSelMenu = helper.menuHelper.createMenu({
-        menuTypes: [Table.MenuTypes.SingleSelection, Table.MenuTypes.MultiSelection]
+        menuTypes: [Table.MenuType.SingleSelection, Table.MenuType.MultiSelection]
       });
       table.menus = [singleSelMenu, multiSelMenu, emptySpaceMenu, bothSelMenu];
       table.selectRows(table.rows[0]);
@@ -1887,11 +1887,11 @@ describe('Table', () => {
     beforeEach(() => {
       singleSelMenu = scout.create(Menu, {
         parent: session.desktop,
-        menuTypes: [Table.MenuTypes.SingleSelection]
+        menuTypes: [Table.MenuType.SingleSelection]
       });
       multiSelMenu = scout.create(Menu, {
         parent: session.desktop,
-        menuTypes: [Table.MenuTypes.MultiSelection]
+        menuTypes: [Table.MenuType.MultiSelection]
       });
       emptySpaceMenu = scout.create(Menu, {
         parent: session.desktop
@@ -1939,7 +1939,7 @@ describe('Table', () => {
         selectedRows: ['firstRow'],
         menus: [{
           objectType: Menu,
-          menuTypes: [Table.MenuTypes.SingleSelection],
+          menuTypes: [Table.MenuType.SingleSelection],
           inheritAccessibility: false
         }]
       }));
@@ -2043,15 +2043,15 @@ describe('Table', () => {
       });
       singleSelMenu = scout.create(Menu, {
         parent: table,
-        menuTypes: [Table.MenuTypes.SingleSelection]
+        menuTypes: [Table.MenuType.SingleSelection]
       });
       singleMultiSelMenu = scout.create(Menu, {
         parent: table,
-        menuTypes: [Table.MenuTypes.SingleSelection, Table.MenuTypes.MultiSelection]
+        menuTypes: [Table.MenuType.SingleSelection, Table.MenuType.MultiSelection]
       });
       multiSelMenu = scout.create(Menu, {
         parent: table,
-        menuTypes: [Table.MenuTypes.MultiSelection]
+        menuTypes: [Table.MenuType.MultiSelection]
       });
       emptySpaceMenu = scout.create(Menu, {
         parent: table
@@ -2128,7 +2128,7 @@ describe('Table', () => {
       // Create a new menu which is not part of the menu bar -> the menu items of the menu bar are still the same
       menus = menus.concat([scout.create(Menu, {
         parent: table,
-        menuTypes: [Table.MenuTypes.Header]
+        menuTypes: [Table.MenuType.Header]
       })]);
       table.setMenus(menus);
       expect(menus[0].parent).toBe(table.menuBar.menuboxLeft);

--- a/eclipse-scout-migrate/src/common.js
+++ b/eclipse-scout-migrate/src/common.js
@@ -648,19 +648,19 @@ export const defaultRecastOptions = {
 };
 
 export const defaultMenuTypesMap = {
-  'Table.EmptySpace': {objectType: 'Table', menuTypes: 'MenuTypes', menuType: 'EmptySpace'},
-  'Table.SingleSelection': {objectType: 'Table', menuTypes: 'MenuTypes', menuType: 'SingleSelection'},
-  'Table.MultiSelection': {objectType: 'Table', menuTypes: 'MenuTypes', menuType: 'MultiSelection'},
-  'Table.Header': {objectType: 'Table', menuTypes: 'MenuTypes', menuType: 'Header'},
-  'TabBox.Header': {objectType: 'TabBox', menuTypes: 'MenuTypes', menuType: 'Header'},
-  'Tree.EmptySpace': {objectType: 'Tree', menuTypes: 'MenuTypes', menuType: 'EmptySpace'},
-  'Tree.SingleSelection': {objectType: 'Tree', menuTypes: 'MenuTypes', menuType: 'SingleSelection'},
-  'Tree.MultiSelection': {objectType: 'Tree', menuTypes: 'MenuTypes', menuType: 'MultiSelection'},
-  'Tree.Header': {objectType: 'Tree', menuTypes: 'MenuTypes', menuType: 'Header'},
-  'Planner.Activity': {objectType: 'Planner', menuTypes: 'MenuTypes', menuType: 'Activity'},
-  'Planner.EmptySpace': {objectType: 'Planner', menuTypes: 'MenuTypes', menuType: 'EmptySpace'},
-  'Planner.Range': {objectType: 'Planner', menuTypes: 'MenuTypes', menuType: 'Range'},
-  'Planner.Resource': {objectType: 'Planner', menuTypes: 'MenuTypes', menuType: 'Resource'},
-  'Calendar.EmptySpace': {objectType: 'Calendar', menuTypes: 'MenuTypes', menuType: 'EmptySpace'},
-  'Calendar.CalendarComponent': {objectType: 'Calendar', menuTypes: 'MenuTypes', menuType: 'CalendarComponent'}
+  'Table.EmptySpace': {objectType: 'Table', menuTypes: 'MenuType', menuType: 'EmptySpace'},
+  'Table.SingleSelection': {objectType: 'Table', menuTypes: 'MenuType', menuType: 'SingleSelection'},
+  'Table.MultiSelection': {objectType: 'Table', menuTypes: 'MenuType', menuType: 'MultiSelection'},
+  'Table.Header': {objectType: 'Table', menuTypes: 'MenuType', menuType: 'Header'},
+  'TabBox.Header': {objectType: 'TabBox', menuTypes: 'MenuType', menuType: 'Header'},
+  'Tree.EmptySpace': {objectType: 'Tree', menuTypes: 'MenuType', menuType: 'EmptySpace'},
+  'Tree.SingleSelection': {objectType: 'Tree', menuTypes: 'MenuType', menuType: 'SingleSelection'},
+  'Tree.MultiSelection': {objectType: 'Tree', menuTypes: 'MenuType', menuType: 'MultiSelection'},
+  'Tree.Header': {objectType: 'Tree', menuTypes: 'MenuType', menuType: 'Header'},
+  'Planner.Activity': {objectType: 'Planner', menuTypes: 'MenuType', menuType: 'Activity'},
+  'Planner.EmptySpace': {objectType: 'Planner', menuTypes: 'MenuType', menuType: 'EmptySpace'},
+  'Planner.Range': {objectType: 'Planner', menuTypes: 'MenuType', menuType: 'Range'},
+  'Planner.Resource': {objectType: 'Planner', menuTypes: 'MenuType', menuType: 'Resource'},
+  'Calendar.EmptySpace': {objectType: 'Calendar', menuTypes: 'MenuType', menuType: 'EmptySpace'},
+  'Calendar.CalendarComponent': {objectType: 'Calendar', menuTypes: 'MenuType', menuType: 'CalendarComponent'}
 };

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonTablePageModel.ts
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonTablePageModel.ts
@@ -53,7 +53,7 @@ export default (): PageWithTableModel => ({
         objectType: Menu,
         text: '${symbol_dollar}{textKey:EditPerson}',
         iconId: icons.PENCIL,
-        menuTypes: [Table.MenuTypes.SingleSelection]
+        menuTypes: [Table.MenuType.SingleSelection]
       },
       {
         id: 'CreatePersonMenu',
@@ -67,7 +67,7 @@ export default (): PageWithTableModel => ({
         text: '${symbol_dollar}{textKey:DeletePerson}',
         iconId: icons.REMOVE,
         menuTypes: [
-          Table.MenuTypes.SingleSelection
+          Table.MenuType.SingleSelection
         ]
       }
     ],


### PR DESCRIPTION
constants:
* Calendar.MenuTypes -> Calendar.MenuType
* ImageField.MenuTypes -> ImageField.MenuType
* Planner.MenuTypes -> Planner.MenuType
* TabBox.MenuTypes -> TabBox.MenuType
* Table.MenuTypes -> Table.MenuType
* TileGrid.MenuTypes -> TileGrid.MenuType
* Tree.MenuTypes -> Tree.MenuType
* ValueField.MenuTypes -> ValueField.MenuType types:
* CalendarMenuTypes -> CalendarMenuType
* ImageFieldMenuTypes -> ImageFieldMenuType
* PlannerMenuTypes -> PlannerMenuType
* TabBoxMenuTypes -> TabBoxMenuType
* TableMenuTypes -> TableMenuType
* TileGridMenuTypes -> TileGridMenuType
* TreeMenuTypes -> TreeMenuType
* ValueFieldMenuTypes -> ValueFieldMenuType