### PR TITLE
Implement tag replacement without lookbehind

### DIFF
--- a/eclipse-scout-core/src/encoder/PlainTextEncoder.js
+++ b/eclipse-scout-core/src/encoder/PlainTextEncoder.js
@@ -41,8 +41,8 @@ export default class PlainTextEncoder {
     }
 
     // Remove script and style contents
-    text = text.replace(/(?<=<script>).*?(?=<\/script>)/gi, '');
-    text = text.replace(/(?<=<style>).*?(?=<\/style>)/gi, '');
+    text = text.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+    text = text.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '');
 
     // Replace remaining tags
     text = text.replace(/<[^>]+>/gi, '');

--- a/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.js
+++ b/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.js
@@ -34,12 +34,28 @@ describe('PlainTextEncoder', () => {
   });
 
   it('removes style and script tags', () => {
-    let htmlText = '<style>p{color: #26b72b;}</style>'
+    let htmlText = '<h1>Lorem ipsum dolor</h1>\n'
+      + '<style>\n'
+      + 'p {\n'
+      + '  color: #26b72b;\n'
+      + '}\n'
+      + '</style>'
       + '<p style="color: blue">Donec mattis metus lorem. Aenean posuere tincidunt enim.</p>'
-      + '<script>alert(\'Hello World\');</script>'
-      + '<p style="color: green">Pellentesque eu euismod eros, in ullamcorper erat.</p>';
+      + '<script>alert(\'Hello World!\');</script>'
+      + '<p style="color: green">Pellentesque eu euismod eros, '
+      + '<script>alert(\'Hello World 2!\');</script><script>alert(\'Hello World 3!\');</script>'
+      + '<script type=\'text/javascript\'>\n'
+      + '  document.write(123);\n'
+      + '</script>'
+      + '<style media=\'print\'>\n'
+      + 'p {\n'
+      + '  color: #26b72b;\n'
+      + '}\n'
+      + '</style>'
+      + 'in ullamcorper erat.</p>';
 
-    expect(encoder.encode(htmlText)).toBe('Donec mattis metus lorem. Aenean posuere tincidunt enim.\n' +
+    expect(encoder.encode(htmlText)).toBe('Lorem ipsum dolor\n' +
+      'Donec mattis metus lorem. Aenean posuere tincidunt enim.\n' +
       'Pellentesque eu euismod eros, in ullamcorper erat.\n');
   });
 

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
@@ -87,12 +87,22 @@ public class HtmlHelperTest {
             "<h1>Lorem ipsum dolor</h1>\n"
                 + "<style>\n"
                 + "p {\n"
-                + " color: #26b72b;\n"
+                + "  color: #26b72b;\n"
                 + "}\n"
-                + "</style>\n"
+                + "</style>"
                 + "<p style=\"color: blue\">Donec mattis metus lorem. Aenean posuere tincidunt enim.</p>\n"
-                + "<script>alert('Hello World!');</script>\n"
-                + "<p style=\"color: green\">Pellentesque eu euismod eros, in ullamcorper erat.</p>"));
+                + "<script>alert('Hello World!');</script>"
+                + "<p style=\"color: green\">Pellentesque eu euismod eros, "
+                + "<script>alert('Hello World 2!');</script><script>alert('Hello World 3!');</script>"
+                + "<script type='text/javascript'>\n"
+                + "  document.write(123);\n"
+                + "</script>"
+                + "<style type='text/css'>\n"
+                + "p {\n"
+                + "  color: #26b72b;\n"
+                + "}\n"
+                + "</style>"
+                + "in ullamcorper erat.</p>"));
 
     //Emojis
     assertEquals(""

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
@@ -26,8 +26,8 @@ public class HtmlHelper {
   private static final Pattern HTML_PARAGRAPH_END_TAGS = Pattern.compile("<br/?></div>|</div>|<br/?>|</p>|<p/>|</tr>|</h[1-6]>|</dt>|</dd>|</dl>|</table>|</li>|</head>", Pattern.CASE_INSENSITIVE);
   private static final Pattern HTML_SPACE_END_TAGS = Pattern.compile("</td>|</th>", Pattern.CASE_INSENSITIVE);
   private static final Pattern HTML_TAGS = Pattern.compile("<[^>]+>", Pattern.DOTALL);
-  private static final Pattern HTML_SCRIPTS = Pattern.compile("(?<=<script>).*?(?=<\\/script>)", Pattern.CASE_INSENSITIVE);
-  private static final Pattern HTML_STYLES = Pattern.compile("(?<=<style>).*?(?=<\\/style>)", Pattern.CASE_INSENSITIVE);
+  private static final Pattern HTML_SCRIPTS = Pattern.compile("<script\\b[^<]*(?:(?!</script>)<[^<]*)*</script>", Pattern.CASE_INSENSITIVE);
+  private static final Pattern HTML_STYLES = Pattern.compile("<style\\b[^<]*(?:(?!</style>)<[^<]*)*</style>", Pattern.CASE_INSENSITIVE);
   private static final Pattern MULTIPLE_SPACES = Pattern.compile("[ ]+");
   private static final Pattern SPACES_ADJACENT_LINEBREAKS = Pattern.compile("[ ]+\n[ ]?|[ ]?\n[ ]+");
   private static final Pattern DECIMAL_NCR = Pattern.compile("&#(\\d+);");


### PR DESCRIPTION
Regexp lookbehind is not supported by some safari browsers (<16.4).