### PR TITLE
TileGrid: add generic

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageTileGrid.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageTileGrid.ts
@@ -12,11 +12,10 @@ import {
   TreeAllChildNodesDeletedEvent, TreeChildNodeOrderChangedEvent, TreeNodeChangedEvent, TreeNodesDeletedEvent, TreeNodesInsertedEvent
 } from '../../../index';
 
-export class PageTileGrid extends TileGrid implements PageTileGridModel {
+export class PageTileGrid extends TileGrid<ButtonTile> implements PageTileGridModel {
   declare model: PageTileGridModel;
   declare eventMap: PageTileGridEventMap;
   declare self: PageTileGrid;
-  declare tiles: ButtonTile[];
 
   compact: boolean;
   compactLayoutConfig: TileGridLayoutConfig;

--- a/eclipse-scout-core/src/desktop/viewbutton/ViewMenuPopup.ts
+++ b/eclipse-scout-core/src/desktop/viewbutton/ViewMenuPopup.ts
@@ -14,7 +14,7 @@ import {ChildModelOf, CompositeTile, CompositeTileModel, Icon, InitModelOf, Labe
  */
 export class ViewMenuPopup extends WidgetPopup implements ViewMenuPopupModel {
   declare model: ViewMenuPopupModel;
-  declare content: TileGrid;
+  declare content: TileGrid<ViewButtonTile>;
 
   defaultIconId: string;
   viewMenus: ViewButton[];
@@ -31,7 +31,7 @@ export class ViewMenuPopup extends WidgetPopup implements ViewMenuPopupModel {
     super._init(options);
     let tiles = this._createTiles();
     let noIcons = tiles.every(tile => !tile.widgets[0].visible);
-    this.content = scout.create(TileGrid, {
+    this.content = scout.create((TileGrid<ViewButtonTile>), {
       parent: this,
       tiles: tiles,
       cssClass: noIcons ? 'no-icons' : '',
@@ -45,7 +45,7 @@ export class ViewMenuPopup extends WidgetPopup implements ViewMenuPopupModel {
         hgap: 10
       }
     });
-    let viewButtonTiles = this.content.tiles as ViewButtonTile[];
+    let viewButtonTiles = this.content.tiles;
     let tile = viewButtonTiles.find(tile => tile.viewMenu.selected);
     if (tile) {
       this.content.selectTile(tile);

--- a/eclipse-scout-core/src/form/fields/tilefield/TileField.ts
+++ b/eclipse-scout-core/src/form/fields/tilefield/TileField.ts
@@ -7,14 +7,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {EventDelegator, FormField, InitModelOf, LoadingSupport, ObjectOrChildModel, TileFieldEventMap, TileFieldModel, TileGrid, Widget} from '../../../index';
+import {EventDelegator, FormField, InitModelOf, LoadingSupport, ObjectOrChildModel, Tile, TileFieldEventMap, TileFieldModel, TileGrid, Widget} from '../../../index';
 
-export class TileField extends FormField implements TileFieldModel {
+export class TileField<TTile extends Tile = Tile> extends FormField implements TileFieldModel {
   declare model: TileFieldModel;
   declare eventMap: TileFieldEventMap;
-  declare self: TileField;
+  declare self: TileField<TTile>;
 
-  tileGrid: TileGrid;
+  tileGrid: TileGrid<TTile>;
   eventDelegator: EventDelegator;
 
   constructor() {
@@ -49,11 +49,11 @@ export class TileField extends FormField implements TileFieldModel {
     this._renderDropType();
   }
 
-  setTileGrid(tileGrid: ObjectOrChildModel<TileGrid>) {
+  setTileGrid(tileGrid: ObjectOrChildModel<TileGrid<TTile>>) {
     this.setProperty('tileGrid', tileGrid);
   }
 
-  protected _setTileGrid(tileGrid: TileGrid) {
+  protected _setTileGrid(tileGrid: TileGrid<TTile>) {
     if (this.tileGrid) {
       if (this.eventDelegator) {
         this.eventDelegator.destroy();

--- a/eclipse-scout-core/src/tile/TileGridGridConfig.ts
+++ b/eclipse-scout-core/src/tile/TileGridGridConfig.ts
@@ -13,6 +13,6 @@ export class TileGridGridConfig extends LogicalGridConfig {
   declare widget: TileGrid;
 
   override getGridWidgets(): LogicalGridWidget[] {
-    return this.widget.filteredTiles;
+    return this.widget.getFilteredTilesWithPlaceholders();
   }
 }

--- a/eclipse-scout-core/src/tile/TileGridLayout.ts
+++ b/eclipse-scout-core/src/tile/TileGridLayout.ts
@@ -11,7 +11,7 @@ import {arrays, Dimension, graphics, HtmlComponent, HtmlCompPrefSizeOptions, Ins
 import $ from 'jquery';
 
 export class TileGridLayout extends LogicalGridLayout {
-  declare widget: TileGrid;
+  declare widget: TileGrid<Tile>;
   containerPos: Point;
   containerScrollTop: number;
   maxWidth: number;
@@ -73,7 +73,7 @@ export class TileGridLayout extends LogicalGridLayout {
 
     // Animate only once on startup (if enabled) but animate every time on resize
     let animated = htmlComp.layouted || (this.widget.startupAnimationEnabled && !this.widget.startupAnimationDone) || this.widget.renderAnimationEnabled;
-    this.tiles = this.widget.renderedTiles();
+    this.tiles = this.widget.renderedTiles(true);
 
     // Make them invisible otherwise the influence scrollHeight (e.g. if grid is scrolled to the very bottom and tiles are filtered, scrollbar would still increase scroll height)
     scrollbars.setVisible($container, false);
@@ -366,7 +366,7 @@ export class TileGridLayout extends LogicalGridLayout {
 
   /**
    * Calculates the preferred size only based on the grid column count, row count and layout config. Does not use rendered elements.
-   * Therefore only works if all tiles are of the same size (which is a precondition for the virtual scrolling anyway).
+   * Therefore, it only works if all tiles are of the same size (which is a precondition for the virtual scrolling anyway).
    */
   virtualPrefSize($container: JQuery, options: HtmlCompPrefSizeOptions): Dimension {
     let rowCount, columnCount;

--- a/eclipse-scout-core/src/tile/TileGridModel.ts
+++ b/eclipse-scout-core/src/tile/TileGridModel.ts
@@ -54,6 +54,7 @@ export interface TileGridModel extends WidgetModel {
   multiSelect?: boolean;
   /**
    * Specifies whether an animation should be executed whenever the tile grid is rendered.
+   *
    * The animation is quite small and discreet and just moves the tiles a little.
    * It will happen if the startup animation is disabled or done and every time the tiles are rendered anew.
    *
@@ -71,6 +72,7 @@ export interface TileGridModel extends WidgetModel {
   selectionHandler?: TileGridSelectionHandler;
   /**
    * Specifies whether the tile grid should be scrollable or not.
+   *
    * If true, it will be vertically scrollable.
    * It will also be horizontally scrollable but only if {@link LogicalGridLayoutConfig.minWidth} is set.
    *
@@ -110,17 +112,20 @@ export interface TileGridModel extends WidgetModel {
   virtual?: boolean;
   /**
    * If enabled, artificial placeholder tiles are added automatically if the tiles in the last row don't fill the whole row.
+   *
    * Default is false.
    */
   withPlaceholders?: boolean;
   /**
    * If enabled, a text field is shown when the tile grid is focused or hovered so the user can filter the tiles by typing.
+   *
    * Default is false.
    */
   textFilterEnabled?: boolean;
   filterSupport?: FilterSupport<Tile>;
   /**
    * Factory function to create a custom {@link TextFilter} that is used if {@link textFilterEnabled} is set to true.
+   *
    * If no function is set, the {@link TileTextFilter} will be used that will convert the rendered content of the tile to plain text and apply the filter to that.
    *
    * Default is null which means the {@link TileTextFilter} is active.
@@ -128,7 +133,9 @@ export interface TileGridModel extends WidgetModel {
   createTextFilter?: () => TextFilter<Tile>;
   /**
    * A function to update the {@link TextFilter.acceptedText}.
+   *
    * Setting this property may be necessary if a custom {@link TextFilter} is set using {@link createTextFilter}.
+   *
    * Default is null which means {@link TileGrid._updateTextFilterText} is used that works with {@link TileTextFilter.setText}.
    */
   updateTextFilterText?: string;

--- a/eclipse-scout-core/src/tile/keystrokes/TileGridSelectAllKeyStroke.ts
+++ b/eclipse-scout-core/src/tile/keystrokes/TileGridSelectAllKeyStroke.ts
@@ -19,7 +19,7 @@ export class TileGridSelectAllKeyStroke extends TileGridSelectKeyStroke {
     this.renderingHints.$drawingArea = ($drawingArea, event) => {
       let tile = this.getSelectionHandler().getVisibleTiles()[0];
       if (tile) {
-        // Draw in first tile so that other key stroke hints (e.g. left, right etc.) don't overlap this one
+        // Draw in first tile so that other keystroke hints (e.g. left, right etc.) don't overlap this one
         return tile.$container;
       }
     };

--- a/eclipse-scout-core/test/tile/TileGridSpec.ts
+++ b/eclipse-scout-core/test/tile/TileGridSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Group, InitModelOf, RemoteTileFilter, scout, Tile, TileGrid, TileGridModel, TileModel} from '../../src/index';
+import {Group, InitModelOf, PlaceholderTile, RemoteTileFilter, scout, Tile, TileGrid, TileGridModel, TileModel} from '../../src/index';
 import {JQueryTesting} from '../../src/testing/index';
 
 describe('TileGrid', () => {
@@ -121,6 +121,23 @@ describe('TileGrid', () => {
 
       tileGrid.selectTiles(tileGrid.tiles[1]);
       expect(tileGrid.tiles[1].selected).toBe(true);
+    });
+
+    it('does not select placeholder tiles', () => {
+      let tileGrid = createTileGrid(3, {
+        selectable: true,
+        withPlaceholders: true
+      });
+      tileGrid.validateLogicalGrid();
+
+      let tile = tileGrid.tiles[0];
+      let placeholder = tileGrid.getFilteredTilesWithPlaceholders()[3];
+      expect(placeholder).toBeInstanceOf(PlaceholderTile);
+
+      tileGrid.selectTiles([tile, placeholder]);
+      expect(tile.selected).toBe(true);
+      expect(placeholder.selected).toBe(false);
+      expect(tileGrid.selectedTiles).toEqual([tile]);
     });
 
     it('triggers a property change event', () => {
@@ -1115,6 +1132,22 @@ describe('TileGrid', () => {
       expect(tileGrid2.tiles[2].filterAccepted).toBe(true);
     });
 
+    it('ignores placeholder tiles', () => {
+      let tileGrid = createTileGrid(1, {
+        withPlaceholders: true
+      });
+      let filter = {
+        accept: tile => !(tile instanceof PlaceholderTile)
+      };
+      tileGrid.addFilter(filter);
+      tileGrid.validateLogicalGrid();
+
+      let tile = tileGrid.tiles[0];
+      let placeholder = tileGrid.getFilteredTilesWithPlaceholders()[1];
+      expect(placeholder).toBeInstanceOf(PlaceholderTile);
+      expect(tileGrid.tiles).toEqual([tile]);
+      expect(tileGrid.filteredTiles).toEqual([tile]);
+    });
   });
 
   describe('addFilter', () => {


### PR DESCRIPTION
If placeholders are enabled, the tiles may also contain placeholder tiles. The user cannot interact with these tiles and the developer working with the tile grid should not either -> Placeholder tiles are internal and should not be exposed.

- TileGrid.tiles and TileGrid.filteredTiles don't return the placeholder tiles anymore
- TileGrid.selectTiles now filter the placeholder tiles, so they cannot be selected anymore.

334151