### PR TITLE
JsonJsForm: don't send root group box to UI

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/AbstractJsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/AbstractJsForm.java
@@ -155,7 +155,7 @@ public abstract class AbstractJsForm<IN extends IDataObject, OUT extends IDataOb
 
   @Order(1000)
   @ClassId("4d09d51a-2a15-4863-8921-2eead40957fa")
-  public class MainBox extends AbstractGroupBox {
+  public final class MainBox extends AbstractGroupBox {
   }
 
   protected class P_UIFacade extends AbstractForm.P_UIFacade implements IJsFormUIFacade<OUT> {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/IJsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/IJsForm.java
@@ -14,10 +14,17 @@ import org.eclipse.scout.rt.dataobject.IDataObject;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 
 /**
- * Wraps a form implemented in ScoutJS. This jsForm will be opened by the JsFormAdapter and its whole lifecycle will be
- * handled by the browser. To determine which jsForm is opened the property {@code jsFormObjectType} is used, an
- * additional model can be passed using {@code jsFormModel}. It is possible to pass some {@code inputData} into the
- * jsForm and retrieve an {@code outputData} after the jsForm is closed.
+ * Wraps a form implemented in Scout JS.
+ * <p>
+ * The jsForm will be opened by the JsFormAdapter and its whole lifecycle will be handled by the browser. To determine
+ * which jsForm will be opened, the property {@code jsFormObjectType} is used.
+ * <p>
+ * Except for {@link IForm#getDisplayHint()} and {@link IForm#getDisplayParent()}, no form properties will be sent to
+ * the browser, they need to be set using JavaScript. However, it is possible to set some properties from Java code by
+ * passing an additional model using {@link IJsForm#setJsFormModel(IDoEntity)}.
+ * <p>
+ * To set the data property of the jsForm, use {@link IJsForm#setInputData(IDataObject)}. Once the jsForm is closed, the
+ * updated data will be sent back to the server and can be retrieved using {@link IJsForm#getOutputData()}.
  */
 public interface IJsForm<IN extends IDataObject, OUT extends IDataObject> extends IForm {
 

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/JsonForm.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/JsonForm.java
@@ -15,6 +15,7 @@ import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
 import org.eclipse.scout.rt.client.ui.form.FormEvent;
 import org.eclipse.scout.rt.client.ui.form.FormListener;
 import org.eclipse.scout.rt.client.ui.form.IForm;
+import org.eclipse.scout.rt.client.ui.form.fields.groupbox.IGroupBox;
 import org.eclipse.scout.rt.platform.status.IStatus;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.ui.html.IUiSession;
@@ -24,6 +25,7 @@ import org.eclipse.scout.rt.ui.html.json.JsonAdapterUtility;
 import org.eclipse.scout.rt.ui.html.json.JsonEvent;
 import org.eclipse.scout.rt.ui.html.json.JsonProperty;
 import org.eclipse.scout.rt.ui.html.json.JsonStatus;
+import org.eclipse.scout.rt.ui.html.json.form.fields.JsonAdapterProperty;
 import org.eclipse.scout.rt.ui.html.res.BinaryResourceUrlUtility;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -82,6 +84,41 @@ public class JsonForm<FORM extends IForm> extends AbstractJsonWidget<FORM> {
   @Override
   protected void initJsonProperties(FORM model) {
     super.initJsonProperties(model);
+    putJsonProperty(new JsonAdapterProperty<>(PROP_ROOT_GROUP_BOX, model, getUiSession()) {
+      @Override
+      protected IGroupBox modelValue() {
+        return getModel().getRootGroupBox();
+      }
+    });
+    putJsonProperty(new JsonProperty<IForm>(PROP_MODAL, model) {
+      @Override
+      protected Boolean modelValue() {
+        return getModel().isModal();
+      }
+    });
+    putJsonProperty(new JsonProperty<IForm>(PROP_CACHE_BOUNDS, model) {
+      @Override
+      protected Boolean modelValue() {
+        return getModel().isCacheBounds();
+      }
+    });
+    putJsonProperty(new JsonProperty<IForm>(PROP_CACHE_BOUNDS_KEY, model) {
+      @Override
+      protected String modelValue() {
+        return getModel().computeCacheBoundsKey();
+      }
+
+      @Override
+      public boolean accept() {
+        return getModel().isCacheBounds();
+      }
+    });
+    putJsonProperty(new JsonProperty<IForm>(PROP_DISPLAY_VIEW_ID, model) {
+      @Override
+      protected String modelValue() {
+        return getModel().getDisplayViewId();
+      }
+    });
     putJsonProperty(new JsonProperty<IForm>(IForm.PROP_HEADER_VISIBLE, model) {
       @Override
       protected Boolean modelValue() {
@@ -152,8 +189,6 @@ public class JsonForm<FORM extends IForm> extends AbstractJsonWidget<FORM> {
   @Override
   protected void attachChildAdapters() {
     super.attachChildAdapters();
-    attachAdapter(getModel().getRootGroupBox());
-
     attachGlobalAdapters(m_desktop.getViews(getModel()));
     attachGlobalAdapters(m_desktop.getDialogs(getModel(), false));
     attachGlobalAdapters(m_desktop.getMessageBoxes(getModel()));
@@ -183,15 +218,7 @@ public class JsonForm<FORM extends IForm> extends AbstractJsonWidget<FORM> {
   @Override
   public JSONObject toJson() {
     JSONObject json = super.toJson();
-    IForm model = getModel();
-    putProperty(json, PROP_MODAL, model.isModal());
-    putProperty(json, PROP_DISPLAY_HINT, displayHintToJson(model.getDisplayHint()));
-    putProperty(json, PROP_DISPLAY_VIEW_ID, model.getDisplayViewId());
-    putProperty(json, PROP_CACHE_BOUNDS, model.isCacheBounds());
-    if (model.isCacheBounds()) {
-      putProperty(json, PROP_CACHE_BOUNDS_KEY, model.computeCacheBoundsKey());
-    }
-    putAdapterIdProperty(json, PROP_ROOT_GROUP_BOX, model.getRootGroupBox());
+    putProperty(json, PROP_DISPLAY_HINT, displayHintToJson(getModel().getDisplayHint()));
     setInitialFocusProperty(json);
     putAdapterIdsProperty(json, "views", m_desktop.getViews(getModel()));
     putAdapterIdsProperty(json, "dialogs", m_desktop.getDialogs(getModel(), false));

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/js/JsonJsForm.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/js/JsonJsForm.java
@@ -40,6 +40,8 @@ public class JsonJsForm<IN extends IDataObject, OUT extends IDataObject, T exten
 
   @Override
   protected void initJsonProperties(T model) {
+    // Don't call super() because only a small subset of the properties needs to be sent to the UI
+
     putJsonProperty(new JsonProperty<IJsForm<IN, OUT>>(IJsForm.PROP_INPUT_DATA, model) {
       @Override
       protected IN modelValue() {


### PR DESCRIPTION
It is not necessary, and it may even create errors. For example: the menus of a page will be wrapped and passed to the detail form.
If a property change happens on such a menu and the menu is sent to the UI, the property change is sent as well.
Since the JsFormAdapter ignores the root group box and its menus, handling the property change events for the menus will fail because the menus don't exist in the browser.

355950