### PR TITLE
Notification: don't fail if system does not support native notifications

### DIFF
--- a/eclipse-scout-core/src/desktop/notification/DesktopNotification.ts
+++ b/eclipse-scout-core/src/desktop/notification/DesktopNotification.ts
@@ -173,7 +173,7 @@ export class DesktopNotification extends ScoutNotification implements DesktopNot
       return;
     }
 
-    if (window.Notification && Notification.permission === 'denied') {
+    if (!window.Notification || Notification.permission === 'denied') {
       this._hideLaterIfNativeOnly();
       return;
     }


### PR DESCRIPTION
iOS Safari started supporting notifications with version 16.4. Earlier versions fail with the following error:

Can't find variable: Notification
    at requestPermission (../src/desktop/notification/DesktopNotification.ts:184:19)

355298