### PR TITLE
Scout JS: improve permission bootstrap

### DIFF
--- a/eclipse-scout-core/src/testing/security/accessSpecHelper.ts
+++ b/eclipse-scout-core/src/testing/security/accessSpecHelper.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {access, AccessControl, arrays, Event, ObjectFactory, ObjectOrModel, Permission, PermissionCollection, PermissionCollectionModel, PermissionCollectionType} from '../../index';
+import {access, AccessControl, arrays, ObjectFactory, ObjectOrModel, Permission, PermissionCollection, PermissionCollectionModel, PermissionCollectionType} from '../../index';
 import $ from 'jquery';
 
 export const accessSpecHelper = {
@@ -59,7 +59,7 @@ class StaticAccessControl extends AccessControl {
     // nop
   }
 
-  override whenSync(): JQuery.Promise<Event<AccessControl>> {
+  override whenSync(): JQuery.Promise<void> {
     return $.resolvedPromise();
   }
 }

--- a/eclipse-scout-core/test/security/AccessControlSpec.ts
+++ b/eclipse-scout-core/test/security/AccessControlSpec.ts
@@ -166,7 +166,11 @@ describe('AccessControl', () => {
           type: 'ALL'
         })
       });
-      await accessControl.whenSync();
+      accessControl.whenSyncError().then(fail);
+      await Promise.all([
+        accessControl.whenSyncSuccess(),
+        accessControl.whenSync()
+      ]);
 
       expect(accessControl._permissionCollection).not.toBeNull();
     });
@@ -179,6 +183,7 @@ describe('AccessControl', () => {
         status: 500
       });
       accessControl.whenSync().then(fail);
+      accessControl.whenSyncSuccess().then(fail);
       jasmine.clock().tick(1);
 
       expect(accessControl._permissionCollection).not.toBeNull();


### PR DESCRIPTION
Reject the promise returned by AccessControl.whenSync() if the sync results in an error. This will result in a startup error which is shown to the user. Otherwise, the application will never exit its loading state.

356293