### PR TITLE
_readDisplayText should consider current displayText property by default

### DIFF
--- a/eclipse-scout-core/src/form/fields/LookupBox.js
+++ b/eclipse-scout-core/src/form/fields/LookupBox.js
@@ -228,10 +228,6 @@ export default class LookupBox extends ValueField {
     return strings.join(', ', formatted);
   }
 
-  _readDisplayText() {
-    return this.displayText;
-  }
-
   _clear() {
     this.setValue(null);
   }

--- a/eclipse-scout-core/src/form/fields/ValueField.js
+++ b/eclipse-scout-core/src/form/fields/ValueField.js
@@ -94,7 +94,7 @@ export default class ValueField extends FormField {
    * The default impl. returns an empty string, because not every ValueField has a sensible display text.
    */
   _readDisplayText() {
-    return '';
+    return scout.nvl(this.displayText, '');
   }
 
   _onClearIconMouseDown(event) {

--- a/eclipse-scout-core/src/form/fields/beanfield/BeanField.js
+++ b/eclipse-scout-core/src/form/fields/beanfield/BeanField.js
@@ -68,11 +68,6 @@ export default class BeanField extends ValueField {
     return this.value;
   }
 
-  _readDisplayText() {
-    // DisplayText cannot be changed, therefore it must be equal to the current value (see comment in _formatValue)
-    return this.displayText;
-  }
-
   /**
    * @override
    */

--- a/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.js
+++ b/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.js
@@ -120,17 +120,6 @@ export default class ClipboardField extends ValueField {
     }
   }
 
-  // Because a <div> is used as field, jQuery's val() used in ValueField.js is not working here, so
-  // the content of displayText variable is used instead.
-  // (For reading the displayText innerHmtl() _could_ be used on the div-field, but some browsers
-  // would collapse whitespaces which would also collapse multiple tabs when coping some table rows.
-  // So instead of reading the effective displayText from the field, the internal displayText value
-  // will be reused without actual reading. Parsing of pasted content is handled onPaste() and stored
-  // in this.displayText.)
-  _readDisplayText() {
-    return this.displayText;
-  }
-
   _getSelection() {
     let selection, myWindow = this.$container.window(true);
     if (myWindow.getSelection) {

--- a/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.js
+++ b/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.js
@@ -45,10 +45,6 @@ export default class HtmlField extends ValueField {
     this._renderSelectable();
   }
 
-  _readDisplayText() {
-    return this.displayText;
-  }
-
   /**
    * @override
    */


### PR DESCRIPTION
Backport from 23.2 (70755fc7f2bb6fdb412eefcb53b45db8778efe9b)