### PR TITLE
Fix active value field detection for value fields containing a widget

### DIFF
--- a/eclipse-scout-core/src/form/fields/ValueField.js
+++ b/eclipse-scout-core/src/form/fields/ValueField.js
@@ -640,9 +640,10 @@ export default class ValueField extends FormField {
   static _getActiveValueField(target) {
     let $activeElement = $(target).activeElement(),
       activeWidget = scout.widget($activeElement);
-    if (activeWidget instanceof ValueField && activeWidget.enabledComputed) {
-      return activeWidget;
+    if (activeWidget instanceof ValueField) {
+      return activeWidget.enabledComputed ? activeWidget : null;
     }
-    return null;
+    const parent = activeWidget && activeWidget.findParent(parent => parent instanceof ValueField);
+    return (parent && parent.enabledComputed) ? parent : null;
   }
 }


### PR DESCRIPTION
The method _getActiveValueField can not detect the active value field for value fields that include a widget (e.g. a value field containing a code editor widget), because the contained widget is not a value field itself.

As a solution for this kind of fields look for the parents as well.