### PR TITLE
_readDisplayText should consider current displayText property by default

### DIFF
--- a/eclipse-scout-core/src/form/fields/LookupBox.ts
+++ b/eclipse-scout-core/src/form/fields/LookupBox.ts
@@ -233,10 +233,6 @@ export abstract class LookupBox<TValue> extends ValueField<TValue[], TValue | TV
     return strings.join(', ', ...formatted);
   }
 
-  protected override _readDisplayText(): string {
-    return this.displayText;
-  }
-
   protected override _clear() {
     this.setValue(null);
   }

--- a/eclipse-scout-core/src/form/fields/ValueField.ts
+++ b/eclipse-scout-core/src/form/fields/ValueField.ts
@@ -115,7 +115,7 @@ export class ValueField<TValue extends TModelValue, TModelValue = TValue> extend
    * The default impl. returns an empty string, because not every ValueField has a sensible display text.
    */
   protected _readDisplayText(): string {
-    return '';
+    return scout.nvl(this.displayText, '');
   }
 
   protected _onClearIconMouseDown(event: JQuery.MouseDownEvent) {

--- a/eclipse-scout-core/src/form/fields/beanfield/BeanField.ts
+++ b/eclipse-scout-core/src/form/fields/beanfield/BeanField.ts
@@ -64,11 +64,6 @@ export class BeanField<TValue extends object> extends ValueField<TValue> impleme
     return this.value;
   }
 
-  protected override _readDisplayText(): string {
-    // DisplayText cannot be changed, therefore it must be equal to the current value (see comment in _formatValue)
-    return this.displayText;
-  }
-
   protected override _renderDisplayText() {
     // nop
   }

--- a/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.ts
+++ b/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.ts
@@ -123,17 +123,6 @@ export class ClipboardField extends ValueField<string> implements ClipboardField
     }
   }
 
-  // Because a <div> is used as field, jQuery's val() used in ValueField.js is not working here, so
-  // the content of displayText variable is used instead.
-  // (For reading the displayText innerHtml() _could_ be used on the div-field, but some browsers
-  // would collapse whitespaces which would also collapse multiple tabs when coping some table rows.
-  // So instead of reading the effective displayText from the field, the internal displayText value
-  // will be reused without actual reading. Parsing of pasted content is handled onPaste() and stored
-  // in this.displayText.)
-  protected override _readDisplayText(): string {
-    return this.displayText;
-  }
-
   protected _getSelection(): Selection {
     let selection: Selection,
       myWindow = this.$container.window(true);

--- a/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.ts
+++ b/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.ts
@@ -47,10 +47,6 @@ export class HtmlField extends ValueField<string> implements HtmlFieldModel {
     this._renderSelectable();
   }
 
-  protected override _readDisplayText(): string {
-    return this.displayText;
-  }
-
   protected override _renderDisplayText() {
     if (!this.displayText) {
       this.$field.empty();


### PR DESCRIPTION
Backport from 23.2 (70755fc7f2bb6fdb412eefcb53b45db8778efe9b)