### PR TITLE
Scout JS: improve permissions

### DIFF
--- a/eclipse-scout-core/src/security/AccessControl.ts
+++ b/eclipse-scout-core/src/security/AccessControl.ts
@@ -9,7 +9,8 @@
  */
 
 import {
-  ajax, AjaxError, ErrorHandler, Event, InitModelOf, ObjectModel, Permission, PermissionCollection, PermissionCollectionModel, PermissionCollectionType, PropertyChangeEvent, PropertyEventEmitter, PropertyEventMap, scout, SomeRequired
+  ajax, AjaxError, ErrorHandler, Event, InitModelOf, ObjectModel, Permission, PermissionCollection, PermissionCollectionModel, PermissionCollectionType, PermissionLevel, PropertyChangeEvent, PropertyEventEmitter, PropertyEventMap, scout,
+  SomeRequired
 } from '../index';
 
 export class AccessControl extends PropertyEventEmitter implements AccessControlModel {
@@ -90,7 +91,7 @@ export class AccessControl extends PropertyEventEmitter implements AccessControl
   }
 
   protected _loadPermissionCollection(): JQuery.Promise<PermissionCollectionModel, AjaxError> {
-    return ajax.getJson(this.permissionsUrl, {}, {retryIntervals: this._retryIntervals});
+    return ajax.getJson(this.permissionsUrl, {cache: true}, {retryIntervals: this._retryIntervals});
   }
 
   protected _onSync() {
@@ -116,6 +117,20 @@ export class AccessControl extends PropertyEventEmitter implements AccessControl
       return quick ? false : $.resolvedPromise(false);
     }
     return this._permissionCollection.implies(permission, quick);
+  }
+
+  /**
+   * Returns the granted {@link PermissionLevel} for a given permission instance `permission`.
+   * - {@link Permission.Level.UNDEFINED} if `permission` is `null` or in general 'not an {@link Permission}'
+   * - {@link Permission.Level.NONE} if no level at all is granted to `permission`
+   * - {@link PermissionLevel} if the level can be determined exactly.
+   * - {@link Permission.Level.UNDEFINED} if there are multiple granted permission levels possible and there is not enough data in the `permission` contained to determine the result closer.
+   */
+  getGrantedPermissionLevel(permission: Permission): PermissionLevel {
+    if (!this._permissionCollection) {
+      return Permission.Level.UNDEFINED;
+    }
+    return this._permissionCollection.getGrantedPermissionLevel(permission);
   }
 }
 

--- a/eclipse-scout-core/src/security/access.ts
+++ b/eclipse-scout-core/src/security/access.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AccessControl, Permission, scout} from '../index';
+import {AccessControl, Permission, PermissionLevel, scout} from '../index';
 import $ from 'jquery';
 
 let accessControl: AccessControl = null;
@@ -44,6 +44,23 @@ export const access = {
    */
   check(permission: string | Permission): JQuery.Promise<boolean> {
     return check(permission);
+  },
+
+  /**
+   * Returns the granted {@link PermissionLevel} for a given permission instance `permission`.
+   * - {@link Permission.Level.UNDEFINED} if `permission` is `null` or in general 'not an {@link Permission}'
+   * - {@link Permission.Level.NONE} if no level at all is granted to `permission`
+   * - {@link PermissionLevel} if the level can be determined exactly.
+   * - {@link Permission.Level.UNDEFINED} if there are multiple granted permission levels possible and there is not enough data in the `permission` contained to determine the result closer.
+   */
+  getGrantedPermissionLevel(permission: string | Permission): PermissionLevel {
+    if (!accessControl) {
+      return Permission.Level.UNDEFINED;
+    }
+    if (!(permission instanceof Permission)) {
+      permission = Permission.quick(permission);
+    }
+    return accessControl.getGrantedPermissionLevel(permission);
   },
 
   getPermissionsUrl(): string {

--- a/eclipse-scout-core/test/security/PermissionCollectionSpec.ts
+++ b/eclipse-scout-core/test/security/PermissionCollectionSpec.ts
@@ -123,6 +123,45 @@ describe('PermissionCollection', () => {
     });
   });
 
+  describe('getGrantedPermissionLevel', () => {
+
+    it('is Permission.Level.ALL if type is ALL', () => {
+      const collection = scout.create(PermissionCollection, {type: PermissionCollectionType.ALL});
+
+      expect(collection.getGrantedPermissionLevel(null)).toBe(Permission.Level.UNDEFINED);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('some'))).toBe(Permission.Level.ALL);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('other'))).toBe(Permission.Level.ALL);
+    });
+
+    it('is Permission.Level.NONE if type is NONE', () => {
+      const collection = scout.create(PermissionCollection, {type: PermissionCollectionType.NONE});
+
+      expect(collection.getGrantedPermissionLevel(null)).toBe(Permission.Level.UNDEFINED);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('some'))).toBe(Permission.Level.NONE);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('other'))).toBe(Permission.Level.NONE);
+    });
+
+    it('gets the correct permission level if type is DEFAULT', () => {
+      const collection = scout.create(PermissionCollection, {
+        permissions: {
+          undef: [scout.create(Permission, {name: 'undef', level: Permission.Level.UNDEFINED})],
+          none: [scout.create(Permission, {name: 'none', level: Permission.Level.NONE})],
+          all: [scout.create(Permission, {name: 'all', level: Permission.Level.ALL})],
+          multiple: [scout.create(Permission, {name: 'multiple', level: Permission.Level.NONE}), scout.create(Permission, {name: 'multiple', level: Permission.Level.ALL})],
+          multipleSame: [scout.create(Permission, {name: 'multipleSame', level: Permission.Level.ALL}), scout.create(Permission, {name: 'multipleSame', level: Permission.Level.ALL})]
+        }
+      });
+
+      expect(collection.getGrantedPermissionLevel(null)).toBe(Permission.Level.UNDEFINED);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('undef'))).toBe(Permission.Level.UNDEFINED);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('none'))).toBe(Permission.Level.NONE);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('all'))).toBe(Permission.Level.ALL);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('multiple'))).toBe(Permission.Level.UNDEFINED);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('multipleSame'))).toBe(Permission.Level.ALL);
+      expect(collection.getGrantedPermissionLevel(Permission.quick('other'))).toBe(Permission.Level.NONE);
+    });
+  });
+
   describe('permissions', () => {
 
     it('is always of type PermissionMap', () => {

--- a/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/security/PermissionDo.java
+++ b/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/security/PermissionDo.java
@@ -15,7 +15,9 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.security.IPermission;
+import org.eclipse.scout.rt.security.PermissionLevel;
 
 /**
  * This data object represents a Scout JS object model and supports subclassing.<br>
@@ -37,6 +39,10 @@ public class PermissionDo extends DoEntity {
     return doValue("name");
   }
 
+  public DoValue<Integer> level() {
+    return doValue("level");
+  }
+
   /* **************************************************************************
    * CUSTOM CONVENIENCE TO DO FUNCTION
    * *************************************************************************/
@@ -46,7 +52,8 @@ public class PermissionDo extends DoEntity {
     public void apply(IPermission permission, PermissionDo permissionDo) {
       permissionDo
           .withObjectType(PERMISSION_OBJECT_TYPE)
-          .withName(permission.getName());
+          .withName(permission.getName())
+          .withLevel(ObjectUtility.nvl(permission.getLevel(), PermissionLevel.UNDEFINED).getValue());
     }
   }
 
@@ -80,5 +87,16 @@ public class PermissionDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public String getName() {
     return name().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public PermissionDo withLevel(Integer level) {
+    level().set(level);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Integer getLevel() {
+    return level().get();
   }
 }

--- a/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/security/PermissionResource.java
+++ b/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/security/PermissionResource.java
@@ -11,22 +11,44 @@ package org.eclipse.scout.rt.api.security;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 
 import org.eclipse.scout.rt.api.data.security.IToPermissionCollectionDoFunction;
-import org.eclipse.scout.rt.api.data.security.PermissionCollectionDo;
 import org.eclipse.scout.rt.dataobject.mapping.ToDoFunctionHelper;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.rest.IRestResource;
 import org.eclipse.scout.rt.security.IAccessControlService;
+import org.eclipse.scout.rt.security.IPermissionCollection;
 
 @Path("permissions")
 public class PermissionResource implements IRestResource {
 
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  public PermissionCollectionDo getAllPermissions() {
-    return BEANS.get(ToDoFunctionHelper.class).toDo(BEANS.get(IAccessControlService.class).getPermissions(), IToPermissionCollectionDoFunction.class);
+  public Response getAllPermissions(@Context Request request) {
+    IPermissionCollection permissionCollection = BEANS.get(IAccessControlService.class).getPermissions();
+
+    EntityTag etag = EntityTag.valueOf("W/\"" + permissionCollection.hashCode() + "\"");
+    ResponseBuilder responseBuilder = request.evaluatePreconditions(etag);
+    if (responseBuilder != null) {
+      // 304 Not Modified (client's cached version is still up-to-date)
+      return responseBuilder.build();
+    }
+
+    CacheControl cc = new CacheControl();
+    cc.setPrivate(true);
+    cc.setMustRevalidate(true);
+
+    return Response.ok()
+        .entity(BEANS.get(ToDoFunctionHelper.class).toDo(permissionCollection, IToPermissionCollectionDoFunction.class))
+        .type(MediaType.APPLICATION_JSON)
+        .tag(etag)
+        .cacheControl(cc)
+        .build();
   }
 }

--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/PermissionLevel.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/PermissionLevel.java
@@ -155,7 +155,7 @@ public final class PermissionLevel implements Serializable {
   private Object readResolve() throws ObjectStreamException {
     PermissionLevel existing = opt(m_value);
     if (existing == null) {
-      return register(m_value, "UNKNOWN[" + m_value + "]", false, () -> "Unknown PermssionLevel");
+      return register(m_value, "UNKNOWN[" + m_value + "]", false, () -> "Unknown PermissionLevel");
     }
     else {
       return existing;


### PR DESCRIPTION
Introduce caching for the current permissionCollection of the user. Add level to Scout JS permission and access.getGrantedPermissionLevel().

326169