### PR TITLE
Decrease memory footprint of AbstractContributionComposite

### DIFF
--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/extension/AbstractContributionComposite.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/extension/AbstractContributionComposite.java
@@ -9,23 +9,22 @@
  */
 package org.eclipse.scout.rt.shared.extension;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
 public abstract class AbstractContributionComposite implements IContributionOwner, Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private Map<Class<?> /* type of the contribution */, ArrayList<?>/* contribution instances */> m_contributionsByType;
   private Map<Class<?> /* concrete contribution class */, Object /* contribution instance */> m_contributionsByClass;
 
   protected AbstractContributionComposite() {
@@ -57,11 +56,10 @@ public abstract class AbstractContributionComposite implements IContributionOwne
       owner = o;
     }
     List<?> contributionsForMe = extensionRegistry.createContributionsFor(owner, type);
-    if (type == null) {
-      m_contributionsByType = new HashMap<>();
-      m_contributionsByClass = new HashMap<>(contributionsForMe.size());
-    }
     if (CollectionUtility.hasElements(contributionsForMe)) {
+      if (m_contributionsByClass == null) {
+        m_contributionsByClass = new HashMap<>(contributionsForMe.size(), 1.0f); // use fixed size and loadFactor
+      }
       for (Object contribution : contributionsForMe) {
         m_contributionsByClass.put(contribution.getClass(), contribution);
       }
@@ -69,51 +67,41 @@ public abstract class AbstractContributionComposite implements IContributionOwne
   }
 
   public <T> void resetContributionsByClass(Object o, Class<T> type) {
-    m_contributionsByType.remove(type);
-    m_contributionsByClass.values().removeIf(obj -> type.isAssignableFrom(obj.getClass()));
+    Assertions.assertNotNull(type, "Contribution type class must be specified");
+    if (m_contributionsByClass != null) {
+      m_contributionsByClass.values().removeIf(obj -> type.isAssignableFrom(obj.getClass()));
+    }
     IInternalExtensionRegistry extensionRegistry = BEANS.get(IInternalExtensionRegistry.class);
     initContributionsMap(o, extensionRegistry, type);
   }
 
-  private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException {
-    s.defaultReadObject();
-    if (m_contributionsByClass == null || m_contributionsByType == null) {
-      // ensure that the contributions have been initialized
-      IInternalExtensionRegistry extensionRegistry = BEANS.get(IInternalExtensionRegistry.class);
-      initContributionsMap(null, extensionRegistry, null);
+  protected Collection<Object> getAllContributionsInternal() {
+    if (m_contributionsByClass == null) {
+      return null;
     }
-  }
-
-  protected Collection<Object> geAllContributionsInternal() {
     return m_contributionsByClass.values();
   }
 
   @Override
   public List<Object> getAllContributions() {
-    return CollectionUtility.arrayList(geAllContributionsInternal());
+    return CollectionUtility.arrayList(getAllContributionsInternal());
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public <T> List<T> getContributionsByClass(Class<T> type) {
     if (type == null) {
       throw new IllegalArgumentException("Contribution type class must be specified.");
     }
 
-    ArrayList<T> contributionsOfType = (ArrayList<T>) m_contributionsByType.get(type);
-    if (contributionsOfType == null) {
-      Collection<Object> values = m_contributionsByClass.values();
-      contributionsOfType = new ArrayList<>(values.size());
-      for (Object o : values) {
-        if (type.isAssignableFrom(o.getClass())) {
-          T contribution = type.cast(o);
-          contributionsOfType.add(contribution);
-        }
-      }
-      contributionsOfType.trimToSize();
-      m_contributionsByType.put(type, contributionsOfType);
+    if (m_contributionsByClass == null) {
+      return new ArrayList<>(0);
     }
-    return CollectionUtility.arrayList(contributionsOfType);
+
+    return m_contributionsByClass.values()
+        .stream()
+        .filter(type::isInstance)
+        .map(type::cast)
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -129,6 +117,9 @@ public abstract class AbstractContributionComposite implements IContributionOwne
   public <T> T optContribution(final Class<T> contribution) {
     if (contribution == null) {
       throw new IllegalArgumentException("Contribution class must be specified.");
+    }
+    if (m_contributionsByClass == null) {
+      return null;
     }
 
     // check in my contributions


### PR DESCRIPTION
Remove m_contributionsByType which is only used by init methods. Therefore, caching those entries is not needed.