### PR TITLE
Add basic OpenTelemetry integration for signal metrics

### DIFF
--- a/org.eclipse.scout.rt.opentelemetry.sdk/pom.xml
+++ b/org.eclipse.scout.rt.opentelemetry.sdk/pom.xml
@@ -1,0 +1,71 @@
+<!--
+  ~ Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ https://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     BSI Business Systems Integration AG - initial API and implementation
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.scout.rt</groupId>
+    <artifactId>org.eclipse.scout.rt</artifactId>
+    <version>22.0-SNAPSHOT</version>
+    <relativePath>../org.eclipse.scout.rt</relativePath>
+  </parent>
+
+  <artifactId>org.eclipse.scout.rt.opentelemetry.sdk</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.scout.rt</groupId>
+      <artifactId>org.eclipse.scout.rt.platform</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+      <version>${opentelemetry.version}-alpha</version>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.eclipse.scout.rt</groupId>
+      <artifactId>org.eclipse.scout.rt.platform.test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/org.eclipse.scout.rt.opentelemetry.sdk/src/main/java/org/eclipse/scout/rt/opentelemetry/sdk/OpenTelemetryInitializer.java
+++ b/org.eclipse.scout.rt.opentelemetry.sdk/src/main/java/org/eclipse/scout/rt/opentelemetry/sdk/OpenTelemetryInitializer.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.opentelemetry.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IPlatform;
+import org.eclipse.scout.rt.platform.IPlatform.State;
+import org.eclipse.scout.rt.platform.IPlatformListener;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.platform.Platform;
+import org.eclipse.scout.rt.platform.PlatformEvent;
+import org.eclipse.scout.rt.platform.config.AbstractBooleanConfigProperty;
+import org.eclipse.scout.rt.platform.config.AbstractStringConfigProperty;
+import org.eclipse.scout.rt.platform.config.CONFIG;
+import org.eclipse.scout.rt.platform.config.PlatformConfigProperties.ApplicationNameProperty;
+import org.eclipse.scout.rt.platform.context.NodeIdentifier;
+import org.eclipse.scout.rt.platform.opentelemetry.IHistogramViewHintProvider;
+import org.eclipse.scout.rt.platform.opentelemetry.IMetricProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.View;
+
+/**
+ * Initialize {@link GlobalOpenTelemetry} instance, "auto" configured by using environment properties, system properties
+ * and/or Scout config properties.
+ *
+ * @see AutoConfiguredOpenTelemetrySdk
+ * @see <a href=
+ *      "https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md">OpenTelemetry
+ *      SDK Autoconfigure</a>
+ */
+@Order(4_001)
+public class OpenTelemetryInitializer implements IPlatformListener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OpenTelemetryInitializer.class);
+
+  protected OpenTelemetrySdk m_openTelemetry;
+
+  @Override
+  public void stateChanged(PlatformEvent event) {
+    if (event.getState() == State.BeanManagerPrepared) {
+      initOpenTelemetry();
+    }
+  }
+
+  /**
+   * Registers an {@link IPlatformListener} that shutdown OpenTelemetry on an {@link IPlatform.State#PlatformStopping}
+   * event. It does nothing if this method is invoked when no platform is active (i.e. {@link Platform#peek()} returns
+   * {@code null}).
+   * <p>
+   * <b>Note:</b> We use a separate listener instead to provide OpenTelemetry functionality as long as possible during
+   * shutdown.
+   */
+  protected void registerShutdownListener() {
+    final IPlatform platform = Platform.peek();
+    if (platform == null) {
+      return;
+    }
+    platform.getBeanManager().registerBean(new BeanMetaData(IPlatformListener.class)
+        .withApplicationScoped(true)
+        .withOrder(5_999)
+        .withInitialInstance((IPlatformListener) event -> {
+          if (event.getState() == IPlatform.State.PlatformStopping) {
+            shutdownOpenTelemetry();
+          }
+        }));
+  }
+
+  protected void initOpenTelemetry() {
+    if (!CONFIG.getPropertyValue(OpenTelemetryInitializerEnabledProperty.class)) {
+      LOG.info("Skip Scout OpenTelemetry initialization.");
+      return;
+    }
+    LOG.info("Initialize OpenTelemetry");
+
+    // configuration provided by environment variables and/or system properties
+    m_openTelemetry = AutoConfiguredOpenTelemetrySdk.builder()
+        .addPropertiesSupplier(this::getDefaultProperties)
+        .addMeterProviderCustomizer(this::customizeMeterProvider)
+        .disableShutdownHook()
+        .setResultAsGlobal()
+        .build()
+        .getOpenTelemetrySdk();
+
+    registerShutdownListener();
+
+    initMetrics();
+  }
+
+  protected Map<String, String> getDefaultProperties() {
+    String defaultExporter = CONFIG.getPropertyValue(OpenTelemetryDefaultExporterProperty.class);
+    Map<String, String> defaultConfig = new HashMap<>();
+    defaultConfig.put("otel.traces.exporter", "none");
+    defaultConfig.put("otel.logs.exporter", "none");
+    defaultConfig.put("otel.metrics.exporter", defaultExporter);
+    defaultConfig.put("otel.exporter.otlp.protocol", "http/protobuf");
+    defaultConfig.put("otel.metric.export.interval", "30000"); // 30s
+
+    defaultConfig.put("otel.service.name", CONFIG.getPropertyValue(ApplicationNameProperty.class));
+    defaultConfig.put("otel.resource.attributes", "service.instance.id=" + BEANS.get(NodeIdentifier.class).get());
+    return defaultConfig;
+  }
+
+  protected SdkMeterProviderBuilder customizeMeterProvider(SdkMeterProviderBuilder builder, ConfigProperties config) {
+    for (IHistogramViewHintProvider viewHintProvider : BEANS.all(IHistogramViewHintProvider.class)) {
+      LOG.info("Initialize view from {}", viewHintProvider.getClass().getName());
+      builder.registerView(
+          InstrumentSelector.builder()
+              .setName(viewHintProvider.getInstrumentName())
+              .setType(InstrumentType.HISTOGRAM)
+              .build(),
+          View.builder()
+              .setAggregation(Aggregation.explicitBucketHistogram(viewHintProvider.getExplicitBuckets()))
+              .build());
+    }
+    return builder;
+  }
+
+  protected void initMetrics() {
+    for (IMetricProvider metricProvider : BEANS.all(IMetricProvider.class)) {
+      LOG.info("Initialize metrics from {}", metricProvider.getClass().getName());
+      metricProvider.register(GlobalOpenTelemetry.get());
+    }
+  }
+
+  protected void shutdownOpenTelemetry() {
+    LOG.info("Shutting down OpenTelemetry");
+    if (m_openTelemetry == null) {
+      return;
+    }
+
+    BEANS.all(IMetricProvider.class).forEach(IMetricProvider::close);
+    m_openTelemetry.close();
+    m_openTelemetry = null;
+  }
+
+  public static class OpenTelemetryInitializerEnabledProperty extends AbstractBooleanConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.otel.initializerEnabled";
+    }
+
+    @Override
+    public String description() {
+      return "Property to specify if the application is using the Scout OpenTelemetry initializer. Default is false. Set to false if you are using the OpenTelemetry Java Agent.";
+    }
+
+    @Override
+    public Boolean getDefaultValue() {
+      return Boolean.FALSE;
+    }
+  }
+
+  public static class OpenTelemetryDefaultExporterProperty extends AbstractStringConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.otel.defaultExporter";
+    }
+
+    @Override
+    public String description() {
+      return "List of exporters to be used for traces, metrics and logs, separated by commas. Default is 'otlp' or 'none' in dev mode. Use this property to override the default.";
+    }
+
+    @Override
+    public String getDefaultValue() {
+      if (Platform.get().inDevelopmentMode()) {
+        return "none"; // use no autoconfigured exporter
+      }
+      return "otlp";
+    }
+  }
+}

--- a/org.eclipse.scout.rt.opentelemetry.sdk/src/main/java/org/eclipse/scout/rt/opentelemetry/sdk/metrics/JvmMetricProvider.java
+++ b/org.eclipse.scout.rt.opentelemetry.sdk/src/main/java/org/eclipse/scout/rt/opentelemetry/sdk/metrics/JvmMetricProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.opentelemetry.sdk.metrics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.scout.rt.platform.opentelemetry.IMetricProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.BufferPools;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.Classes;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.Cpu;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.MemoryPools;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.Threads;
+
+/**
+ * {@link IMetricProvider} which serves the default Java runtime environment metrics (jvm)
+ *
+ * @see <a href=
+ *      "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-telemetry/runtime-telemetry-java8/library">JVM
+ *      Metrics</a>
+ */
+public class JvmMetricProvider implements IMetricProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JvmMetricProvider.class);
+
+  private List<AutoCloseable> m_observables = new ArrayList<>();
+
+  @Override
+  public void register(OpenTelemetry openTelemetry) {
+    // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-telemetry/runtime-telemetry-java8/library#usage
+    m_observables.addAll(BufferPools.registerObservers(openTelemetry));
+    m_observables.addAll(Classes.registerObservers(openTelemetry));
+    m_observables.addAll(Cpu.registerObservers(openTelemetry));
+    m_observables.addAll(MemoryPools.registerObservers(openTelemetry));
+    m_observables.addAll(Threads.registerObservers(openTelemetry));
+    m_observables.addAll(GarbageCollector.registerObservers(openTelemetry));
+  }
+
+  @Override
+  public void close() {
+    for (AutoCloseable observable : m_observables) {
+      try {
+        observable.close();
+      }
+      catch (Exception e) {
+        LOG.warn("Failed to close metric observable", e);
+      }
+    }
+  }
+}

--- a/org.eclipse.scout.rt.opentelemetry.sdk/src/main/resources/META-INF/scout.xml
+++ b/org.eclipse.scout.rt.opentelemetry.sdk/src/main/resources/META-INF/scout.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ https://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     BSI Business Systems Integration AG - initial API and implementation
+  -->
+<scout>
+</scout>

--- a/org.eclipse.scout.rt.opentelemetry.sdk/src/test/java/org/eclipse/scout/rt/opentelemetry/sdk/OpenTelemetryInitializerTest.java
+++ b/org.eclipse.scout.rt.opentelemetry.sdk/src/test/java/org/eclipse/scout/rt/opentelemetry/sdk/OpenTelemetryInitializerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.opentelemetry.sdk;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.scout.rt.opentelemetry.sdk.OpenTelemetryInitializer.OpenTelemetryInitializerEnabledProperty;
+import org.eclipse.scout.rt.opentelemetry.sdk.OpenTelemetryInitializerTest.OpenTelemetryInitializerPlatform;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.platform.opentelemetry.IHistogramViewHintProvider;
+import org.eclipse.scout.rt.platform.opentelemetry.IMetricProvider;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.eclipse.scout.rt.testing.platform.TestingDefaultPlatform;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithNewPlatform;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.events.GlobalEventEmitterProvider;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
+@RunWith(PlatformTestRunner.class)
+@RunWithNewPlatform(platform = OpenTelemetryInitializerPlatform.class)
+public class OpenTelemetryInitializerTest {
+
+  private final List<IBean<?>> m_beans = new ArrayList<>();
+
+  private IMetricProvider m_metricProvider;
+  private IHistogramViewHintProvider m_histogramViewHintProvider;
+
+  @Before
+  public void before() {
+    GlobalOpenTelemetry.resetForTest();
+    GlobalEventEmitterProvider.resetForTest();
+    // OpenTelemetryInitializer is excluded in testing platform and initialized manually by test methods
+    OpenTelemetryInitializer initializer = BEANS.opt(OpenTelemetryInitializer.class);
+    assertNull(initializer);
+
+    m_metricProvider = Mockito.mock(IMetricProvider.class);
+    m_histogramViewHintProvider = Mockito.mock(IHistogramViewHintProvider.class);
+    Mockito.when(m_histogramViewHintProvider.getInstrumentName()).thenReturn("test");
+    m_beans.addAll(BeanTestingHelper.get().registerBeans(
+        new BeanMetaData(IMetricProvider.class)
+            .withApplicationScoped(true)
+            .withInitialInstance(m_metricProvider),
+        new BeanMetaData(IHistogramViewHintProvider.class)
+            .withApplicationScoped(true)
+            .withInitialInstance(m_histogramViewHintProvider),
+        new BeanMetaData(OpenTelemetryInitializer.class)));
+    initializer = BEANS.opt(OpenTelemetryInitializer.class);
+    assertNotNull(initializer);
+  }
+
+  @After
+  public void after() {
+    BeanTestingHelper.get().unregisterBeans(m_beans);
+    m_beans.clear();
+  }
+
+  @Test
+  public void testInitializerEnabled() {
+    m_beans.add(BeanTestingHelper.get().mockConfigProperty(OpenTelemetryInitializerEnabledProperty.class, Boolean.TRUE));
+
+    OpenTelemetryInitializer initializer = BEANS.opt(OpenTelemetryInitializer.class);
+    initializer.initOpenTelemetry();
+    assertMetricProviderInvocations(1, 0);
+    assertHistogramViewHintProviderInvocations(1);
+
+    OpenTelemetrySdk scoutOpenTelemetry = initializer.m_openTelemetry;
+    assertNotNull(scoutOpenTelemetry);
+    OpenTelemetry globalOpenTelemetry = GlobalOpenTelemetry.get();
+    assertNotNull(globalOpenTelemetry);
+    assertSame(scoutOpenTelemetry.getPropagators(), globalOpenTelemetry.getPropagators());
+    assertSame(scoutOpenTelemetry.getLogsBridge(), globalOpenTelemetry.getLogsBridge());
+    assertSame(scoutOpenTelemetry.getMeterProvider(), globalOpenTelemetry.getMeterProvider());
+    assertSame(scoutOpenTelemetry.getTracerProvider(), globalOpenTelemetry.getTracerProvider());
+
+    initializer.shutdownOpenTelemetry();
+    assertMetricProviderInvocations(1, 1);
+    assertNull(initializer.m_openTelemetry);
+  }
+
+  @Test
+  public void testInitializerDisabled() {
+    m_beans.add(BeanTestingHelper.get().mockConfigProperty(OpenTelemetryInitializerEnabledProperty.class, Boolean.FALSE));
+
+    OpenTelemetryInitializer initializer = BEANS.opt(OpenTelemetryInitializer.class);
+    initializer.initOpenTelemetry();
+    assertMetricProviderInvocations(0, 0);
+    assertHistogramViewHintProviderInvocations(0);
+
+    OpenTelemetrySdk scoutOpenTelemetry = initializer.m_openTelemetry;
+    assertNull(scoutOpenTelemetry);
+    OpenTelemetry globalOpenTelemetry = GlobalOpenTelemetry.get();
+    assertSame(OpenTelemetry.noop(), globalOpenTelemetry);
+
+    initializer.shutdownOpenTelemetry();
+    assertMetricProviderInvocations(0, 0);
+    assertNull(initializer.m_openTelemetry);
+  }
+
+  private void assertMetricProviderInvocations(int expectedRegisterInvocations, int expectedCloseInvocations) {
+    Mockito.verify(m_metricProvider, Mockito.times(expectedRegisterInvocations)).register(Mockito.any());
+    Mockito.verify(m_metricProvider, Mockito.times(expectedCloseInvocations)).close();
+  }
+
+  private void assertHistogramViewHintProviderInvocations(int expectedInvocations) {
+    Mockito.verify(m_histogramViewHintProvider, Mockito.times(expectedInvocations)).getInstrumentName();
+    Mockito.verify(m_histogramViewHintProvider, Mockito.times(expectedInvocations)).getExplicitBuckets();
+  }
+
+  public static class OpenTelemetryInitializerPlatform extends TestingDefaultPlatform {
+
+    @Override
+    protected boolean acceptBean(Class<?> bean) {
+      if (OpenTelemetryInitializer.class.isAssignableFrom(bean)) {
+        return false;
+      }
+      if (IMetricProvider.class.isAssignableFrom(bean)) {
+        // do register default metrics during tests
+        return false;
+      }
+      return super.acceptBean(bean);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.opentelemetry.sdk/src/test/resources/logback-test.xml
+++ b/org.eclipse.scout.rt.opentelemetry.sdk/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ https://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     BSI Business Systems Integration AG - initial API and implementation
+  -->
+<configuration>
+  <include resource="logback-test-scout.xml" />
+</configuration>

--- a/org.eclipse.scout.rt.opentelemetry.sdk/src/test/resources/scout.xml
+++ b/org.eclipse.scout.rt.opentelemetry.sdk/src/test/resources/scout.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ https://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     BSI Business Systems Integration AG - initial API and implementation
+  -->
+<scout>
+</scout>

--- a/org.eclipse.scout.rt.platform/pom.xml
+++ b/org.eclipse.scout.rt.platform/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+  ~ Copyright (c) 2010-2023 BSI Business Systems Integration AG.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at
-  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~ https://www.eclipse.org/legal/epl-v10.html
   ~
   ~ Contributors:
   ~     BSI Business Systems Integration AG - initial API and implementation
@@ -62,6 +62,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
       <optional>true</optional>
+    </dependency>
+
+    <!-- OpenTelemetry -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/opentelemetry/IHistogramViewHintProvider.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/opentelemetry/IHistogramViewHintProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.platform.opentelemetry;
+
+import java.util.List;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+/**
+ * Bean to define custom explicit bucket distribution of specific histogram metrics.
+ * <p>
+ * Scout's {@link org.eclipse.scout.rt.opentelemetry.sdk.OpenTelemetryInitializer} registers for each hint an
+ * OpenTelemetry view.
+ * </p>
+ * <p>
+ * Such explicit bucket definitions will be obsolete as soon as
+ * <a href="https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram">exponential
+ * histograms</a> become widely adopted.
+ * </p>
+ * <p>
+ * <b>Attention:</b> This feature is not supported when using a OpenTelemetry Java Agent.
+ * </p>
+ *
+ * @see io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
+ * @see io.opentelemetry.sdk.metrics.InstrumentSelector
+ * @see io.opentelemetry.sdk.metrics.View
+ * @see <a href="https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view">OpenTelemetry Metrics: View</a>
+ * @see <a href=
+ *      "https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation">OpenTelemetry
+ *      Metrics: Explicit Bucket Histogram Aggregation</a>
+ */
+@ApplicationScoped
+public interface IHistogramViewHintProvider {
+
+  /**
+   * Select instruments with the given {@code name}.
+   * <p>
+   * Instrument name may contain the wildcard characters {@code *} and {@code ?} with the following matching criteria:
+   * <ul>
+   * <li>{@code *} matches 0 or more instances of any character
+   * <li>{@code ?} matches exactly one instance of any character
+   * </ul>
+   * </p>
+   *
+   * @see io.opentelemetry.sdk.metrics.InstrumentSelector
+   */
+  String getInstrumentName();
+
+  /**
+   * @return A list of (inclusive) upper bounds for the histogram. Should be in order from lowest to highest.
+   * @see io.opentelemetry.sdk.metrics.Aggregation#explicitBucketHistogram(List)
+   */
+  List<Double> getExplicitBuckets();
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/opentelemetry/IMetricProvider.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/opentelemetry/IMetricProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.rt.platform.opentelemetry;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+import io.opentelemetry.api.OpenTelemetry;
+
+/**
+ * A provider of one or more application metrics based on OpenTelemetry.
+ * <p>
+ * A metric provider is usually used for more generally or feature-independent metrics such as JVM/cpu metrics. It can
+ * also be used for metrics whose source code is not under your control, e.g. external libraries.
+ * </p>
+ * <p>
+ * Such metric providers are responsible to set up the corresponding metric(s) and also to properly close/free used
+ * resources on Scout platform shutdown.
+ * <p>
+ * A metric provider usually interacts with a {@link OpenTelemetry} instance.
+ *
+ * @see OpenTelemetry
+ */
+@ApplicationScoped
+public interface IMetricProvider {
+
+  /**
+   * Register the metrics to the given {@link OpenTelemetry}.
+   * <p>
+   * This method is usually called once at Scout platform startup.
+   *
+   * @see OpenTelemetry#getMeter(String)
+   */
+  void register(OpenTelemetry openTelemetry);
+
+  /**
+   * Close/free used resources.
+   */
+  void close();
+}

--- a/org.eclipse.scout.rt.server.jdbc/pom.xml
+++ b/org.eclipse.scout.rt.server.jdbc/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+  ~ Copyright (c) 2010-2023 BSI Business Systems Integration AG.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at
-  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~ https://www.eclipse.org/legal/epl-v10.html
   ~
   ~ Contributors:
   ~     BSI Business Systems Integration AG - initial API and implementation

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -96,6 +96,8 @@
 
     <module>../org.eclipse.scout.rt.oauth2</module>
 
+    <module>../org.eclipse.scout.rt.opentelemetry.sdk</module>
+
     <!-- chart -->
     <module>../eclipse-scout-chart</module>
     <module>../org.eclipse.scout.rt.chart.client</module>
@@ -125,6 +127,7 @@
     <artemis.version>2.20.0</artemis.version>
     <com.google.http-client.version>1.40.1</com.google.http-client.version>
     <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
+    <opentelemetry.version>1.28.0</opentelemetry.version>
 
     <master_coverage_jacoco_destFile>${basedir}/../org.eclipse.scout.rt/target/jacoco-all.exec</master_coverage_jacoco_destFile>
     <master_test_forkCount>1</master_test_forkCount>
@@ -560,6 +563,11 @@
         <artifactId>org.eclipse.scout.rt.oauth2</artifactId>
         <version>22.0-SNAPSHOT</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.scout.rt</groupId>
+        <artifactId>org.eclipse.scout.rt.opentelemetry.sdk</artifactId>
+        <version>22.0-SNAPSHOT</version>
+      </dependency>
 
       <dependency>
         <groupId>commons-fileupload</groupId>
@@ -947,6 +955,14 @@
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
         <version>4.11.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The Scout OpenTelemetry integration uses OpenTelemetry SDK Autoconfigure
for initialization.

The other signals traces and logs are currently not tested and therefore
not activated/exported by default.

353620