### PR TITLE
FormField: add lifecycleBoundary flag

### DIFF
--- a/eclipse-scout-core/src/form/fields/FormField.ts
+++ b/eclipse-scout-core/src/form/fields/FormField.ts
@@ -48,6 +48,7 @@ export class FormField extends Widget implements FormFieldModel {
   /** If set to true, the field needs to be saved. This will be computed by {@link computeSaveNeeded}. */
   saveNeeded: boolean;
   checkSaveNeeded: boolean;
+  lifecycleBoundary: boolean;
   statusPosition: FormFieldStatusPosition;
   statusVisible: boolean;
   suppressStatus: FormFieldSuppressStatus;
@@ -120,6 +121,7 @@ export class FormField extends Widget implements FormFieldModel {
     this.preventInitialFocus = false;
     this.saveNeeded = false;
     this.checkSaveNeeded = true;
+    this.lifecycleBoundary = false;
     this.statusPosition = FormField.StatusPosition.DEFAULT;
     this.statusVisible = true;
     this.suppressStatus = null;

--- a/eclipse-scout-core/src/form/fields/FormFieldModel.ts
+++ b/eclipse-scout-core/src/form/fields/FormFieldModel.ts
@@ -216,4 +216,10 @@ export interface FormFieldModel extends WidgetModel {
    * Default is true.
    */
   checkSaveNeeded?: boolean;
+  /**
+   * Specifies whether the form lifecycle ignores child fields when visiting this field.
+   *
+   * The default is false.
+   */
+  lifecycleBoundary?: boolean;
 }


### PR DESCRIPTION
Commit af63fe3 introduced a way of controlling the visit result during the form field validation. This allowed form fields to let the form lifecycle skip their child fields by returning the visit result SKIP_SUBTREE on the validation result object. However, other lifecycle operations that use a form field visitor (e.g. reset()) cannot be controlled in a  similar way, since the corresponding methods don't have a return object.

To generally stop form field visitors in the form lifecycle from visiting child fields, a new flag "lifecycleBoundary" was introduced on the FormField class. The default value is false (no change). When set to true, all form field visitors in the form lifecycle automatically skip the subtree of that field.

Note: when lifecycleBoundary=true, the visitResult from the validation result is no longer relevant and is always ignored.