### PR TITLE
Rework ActionUtility and filter menus recursively

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/action/ActionUtilityTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/action/ActionUtilityTest.java
@@ -9,8 +9,7 @@
  */
 package org.eclipse.scout.rt.client.ui.action;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,7 +37,8 @@ public class ActionUtilityTest {
 
   @Test
   public void testCleanupWithEmptyList() {
-    List<IMenu> cleanList = ActionUtility.visibleNormalizedActions(Collections.<IMenu> emptyList());
+    //noinspection deprecation
+    List<IMenu> cleanList = ActionUtility.visibleNormalizedActions(Collections.emptyList());
     assertTrue(cleanList.isEmpty());
   }
 
@@ -47,6 +47,7 @@ public class ActionUtilityTest {
     IMenu s1 = createMenu("s1", true, true);
     IMenu s2 = createMenu("s2", true, true);
     IMenu s3 = createMenu("s3", true, true);
+    //noinspection deprecation
     List<IMenu> cleanList = ActionUtility.visibleNormalizedActions(CollectionUtility.arrayList(s1, s2, s3));
     assertEquals(Collections.emptyList(), cleanList);
   }
@@ -57,6 +58,7 @@ public class ActionUtilityTest {
     IMenu s2 = createMenu("s2", true, true);
     IMenu s3 = createMenu("s3", true, true);
     IMenu m4 = createMenu("m4", false, true);
+    //noinspection deprecation
     List<IMenu> cleanList = ActionUtility.visibleNormalizedActions(CollectionUtility.arrayList(s1, s2, s3, m4));
     assertEquals(Arrays.asList(m4), cleanList);
   }
@@ -70,6 +72,7 @@ public class ActionUtilityTest {
     IMenu s5 = createMenu("s5", true, true);
     IMenu s6 = createMenu("s6", true, true);
     IMenu s7 = createMenu("s7", true, true);
+    //noinspection deprecation
     List<IMenu> cleanList = ActionUtility.visibleNormalizedActions(CollectionUtility.arrayList(s1, s2, s3, m4, s5, s6, s7));
     assertEquals(Arrays.asList(m4), cleanList);
   }
@@ -84,6 +87,7 @@ public class ActionUtilityTest {
     IMenu s6 = createMenu("s6", true, true);
     IMenu s7 = createMenu("s7", true, true);
     IMenu m8 = createMenu("m8", false, true);
+    //noinspection deprecation
     List<IMenu> cleanList = ActionUtility.visibleNormalizedActions(CollectionUtility.arrayList(s1, s2, s3, m4, s5, s6, s7, m8));
     assertEquals(Arrays.asList(m4, s5, m8), cleanList);
   }

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/action/menu/MenuUtilityTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/action/menu/MenuUtilityTest.java
@@ -9,17 +9,17 @@
  */
 package org.eclipse.scout.rt.client.ui.action.menu;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.scout.rt.client.ui.IWidget;
 import org.eclipse.scout.rt.client.ui.action.menu.root.AbstractContextMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.root.IContextMenuOwner;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,7 +42,7 @@ public class MenuUtilityTest {
 
   @Test
   public void testGetMenuByClassNullMenuType() {
-    TestContextMenu contextMenu = new TestContextMenu(mock(IWidget.class), Collections.<IMenu> emptyList());
+    TestContextMenu contextMenu = new TestContextMenu(mock(IWidget.class), Collections.emptyList());
     when(m_contextMenuOwner.getContextMenu()).thenReturn(contextMenu);
     assertNull(MenuUtility.getMenuByClass(m_contextMenuOwner, null));
   }
@@ -55,7 +55,7 @@ public class MenuUtilityTest {
 
   @Test
   public void testGetMenuByClassMenuDoesNotExist() {
-    TestContextMenu contextMenu = new TestContextMenu(mock(IWidget.class), Collections.<IMenu> emptyList());
+    TestContextMenu contextMenu = new TestContextMenu(mock(IWidget.class), Collections.emptyList());
     when(m_contextMenuOwner.getContextMenu()).thenReturn(contextMenu);
     assertNull(MenuUtility.getMenuByClass(m_contextMenuOwner, TestMenu.class));
   }
@@ -66,6 +66,140 @@ public class MenuUtilityTest {
     TestContextMenu contextMenu = new TestContextMenu(mock(IWidget.class), Collections.singletonList(menu));
     when(m_contextMenuOwner.getContextMenu()).thenReturn(contextMenu);
     assertSame(menu, MenuUtility.getMenuByClass(m_contextMenuOwner, TestMenu.class));
+  }
+
+  @Test
+  public void testCleanupWithEmptyList() {
+    List<IMenu> cleanList = MenuUtility.visibleNormalizedMenus(Collections.emptyList());
+    assertTrue(cleanList.isEmpty());
+  }
+
+  @Test
+  public void testCleanupWithOnlySeparators() {
+    IMenu s1 = createMenu("s1", true, true);
+    IMenu s2 = createMenu("s2", true, true);
+    IMenu s3 = createMenu("s3", true, true);
+    List<IMenu> cleanList = MenuUtility.visibleNormalizedMenus(CollectionUtility.arrayList(s1, s2, s3));
+    assertEquals(Collections.emptyList(), cleanList);
+  }
+
+  @Test
+  public void testCleanupWithLeadingSeparators() {
+    IMenu s1 = createMenu("s1", true, true);
+    IMenu s2 = createMenu("s2", true, true);
+    IMenu s3 = createMenu("s3", true, true);
+    IMenu m4 = createMenu("m4", false, true);
+    List<IMenu> cleanList = MenuUtility.visibleNormalizedMenus(CollectionUtility.arrayList(s1, s2, s3, m4));
+    assertEquals(Arrays.asList(m4), cleanList);
+  }
+
+  @Test
+  public void testCleanupWithEndingSeparators() {
+    IMenu s1 = createMenu("s1", true, true);
+    IMenu s2 = createMenu("s2", true, true);
+    IMenu s3 = createMenu("s3", true, true);
+    IMenu m4 = createMenu("m4", false, true);
+    IMenu s5 = createMenu("s5", true, true);
+    IMenu s6 = createMenu("s6", true, true);
+    IMenu s7 = createMenu("s7", true, true);
+    List<IMenu> cleanList = MenuUtility.visibleNormalizedMenus(CollectionUtility.arrayList(s1, s2, s3, m4, s5, s6, s7));
+    assertEquals(Arrays.asList(m4), cleanList);
+  }
+
+  @Test
+  public void testCleanupWithDoubleSeparators() {
+    IMenu s1 = createMenu("s1", true, true);
+    IMenu s2 = createMenu("s2", true, true);
+    IMenu s3 = createMenu("s3", true, true);
+    IMenu m4 = createMenu("m4", false, true);
+    IMenu s5 = createMenu("s5", true, true);
+    IMenu s6 = createMenu("s6", true, true);
+    IMenu s7 = createMenu("s7", true, true);
+    IMenu m8 = createMenu("m8", false, true);
+    List<IMenu> cleanList = MenuUtility.visibleNormalizedMenus(CollectionUtility.arrayList(s1, s2, s3, m4, s5, s6, s7, m8));
+    assertEquals(Arrays.asList(m4, s5, m8), cleanList);
+  }
+
+  @Test
+  public void testDispose() {
+    Menu m0 = createMenu("m0");
+    Menu m1 = createMenu("m1");
+    Menu m2 = createMenu("m2");
+    Menu m3 = createMenu("m3");
+    Menu m4 = createMenu("m4");
+    m1.addChildAction(m2);
+    m2.addChildAction(m3);
+    m2.addChildAction(m4);
+    m0.dispose();
+    m1.dispose();
+
+    assertTrue(m0.isExecDisposeCalled());
+    assertTrue(m1.isExecDisposeCalled());
+    assertTrue(m2.isExecDisposeCalled());
+    assertTrue(m3.isExecDisposeCalled());
+    assertTrue(m4.isExecDisposeCalled());
+  }
+
+  private Menu createMenu(String label) {
+    return new Menu(label);
+  }
+
+  private Menu createMenu(String label, boolean separator, boolean visible) {
+    return new Menu(label, separator, visible);
+  }
+
+  private static class Menu extends AbstractMenu {
+    private String m_label;
+    private boolean m_separator;
+    private boolean m_visible;
+    private boolean m_execDisposeCalled;
+
+    public Menu(String label) {
+      this(label, false, true);
+    }
+
+    public Menu(String label, boolean separator, boolean visible) {
+      super(false);
+      m_label = label;
+      m_separator = separator;
+      m_visible = visible;
+      callInitializer();
+    }
+
+    @Override
+    protected boolean getConfiguredVisible() {
+      return m_visible;
+    }
+
+    @Override
+    protected boolean getConfiguredSeparator() {
+      return m_separator;
+    }
+
+    @Override
+    protected String getConfiguredText() {
+      return m_label;
+    }
+
+    @Override
+    protected void execOwnerValueChanged(Object newOwnerValue) {
+
+    }
+
+    @Override
+    protected void execDispose() {
+      super.execDispose();
+      m_execDisposeCalled = true;
+    }
+
+    public boolean isExecDisposeCalled() {
+      return m_execDisposeCalled;
+    }
+
+    @Override
+    public String toString() {
+      return getText();
+    }
   }
 
   private static class TestContextMenu extends AbstractContextMenu<IWidget> {

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/action/menu/TableMenuTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/action/menu/TableMenuTest.java
@@ -18,8 +18,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
-import org.eclipse.scout.rt.client.ui.action.IAction;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuTest.Table2.CompositeMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuTest.Table2.CompositeMenu.CompositeSubMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuTest.Table2.CompositeMenu.CompositeSubMenu.EmptySpaceSubSubMenu;
@@ -86,16 +84,16 @@ public class TableMenuTest {
 
     // single hugo boss
     t.selectRows(CollectionUtility.arrayList(t.getRow(0)), false);
-    Predicate<IAction> filter = ActionUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
-    List<IMenu> visibleMenus = ActionUtility.normalizedActions(contextMenu.getChildActions(), filter);
+    Predicate<IMenu> filter = MenuUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
+    List<IMenu> visibleMenus = MenuUtility.normalizedMenus(contextMenu.getChildActions(), filter);
     assertEquals(2, visibleMenus.size());
     assertEquals("SingleSelectionMenu", visibleMenus.get(0).getClass().getSimpleName());
     assertEquals("HugoBossMenu", visibleMenus.get(1).getClass().getSimpleName());
 
     // single only meier
     t.selectRows(CollectionUtility.arrayList(t.getRow(1)), false);
-    filter = ActionUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
-    visibleMenus = ActionUtility.normalizedActions(contextMenu.getChildActions(), filter);
+    filter = MenuUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
+    visibleMenus = MenuUtility.normalizedMenus(contextMenu.getChildActions(), filter);
     assertEquals(1, visibleMenus.size());
     assertEquals("SingleSelectionMenu", visibleMenus.get(0).getClass().getSimpleName());
   }
@@ -110,8 +108,8 @@ public class TableMenuTest {
     ITableContextMenu contextMenu = t.getContextMenu();
     // multi selection
     t.selectRows(CollectionUtility.arrayList(t.getRow(0), t.getRow(1)), false);
-    Predicate<IAction> filter = ActionUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
-    List<IMenu> visibleMenus = ActionUtility.normalizedActions(contextMenu.getChildActions(), filter);
+    Predicate<IMenu> filter = MenuUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
+    List<IMenu> visibleMenus = MenuUtility.normalizedMenus(contextMenu.getChildActions(), filter);
     assertEquals(1, visibleMenus.size());
     assertEquals("MultiSelectionMenu", visibleMenus.get(0).getClass().getSimpleName());
   }
@@ -126,8 +124,8 @@ public class TableMenuTest {
     ITableContextMenu contextMenu = t.getContextMenu();
     // empty selection
     t.selectRows(CollectionUtility.emptyArrayList(), false);
-    Predicate<IAction> filter = ActionUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
-    List<IMenu> visibleMenus = ActionUtility.normalizedActions(contextMenu.getChildActions(), filter);
+    Predicate<IMenu> filter = MenuUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
+    List<IMenu> visibleMenus = MenuUtility.normalizedMenus(contextMenu.getChildActions(), filter);
     assertEquals(1, visibleMenus.size());
     assertEquals("EmptySpaceMenu", visibleMenus.get(0).getClass().getSimpleName());
   }
@@ -143,8 +141,8 @@ public class TableMenuTest {
     ITableContextMenu contextMenu = t.getContextMenu();
 
     t.selectRows(CollectionUtility.emptyArrayList(), false);
-    Predicate<IAction> filter = ActionUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
-    List<IMenu> visibleMenus = ActionUtility.normalizedActions(contextMenu.getChildActions(), filter);
+    Predicate<IMenu> filter = MenuUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
+    List<IMenu> visibleMenus = MenuUtility.normalizedMenus(contextMenu.getChildActions(), filter);
     assertFalse(visibleMenus.get(0).isEnabledIncludingParents());
   }
 
@@ -159,8 +157,8 @@ public class TableMenuTest {
     ITableContextMenu contextMenu = t.getContextMenu();
 
     t.selectRows(CollectionUtility.arrayList(t.getRow(0)), false);
-    Predicate<IAction> filter = ActionUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
-    List<IMenu> visibleMenus = ActionUtility.normalizedActions(contextMenu.getChildActions(), filter);
+    Predicate<IMenu> filter = MenuUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
+    List<IMenu> visibleMenus = MenuUtility.normalizedMenus(contextMenu.getChildActions(), filter);
     assertFalse(visibleMenus.get(0).isEnabledIncludingParents());
   }
 
@@ -176,8 +174,8 @@ public class TableMenuTest {
     t.getRow(0).setEnabled(false);
 
     t.selectRows(CollectionUtility.emptyArrayList(), false);
-    Predicate<IAction> filter = ActionUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
-    List<IMenu> visibleMenus = ActionUtility.normalizedActions(contextMenu.getChildActions(), filter);
+    Predicate<IMenu> filter = MenuUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
+    List<IMenu> visibleMenus = MenuUtility.normalizedMenus(contextMenu.getChildActions(), filter);
     assertTrue(visibleMenus.get(0).isEnabled());
   }
 
@@ -193,8 +191,8 @@ public class TableMenuTest {
     t.getRow(0).setEnabled(false);
 
     t.selectRows(CollectionUtility.arrayList(t.getRow(0)), false);
-    Predicate<IAction> filter = ActionUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
-    List<IMenu> visibleMenus = ActionUtility.normalizedActions(contextMenu.getChildActions(), filter);
+    Predicate<IMenu> filter = MenuUtility.createMenuFilterMenuTypes(contextMenu.getCurrentMenuTypes(), true);
+    List<IMenu> visibleMenus = MenuUtility.normalizedMenus(contextMenu.getChildActions(), filter);
     assertFalse(visibleMenus.get(0).isEnabledIncludingParents());
   }
 

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/PageWithTable6Test.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/PageWithTable6Test.java
@@ -17,10 +17,10 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.AbstractMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenuType;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuType;
 import org.eclipse.scout.rt.client.ui.basic.table.AbstractTable;
 import org.eclipse.scout.rt.client.ui.basic.table.columns.AbstractIntegerColumn;
@@ -80,7 +80,7 @@ public class PageWithTable6Test {
 
   private static void assertMenus(PageWithTable.Table table, String[] expectedMenus) {
     List<String> actualMenus = new ArrayList<>();
-    for (IMenu m : ActionUtility.normalizedActions(table.getContextMenu().getChildActions(), ActionUtility.createMenuFilterMenuTypes(table.getContextMenu().getCurrentMenuTypes(), true))) {
+    for (IMenu m : MenuUtility.normalizedMenus(table.getContextMenu().getChildActions(), MenuUtility.createMenuFilterMenuTypes(table.getContextMenu().getCurrentMenuTypes(), true))) {
       if (m.isEnabledIncludingParents()) {
         actualMenus.add(m.getText());
       }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/ActionUtility.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/ActionUtility.java
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.client.ui.action;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -19,12 +20,10 @@ import java.util.function.Predicate;
 import org.eclipse.scout.rt.client.ui.IWidget;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenuType;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.root.AbstractContextMenu;
 import org.eclipse.scout.rt.client.ui.action.tree.IActionNode;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
-import org.eclipse.scout.rt.platform.util.visitor.DepthFirstTreeVisitor;
-import org.eclipse.scout.rt.platform.util.visitor.TreeVisitResult;
-import org.eclipse.scout.rt.shared.dimension.IDimensions;
 
 public final class ActionUtility {
 
@@ -36,14 +35,18 @@ public final class ActionUtility {
   public static final Predicate<IAction> TRUE_FILTER = action -> true;
 
   /**
-   * Removes invisible actions. Also removes leading and trailing separators as well as multiple consecutive separators.
-   *
-   * @since 3.8.1
+   * @deprecated will be removed in 24.1, use {@link MenuUtility#visibleNormalizedMenus(List)}.
    */
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated
   public static <T extends IAction> List<T> visibleNormalizedActions(List<T> actionNodes) {
     return normalizedActions(actionNodes, createVisibleFilter());
   }
 
+  /**
+   * @deprecated will be removed in 24.1, use {@link MenuUtility#normalizedMenus(List, Predicate)}.
+   */
+  @Deprecated
   public static <T extends IAction> List<T> normalizedActions(List<T> actionNodes, Predicate<IAction> filter) {
     if (actionNodes == null) {
       return CollectionUtility.emptyArrayList();
@@ -80,6 +83,10 @@ public final class ActionUtility {
     }
   }
 
+  /**
+   * @deprecated will be removed in 24.1, use {@link MenuUtility#filterMenusRec(List, Predicate)}.
+   */
+  @Deprecated
   public static <T extends IAction> List<T> getActions(List<T> actions, final Predicate<IAction> filter) {
     if (actions != null) {
       List<T> result = new ArrayList<>(actions.size());
@@ -96,8 +103,12 @@ public final class ActionUtility {
     return CollectionUtility.emptyArrayList();
   }
 
+  /**
+   * @deprecated will be removed in 24.1, use {@link MenuUtility#createVisibleFilter()}.
+   */
+  @Deprecated
   public static Predicate<IAction> createVisibleFilter() {
-    return new Predicate<IAction>() {
+    return new Predicate<>() {
       @Override
       public boolean test(IAction action) {
         if (action.isVisible()) {
@@ -114,64 +125,51 @@ public final class ActionUtility {
   }
 
   /**
-   * Updates the enabled state of the given {@link AbstractContextMenu} to the enabled state of its containing
-   * widget.<br>
-   * If the widget is enabled, the given selectionEnabledStateSupplier is evaluated and all child {@link IActionNode
-   * action-nodes} (having at least one of the given menu types) are updated according to the value of the supplier.
-   *
-   * @param contextMenu
-   *          The {@link AbstractContextMenu} to update. Must not be {@code null}.
-   * @param selectionEnabledStateSupplier
-   *          Only invoked if the container of the context menu itself is enabled. Returns if all selected elements of
-   *          the container are enabled ({@code true}) or not.
-   * @see #updateEnabledStateOfMenus(IWidget, boolean, IMenuType...)
-   * @see UpdateMenuEnabledStateVisitor
+   * @deprecated will be removed in 24.1, use
+   *             {@link MenuUtility#updateContextMenuEnabledState(AbstractContextMenu, BooleanSupplier, IMenuType...)}.
    */
+  @Deprecated
   public static void updateContextMenuEnabledState(AbstractContextMenu<? extends IWidget> contextMenu, BooleanSupplier selectionEnabledStateSupplier, IMenuType... menuTypes) {
-    boolean containerEnabled = contextMenu.getContainer().isEnabled();
-    contextMenu.setEnabled(containerEnabled);
-    if (containerEnabled) {
-      updateEnabledStateOfMenus(contextMenu, selectionEnabledStateSupplier.getAsBoolean(), menuTypes);
-    }
+    MenuUtility.updateContextMenuEnabledState(contextMenu, selectionEnabledStateSupplier, menuTypes);
   }
 
   /**
-   * Recursively updates the {@link IDimensions#ENABLED_SLAVE} for all {@link IActionNode} instances (having at least
-   * one of the given menu types) of the given {@link IWidget}.
-   *
-   * @param widget
-   *          The {@link IWidget} whose {@link IActionNode actions} should be changed (recursively). Must not be
-   *          {@code null}.
-   * @param enabled
-   *          The new enabled state of the {@link IActionNode actions} found.
-   * @param menuTypes
-   *          The menu types to update
+   * @deprecated will be removed in 24.1, use
+   *             {@link MenuUtility#updateEnabledStateOfMenus(IWidget, boolean, IMenuType...)}.
    */
+  @Deprecated
   public static void updateEnabledStateOfMenus(IWidget widget, boolean enabled, IMenuType... menuTypes) {
-    Predicate<IAction> menusToUpdate = createMenuFilterMenuTypes(false, menuTypes);
-    widget.visit(new UpdateMenuEnabledStateVisitor<>(enabled, menusToUpdate), IActionNode.class);
+    MenuUtility.updateEnabledStateOfMenus(widget, enabled, menuTypes);
   }
 
   /**
-   * @see #createMenuFilterMenuTypes(Set, boolean)
+   * @deprecated will be removed in 24.1, use {@link MenuUtility#createMenuFilterMenuTypes(boolean, IMenuType...)}.
    */
+  @Deprecated
   public static Predicate<IAction> createMenuFilterMenuTypes(boolean visibleOnly, IMenuType... menuTypes) {
-    return createMenuFilterMenuTypes(CollectionUtility.hashSet(menuTypes), visibleOnly);
+    return action -> Optional.ofNullable(action)
+        .filter(IMenu.class::isInstance)
+        .map(IMenu.class::cast)
+        .filter(MenuUtility.createMenuFilterMenuTypes(visibleOnly, menuTypes))
+        .isPresent();
   }
 
   /**
-   * <ul>
-   * <li>If the menu is a leaf (menu without any child menus) the filter accepts a menu when it is visible (depending on
-   * visibleOnly) and it has one of the passed menu types.</li>
-   * <li>If the menu has child menus (is a menu group) then the filter accepts a menu if it is visible (depending on
-   * visibleOnly) and at least one of its leaf children (recursively) is visible (depending on visible only) and and has
-   * one of the passed menu types.</li>
-   * </ul>
+   * @deprecated will be removed in 24.1, use {@link MenuUtility#createMenuFilterMenuTypes(Set, boolean)}.
    */
+  @Deprecated
   public static Predicate<IAction> createMenuFilterMenuTypes(Set<? extends IMenuType> menuTypes, boolean visibleOnly) {
-    return new MenuTypeFilter(menuTypes, visibleOnly);
+    return action -> Optional.ofNullable(action)
+        .filter(IMenu.class::isInstance)
+        .map(IMenu.class::cast)
+        .filter(MenuUtility.createMenuFilterMenuTypes(menuTypes, visibleOnly))
+        .isPresent();
   }
 
+  /**
+   * @deprecated will be removed in 24.1, use {@link Predicate#and(Predicate)}.
+   */
+  @Deprecated
   @SafeVarargs
   public static Predicate<IAction> createCombinedFilter(final Predicate<IAction>... actionFilters) {
     if (actionFilters != null) {
@@ -185,94 +183,5 @@ public final class ActionUtility {
       };
     }
     return TRUE_FILTER;
-  }
-
-  public static class MenuTypeFilter implements Predicate<IAction> {
-
-    private final boolean m_visibleOnly;
-    private final Set<? extends IMenuType> m_menuTypes;
-
-    public MenuTypeFilter(Set<? extends IMenuType> menuTypes, boolean visibleOnly) {
-      m_menuTypes = menuTypes;
-      m_visibleOnly = visibleOnly;
-    }
-
-    @Override
-    public boolean test(IAction action) {
-      if (action instanceof IMenu) {
-        IMenu menu = (IMenu) action;
-        if (isVisibleOnly() && !menu.isVisible()) {
-          return false;
-        }
-        else {
-          if (menu.hasChildActions()) {
-            // check for filter matching child menus
-            return !normalizedActions(menu.getChildActions(), this).isEmpty();
-          }
-          if (getMenuTypes() != null) {
-            for (IMenuType t : getMenuTypes()) {
-              if (menu.getMenuTypes().contains(t)) {
-                return true;
-              }
-            }
-            return false;
-          }
-          else {
-            return true;
-          }
-        }
-      }
-      return false;
-    }
-
-    public Set<? extends IMenuType> getMenuTypes() {
-      return m_menuTypes;
-    }
-
-    public boolean isVisibleOnly() {
-      return m_visibleOnly;
-    }
-  }
-
-  /**
-   * Updates the {@link IDimensions#ENABLED_SLAVE} state to the given value for all {@link IActionNode} instances
-   * accepting the given {@link Predicate}.<br>
-   * If a menu contains children it is disabled if all the child menus are disabled (according to
-   * {@link IDimensions#ENABLED_SLAVE}) as well.<br>
-   * Separators (see {@link IAction#isSeparator()}) are always ignored.<br>
-   * {@link IActionNode} instances not matching the given filter are not touched.
-   */
-  public static class UpdateMenuEnabledStateVisitor<T extends IActionNode<?>> extends DepthFirstTreeVisitor<T> {
-
-    private final boolean m_enabled;
-    private final Predicate<? super T> m_filter;
-
-    public UpdateMenuEnabledStateVisitor(boolean enabled, Predicate<? super T> filter) {
-      m_enabled = enabled;
-      m_filter = filter;
-    }
-
-    @Override
-    public TreeVisitResult preVisit(T element, int level, int index) {
-      if (isSkipElement(element)) {
-        return TreeVisitResult.SKIP_SUBTREE;
-      }
-      return TreeVisitResult.CONTINUE;
-    }
-
-    protected boolean isSkipElement(T element) {
-      return element.isSeparator() || !element.isInheritAccessibility();
-    }
-
-    @Override
-    public boolean postVisit(T element, int level, int index) {
-      if (isSkipElement(element)) {
-        return true;
-      }
-      if (!element.hasChildActions() && m_filter.test(element)) {
-        element.setEnabled(m_enabled, IDimensions.ENABLED_SLAVE);
-      }
-      return true;
-    }
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/MenuUtility.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/MenuUtility.java
@@ -9,13 +9,28 @@
  */
 package org.eclipse.scout.rt.client.ui.action.menu;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 
+import org.eclipse.scout.rt.client.ui.IWidget;
 import org.eclipse.scout.rt.client.ui.action.ActionFinder;
+import org.eclipse.scout.rt.client.ui.action.ActionUtility;
+import org.eclipse.scout.rt.client.ui.action.IAction;
+import org.eclipse.scout.rt.client.ui.action.menu.root.AbstractContextMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.root.IContextMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.root.IContextMenuOwner;
 import org.eclipse.scout.rt.client.ui.action.tree.IActionNode;
+import org.eclipse.scout.rt.client.ui.desktop.outline.MenuWrapper;
+import org.eclipse.scout.rt.client.ui.desktop.outline.OutlineMenuWrapper;
+import org.eclipse.scout.rt.client.ui.desktop.outline.OutlineMenuWrapper.IMenuTypeMapper;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.visitor.DepthFirstTreeVisitor;
+import org.eclipse.scout.rt.platform.util.visitor.TreeVisitResult;
+import org.eclipse.scout.rt.shared.dimension.IDimensions;
 
 /**
  * Utility class for menus
@@ -75,4 +90,210 @@ public final class MenuUtility {
     return new ActionFinder().findAction(rootMenus, menuType);
   }
 
+  /**
+   * Removes invisible menus. Also removes leading and trailing separators as well as multiple consecutive separators.
+   *
+   * @since 3.8.1
+   */
+  public static List<IMenu> visibleNormalizedMenus(List<IMenu> menus) {
+    return normalizedMenus(menus, createVisibleFilter());
+  }
+
+  public static List<IMenu> normalizedMenus(List<IMenu> menus, final Predicate<IMenu> filter) {
+    if (menus == null) {
+      return CollectionUtility.emptyArrayList();
+    }
+
+    // only visible
+    List<IMenu> cleanedMenus = filterMenusRec(menus, filter);
+
+    ActionUtility.normalizeSeparators(cleanedMenus);
+    return cleanedMenus;
+  }
+
+  /**
+   * Filters the given list of menus. If a menu has child menus, the menu is wrapped (see
+   * {@link MenuWrapper#wrapMenu(IMenu, IMenuTypeMapper, Predicate)}) and its child menus are filtered as well.
+   */
+  public static List<IMenu> filterMenusRec(List<IMenu> menus, final Predicate<IMenu> filter) {
+    if (menus != null) {
+      List<IMenu> result = new ArrayList<>(menus.size());
+      for (IMenu m : menus) {
+        if (m.isSeparator()) {
+          result.add(m);
+        }
+        else if (filter.test(m)) {
+          if (m.hasChildActions()) {
+            m = MenuWrapper.wrapMenu(m, OutlineMenuWrapper.AUTO_MENU_TYPE_MAPPER, filter);
+          }
+          result.add(m);
+        }
+      }
+      return result;
+    }
+    return CollectionUtility.emptyArrayList();
+  }
+
+  public static Predicate<IMenu> createVisibleFilter() {
+    return new Predicate<>() {
+      @Override
+      public boolean test(IMenu menu) {
+        if (menu != null && menu.isVisible()) {
+          // remove menu groups with no visible child menu
+          if (menu.hasChildActions()) {
+            List<?> visibleChildActions = filterMenusRec(menu.getChildActions(), this);
+            return !visibleChildActions.isEmpty();
+          }
+          return true;
+        }
+        return false;
+      }
+    };
+  }
+
+  /**
+   * Updates the enabled state of the given {@link AbstractContextMenu} to the enabled state of its containing
+   * widget.<br>
+   * If the widget is enabled, the given selectionEnabledStateSupplier is evaluated and all child {@link IMenu menus}
+   * (having at least one of the given menu types) are updated according to the value of the supplier.
+   *
+   * @param contextMenu
+   *          The {@link AbstractContextMenu} to update. Must not be {@code null}.
+   * @param selectionEnabledStateSupplier
+   *          Only invoked if the container of the context menu itself is enabled. Returns if all selected elements of
+   *          the container are enabled ({@code true}) or not.
+   * @see #updateEnabledStateOfMenus(IWidget, boolean, IMenuType...)
+   * @see UpdateMenuEnabledStateVisitor
+   */
+  public static void updateContextMenuEnabledState(AbstractContextMenu<? extends IWidget> contextMenu, BooleanSupplier selectionEnabledStateSupplier, IMenuType... menuTypes) {
+    boolean containerEnabled = contextMenu.getContainer().isEnabled();
+    contextMenu.setEnabled(containerEnabled);
+    if (containerEnabled) {
+      updateEnabledStateOfMenus(contextMenu, selectionEnabledStateSupplier.getAsBoolean(), menuTypes);
+    }
+  }
+
+  /**
+   * Recursively updates the {@link IDimensions#ENABLED_SLAVE} for all {@link IMenu} instances (having at least one of
+   * the given menu types) of the given {@link IWidget}.
+   *
+   * @param widget
+   *          The {@link IWidget} whose {@link IMenu menus} should be changed (recursively). Must not be {@code null}.
+   * @param enabled
+   *          The new enabled state of the {@link IMenu menus} found.
+   * @param menuTypes
+   *          The menu types to update
+   */
+  public static void updateEnabledStateOfMenus(IWidget widget, boolean enabled, IMenuType... menuTypes) {
+    Predicate<IMenu> menusToUpdate = createMenuFilterMenuTypes(false, menuTypes);
+    widget.visit(new UpdateMenuEnabledStateVisitor<>(enabled, menusToUpdate), IMenu.class);
+  }
+
+  /**
+   * @see #createMenuFilterMenuTypes(Set, boolean)
+   */
+  public static Predicate<IMenu> createMenuFilterMenuTypes(boolean visibleOnly, IMenuType... menuTypes) {
+    return createMenuFilterMenuTypes(CollectionUtility.hashSet(menuTypes), visibleOnly);
+  }
+
+  /**
+   * <ul>
+   * <li>If the menu is a leaf (menu without any child menus) the filter accepts a menu when it is visible (depending on
+   * visibleOnly) and it has one of the passed menu types.</li>
+   * <li>If the menu has child menus (is a menu group) then the filter accepts a menu if it is visible (depending on
+   * visibleOnly) and at least one of its leaf children (recursively) is visible (depending on visible only) and and has
+   * one of the passed menu types.</li>
+   * </ul>
+   */
+  public static Predicate<IMenu> createMenuFilterMenuTypes(Set<? extends IMenuType> menuTypes, boolean visibleOnly) {
+    return new MenuTypeFilter(menuTypes, visibleOnly);
+  }
+
+  public static class MenuTypeFilter implements Predicate<IMenu> {
+
+    private final boolean m_visibleOnly;
+    private final Set<? extends IMenuType> m_menuTypes;
+
+    public MenuTypeFilter(Set<? extends IMenuType> menuTypes, boolean visibleOnly) {
+      m_menuTypes = menuTypes;
+      m_visibleOnly = visibleOnly;
+    }
+
+    @Override
+    public boolean test(IMenu menu) {
+      if (menu == null) {
+        return false;
+      }
+      if (isVisibleOnly() && !menu.isVisible()) {
+        return false;
+      }
+      else {
+        if (menu.hasChildActions()) {
+          // check for filter matching child menus
+          return !normalizedMenus(menu.getChildActions(), this).isEmpty();
+        }
+        if (getMenuTypes() != null) {
+          for (IMenuType t : getMenuTypes()) {
+            if (menu.getMenuTypes().contains(t)) {
+              return true;
+            }
+          }
+          return false;
+        }
+        else {
+          return true;
+        }
+      }
+    }
+
+    public Set<? extends IMenuType> getMenuTypes() {
+      return m_menuTypes;
+    }
+
+    public boolean isVisibleOnly() {
+      return m_visibleOnly;
+    }
+  }
+
+  /**
+   * Updates the {@link IDimensions#ENABLED_SLAVE} state to the given value for all {@link IMenu} instances accepting
+   * the given {@link Predicate}.<br>
+   * If a menu contains children it is disabled if all the child menus are disabled (according to
+   * {@link IDimensions#ENABLED_SLAVE}) as well.<br>
+   * Separators (see {@link IAction#isSeparator()}) are always ignored.<br>
+   * {@link IMenu} instances not matching the given filter are not touched.
+   */
+  public static class UpdateMenuEnabledStateVisitor<T extends IMenu> extends DepthFirstTreeVisitor<T> {
+
+    private final boolean m_enabled;
+    private final Predicate<? super T> m_filter;
+
+    public UpdateMenuEnabledStateVisitor(boolean enabled, Predicate<? super T> filter) {
+      m_enabled = enabled;
+      m_filter = filter;
+    }
+
+    @Override
+    public TreeVisitResult preVisit(T element, int level, int index) {
+      if (isSkipElement(element)) {
+        return TreeVisitResult.SKIP_SUBTREE;
+      }
+      return TreeVisitResult.CONTINUE;
+    }
+
+    protected boolean isSkipElement(T element) {
+      return element.isSeparator() || !element.isInheritAccessibility();
+    }
+
+    @Override
+    public boolean postVisit(T element, int level, int index) {
+      if (isSkipElement(element)) {
+        return true;
+      }
+      if (!element.hasChildActions() && m_filter.test(element)) {
+        element.setEnabled(m_enabled, IDimensions.ENABLED_SLAVE);
+      }
+      return true;
+    }
+  }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/TileGridMenuType.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/TileGridMenuType.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
 import org.eclipse.scout.rt.client.ui.action.IAction;
 import org.eclipse.scout.rt.client.ui.action.menu.root.IContextMenu;
 import org.eclipse.scout.rt.client.ui.tile.ITile;
@@ -51,7 +50,7 @@ public enum TileGridMenuType implements IMenuType {
    *          (optional) menus are filtered with this predicate before visibility is updated
    */
   public static void updateMenuVisibilities(IContextMenu contextMenu, Set<IMenuType> acceptedMenuTypes, Predicate<IAction> filter) {
-    final Predicate<IAction> activeFilter = ActionUtility.createMenuFilterMenuTypes(acceptedMenuTypes, false);
+    final Predicate<IMenu> activeFilter = MenuUtility.createMenuFilterMenuTypes(acceptedMenuTypes, false);
     contextMenu.visit(menu -> {
       if (filter != null && !filter.test(menu)) {
         return;

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/root/AbstractContextMenu.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/root/AbstractContextMenu.java
@@ -18,11 +18,10 @@ import java.util.function.Predicate;
 
 import org.eclipse.scout.rt.client.extension.ui.action.menu.root.IContextMenuExtension;
 import org.eclipse.scout.rt.client.ui.IWidget;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
-import org.eclipse.scout.rt.client.ui.action.IAction;
 import org.eclipse.scout.rt.client.ui.action.menu.AbstractMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenuType;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.platform.classid.ClassId;
 import org.eclipse.scout.rt.platform.holders.BooleanHolder;
 import org.eclipse.scout.rt.platform.util.event.FastListenerList;
@@ -129,7 +128,7 @@ public abstract class AbstractContextMenu<T extends IWidget> extends AbstractMen
   }
 
   protected void calculateLocalVisibility() {
-    final Predicate<IAction> activeFilter = ActionUtility.createMenuFilterMenuTypes(getCurrentMenuTypes(), true);
+    final Predicate<IMenu> activeFilter = MenuUtility.createMenuFilterMenuTypes(getCurrentMenuTypes(), true);
     if (activeFilter != null) {
       final BooleanHolder visibleHolder = new BooleanHolder(false);
       visit(menu -> {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/root/internal/TableContextMenu.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/root/internal/TableContextMenu.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.scout.rt.client.ui.IWidget;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.root.AbstractContextMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.root.ITableContextMenu;
@@ -100,7 +100,7 @@ public class TableContextMenu extends AbstractContextMenu<ITable> implements ITa
    * called on selection change (selected rows) or when the table enabled state changes
    */
   protected void calculateEnabledState() {
-    ActionUtility.updateContextMenuEnabledState(this, this::isSelectionEnabled, TableMenuType.MultiSelection, TableMenuType.SingleSelection);
+    MenuUtility.updateContextMenuEnabledState(this, this::isSelectionEnabled, TableMenuType.MultiSelection, TableMenuType.SingleSelection);
   }
 
   protected Set<TableMenuType> getMenuTypesForSelection(List<? extends ITableRow> selection) {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/root/internal/TreeContextMenu.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/root/internal/TreeContextMenu.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.scout.rt.client.ui.IWidget;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.TreeMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.root.AbstractContextMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.root.ITreeContextMenu;
@@ -105,7 +105,7 @@ public class TreeContextMenu extends AbstractContextMenu<ITree> implements ITree
    * called on selection change (selected tree nodes) or when the tree enabled state changes
    */
   protected void calculateEnabledState() {
-    ActionUtility.updateContextMenuEnabledState(this, this::isSelectionEnabled, TreeMenuType.MultiSelection, TreeMenuType.SingleSelection);
+    MenuUtility.updateContextMenuEnabledState(this, this::isSelectionEnabled, TreeMenuType.MultiSelection, TreeMenuType.SingleSelection);
   }
 
   protected Set<TreeMenuType> getMenuTypesForSelection(Set<? extends ITreeNode> selection) {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/AbstractCalendar.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/AbstractCalendar.java
@@ -34,7 +34,6 @@ import org.eclipse.scout.rt.client.extension.ui.basic.calendar.CalendarChains.Ca
 import org.eclipse.scout.rt.client.extension.ui.basic.calendar.ICalendarExtension;
 import org.eclipse.scout.rt.client.ui.AbstractWidget;
 import org.eclipse.scout.rt.client.ui.IWidget;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.CalendarMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
@@ -247,7 +246,7 @@ public abstract class AbstractCalendar extends AbstractWidget implements ICalend
         ICalendarItemProvider provider = ConfigurationUtility.newInnerInstance(this, itemProviderClazz);
         producerList.add(provider);
         // add empty space menus to the context menu
-        menus.addAllOrdered(ActionUtility.getActions(provider.getMenus(), ActionUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(CalendarMenuType.EmptySpace), false)));
+        menus.addAllOrdered(MenuUtility.filterMenusRec(provider.getMenus(), MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(CalendarMenuType.EmptySpace), false)));
       }
       catch (Exception e) {
         BEANS.get(ExceptionHandler.class).handle(new ProcessingException("error creating instance of class '" + itemProviderClazz.getName() + "'.", e));
@@ -616,7 +615,7 @@ public abstract class AbstractCalendar extends AbstractWidget implements ICalend
     }
     // add menus of provider
     if (provider != null) {
-      m_inheritedMenusOfSelectedProvider = ActionUtility.getActions(provider.getMenus(), ActionUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(CalendarMenuType.CalendarComponent), false));
+      m_inheritedMenusOfSelectedProvider = MenuUtility.filterMenusRec(provider.getMenus(), MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(CalendarMenuType.CalendarComponent), false));
       getContextMenu().addChildActions(m_inheritedMenusOfSelectedProvider);
     }
   }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/MenuWrapper.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/MenuWrapper.java
@@ -12,7 +12,6 @@ package org.eclipse.scout.rt.client.ui.desktop.outline;
 import java.util.Collection;
 import java.util.function.Predicate;
 
-import org.eclipse.scout.rt.client.ui.action.IAction;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IReadOnlyMenu;
 import org.eclipse.scout.rt.client.ui.desktop.outline.OutlineMenuWrapper.IMenuTypeMapper;
@@ -60,18 +59,18 @@ public class MenuWrapper {
    *          Filter used when wrapping child menus.
    * @return Wrapped menu
    */
-  public static IMenu wrapMenu(IMenu menu, IMenuTypeMapper menuTypeMapper, Predicate<IAction> menuFilter) {
+  public static IMenu wrapMenu(IMenu menu, IMenuTypeMapper menuTypeMapper, Predicate<IMenu> menuFilter) {
     return BEANS.get(MenuWrapper.class).doWrapMenu(menu, menuTypeMapper, menuFilter);
   }
 
-  protected IReadOnlyMenu doWrapMenuIfNotWrapped(IMenu menu, IMenuTypeMapper menuTypeMapper, Predicate<IAction> menuFilter) {
+  protected IReadOnlyMenu doWrapMenuIfNotWrapped(IMenu menu, IMenuTypeMapper menuTypeMapper, Predicate<IMenu> menuFilter) {
     if (menu instanceof IReadOnlyMenu) {
       return (IReadOnlyMenu) menu; // already wrapped - don't wrap again
     }
     return doWrapMenu(menu, menuTypeMapper, menuFilter);
   }
 
-  protected IReadOnlyMenu doWrapMenu(IMenu menu, IMenuTypeMapper menuTypeMapper, Predicate<IAction> menuFilter) {
+  protected IReadOnlyMenu doWrapMenu(IMenu menu, IMenuTypeMapper menuTypeMapper, Predicate<IMenu> menuFilter) {
     if (menu instanceof IFormMenu<?>) {
       return new OutlineFormMenuWrapper((IFormMenu<?>) menu, menuTypeMapper, menuFilter);
     }
@@ -95,7 +94,7 @@ public class MenuWrapper {
   public static boolean containsWrappedMenu(Collection<IMenu> menus, IMenu menu) {
     if (menu instanceof IReadOnlyMenu) {
       IReadOnlyMenu wrapper = (IReadOnlyMenu) menu;
-      return menus.contains(wrapper.getWrappedMenu());
+      return menus.contains(wrapper.getWrappedMenu()) || containsWrappedMenu(menus, wrapper.getWrappedMenu());
     }
     return false;
   }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/OutlineFormMenuWrapper.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/OutlineFormMenuWrapper.java
@@ -11,7 +11,7 @@ package org.eclipse.scout.rt.client.ui.desktop.outline;
 
 import java.util.function.Predicate;
 
-import org.eclipse.scout.rt.client.ui.action.IAction;
+import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.form.IForm;
 import org.eclipse.scout.rt.client.ui.form.IFormMenu;
 import org.eclipse.scout.rt.platform.classid.ClassId;
@@ -30,7 +30,7 @@ import org.eclipse.scout.rt.platform.classid.ClassId;
 @ClassId("19966ccc-1ead-420b-8bad-bb97480230d6")
 public class OutlineFormMenuWrapper extends OutlineMenuWrapper implements IFormMenu<IForm> {
 
-  protected OutlineFormMenuWrapper(IFormMenu<? extends IForm> menu, IMenuTypeMapper menuTypeMapper, Predicate<IAction> menuFilter) {
+  protected OutlineFormMenuWrapper(IFormMenu<? extends IForm> menu, IMenuTypeMapper menuTypeMapper, Predicate<IMenu> menuFilter) {
     super(menu, menuTypeMapper, menuFilter);
   }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/OutlineMenuWrapper.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/OutlineMenuWrapper.java
@@ -21,12 +21,11 @@ import java.util.function.Predicate;
 
 import org.eclipse.scout.rt.client.ui.AbstractWidget;
 import org.eclipse.scout.rt.client.ui.IWidget;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
-import org.eclipse.scout.rt.client.ui.action.IAction;
 import org.eclipse.scout.rt.client.ui.action.IActionUIFacade;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.IReadOnlyMenu;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.tree.IActionNode;
 import org.eclipse.scout.rt.platform.classid.ClassId;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -48,10 +47,10 @@ public class OutlineMenuWrapper extends AbstractWidget implements IReadOnlyMenu 
   private final IMenu m_wrappedMenu;
   private final PropertyChangeListener m_wrappedMenuPropertyChangeListener;
   private final Set<IMenuType> m_menuTypes;
-  private final Predicate<IAction> m_menuFilter;
+  private final Predicate<IMenu> m_menuFilter;
   private final IMenuTypeMapper m_menuTypeMapper;
 
-  public static final Predicate<IAction> ACCEPT_ALL_FILTER = action -> true;
+  public static final Predicate<IMenu> ACCEPT_ALL_FILTER = menu -> true;
 
   public static final IMenuTypeMapper AUTO_MENU_TYPE_MAPPER = menuType -> menuType;
 
@@ -82,7 +81,7 @@ public class OutlineMenuWrapper extends AbstractWidget implements IReadOnlyMenu 
    *          the menuTypes for the menu and for each menu in the sub-hierarchy are individually computed with this
    *          mapper
    */
-  protected OutlineMenuWrapper(IMenu menu, IMenuTypeMapper menuTypeMapper, Predicate<IAction> menuFilter) {
+  protected OutlineMenuWrapper(IMenu menu, IMenuTypeMapper menuTypeMapper, Predicate<IMenu> menuFilter) {
     m_wrappedMenu = menu;
     m_menuTypeMapper = menuTypeMapper;
     m_menuFilter = menuFilter;
@@ -109,10 +108,8 @@ public class OutlineMenuWrapper extends AbstractWidget implements IReadOnlyMenu 
     List<IMenu> childActions = m_wrappedMenu.getChildActions();
     List<IMenu> wrappedChildActions = new ArrayList<>(childActions.size());
     // create child wrappers
-    for (IAction a : ActionUtility.getActions(childActions, m_menuFilter)) {
-      if (a instanceof IMenu) {
-        wrappedChildActions.add(new OutlineMenuWrapper((IMenu) a, m_menuTypeMapper, m_menuFilter));
-      }
+    for (IMenu m : MenuUtility.filterMenusRec(childActions, m_menuFilter)) {
+      wrappedChildActions.add(new OutlineMenuWrapper(m, m_menuTypeMapper, m_menuFilter));
     }
     propertySupport.setProperty(PROP_CHILD_ACTIONS, wrappedChildActions);
   }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPage.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPage.java
@@ -37,10 +37,10 @@ import org.eclipse.scout.rt.client.extension.ui.desktop.outline.pages.PageChains
 import org.eclipse.scout.rt.client.extension.ui.desktop.outline.pages.PageChains.PageReloadPageChain;
 import org.eclipse.scout.rt.client.services.common.icon.IIconProviderService;
 import org.eclipse.scout.rt.client.session.ClientSessionProvider;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
 import org.eclipse.scout.rt.client.ui.action.keystroke.AbstractKeyStroke;
 import org.eclipse.scout.rt.client.ui.action.keystroke.IKeyStroke;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.TreeMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.root.ITableContextMenu;
@@ -618,7 +618,7 @@ public abstract class AbstractPage<T extends ITable> extends AbstractTreeNode im
     }
     ITable table = parentTablePage.getTable();
     table.getUIFacade().setSelectedRowsFromUI(CollectionUtility.arrayList(row));
-    return ActionUtility.getActions(table.getContextMenu().getChildActions(), ActionUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(TableMenuType.SingleSelection), false));
+    return MenuUtility.filterMenusRec(table.getContextMenu().getChildActions(), MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(TableMenuType.SingleSelection), false));
   }
 
   protected abstract T createTable();

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithNodes.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithNodes.java
@@ -16,9 +16,8 @@ import java.util.function.Predicate;
 import org.eclipse.scout.rt.client.extension.ui.basic.tree.ITreeNodeExtension;
 import org.eclipse.scout.rt.client.extension.ui.desktop.outline.pages.IPageWithNodesExtension;
 import org.eclipse.scout.rt.client.extension.ui.desktop.outline.pages.PageWithNodesChains.PageWithNodesCreateChildPagesChain;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
-import org.eclipse.scout.rt.client.ui.action.IAction;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.TreeMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.root.IFormFieldContextMenu;
@@ -311,8 +310,8 @@ public abstract class AbstractPageWithNodes extends AbstractPage<ITable> impleme
       ITreeNode node = getTreeNodeFor(CollectionUtility.firstElement(selectedRows));
       if (node instanceof IPageWithNodes) {
         IPageWithNodes pageWithNodes = (IPageWithNodes) node;
-        Predicate<IAction> filter = ActionUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(TreeMenuType.SingleSelection), false);
-        List<IMenu> menus = ActionUtility.getActions(pageWithNodes.getMenus(), filter);
+        Predicate<IMenu> filter = MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(TreeMenuType.SingleSelection), false);
+        List<IMenu> menus = MenuUtility.filterMenusRec(pageWithNodes.getMenus(), filter);
         for (IMenu m : menus) {
           pageMenus.add(MenuWrapper.wrapMenu(m, TREE_MENU_TYPE_MAPPER, filter));
         }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithTable.java
@@ -26,8 +26,8 @@ import org.eclipse.scout.rt.client.extension.ui.desktop.outline.pages.PageWithTa
 import org.eclipse.scout.rt.client.extension.ui.desktop.outline.pages.PageWithTableChains.PageWithTablePopulateTableChain;
 import org.eclipse.scout.rt.client.services.common.search.ISearchFilterService;
 import org.eclipse.scout.rt.client.session.ClientSessionProvider;
-import org.eclipse.scout.rt.client.ui.action.ActionUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
+import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuType;
 import org.eclipse.scout.rt.client.ui.basic.cell.Cell;
 import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
@@ -336,7 +336,7 @@ public abstract class AbstractPageWithTable<T extends ITable> extends AbstractPa
     if (table == null) {
       return CollectionUtility.emptyArrayList();
     }
-    return ActionUtility.getActions(table.getMenus(), ActionUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(TableMenuType.EmptySpace), false));
+    return MenuUtility.filterMenusRec(table.getMenus(), MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(TableMenuType.EmptySpace), false));
   }
 
   protected IPage<?> createDefaultChildPage(ITableRow row) {


### PR DESCRIPTION
Most methods of ActionUtility are built for menus but accept IAction.
Therefore, they do not handle child menus as IAction does not know child
actions. Move those methods to MenuUtility, change their signature to
IMenu and migrate all usages. As a consequence also the signature of
MenuWrapper, OutlineMenuWrapper and OutlineFormMenuWrapper are changed
accordingly.
The behaviour of MenuUtility.filterMenusRec (moved from
ActionUtility.getActions) was changed slightly. A menu accepted by the
filter that has child menus will now be wrapped and its child menus are
filtered by the given filter as well.
Consider a menu A with child menus B and C and the filter accepts A and
B. The result of MenuUtility.filterMenusRec will be a wrapped menu A
with only one child B.

240403