### PR TITLE
Tree: fix child node index if node with child node model is inserted

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -257,7 +257,7 @@ export class Tree extends Widget implements TreeModel {
     if (this.initialized) {
       let previousNodes = parentNode ? parentNode.childNodes : this.nodes;
       if (previousNodes.length > 0) {
-        nextChildNodeIndex = previousNodes[previousNodes.length - 1].childNodeIndex + 1;
+        nextChildNodeIndex = scout.nvl(previousNodes[previousNodes.length - 1].childNodeIndex, -1) + 1;
       }
     }
     for (let i = 0; i < nodes.length; i++) {

--- a/eclipse-scout-core/src/tree/TreeNode.ts
+++ b/eclipse-scout-core/src/tree/TreeNode.ts
@@ -133,7 +133,7 @@ export class TreeNode implements TreeNodeModel, ObjectWithType {
 
     // make sure all child nodes are TreeNodes too
     if (this.hasChildNodes()) {
-      this.getTree().ensureTreeNodes(this.childNodes, this.parentNode);
+      this.getTree().ensureTreeNodes(this.childNodes, this);
     }
   }
 

--- a/eclipse-scout-core/test/tree/TreeSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeSpec.ts
@@ -152,12 +152,16 @@ describe('Tree', () => {
       tree.insertNodes(nodeModels);
       expect(tree.nodes[2].id).toBe(node2.id);
       expect(tree.nodes[3].text).toBe('node A');
+      expect(tree.nodes[3].childNodeIndex).toBe(3);
       expect(tree.nodes[4].text).toBe('node B');
+      expect(tree.nodes[4].childNodeIndex).toBe(4);
       expect(tree.nodes[3].$node.prev().text()).toBe('node 2_2');
       expect(tree.nodes[3].$node.text()).toBe('node A');
       expect(tree.nodes[3].$node.next().text()).toBe('node A_0');
       expect(tree.nodes[3].childNodes[0].text).toBe('node A_0');
+      expect(tree.nodes[3].childNodes[0].childNodeIndex).toBe(0);
       expect(tree.nodes[3].childNodes[1].text).toBe('node A_1');
+      expect(tree.nodes[3].childNodes[1].childNodeIndex).toBe(1);
       expect(tree.nodes[3].childNodes[0].$node.prev().text()).toBe('node A');
       expect(tree.nodes[3].childNodes[0].$node.text()).toBe('node A_0');
       expect(tree.nodes[3].childNodes[0].$node.next().text()).toBe('node A_1');


### PR DESCRIPTION
When inserting a node model with a child node model, the index for the child node was wrong.