### PR TITLE
FocusManager: provide API to focus the next tabbable element

### DIFF
--- a/eclipse-scout-core/src/focus/FocusManager.js
+++ b/eclipse-scout-core/src/focus/FocusManager.js
@@ -369,6 +369,16 @@ export default class FocusManager {
     });
   }
 
+  /**
+   * Focuses the next or previous valid element within the focus context of the given `activeElement`.
+   */
+  focusNextTabbable(activeElement, forward = true) {
+    let focusContext = this._findFocusContextFor(activeElement);
+    if (focusContext) {
+      focusContext.focusNextTabbable(forward);
+    }
+  }
+
   _findFocusContextFor($element) {
     $element = $.ensure($element);
     let context = null;

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.js
@@ -428,23 +428,7 @@ export default class SmartField extends ValueField {
 
   _focusNextTabbable() {
     if (this._tabPrevented) {
-      let $tabElements = this.entryPoint().find(':tabbable'),
-        direction = this._tabPrevented.shiftKey ? -1 : 1,
-        fieldIndex = $tabElements.index(this.$field),
-        nextIndex = fieldIndex + direction;
-
-      if (nextIndex < 0) {
-        nextIndex = $tabElements.length - 1;
-      } else if (nextIndex >= $tabElements.length) {
-        nextIndex = 0;
-      }
-      $.log.isDebugEnabled() && $.log.debug('(SmartField#_inputAccepted) tab-index=' + fieldIndex + ' next tab-index=' + nextIndex);
-      let $nextElement = $tabElements.eq(nextIndex).focus();
-      if (objects.isFunction($nextElement[0].select)) {
-        $nextElement[0].select();
-      }
-      // This is normally done by FocusManager, but since propagation is stopped, we need to do it here as well
-      $nextElement.addClass('keyboard-navigation');
+      this.session.focusManager.focusNextTabbable(this.$container.activeElement(), !this._tabPrevented.shiftKey);
       this._tabPrevented = null;
     }
   }


### PR DESCRIPTION
Usually, the browser automatically focuses the next tabbable element in the DOM when the user presses the TAB key. This default behavior is prevented in the smart field, because acceptInput() is asynchronous. After the input is accepted, the focus is set to the next element programmatically.

The previous implementation did not consider focus contexts, which caused the focus to get "lost" when the last field on a dialog is a smart field. To fix this, the corresponding logic in FocusContext is exposed on the FocusManager and is now called by the SmartField.

322231