### PR TITLE
Notification: info color is the same as link color

### DIFF
--- a/eclipse-scout-core/src/notification/Notification.less
+++ b/eclipse-scout-core/src/notification/Notification.less
@@ -71,7 +71,7 @@
       color: @notification-alternative-info-color;
       font-weight: @font-weight-bold;
       background-color: @notification-alternative-info-background-color;
-      --no-icon-marker-color: @notification-alternative-info-color;
+      --no-icon-marker-color: @notification-alternative-info-marker-color;
     }
   }
 

--- a/eclipse-scout-core/src/style/colors-dark.less
+++ b/eclipse-scout-core/src/style/colors-dark.less
@@ -178,12 +178,11 @@
 @default-combo-menu-separator-color: @text-inverted-color;
 @dimmed-background-color: @palette-gray-9;
 @group-header-color: @text-color-2;
-@notification-alternative-ok-background-color: fade(@palette-green-5, 60%);
-@notification-alternative-info-background-color: fade(@accent-color-5, 60%);
-@notification-alternative-warning-background-color: fade(@palette-orange-5, 60%);
+@notification-alternative-ok-background-color: fade(@palette-green-5, 40%);
+@notification-alternative-info-background-color: fade(@accent-color-3, 20%);
+@notification-alternative-warning-background-color: fade(@palette-orange-5, 40%);
 @notification-alternative-error-background-color: fade(@palette-red-5, 50%);
 @notification-alternative-ok-color: @ok-color;
-@notification-alternative-info-color: @info-color;
 @notification-alternative-warning-color: @warning-color;
 @notification-alternative-error-color: lighten(@error-color, 5%);
 @outline-group-background-color: @palette-gray-6-1;

--- a/eclipse-scout-core/src/style/colors.less
+++ b/eclipse-scout-core/src/style/colors.less
@@ -314,9 +314,10 @@
 @notification-alternative-warning-background-color: @palette-orange-0;
 @notification-alternative-error-background-color: @palette-red-0;
 @notification-alternative-ok-color: darken(@ok-color, 3%); // Colors need to be a little darker on a background to make them accessible
-@notification-alternative-info-color: @info-color;
+@notification-alternative-info-color: @text-color;
 @notification-alternative-warning-color: darken(@warning-color, 3%);
 @notification-alternative-error-color: darken(@error-color, 8%);
+@notification-alternative-info-marker-color: @info-color;
 @notification-ok-border-color: @ok-color;
 @notification-info-border-color: @info-color;
 @notification-warning-border-color: @warning-color;


### PR DESCRIPTION
If the info notification contains links, they look the same as the text -> use another color for the text.

Also improve dark colors slightly.