### PR TITLE
Multidimensional properties: support truthy and falsy

### DIFF
--- a/eclipse-scout-core/src/events/PropertyEventEmitter.ts
+++ b/eclipse-scout-core/src/events/PropertyEventEmitter.ts
@@ -300,15 +300,15 @@ export class PropertyEventEmitter extends EventEmitter {
   }
 
   /**
-   * If the value is an object, the entries in the object are expected to be property dimensions.
+   * If the value is an object, the entries in the object are expected to be property dimensions and need to have the correct data type (`boolean`).
    * In that case, {@link setPropertyDimensions} is used to set the dimensions.
    * Otherwise, the `default` dimension for the given property is set using {@link setPropertyDimension}.
    */
   setMultiDimensionalProperty(propertyName: string, value: boolean | Record<string, boolean>): boolean {
-    if (typeof value === 'object') {
+    if (!objects.isNullOrUndefined(value) && typeof value === 'object' && Object.values(value).every(val => typeof val === 'boolean')) {
       return this.setPropertyDimensions(propertyName, value);
     }
-    return this.setPropertyDimension(propertyName, 'default', value);
+    return this.setPropertyDimension(propertyName, 'default', !!value);
   }
 
   /**

--- a/eclipse-scout-core/test/events/PropertyEventEmitterSpec.ts
+++ b/eclipse-scout-core/test/events/PropertyEventEmitterSpec.ts
@@ -371,6 +371,73 @@ describe('PropertyEventEmitter', () => {
         expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(false);
       });
 
+      it('only accepts objects with the correct structure for legacy reasons', () => {
+        // Prior to the multidimensional properties, not only real booleans were accepted
+        // but also falsy (null, undefined, empty string, 0) and truthy values (strings, objects, numbers etc.)
+        // Even though it is bad practise, people used it and without using TypeScript, such errors are hard to find
+        // -> falsy and truthy should still be supported as far as possible
+        let emitter = scout.create(DimensionalPropertyEventEmitter);
+        expect(emitter.getPropertyDimension('multiProp', 'default')).toBe(true);
+        expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(true);
+        expect(emitter.getProperty('multiProp')).toBe(true);
+
+        emitter.setProperty('multiProp', null);
+        expect(emitter.getPropertyDimension('multiProp', 'default')).toBe(false);
+        expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(true);
+        expect(emitter.getProperty('multiProp')).toBe(false);
+
+        emitter.setProperty('multiProp', {});
+        expect(emitter.getProperty('multiProp')).toBe(true);
+
+        emitter.setProperty('multiProp', undefined);
+        expect(emitter.getPropertyDimension('multiProp', 'default')).toBe(false);
+        expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(true);
+        expect(emitter.getProperty('multiProp')).toBe(false);
+
+        emitter.setProperty('multiProp', {});
+        expect(emitter.getProperty('multiProp')).toBe(true);
+
+        emitter.setProperty('multiProp', 0);
+        expect(emitter.getPropertyDimension('multiProp', 'default')).toBe(false);
+        expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(true);
+        expect(emitter.getProperty('multiProp')).toBe(false);
+
+        emitter.setProperty('multiProp', {});
+        expect(emitter.getProperty('multiProp')).toBe(true);
+
+        emitter.setProperty('multiProp', '');
+        expect(emitter.getPropertyDimension('multiProp', 'default')).toBe(false);
+        expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(true);
+        expect(emitter.getProperty('multiProp')).toBe(false);
+
+        emitter.setProperty('multiProp', {});
+        expect(emitter.getProperty('multiProp')).toBe(true);
+
+        emitter.setProperty('multiProp', NaN);
+        expect(emitter.getPropertyDimension('multiProp', 'default')).toBe(false);
+        expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(true);
+        expect(emitter.getProperty('multiProp')).toBe(false);
+
+        emitter.setProperty('multiProp', {});
+        expect(emitter.getProperty('multiProp')).toBe(true);
+
+        // Multidimensional properties only work with booleans
+        // If not all values in the given object are booleans, the object will be used as value for the default dimension
+        emitter.setProperty('multiProp', {dim1: 'asdf', default: false});
+        expect(emitter.getPropertyDimension('multiProp', 'default')).toBe(true);
+        expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(true);
+        expect(emitter.getProperty('multiProp')).toBe(true);
+
+        emitter.setProperty('multiProp', {dim1: false, default: true});
+        expect(emitter.getProperty('multiProp')).toBe(false);
+
+        // Assert that only default dimension is changed and dim1 stays false
+        emitter.setProperty('multiProp', {dim1: 'asdf', default: false});
+        expect(emitter.getPropertyDimension('multiProp', 'default')).toBe(true);
+        expect(emitter.getPropertyDimension('multiProp', 'dim1')).toBe(false);
+        expect(emitter.getProperty('multiProp')).toBe(false);
+      });
+
       it('clears the dimension object if dimensions are default', () => {
         let emitter = scout.create(DimensionalPropertyEventEmitter);
         expect(Object.keys(emitter.getPropertyDimensions('multiProp')).length).toBe(0);


### PR DESCRIPTION
In earlier versions, widget.setVisible(null) or widget.setEnabled('hi') worked as expected.
Now, if the parameter is an object, it is treated as dimension object, which means the key is used as dimension and the value as dimension value.
For existing code, this is wrong and creates errors that are hard to find.
To mitigate it, the parameter is now checked for the correct structure. If the structure is wrong, it will be converted to a boolean and used for the default dimension.

This should work except for 2 cases because the structure is correct:
- If an empty object was used ({})
- If an object was used whose values had the correct data type ({dim: false})