### PR TITLE
TabBox: tab is not selected if it is added dynamically

### DIFF
--- a/eclipse-scout-core/src/form/fields/datefield/DateFieldAdapter.ts
+++ b/eclipse-scout-core/src/form/fields/datefield/DateFieldAdapter.ts
@@ -11,7 +11,14 @@ import {App, arrays, DateField, dates, objects, ParsingFailedStatus, RemoteEvent
 
 export class DateFieldAdapter extends ValueFieldAdapter {
 
-  static PROPERTIES_ORDER = ['hasTime', 'hasDate'];
+  constructor() {
+    super();
+    /**
+     * Make sure hasDate and hasTime are always set before displayText, otherwise toggling hasDate and hasTime dynamically
+     * won't work because renderDisplayText would try to write the time into the date field
+     */
+    this._addOrderedProperties(['hasTime', 'hasDate']);
+  }
 
   protected override _onWidgetAcceptInput(event: ValueFieldAcceptInputEvent<Date>) {
     let parsingFailedError = null;
@@ -37,14 +44,6 @@ export class DateFieldAdapter extends ValueFieldAdapter {
         return this.target === previous.target && this.type === previous.type;
       }
     });
-  }
-
-  /**
-   * Make sure hasDate and hasTime are always set before displayText, otherwise toggling hasDate and hasTime dynamically
-   * won't work because renderDisplayText would try to write the time into the date field
-   */
-  protected override _orderPropertyNamesOnSync(newProperties: Record<string, any>): string[] {
-    return Object.keys(newProperties).sort(this._createPropertySortFunc(DateFieldAdapter.PROPERTIES_ORDER));
   }
 
   static isDateAllowedRemote(this: DateField & { isDateAllowedOrig: typeof DateField.prototype.isDateAllowed }, date: Date): boolean {

--- a/eclipse-scout-core/src/form/fields/filechooserfield/FileChooserFieldAdapter.ts
+++ b/eclipse-scout-core/src/form/fields/filechooserfield/FileChooserFieldAdapter.ts
@@ -12,7 +12,15 @@ import {FileChooserField, PropertyChangeEvent, ValueFieldAdapter} from '../../..
 export class FileChooserFieldAdapter extends ValueFieldAdapter {
   declare widget: FileChooserField;
 
-  static PROPERTIES_ORDER = ['value', 'displayText'];
+  constructor() {
+    super();
+    /**
+     * Handle events in this order value, displayText. This allows to set a null value and set a display-text
+     * anyway. Otherwise, the field would be empty. Note: this order is not a perfect solution for every case,
+     * but it solves the issue reported in ticket #290908.
+     */
+    this._addOrderedProperties(['value', 'displayText']);
+  }
 
   protected override _onWidgetPropertyChange(event: PropertyChangeEvent<any, FileChooserField>) {
     super._onWidgetPropertyChange(event);
@@ -32,14 +40,5 @@ export class FileChooserFieldAdapter extends ValueFieldAdapter {
   protected override _syncDisplayText(displayText: string) {
     this.widget.setDisplayText(displayText);
     // When displayText comes from the server we must not call parseAndSetValue here.
-  }
-
-  /**
-   * Handle events in this order value, displayText. This allows to set a null value and set a display-text
-   * anyway. Otherwise the field would be empty. Note: this order is not a perfect solution for every case,
-   * but it solves the issue reported in ticket #290908.
-   */
-  protected override _orderPropertyNamesOnSync(newProperties: Record<string, any>): string[] {
-    return Object.keys(newProperties).sort(this._createPropertySortFunc(FileChooserFieldAdapter.PROPERTIES_ORDER));
   }
 }

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldAdapter.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldAdapter.ts
@@ -16,16 +16,15 @@ export class SmartFieldAdapter extends LookupFieldAdapter {
     super();
 
     this._addRemoteProperties(['activeFilter']);
+    /**
+     * Property lookup-row must be handled before value, since the smart-field has either a lookup-row
+     * or a value but never both (when we only have a value, the smart-field must perform a lookup by key
+     * in order to resolve the display name for that value).
+     *
+     * Intentionally don't re-use properties from super-classes.
+     */
+    this._orderedProperties = ['lookupRow', 'value', 'errorStatus', 'displayText'];
   }
-
-  /**
-   * Property lookup-row must be handled before value, since the smart-field has either a lookup-row
-   * or a value but never both (when we only have a value, the smart-field must perform a lookup by key
-   * in order to resolve the display name for that value).
-   * <br>
-   * Intentionally don't re-use properties from super-classes.
-   */
-  static PROPERTIES_ORDER = ['lookupRow', 'value', 'errorStatus', 'displayText'];
 
   /** @internal */
   override _postCreateWidget() {
@@ -47,10 +46,6 @@ export class SmartFieldAdapter extends LookupFieldAdapter {
   // When displayText comes from the server we must not call parseAndSetValue here.
   protected override _syncDisplayText(displayText: string) {
     this.widget.setDisplayText(displayText);
-  }
-
-  protected override _orderPropertyNamesOnSync(newProperties: Record<string, any>): string[] {
-    return Object.keys(newProperties).sort(this._createPropertySortFunc(SmartFieldAdapter.PROPERTIES_ORDER));
   }
 
   protected override _onWidgetEvent(event: Event<SmartField<any>>) {

--- a/eclipse-scout-core/src/form/fields/tabbox/TabBoxAdapter.ts
+++ b/eclipse-scout-core/src/form/fields/tabbox/TabBoxAdapter.ts
@@ -14,6 +14,7 @@ export class TabBoxAdapter extends CompositeFieldAdapter {
   constructor() {
     super();
     this._addRemoteProperties(['selectedTab']);
+    this._addOrderedProperties(['tabItems', 'selectedTab']);
   }
 
   override exportAdapterData(adapterData: AdapterData): AdapterData {

--- a/eclipse-scout-core/src/planner/PlannerAdapter.ts
+++ b/eclipse-scout-core/src/planner/PlannerAdapter.ts
@@ -15,12 +15,7 @@ export class PlannerAdapter extends ModelAdapter {
   constructor() {
     super();
     this._addRemoteProperties(['displayMode', 'viewRange', 'selectionRange', 'selectedActivity']);
-  }
-
-  static PROPERTIES_ORDER = ['displayMode', 'viewRange'];
-
-  protected override _orderPropertyNamesOnSync(newProperties: Record<string, any>): string[] {
-    return Object.keys(newProperties).sort(this._createPropertySortFunc(PlannerAdapter.PROPERTIES_ORDER));
+    this._addOrderedProperties(['displayMode', 'viewRange']);
   }
 
   protected _sendViewRange(viewRange: DateRange) {

--- a/eclipse-scout-core/test/form/fields/tabbox/TabBoxAdapterSpec.ts
+++ b/eclipse-scout-core/test/form/fields/tabbox/TabBoxAdapterSpec.ts
@@ -52,6 +52,23 @@ describe('TabBoxAdapter', () => {
         sendQueuedAjaxCalls();
         expect(jasmine.Ajax.requests.count()).toBe(0);
       });
+
+      it('is correctly set even if tabItems property is sent as well', () => {
+        let tabBox = helper.createTabBox();
+        linkWidgetAndAdapter(tabBox, 'TabBoxAdapter');
+
+        let message = {
+          adapterData: mapAdapterData([{objectType: 'TabItem', id: 'ti1'}, {objectType: 'TabItem', id: 'ti2'}]),
+          events: [createPropertyChangeEvent(tabBox.modelAdapter, {
+            selectedTab: 'ti2',
+            tabItems: ['ti1', 'ti2'] // server may send it after selectedTab which is actually the wrong order
+          })]
+        };
+        session._processSuccessResponse(message);
+        expect(tabBox.tabItems.length).toBe(2);
+        expect(tabBox.selectedTab).toBe(tabBox.tabItems[1]);
+        expect(tabBox.header.tabArea.selectedTab).toBe(tabBox.header.tabArea.getTabForItem(tabBox.selectedTab));
+      });
     });
   });
 


### PR DESCRIPTION
In Scout Classic, if a TabBox contains no tabs and a TabItem is added dynamically, the TabBox automatically selects the new tab. This happens before the tabItems event is fired so the property changes are sent in the wrong order to the UI and the tab box header tries to select a tab that does not exist yet.

358297