### PR TITLE
Reposition tooltips after layout validation

### DIFF
--- a/eclipse-scout-core/src/desktop/Desktop.js
+++ b/eclipse-scout-core/src/desktop/Desktop.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -63,6 +63,7 @@ export default class Desktop extends Widget {
     this.dense = false;
     this._glassPaneTargetFilters = [];
     this.url = null;
+    this._repositionTooltipsHandler = null;
 
     this._addWidgetProperties(['viewButtons', 'menus', 'views', 'selectedViewTabs', 'dialogs', 'outline', 'messageBoxes', 'notifications', 'fileChoosers', 'addOns', 'keyStrokes', 'activeForm', 'focusedElement']);
     this._addPreserveOnPropertyChangeProperties(['focusedElement']);
@@ -1602,6 +1603,38 @@ export default class Desktop extends Widget {
     } else {
       overlay.$container.insertAfter(parentOverlay ? parentOverlay.$container : this.$overlaySeparator);
     }
+  }
+
+  /**
+   * @param {Tooltip} tooltip
+   */
+  tooltipRendered(tooltip) {
+    this.adjustOverlayOrder(tooltip);
+    if (this._repositionTooltipsHandler) {
+      return;
+    }
+    if (!this.$container.children('.tooltip').length) {
+      return;
+    }
+    this._repositionTooltipsHandler = () => {
+      this.repositionTooltips();
+      this.session.layoutValidator.schedulePostValidateFunction(this._repositionTooltipsHandler);
+    };
+    this.session.layoutValidator.schedulePostValidateFunction(this._repositionTooltipsHandler);
+  }
+
+  /**
+   * @param {Tooltip} tooltip
+   */
+  tooltipRemoved(tooltip) {
+    if (!this._repositionTooltipsHandler) {
+      return;
+    }
+    if (this.$container.children('.tooltip').length) {
+      return;
+    }
+    this.session.layoutValidator.removePostValidateFunction(this._repositionTooltipsHandler);
+    this._repositionTooltipsHandler = null;
   }
 
   repositionTooltips() {

--- a/eclipse-scout-core/src/desktop/DesktopLayout.js
+++ b/eclipse-scout-core/src/desktop/DesktopLayout.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -85,11 +85,7 @@ export default class DesktopLayout extends AbstractLayout {
         benchSize = new Dimension(containerSize.width - navigationWidth, containerSize.height - headerHeight)
           .subtract(htmlBench.margins());
         if (!animated || fullWidthNavigation) {
-          let oldSize = htmlBench.size();
           htmlBench.setSize(benchSize);
-          if (!htmlBench.size().equals(oldSize)) {
-            desktop.repositionTooltips();
-          }
         }
 
         if (animated) {

--- a/eclipse-scout-core/src/form/Form.js
+++ b/eclipse-scout-core/src/form/Form.js
@@ -623,7 +623,7 @@ export default class Form extends Widget {
   _onResize(event) {
     let autoSizeOld = this.htmlComp.layout.autoSize;
     this.htmlComp.layout.autoSize = false;
-    this.htmlComp.revalidateLayout();
+    this.htmlComp.revalidateLayoutTree(false);
     this.htmlComp.layout.autoSize = autoSizeOld;
     this.updateCacheBounds();
     return false;

--- a/eclipse-scout-core/src/form/fields/FormFieldLayout.js
+++ b/eclipse-scout-core/src/form/fields/FormFieldLayout.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -49,7 +49,6 @@ export default class FormFieldLayout extends AbstractLayout {
     let containerPadding, fieldOffset, fieldSize, fieldBounds, htmlField, labelHasFieldWidth, top, bottom, left, right,
       htmlContainer = HtmlComponent.get($container),
       formField = this.formField,
-      tooltip = formField._tooltip(),
       labelWidth = this.labelWidth(),
       statusWidth = this.statusWidth;
 
@@ -177,11 +176,6 @@ export default class FormFieldLayout extends AbstractLayout {
       if (formField.$clearIcon) {
         this._layoutClearIcon(formField, fieldBounds, right, top);
       }
-    }
-
-    // Make sure tooltip is at correct position after layouting, if there is one
-    if (tooltip && tooltip.rendered) {
-      tooltip.position();
     }
 
     // Check for scrollbars, update them if necessary

--- a/eclipse-scout-core/src/form/fields/groupbox/GroupBoxLayout.js
+++ b/eclipse-scout-core/src/form/fields/groupbox/GroupBoxLayout.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -44,7 +44,6 @@ export default class GroupBoxLayout extends AbstractLayout {
       htmlContainer = this.groupBox.htmlComp,
       htmlGbBody = this._htmlGbBody(),
       htmlMenuBar = this._htmlMenuBar(),
-      tooltip = this.groupBox._tooltip(),
       $header = this.groupBox.$header,
       $title = this.groupBox.$title,
       containerSize = htmlContainer.availableSize()
@@ -93,11 +92,6 @@ export default class GroupBoxLayout extends AbstractLayout {
     gbBodySize.height -= menuBarHeight;
     $.log.isTraceEnabled() && $.log.trace('(GroupBoxLayout#layout) gbBodySize=' + gbBodySize);
     htmlGbBody.setSize(gbBodySize);
-
-    // Make sure tooltip is at correct position after layouting, if there is one
-    if (tooltip && tooltip.rendered) {
-      tooltip.position();
-    }
 
     if (htmlGbBody.scrollable || this.groupBox.bodyLayoutConfig.minWidth > 0) {
       scrollbars.update(htmlGbBody.$comp);

--- a/eclipse-scout-core/src/form/fields/tabbox/TabBoxLayout.js
+++ b/eclipse-scout-core/src/form/fields/tabbox/TabBoxLayout.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -41,7 +41,6 @@ export default class TabBoxLayout extends AbstractLayout {
       htmlHeader = HtmlComponent.get(this._tabBox.header.$container),
       headerWidthHint = 0,
       headerSize = new Dimension(),
-      tooltip = this._tabBox._tooltip(),
       $status = this._tabBox.$status,
       statusPosition = this._tabBox.statusPosition;
 
@@ -73,11 +72,6 @@ export default class TabBoxLayout extends AbstractLayout {
     tabContentSize = containerSize.subtract(htmlTabContent.margins());
     tabContentSize.height -= headerSize.height;
     htmlTabContent.setSize(tabContentSize);
-
-    // Make sure tooltip is at correct position after layouting, if there is one
-    if (tooltip && tooltip.rendered) {
-      tooltip.position();
-    }
   }
 
   _layoutStatus(height) {

--- a/eclipse-scout-core/src/layout/LayoutValidator.js
+++ b/eclipse-scout-core/src/layout/LayoutValidator.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -106,10 +106,7 @@ export default class LayoutValidator {
         arrays.remove(this._invalidComponents, comp);
       }
     }, this);
-    this._postValidateFunctions.slice().forEach(function(func) {
-      func();
-      arrays.remove(this._postValidateFunctions, func);
-    }, this);
+    this._postValidateFunctions.splice(0).forEach(func => func());
   }
 
   /**
@@ -141,8 +138,16 @@ export default class LayoutValidator {
    * Runs the given function at the end of validate().
    */
   schedulePostValidateFunction(func) {
-    if (func) {
-      this._postValidateFunctions.push(func);
+    if (!func) {
+      return;
     }
+    this._postValidateFunctions.push(func);
+  }
+
+  removePostValidateFunction(func) {
+    if (!func) {
+      return;
+    }
+    arrays.remove(this._postValidateFunctions, func);
   }
 }

--- a/eclipse-scout-core/src/popup/Popup.js
+++ b/eclipse-scout-core/src/popup/Popup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -249,6 +249,7 @@ export default class Popup extends Widget {
       this.$container.removeClass('before-animate-open');
       this.validateFocus(); // Need to be done after popup is visible again because focus cannot be set on invisible elements.
       this.$container.addClassForAnimation('animate-open');
+      this.$container.oneAnimationEnd(() => this.findDesktop().repositionTooltips());
     });
   }
 

--- a/eclipse-scout-core/src/popup/WidgetPopup.js
+++ b/eclipse-scout-core/src/popup/WidgetPopup.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -186,7 +186,7 @@ export default class WidgetPopup extends Popup {
   _onResize(event) {
     let autoSizeOrig = this.htmlComp.layout.autoSize;
     this.htmlComp.layout.autoSize = false;
-    this.htmlComp.revalidateLayout();
+    this.htmlComp.revalidateLayoutTree(false);
     this.htmlComp.layout.autoSize = autoSizeOrig;
     this._updateArrowPosition();
     return false;

--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -3940,6 +3940,7 @@ export default class Table extends Widget {
       }
     }, this);
 
+    this.findDesktop().repositionTooltips();
     this._triggerColumnResized(column);
   }
 

--- a/eclipse-scout-core/src/table/TableFooterLayout.js
+++ b/eclipse-scout-core/src/table/TableFooterLayout.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -72,13 +72,6 @@ export default class TableFooterLayout extends AbstractLayout {
     // don't animate on the first layouting -> only animate on user interactions
     let animated = this._tableFooter.htmlComp.layouted;
     this._setInfoItemsSize($infoItems, animated);
-
-    if (this._tableFooter._tableStatusTooltip && this._tableFooter._tableStatusTooltip.rendered) {
-      this._tableFooter._tableStatusTooltip.position();
-    }
-    if (this._tableFooter._tableInfoTooltip && this._tableFooter._tableInfoTooltip.rendered) {
-      this._tableFooter._tableInfoTooltip.position();
-    }
 
     // Let table controls update their content according to the new footer size
     this._tableFooter.table.tableControls.forEach(control => {

--- a/eclipse-scout-core/src/table/TableLayout.js
+++ b/eclipse-scout-core/src/table/TableLayout.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -110,12 +110,6 @@ export default class TableLayout extends AbstractLayout {
         this.table._renderScrollTop();
       }
 
-      // Make sure tooltips and editor popup are at correct position after layouting (e.g after window resizing)
-      this.table.tooltips.forEach(tooltip => {
-        if (tooltip.rendered) {
-          tooltip.position();
-        }
-      });
       if (this.table.cellEditorPopup && this.table.cellEditorPopup.rendered) {
         this.table.cellEditorPopup.position();
         this.table.cellEditorPopup.pack();

--- a/eclipse-scout-core/test/accordion/AccordionSpec.js
+++ b/eclipse-scout-core/test/accordion/AccordionSpec.js
@@ -1,14 +1,14 @@
 /*
- * Copyright (c) 2010-2019 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {scout} from '../../src/index';
+import {graphics, scout, Status} from '../../src/index';
 
 describe('Accordion', () => {
   let session;
@@ -311,4 +311,122 @@ describe('Accordion', () => {
 
   });
 
+  describe('collapsible', () => {
+
+    beforeEach(() => {
+      $('<style>' +
+        '.group.collapsed:not(.collapsing) > .group-body { display: none; }' +
+        '</style>').appendTo($('#sandbox'));
+    });
+
+    it('removes status when collapsed', async () => {
+      const accordion = createAccordion(0);
+      const group = createGroup({
+        parent: accordion,
+        body: {
+          objectType: 'GroupBox',
+          fields: [
+            {
+              objectType: 'StringField',
+              errorStatus: {
+                message: 'I am an error!!!'
+              }
+            }
+          ]
+        }
+      });
+      accordion.insertGroup(group);
+      const field = group.body.fields[0];
+
+      accordion.render();
+      expect(field.fieldStatus.tooltip.rendered).toBeTrue();
+      expect(field.fieldStatus.tooltip.$container.isVisible()).toBeTrue();
+
+      group.setCollapsed(true);
+      await group.when('bodyHeightChangeDone');
+      expect(field.fieldStatus).toBeNull();
+
+      field.clearErrorStatus();
+      expect(field.fieldStatus).toBeNull();
+
+      field.addErrorStatus(Status.error('I am a new error!!!'));
+      expect(field.fieldStatus).toBeNull();
+
+      group.setCollapsed(false);
+      await group.when('bodyHeightChangeDone');
+      expect(field.fieldStatus.tooltip.rendered).toBeTrue();
+      expect(field.fieldStatus.tooltip.$container.isVisible()).toBeTrue();
+    });
+
+    it('moves status when sibling is collapsed', async () => {
+      const accordion = createAccordion(0, {exclusiveExpand: false});
+      const group0 = createGroup({
+        parent: accordion,
+        body: {
+          objectType: 'GroupBox',
+          fields: [
+            {
+              objectType: 'StringField'
+            }
+          ]
+        }
+      });
+      const group1 = createGroup({
+        parent: accordion,
+        body: {
+          objectType: 'GroupBox',
+          fields: [
+            {
+              objectType: 'StringField',
+              errorStatus: {
+                message: 'I am an error!!!'
+              }
+            }
+          ]
+        }
+      });
+      accordion.insertGroups([group0, group1]);
+      const fieldWithError = group1.body.fields[0];
+
+      const calcAnchorAndDiffs = t => {
+        const anchorBounds = graphics.offsetBounds(t.$anchor);
+        const tooltipBounds = graphics.offsetBounds(t.$container);
+        const xDiff = anchorBounds.x - tooltipBounds.x;
+        const yDiff = anchorBounds.y - tooltipBounds.y;
+        return {anchor: anchorBounds.point(), xDiff, yDiff};
+      };
+
+      accordion.render();
+      accordion.validateLayout();
+      const tooltip = fieldWithError.fieldStatus.tooltip;
+
+      expect(tooltip.rendered).toBeTrue();
+      expect(tooltip.$container.isVisible()).toBeTrue();
+
+      const anchorAndDiffs = calcAnchorAndDiffs(tooltip);
+
+      group0.setCollapsed(true);
+      await group0.when('bodyHeightChangeDone');
+      accordion.validateLayout();
+      expect(tooltip.$container.isVisible()).toBeTrue();
+
+      const anchorAndDiffsCollapsed = calcAnchorAndDiffs(tooltip);
+
+      expect(anchorAndDiffsCollapsed.anchor).not.toEqual(anchorAndDiffs.anchor);
+      expect(anchorAndDiffsCollapsed.xDiff).toBe(anchorAndDiffs.xDiff);
+      expect(anchorAndDiffsCollapsed.yDiff).toBe(anchorAndDiffs.yDiff);
+
+      group0.setCollapsed(false);
+      await group0.when('bodyHeightChangeDone');
+      accordion.validateLayout();
+      expect(tooltip.$container.isVisible()).toBeTrue();
+
+      const anchorAndDiffsExpanded = calcAnchorAndDiffs(tooltip);
+
+      expect(anchorAndDiffsExpanded.anchor).not.toEqual(anchorAndDiffsCollapsed.anchor);
+      expect(anchorAndDiffsExpanded.anchor).toEqual(anchorAndDiffs.anchor);
+      expect(anchorAndDiffsExpanded.xDiff).toBe(anchorAndDiffs.xDiff);
+      expect(anchorAndDiffsExpanded.yDiff).toBe(anchorAndDiffs.yDiff);
+    });
+  });
 });


### PR DESCRIPTION
Add a permanent (adds itself again an execution) post validation function if there are tooltips present on the desktop. This solves several tooltip position problems:
* collapse a group box containing a tooltip
* collapse a group box so that a sibling group box containing a tooltip moves to a new position
* collapse an accordion group containing a tooltip
* collapse an accordion group so that a sibling accordion group containing a tooltip moves to a new position
* move splitter in order to resize content containing a tooltip And it makes it unnecessary to explicitly call tooltip.position() during layout.
Revalidate layout tree after the resize of a form or widget popup to ensure that all tooltips are correctly positioned. After a popups open-animation ends and after a column resize reposition all tooltips.

308905, 317648, 318045