### PR TITLE
Reposition tooltips after layout validation

### DIFF
--- a/eclipse-scout-core/src/desktop/DesktopLayout.ts
+++ b/eclipse-scout-core/src/desktop/DesktopLayout.ts
@@ -85,11 +85,7 @@ export class DesktopLayout extends AbstractLayout {
         let benchSize = new Dimension(containerSize.width - navigationWidth, containerSize.height - headerHeight)
           .subtract(htmlBench.margins());
         if (!animated || fullWidthNavigation) {
-          let oldSize = htmlBench.size();
           htmlBench.setSize(benchSize);
-          if (!htmlBench.size().equals(oldSize)) {
-            desktop.repositionTooltips();
-          }
         }
 
         if (animated) {

--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -856,7 +856,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
     let layout = this.htmlComp.layout as DialogLayout,
       autoSizeOld = layout.autoSize;
     layout.autoSize = false;
-    this.htmlComp.revalidateLayout();
+    this.htmlComp.revalidateLayoutTree(false);
     layout.autoSize = autoSizeOld;
     this.updateCacheBounds();
     return false;

--- a/eclipse-scout-core/src/form/fields/FormFieldLayout.ts
+++ b/eclipse-scout-core/src/form/fields/FormFieldLayout.ts
@@ -55,7 +55,6 @@ export class FormFieldLayout extends AbstractLayout {
       fieldBounds: Rectangle,
       htmlContainer = HtmlComponent.get($container),
       formField = this.formField,
-      tooltip = formField.tooltip(),
       labelWidth = this.labelWidth(),
       statusWidth = this.statusWidth;
 
@@ -182,11 +181,6 @@ export class FormFieldLayout extends AbstractLayout {
       if (formField.$clearIcon) {
         this._layoutClearIcon(formField, fieldBounds, right, top);
       }
-    }
-
-    // Make sure tooltip is at correct position after layouting, if there is one
-    if (tooltip && tooltip.rendered) {
-      tooltip.position();
     }
 
     // Check for scrollbars, update them if necessary

--- a/eclipse-scout-core/src/form/fields/groupbox/GroupBoxLayout.ts
+++ b/eclipse-scout-core/src/form/fields/groupbox/GroupBoxLayout.ts
@@ -45,7 +45,6 @@ export class GroupBoxLayout extends AbstractLayout {
       htmlContainer = this.groupBox.htmlComp,
       htmlGbBody = this._htmlGbBody(),
       htmlMenuBar = this._htmlMenuBar(),
-      tooltip = this.groupBox.tooltip(),
       $header = this.groupBox.$header,
       $title = this.groupBox.$title,
       containerSize = htmlContainer.availableSize()
@@ -94,11 +93,6 @@ export class GroupBoxLayout extends AbstractLayout {
     gbBodySize.height -= menuBarHeight;
     $.log.isTraceEnabled() && $.log.trace('(GroupBoxLayout#layout) gbBodySize=' + gbBodySize);
     htmlGbBody.setSize(gbBodySize);
-
-    // Make sure tooltip is at correct position after layouting, if there is one
-    if (tooltip && tooltip.rendered) {
-      tooltip.position();
-    }
 
     if (htmlGbBody.scrollable || this.groupBox.bodyLayoutConfig.minWidth > 0) {
       scrollbars.update(htmlGbBody.$comp);

--- a/eclipse-scout-core/src/form/fields/tabbox/TabBoxLayout.ts
+++ b/eclipse-scout-core/src/form/fields/tabbox/TabBoxLayout.ts
@@ -44,7 +44,6 @@ export class TabBoxLayout extends AbstractLayout {
       htmlHeader = HtmlComponent.get(this._tabBox.header.$container),
       headerWidthHint = 0,
       headerSize = new Dimension(),
-      tooltip = this._tabBox.tooltip(),
       $status = this._tabBox.$status,
       statusPosition = this._tabBox.statusPosition;
 
@@ -76,11 +75,6 @@ export class TabBoxLayout extends AbstractLayout {
     tabContentSize = containerSize.subtract(htmlTabContent.margins());
     tabContentSize.height -= headerSize.height;
     htmlTabContent.setSize(tabContentSize);
-
-    // Make sure tooltip is at correct position after layouting, if there is one
-    if (tooltip && tooltip.rendered) {
-      tooltip.position();
-    }
   }
 
   protected _layoutStatus(height = 0) {

--- a/eclipse-scout-core/src/layout/LayoutValidator.ts
+++ b/eclipse-scout-core/src/layout/LayoutValidator.ts
@@ -111,10 +111,7 @@ export class LayoutValidator {
         arrays.remove(this._invalidComponents, comp);
       }
     });
-    this._postValidateFunctions.slice().forEach(func => {
-      func();
-      arrays.remove(this._postValidateFunctions, func);
-    });
+    this._postValidateFunctions.splice(0).forEach(func => func());
   }
 
   /**
@@ -146,8 +143,16 @@ export class LayoutValidator {
    * Runs the given function at the end of {@link validate}.
    */
   schedulePostValidateFunction(func: () => void) {
-    if (func) {
-      this._postValidateFunctions.push(func);
+    if (!func) {
+      return;
     }
+    this._postValidateFunctions.push(func);
+  }
+
+  removePostValidateFunction(func: () => void) {
+    if (!func) {
+      return;
+    }
+    arrays.remove(this._postValidateFunctions, func);
   }
 }

--- a/eclipse-scout-core/src/popup/Popup.ts
+++ b/eclipse-scout-core/src/popup/Popup.ts
@@ -256,6 +256,7 @@ export class Popup extends Widget implements PopupModel {
         return;
       }
       this.$container.addClassForAnimation('animate-open');
+      this.$container.oneAnimationEnd(() => this.findDesktop().repositionTooltips());
     });
   }
 

--- a/eclipse-scout-core/src/popup/WidgetPopup.ts
+++ b/eclipse-scout-core/src/popup/WidgetPopup.ts
@@ -202,7 +202,7 @@ export class WidgetPopup<TContent extends Widget = Widget> extends Popup impleme
     let layout = this.htmlComp.layout as PopupLayout;
     let autoSizeOrig = layout.autoSize;
     layout.autoSize = false;
-    this.htmlComp.revalidateLayout();
+    this.htmlComp.revalidateLayoutTree(false);
     layout.autoSize = autoSizeOrig;
     this._updateArrowPosition();
     return false;

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -4073,6 +4073,8 @@ export class Table extends Widget implements TableModel {
         this._resizeAggregateCell(this.$cell(column, aggregateRow.$row));
       }
     });
+
+    this.findDesktop().repositionTooltips();
   }
 
   /** @internal */
@@ -5588,7 +5590,7 @@ export class Table extends Widget implements TableModel {
    * @param includeCompacted true to also include the columns that are invisible because they are compacted. Default is false which means compacted columns are not returned.
    */
   visibleColumns(includeGuiColumns?: boolean, includeCompacted?: boolean): Column<any>[] {
-    return this.filterColumns(column => scout.nvl(includeCompacted, false) ? column.visibleIgnoreCompacted: column.visible, includeGuiColumns);
+    return this.filterColumns(column => scout.nvl(includeCompacted, false) ? column.visibleIgnoreCompacted : column.visible, includeGuiColumns);
   }
 
   /**

--- a/eclipse-scout-core/src/table/TableFooterLayout.ts
+++ b/eclipse-scout-core/src/table/TableFooterLayout.ts
@@ -70,14 +70,6 @@ export class TableFooterLayout extends AbstractLayout {
     let animated = this._tableFooter.htmlComp.layouted;
     this._setInfoItemsSize($infoItems, animated);
 
-    let tableStatusTooltip = this._tableFooter._tableStatusTooltip;
-    if (tableStatusTooltip && tableStatusTooltip.rendered) {
-      tableStatusTooltip.position();
-    }
-    if (this._tableFooter._tableInfoTooltip && this._tableFooter._tableInfoTooltip.rendered) {
-      this._tableFooter._tableInfoTooltip.position();
-    }
-
     // Let table controls update their content according to the new footer size
     this._tableFooter.table.tableControls.forEach(control => control.revalidateLayout());
   }

--- a/eclipse-scout-core/src/table/TableLayout.ts
+++ b/eclipse-scout-core/src/table/TableLayout.ts
@@ -108,12 +108,6 @@ export class TableLayout extends AbstractLayout {
         this.table._renderScrollTop();
       }
 
-      // Make sure tooltips and editor popup are at correct position after layouting (e.g after window resizing)
-      this.table.tooltips.forEach(tooltip => {
-        if (tooltip.rendered) {
-          tooltip.position();
-        }
-      });
       if (this.table.cellEditorPopup && this.table.cellEditorPopup.rendered) {
         this.table.cellEditorPopup.position();
         this.table.cellEditorPopup.pack();

--- a/eclipse-scout-core/src/testing/JasmineScout.ts
+++ b/eclipse-scout-core/src/testing/JasmineScout.ts
@@ -80,6 +80,7 @@ window.sandboxSession = options => {
   let session = scout.create(Session, model, {
     ensureUniqueId: false
   }) as SandboxSession;
+  $sandbox.data('sandboxSession', session);
 
   // Install non-filtering requestToJson() function. This is required to test
   // the value of the "showBusyIndicator" using toContainEvents(). Usually, this
@@ -244,6 +245,16 @@ export const JasmineScout = {
 
     beforeEach(() => {
       jasmine.addMatchers(jasmineScoutMatchers);
+    });
+
+    afterEach(() => {
+      const $sandbox = $('#sandbox');
+      const session = $sandbox.data('sandboxSession');
+      $sandbox.removeData('sandboxSession');
+      if (session?.layoutValidator) {
+        (session.layoutValidator as { _postValidateFunctions: (() => void)[] })._postValidateFunctions = [];
+        session.layoutValidator.desktop = null;
+      }
     });
 
     context.keys().forEach(context);

--- a/eclipse-scout-core/src/testing/table/SpecTable.ts
+++ b/eclipse-scout-core/src/testing/table/SpecTable.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Column, DoubleClickSupport, EventListener, EventSupport, Range, Table, TableFooter, TableRow} from '../../index';
+import {Column, DoubleClickSupport, EventListener, EventSupport, Range, Status, Table, TableFooter, TableRow} from '../../index';
 
 export class SpecTable extends Table {
   declare _filteredRows: TableRow[];
@@ -34,5 +34,9 @@ export class SpecTable extends Table {
 
   override _selectedRowsToText(): string {
     return super._selectedRowsToText();
+  }
+
+  override _showCellError(row: TableRow, $cell: JQuery, errorStatus: Status) {
+    super._showCellError(row, $cell, errorStatus);
   }
 }


### PR DESCRIPTION
Add a permanent (adds itself again an execution) post validation function if there are tooltips present on the desktop. This solves several tooltip position problems:
* collapse a group box containing a tooltip
* collapse a group box so that a sibling group box containing a tooltip moves to a new position
* collapse an accordion group containing a tooltip
* collapse an accordion group so that a sibling accordion group containing a tooltip moves to a new position
* move splitter in order to resize content containing a tooltip And it makes it unnecessary to explicitly call tooltip.position() during layout.
Revalidate layout tree after the resize of a form or widget popup to ensure that all tooltips are correctly positioned. After a popups open-animation ends and after a column resize reposition all tooltips.

308905, 317648, 318045