### PR TITLE
Add rootDir property to tsconfig.json and unify publishConfig

### DIFF
--- a/eclipse-scout-cli/scripts/karma-defaults.js
+++ b/eclipse-scout-cli/scripts/karma-defaults.js
@@ -30,7 +30,8 @@ module.exports = (config, specEntryPoint) => {
       compilerOptions: {
         // No need to create declarations for tests
         declaration: false,
-        declarationMap: false
+        declarationMap: false,
+        rootDir: findWorkspaceFileDir(__dirname)
       }
     }
   }, config.webpackArgs);
@@ -129,3 +130,25 @@ function searchSpecEntryPoint(specEntryPoint) {
   }
   return path.resolve('test', 'test-index.js');
 }
+
+/**
+ * <b>Copy from update-version.js (eclipse-scout-releng)</b>
+ *
+ * Gets the directory closest to the file-system root that contains a 'pnpm-workspace.yaml' file. The search starts at the given start dir stepping up the parent directories.
+ * @param dir where to start searching.
+ * @returns {string | null} workspace directory.
+ */
+const findWorkspaceFileDir = dir => {
+  let pnpmWorkspace = null;
+  let parentDir = dir;
+  let currentDir;
+  do {
+    currentDir = parentDir;
+    parentDir = path.join(currentDir, '../');
+    let candidate = path.join(currentDir, 'pnpm-workspace.yaml');
+    if (fs.existsSync(candidate)) {
+      pnpmWorkspace = currentDir;
+    }
+  } while (currentDir !== parentDir);
+  return pnpmWorkspace;
+};

--- a/eclipse-scout-tsconfig/README.md
+++ b/eclipse-scout-tsconfig/README.md
@@ -24,6 +24,7 @@ Once the `@eclipse-scout/tsconfig` package is installed, you can use it in your 
 {
   "extends": "@eclipse-scout/tsconfig/tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "target/dist/d.ts"
   },
   "include": [

--- a/org.eclipse.scout.rt.svg.ui.html/package.json
+++ b/org.eclipse.scout.rt.svg.ui.html/package.json
@@ -17,7 +17,7 @@
   "main": "./src/main/js/index.ts",
   "publishConfig": {
     "main": "./target/dist/dev/eclipse-scout-svg.js",
-    "types": "./target/dist/d.ts/index.d.ts"
+    "types": "./target/dist/d.ts/main/js/index.d.ts"
   },
   "files": [
     "src/main/js",

--- a/org.eclipse.scout.rt.svg.ui.html/tsconfig.json
+++ b/org.eclipse.scout.rt.svg.ui.html/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "target/dist/d.ts"
   },
   "include": [

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app/tsconfig.json
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@eclipse-scout/tsconfig/tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "target/dist/d.ts"
   },
   "include": [

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/tsconfig.json
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@eclipse-scout/tsconfig/tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "target/dist/d.ts"
   },
   "include": [

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html/tsconfig.json
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@eclipse-scout/tsconfig/tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "target/dist/d.ts"
   },
   "include": [


### PR DESCRIPTION
When generating type declarations, the longest common path of all TypeScript files is used as root directory. When no tests are present the longest common path is src/main/js, but with tests it will be on the src/ level. To avoid an accidental change of the export path by adding tests to your module, the rootDir property in the tsconfig.json was added to fix the export path. As a result, all paths in modules without tests have to be fixed.

358291