### PR TITLE
JsForm: support exclusive key

### DIFF
--- a/eclipse-scout-core/test/form/js/JsFormAdapterSpec.ts
+++ b/eclipse-scout-core/test/form/js/JsFormAdapterSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {FormSpecHelper} from '../../../src/testing';
-import {Desktop, DesktopAdapter, Form, ObjectFactory, RemoteEvent} from '../../../src';
+import {Desktop, DesktopAdapter, Form, FormModel, ObjectFactory, RemoteEvent} from '../../../src';
 import Deferred = JQuery.Deferred;
 
 describe('JsFormAdapter', () => {
@@ -24,6 +24,10 @@ describe('JsFormAdapter', () => {
   });
 
   class JsForm extends Form {
+
+  }
+
+  class LoadingJsForm extends Form {
     deferred: Deferred<any>;
     closeInPostLoad: boolean;
 
@@ -45,25 +49,39 @@ describe('JsFormAdapter', () => {
     }
   }
 
-  ObjectFactory.get().registerNamespace('jsformspec', {JsForm});
+  ObjectFactory.get().registerNamespace('jsformspec', {JsForm, LoadingJsForm});
 
-  function createAndRegisterFormModel() {
-    registerAdapterData([{
-      id: '10',
+  function createAndRegisterFormModel(id: string, jsFormObjectType: string) {
+    registerAdapterData([createAdapterData(id, jsFormObjectType)], session);
+  }
+
+  function createFormShowEvent(id: string): RemoteEvent {
+    return {
+      target: desktopAdapter.id,
+      displayParent: desktopAdapter.id,
+      form: id,
+      type: 'formShow'
+    };
+  }
+
+  function createAdapterData(id: string, jsFormObjectType: string, jsFormModel?: FormModel) {
+    return {
       objectType: 'JsForm',
-      jsFormObjectType: 'jsformspec.JsForm'
-    }], session);
+      id: id,
+      jsFormObjectType: jsFormObjectType,
+      jsFormModel: jsFormModel
+    };
   }
 
   it('blocks rendering until loading is complete', async () => {
-    createAndRegisterFormModel();
+    createAndRegisterFormModel('10', 'jsformspec.LoadingJsForm');
     let formShowEvent = new RemoteEvent(desktopAdapter.id, 'formShow', {
       form: '10',
       displayParent: desktopAdapter.id
     });
     desktopAdapter.onModelAction(formShowEvent);
-    let form = session.getModelAdapter('10').widget as JsForm;
-    expect(form instanceof JsForm).toBe(true);
+    let form = session.getModelAdapter('10').widget as LoadingJsForm;
+    expect(form instanceof LoadingJsForm).toBe(true);
     expect(form.rendered).toBe(false);
 
     form.deferred.resolve();
@@ -72,14 +90,14 @@ describe('JsFormAdapter', () => {
   });
 
   it('does not try to show the form if form is closed during load', async () => {
-    createAndRegisterFormModel();
+    createAndRegisterFormModel('10', 'jsformspec.LoadingJsForm');
     let formShowEvent = new RemoteEvent(desktopAdapter.id, 'formShow', {
       form: '10',
       displayParent: desktopAdapter.id
     });
     desktopAdapter.onModelAction(formShowEvent);
-    let form = session.getModelAdapter('10').widget as JsForm;
-    expect(form instanceof JsForm).toBe(true);
+    let form = session.getModelAdapter('10').widget as LoadingJsForm;
+    expect(form instanceof LoadingJsForm).toBe(true);
     expect(form.rendered).toBe(false);
 
     form.closeInPostLoad = true;
@@ -87,5 +105,52 @@ describe('JsFormAdapter', () => {
     await form.whenPostLoad();
     expect(form.rendered).toBe(false);
     expect(form.destroyed).toBe(true);
+  });
+
+  it('opens the form exclusively if the model contains an exclusiveKey', async () => {
+    let localJsForm = desktop.createFormExclusive(JsForm, {parent: desktop}, '123');
+    await localJsForm.open();
+    expect(desktop.getShownForms().length).toBe(1);
+    expect(desktop.getShownForms()[0]).toBe(localJsForm);
+
+    // ExclusiveKey is the same -> Does not open the form again
+    let message = {
+      adapterData: mapAdapterData([createAdapterData('js1', 'jsformspec.JsForm', {exclusiveKey: '123'})]),
+      events: [createFormShowEvent('js1')]
+    };
+    session._processSuccessResponse(message);
+    expect(desktop.getShownForms().length).toBe(1);
+    expect(desktop.getShownForms()[0]).toBe(localJsForm);
+
+    // ExclusiveKey is different -> opens the form
+    message = {
+      adapterData: mapAdapterData([createAdapterData('js2', 'jsformspec.JsForm', {exclusiveKey: '222'})]),
+      events: [createFormShowEvent('js2')]
+    };
+    session._processSuccessResponse(message);
+    let js2Form = desktop.session.getModelAdapter('js2').widget;
+    await js2Form.when('render');
+    expect(desktop.getShownForms().length).toBe(2);
+    expect(desktop.getShownForms()[0]).toBe(localJsForm);
+    expect(desktop.getShownForms()[1].id).toBe(js2Form.id);
+
+    // A local form with the same exclusiveKey won't open
+    let localJsForm2 = desktop.createFormExclusive(JsForm, {parent: desktop}, '222');
+    await localJsForm2.open();
+    expect(desktop.getShownForms().length).toBe(2);
+    expect(desktop.getShownForms()[1].id).toBe(js2Form.id);
+
+    // ExclusiveKey is the same but the adapter different -> opens the form
+    message = {
+      adapterData: mapAdapterData([createAdapterData('js3', 'jsformspec.JsForm', {exclusiveKey: '222'})]),
+      events: [createFormShowEvent('js3')]
+    };
+    session._processSuccessResponse(message);
+    let js3Form = desktop.session.getModelAdapter('js3').widget;
+    await js3Form.when('render');
+    expect(desktop.getShownForms().length).toBe(3);
+    expect(desktop.getShownForms()[0]).toBe(localJsForm);
+    expect(desktop.getShownForms()[1].id).toBe(js2Form.id);
+    expect(desktop.getShownForms()[2].id).toBe(js3Form.id);
   });
 });

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/IJsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/js/IJsForm.java
@@ -25,6 +25,9 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
  * <p>
  * To set the data property of the jsForm, use {@link IJsForm#setInputData(IDataObject)}. Once the jsForm is closed, the
  * updated data will be sent back to the server and can be retrieved using {@link IJsForm#getOutputData()}.
+ * <p>
+ * To open a form exclusively, you can use {@link #computeExclusiveKey()} as usual. If you also want to consider the
+ * jsForms opened directly with JavaScript, you need to pass the exclusiveKey as part of the {@link #getJsFormModel()}.
  */
 public interface IJsForm<IN extends IDataObject, OUT extends IDataObject> extends IForm {
 


### PR DESCRIPTION
This makes it possible to ensure a JsForm can only be opened once for a given exclusiveKey, regardless of where it was created (JS or Java).