### PR TITLE
Calendar, Planner: fail early on unexpected input

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -254,6 +254,7 @@ export class Calendar extends Widget implements CalendarModel {
 
   protected _setSelectedDate(date: Date | string) {
     date = dates.ensure(date);
+    scout.assertParameter('selectedDate', date, Date);
     this._setProperty('selectedDate', date);
     this.yearPanel.selectDate(this.selectedDate);
   }

--- a/eclipse-scout-core/src/calendar/DateRange.ts
+++ b/eclipse-scout-core/src/calendar/DateRange.ts
@@ -27,9 +27,7 @@ export class DateRange {
   }
 
   toString(): string {
-    return 'scout.DateRange[' +
-      'from=' + (this.from === null ? 'null' : this.from.toUTCString()) +
-      ' to=' + (this.to === null ? 'null' : this.to.toUTCString()) + ']';
+    return `DateRange {from: ${this.from}, to: ${this.to}}`;
   }
 
   static ensure(dateRange: DateRange | JsonDateRange): DateRange {

--- a/eclipse-scout-core/src/planner/Planner.ts
+++ b/eclipse-scout-core/src/planner/Planner.ts
@@ -444,7 +444,7 @@ export class Planner extends Widget implements PlannerModel {
   }
 
   protected _renderScale() {
-    if (!this.viewRange.from || !this.viewRange.to) {
+    if (!this.viewRange.from || !this.viewRange.to || !this.displayMode) {
       return;
     }
     let that = this,
@@ -1403,6 +1403,9 @@ export class Planner extends Widget implements PlannerModel {
 
   protected _setViewRange(viewRange: DateRange | JsonDateRange) {
     viewRange = DateRange.ensure(viewRange);
+    if (!viewRange || !viewRange.from || !viewRange.to || viewRange.from.valueOf() === viewRange.to.valueOf()) {
+      throw new Error('Invalid viewRange provided: ' + viewRange);
+    }
     this._setProperty('viewRange', viewRange);
     this.yearPanel.setViewRange(this.viewRange);
     this.yearPanel.selectDate(this.viewRange.from);

--- a/eclipse-scout-core/src/util/Range.ts
+++ b/eclipse-scout-core/src/util/Range.ts
@@ -162,8 +162,6 @@ export class Range {
   }
 
   toString(): string {
-    return 'scout.Range[' +
-      'from=' + (this.from === null ? 'null' : this.from) +
-      ' to=' + (this.to === null ? 'null' : this.to) + ']';
+    return `Range {from: ${this.from}, to: ${this.to}}`;
   }
 }

--- a/eclipse-scout-core/test/planner/PlannerAdapterSpec.ts
+++ b/eclipse-scout-core/test/planner/PlannerAdapterSpec.ts
@@ -34,6 +34,7 @@ describe('PlannerAdapter', () => {
     for (let i = 0; i < numResources; i++) {
       model.resources[i] = createResource('resource' + i);
     }
+    model.viewRange = {from: '2020-01-01 00:00:00.000Z', to: '2020-01-01 23:59:59.999Z'};
     return model;
   }
 

--- a/eclipse-scout-core/test/planner/PlannerSpec.ts
+++ b/eclipse-scout-core/test/planner/PlannerSpec.ts
@@ -44,6 +44,7 @@ describe('Planner', () => {
     for (let i = 0; i < numResources; i++) {
       model.resources[i] = createResource('resource' + i);
     }
+    model.viewRange = {from: '2020-01-01 00:00:00.000Z', to: '2020-01-01 23:59:59.999Z'};
     return model;
   }
 

--- a/eclipse-scout-core/test/util/RangeSpec.ts
+++ b/eclipse-scout-core/test/util/RangeSpec.ts
@@ -37,7 +37,7 @@ describe('Range', () => {
       let range2 = new Range(11, 20);
       expect(() => {
         range1.add(range2);
-      }).toThrow(new Error('Range to add has to border on the existing range. scout.Range[from=0 to=10], scout.Range[from=11 to=20]'));
+      }).toThrow(new Error('Range to add has to border on the existing range. Range {from: 0, to: 10}, Range {from: 11, to: 20}'));
     });
 
     it('returns a copy of the non empty range if one range is empty', () => {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/AbstractCalendar.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/AbstractCalendar.java
@@ -50,6 +50,7 @@ import org.eclipse.scout.rt.platform.classid.ClassId;
 import org.eclipse.scout.rt.platform.exception.ExceptionHandler;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.reflect.ConfigurationUtility;
+import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.CompositeObject;
 import org.eclipse.scout.rt.platform.util.Range;
@@ -548,9 +549,11 @@ public abstract class AbstractCalendar extends AbstractWidget implements ICalend
 
   @Override
   public void setSelectedDate(Date d) {
+    Assertions.assertNotNull(d);
     propertySupport.setProperty(PROP_SELECTED_DATE, d);
   }
 
+  @Override
   public Range<Date> getSelectedRange() {
     @SuppressWarnings("unchecked")
     Range<Date> propValue = (Range<Date>) propertySupport.getProperty(PROP_SELECTED_RANGE);

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/planner/AbstractPlanner.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/planner/AbstractPlanner.java
@@ -889,10 +889,11 @@ public abstract class AbstractPlanner<RI, AI> extends AbstractWidget implements 
   @Override
   public void setViewRange(Range<Date> viewRange) {
     LOG.debug("Setting view range to {}", viewRange);
-    if (viewRange != null) {
-      viewRange.setFrom(ensureTruncated(viewRange.getFrom(), "from"));
-      viewRange.setTo(ensureTruncated(viewRange.getTo(), "to"));
+    if (viewRange == null || viewRange.getFrom() == null || viewRange.getTo() == null || viewRange.getFrom().getTime() == viewRange.getTo().getTime()) {
+      throw new IllegalArgumentException("Invalid viewRange provided: " + viewRange);
     }
+    viewRange.setFrom(ensureTruncated(viewRange.getFrom(), "from"));
+    viewRange.setTo(ensureTruncated(viewRange.getTo(), "to"));
     propertySupport.setProperty(PROP_VIEW_RANGE, viewRange);
   }
 


### PR DESCRIPTION
YearPanel fails if the selected date is null.
Planner fails if the viewRange is invalid.
Invalid means from or to are not set, or they are set to the same value which will break at least the calendar-week mode. -> Don't allow invalid parameters to fail as early as possible and make finding the root cause easier.

357593, 357597