### PR TITLE
Widget: improve findChild

### DIFF
--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -2072,9 +2072,16 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
   }
 
   /**
-   * @returns the first child for which the given function returns true.
+   * @param predicateOrClass may be a {@link Predicate} or a sub-class of {@link Widget}.
+   * @returns the first child for which the given predicate returns true or that matches the given widget type if a subclass of {@link Widget} is provided.
    */
-  findChild(predicate: Predicate<Widget>): Widget {
+  findChild<T extends Widget>(predicateOrClass: Predicate<Widget> | (abstract new() => T)): T {
+    let predicate;
+    if (objects.isSameOrExtendsClass(predicateOrClass, Widget)) {
+      predicate = widget => widget instanceof predicateOrClass;
+    } else {
+      predicate = predicateOrClass;
+    }
     let foundChild = null;
     this.visitChildren(child => {
       if (predicate(child)) {

--- a/eclipse-scout-core/test/widget/WidgetSpec.ts
+++ b/eclipse-scout-core/test/widget/WidgetSpec.ts
@@ -438,6 +438,74 @@ describe('Widget', () => {
     });
   });
 
+  describe('findChild', () => {
+    it('finds the first child which has the given type', () => {
+      let child = new SubTestWidget();
+      child.init({
+        id: 'child',
+        parent: parent
+      });
+      let grandChild1 = new AnotherTestWidget();
+      grandChild1.init({
+        id: 'grandChild1',
+        parent: child
+      });
+      let grandChild2 = new AnotherTestWidget();
+      grandChild2.init({
+        id: 'grandChild2',
+        parent: child
+      });
+      let grandGrandChild = new AnotherTestWidget();
+      grandGrandChild.init({
+        id: 'grandGrandChild',
+        parent: grandChild1
+      });
+      expect(parent.findChild(Widget)).toBe(child);
+      expect(parent.findChild(SubTestWidget)).toBe(child);
+      expect(parent.findChild(AnotherTestWidget)).toBe(grandChild1);
+      expect(child.findChild(AnotherTestWidget)).toBe(grandChild1);
+      expect(grandChild1.findChild(AnotherTestWidget)).toBe(grandGrandChild);
+      expect(child.findChild(TestWidget)).toBe(null);
+
+      let thrown;
+      try {
+        // @ts-expect-error TableRow does not extend widget -> it will be treated as predicate which won't work (TypeError: Class constructor TableRow cannot be invoked without 'new')
+        parent.findParent(TableRow);
+      } catch (error) {
+        thrown = true;
+      }
+      expect(thrown).toBe(true);
+    });
+
+    it('finds the first child that is accepted by the given predicate', () => {
+      let child = new SubTestWidget();
+      child.init({
+        id: 'child',
+        parent: parent
+      });
+      let grandChild1 = new AnotherTestWidget();
+      grandChild1.init({
+        id: 'grandChild1',
+        parent: child
+      });
+      let grandChild2 = new AnotherTestWidget();
+      grandChild2.init({
+        id: 'grandChild2',
+        parent: child
+      });
+      let grandGrandChild = new AnotherTestWidget();
+      grandGrandChild.init({
+        id: 'grandGrandChild',
+        parent: grandChild1
+      });
+      expect(parent.findChild(child => child.id === 'child')).toBe(child);
+      expect(parent.findChild(child => child.id === 'grandChild1')).toBe(grandChild1);
+      expect(parent.findChild(child => child.id === 'grandChild2')).toBe(grandChild2);
+      expect(parent.findChild(child => child.id === 'grandGrandChild')).toBe(grandGrandChild);
+      expect(parent.findChild(child => false)).toBe(null);
+    });
+  });
+
   describe('enabled', () => {
     it('should be propagated correctly', () => {
       let widget = createWidget({


### PR DESCRIPTION
findChild() can now also find the first child widget matching a given class. The result automatically has the given type. The implementation is analog to findParent().