### PR TITLE
DefaultValuesFilter improve handling for JSON-null values

### DIFF
--- a/org.eclipse.scout.rt.chart.ui.html/src/main/resources/org/eclipse/scout/rt/chart/ui/html/json/defaultValues.json
+++ b/org.eclipse.scout.rt.chart.ui.html/src/main/resources/org/eclipse/scout/rt/chart/ui/html/json/defaultValues.json
@@ -30,7 +30,7 @@
       }
     },
     "ChartTableControl": {
-      "chartType": 3,
+      "chartType": "bar",
       "chartAggregation": {
         "modifier": -1
       }

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/DefaultValuesFilterTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/DefaultValuesFilterTest.java
@@ -73,8 +73,8 @@ public class DefaultValuesFilterTest {
 
     JSONObject table = (JSONObject) adapterData.get(4);
     assertEquals(Boolean.FALSE, table.opt("enabled"));
-    assertEquals(Boolean.FALSE, table.optJSONObject("rows").opt("enabled"));
-    JSONArray cells = table.optJSONObject("rows").optJSONArray("cells");
+    assertEquals(Boolean.FALSE, table.optJSONArray("rows").getJSONObject(0).opt("enabled"));
+    JSONArray cells = table.optJSONArray("rows").getJSONObject(0).optJSONArray("cells");
     for (int i = 0; i < cells.length(); i++) {
       filter.filter(cells.getJSONObject(i), "Cell"); // Custom type
     }
@@ -204,5 +204,42 @@ public class DefaultValuesFilterTest {
     JSONObject jsonDefaultValueConfiguration = readJsonFile("json/DefaultValuesFilterTest_defaults_loopHierarchy.json");
     DefaultValuesFilter filter = new DefaultValuesFilter();
     filter.importConfiguration(jsonDefaultValueConfiguration);
+  }
+
+  @Test
+  public void testFilterJsonNullValue() {
+    runTestFilterJsonNullValue("foo", JSONObject.NULL, true);
+    runTestFilterJsonNullValue("", JSONObject.NULL, true);
+    runTestFilterJsonNullValue(null, JSONObject.NULL, false);
+    runTestFilterJsonNullValue(JSONObject.NULL, JSONObject.NULL, false);
+
+    runTestFilterJsonNullValue("foo", "defaultValue", true);
+    runTestFilterJsonNullValue("", "defaultValue", true);
+    runTestFilterJsonNullValue(null, "defaultValue", false);
+    runTestFilterJsonNullValue(JSONObject.NULL, "defaultValue", true);
+    runTestFilterJsonNullValue("defaultValue", "defaultValue", false);
+  }
+
+  protected void runTestFilterJsonNullValue(Object propValue, Object propDefaultValue, boolean expectedPropExists) {
+    JSONObject jsonDefaultValueConfiguration = new JSONObject()
+        .put("defaults", new JSONObject()
+            .put("FormField", new JSONObject()
+                .put("myProp", propDefaultValue)));
+    DefaultValuesFilter filter = new DefaultValuesFilter();
+    filter.importConfiguration(jsonDefaultValueConfiguration);
+
+    JSONObject adapterData = new JSONObject()
+        .put("objectType", "FormField")
+        .put("myProp", propValue);
+
+    filter.filter(adapterData);
+
+    if (expectedPropExists) {
+      assertTrue(adapterData.has("myProp"));
+      assertEquals(propValue, adapterData.opt("myProp"));
+    }
+    else {
+      assertFalse(adapterData.has("myProp"));
+    }
   }
 }

--- a/org.eclipse.scout.rt.ui.html.test/src/test/resources/org/eclipse/scout/rt/ui/html/json/DefaultValuesFilterTest_test_simple.json
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/resources/org/eclipse/scout/rt/ui/html/json/DefaultValuesFilterTest_test_simple.json
@@ -33,19 +33,21 @@
       "id": "5",
       "objectType": "Table",
       "enabled": false,
-      "rows": {
-        "enabled": false,
-        "cells": [
-          {
-            "editable": true,
-            "text": "cell1"
-        },
+      "rows": [
         {
-          "editable": false,
-          "text": "cell2"
+          "enabled": false,
+          "cells": [
+            {
+              "editable": true,
+              "text": "cell1"
+          },
+          {
+            "editable": false,
+            "text": "cell2"
+          }
+          ]
         }
-        ]
-      }
+      ]
     },
     {
       "id": "6",

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/DefaultValuesFilter.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/DefaultValuesFilter.java
@@ -30,9 +30,13 @@ import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Bean
 public class DefaultValuesFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultValuesFilter.class);
 
   public static final String PROP_DEFAULTS = "defaults";
   public static final String PROP_OBJECT_TYPE_HIERARCHY = "objectTypeHierarchy";
@@ -202,10 +206,10 @@ public class DefaultValuesFilter {
 
   protected boolean checkValueEqualToDefaultValue(Object value, Object defaultValue, FilterState filterState) {
     // Now compare the given value to the found default value
-    if (value == null && defaultValue == null) {
+    if (JSONObject.NULL.equals(value) && JSONObject.NULL.equals(defaultValue)) {
       return true;
     }
-    if (value == null || defaultValue == null) {
+    if (JSONObject.NULL.equals(value) || JSONObject.NULL.equals(defaultValue)) {
       return false;
     }
     if (defaultValue instanceof JSONObject) {
@@ -241,6 +245,7 @@ public class DefaultValuesFilter {
       value = TypeCastUtility.castValue(value, defaultValue.getClass());
     }
     catch (RuntimeException e) { // NOSONAR
+      LOG.warn("Could not cast value '{}' to default value type '{}' for property '{}'", value, defaultValue.getClass().getName(), filterState.getCurrentProperty());
       // Types do not match
       return false;
     }


### PR DESCRIPTION
Avoid trying to cast values if default value is JSONObject.NULL which lead to unnecessary IllegalArgumentException before this fix.

Improved (and fixed) DefaultValuesFilterTest

359229