### PR TITLE
Create ValueDo in TypeScript as equivalent to IValueDo in Java

### DIFF
--- a/eclipse-scout-core/src/dataobject/ValueDo.ts
+++ b/eclipse-scout-core/src/dataobject/ValueDo.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {DoEntity} from './DoEntity';
+
+/**
+ * <strong>Wrapper data object for a generic value.</strong>
+ *
+ * In Java, we have a separate implementation for each data type. This
+ * is because the Jackson object mapper cannot map a generic object.
+ * In TypeScript, we do not have this issue, so there is just this
+ * generic interface.
+ *
+ * @see "org.eclipse.scout.rt.dataobject.value.IValueDo"
+ */
+export interface ValueDo<T> extends DoEntity {
+  value: T;
+}

--- a/eclipse-scout-core/src/dataobject/ValueDo.ts
+++ b/eclipse-scout-core/src/dataobject/ValueDo.ts
@@ -7,10 +7,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {DoEntity} from './DoEntity';
+import {DoEntity} from './../index';
 
 /**
- * <strong>Wrapper data object for a generic value.</strong>
+ * Wrapper data object for a generic value.
  *
  * In Java, we have a separate implementation for each data type. This
  * is because the Jackson object mapper cannot map a generic object.

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -58,6 +58,7 @@ export * from './widget/NullWidgetModel';
 export * from './widget/NullWidgetEventMap';
 export * from './widget/NullWidgetAdapter';
 export * from './util/arrays';
+export * from './util/BinaryResource';
 export * from './util/CallModel';
 export * from './util/Call';
 export * from './util/clipboard';

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -130,6 +130,7 @@ export * from './code/CodeTypeModel';
 export * from './code/codes';
 export * from './code/CodeLookupCall';
 export * from './dataobject/DoEntity';
+export * from './dataobject/ValueDo';
 export * from './security/access';
 export * from './security/AccessControl';
 export * from './security/Permission';

--- a/eclipse-scout-core/src/util/BinaryResource.ts
+++ b/eclipse-scout-core/src/util/BinaryResource.ts
@@ -9,10 +9,9 @@
  */
 
 /**
- * Warper for binary content with metadata.
- * <p>
- * TypeScript's representation of Java class
- * org.eclipse.scout.rt.platform.resource.BinaryResource.
+ * Wrapper for binary content with metadata.
+ *
+ * @see "org.eclipse.scout.rt.platform.resource.BinaryResource"
  */
 export interface BinaryResource {
   filename: string;

--- a/eclipse-scout-core/src/util/BinaryResource.ts
+++ b/eclipse-scout-core/src/util/BinaryResource.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Warper for binary content with metadata.
+ * <p>
+ * TypeScript's representation of Java class
+ * org.eclipse.scout.rt.platform.resource.BinaryResource.
+ */
+export interface BinaryResource {
+  filename: string;
+  content: string; // Blob
+  contentType: string;
+}


### PR DESCRIPTION
In Java, we have a separate implementation for each data type. This is because the Jackson object mapper cannot map a generic object. In TypeScript, we do not have this issue, so there is just this generic interface.

348303