### PR TITLE
TableProposalChooser: disable mouse move selection

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/TableProposalChooser.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/TableProposalChooser.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -64,7 +64,7 @@ export default class TableProposalChooser extends ProposalChooser {
   }
 
   _createTable(columns, headerVisible) {
-    return scout.create('Table', {
+    const table = scout.create('Table', {
       parent: this,
       headerVisible: headerVisible,
       autoResizeColumns: true,
@@ -75,6 +75,8 @@ export default class TableProposalChooser extends ProposalChooser {
       headerMenusEnabled: false,
       textFilterEnabled: false
     });
+    table.selectionHandler.mouseMoveSelectionEnabled = false;
+    return table;
   }
 
   _onRowClick(event) {

--- a/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.js
+++ b/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -1027,4 +1027,17 @@ describe('SmartField', () => {
     });
   });
 
+  describe('proposalChooser', () => {
+
+    it('does not support mouse move selection', () => {
+      const field = createFieldWithLookupCall();
+      field.render();
+      field.$field.focus();
+      field._lookupByTextOrAllDone({
+        queryBy: QueryBy.ALL,
+        lookupRows: [1, 2, 3, 4, 5]
+      });
+      expect(field.popup.proposalChooser.model.selectionHandler.mouseMoveSelectionEnabled).toBeFalse();
+    });
+  });
 });


### PR DESCRIPTION
Mouse move selection leeds to scrolling if one clicks a row at the bottom that is only half visible, as the clicked row will be selected and revealed, after which the next row is at the position of the cursor. The mouse move selection will then select the next row and the table starts scrolling until the end or until the user releases the mouse button.
As the tree does not support mouse move selection, disabling it for the TableProposalChooser also leads to a consistent behaviour over all types of SmartFields.

335305