### PR TITLE
SmartField: abort current lookupCall when a new value is set

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
@@ -703,7 +703,7 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
     return this._invalidKeyLookup(result.key);
   }
 
-  protected _invalidKeyLookup(key : TValue) : string {
+  protected _invalidKeyLookup(key: TValue): string {
     // lookup call didn't return a result. Maybe the data belonging to the key has been deleted.
     let invalidValueMessage = this.session.text('ui.InvalidValue');
     this.setLookupRow(scout.create((LookupRow<TValue>), {
@@ -1556,6 +1556,8 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
         }
       }
     }
+    this.original()._currentLookupCall?.abort();
+    this.original()._currentLookupCall = null;
     super._setValue(value);
     this._notUnique = false;
   }

--- a/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.ts
@@ -1033,6 +1033,68 @@ describe('SmartField', () => {
       expect(smartField.displayText).toBe('');
     });
 
+    it('aborts previous lookup call when setValue() is called multiple times', () => {
+
+      // --- Case 1: initial value exists, then value is set to null ---
+
+      let smartField = scout.create(SmartField, {
+        parent: session.desktop,
+        lookupCall,
+        value: 1
+      });
+      expect(smartField.value).toBe(1);
+      expect(smartField.displayText).toBe(null);
+
+      smartField.setValue(null);
+      expect(smartField.value).toBe(null);
+      expect(smartField.displayText).toBe('');
+
+      jasmine.clock().tick(300);
+      expect(smartField.value).toBe(null);
+      expect(smartField.displayText).toBe('');
+
+      // --- Case 2: value is set to '1', then to null again ---
+
+      smartField = scout.create(SmartField, {
+        parent: session.desktop,
+        lookupCall
+      });
+      expect(smartField.value).toBe(null);
+      expect(smartField.displayText).toBe('');
+
+      smartField.setValue(1);
+      expect(smartField.value).toBe(1);
+      expect(smartField.displayText).toBe('');
+
+      smartField.setValue(null);
+      expect(smartField.value).toBe(null);
+      expect(smartField.displayText).toBe('');
+
+      jasmine.clock().tick(300);
+      expect(smartField.value).toBe(null);
+      expect(smartField.displayText).toBe('');
+
+      // --- Case 3: value is set to '1', then to '2' ---
+
+      smartField = scout.create(SmartField, {
+        parent: session.desktop,
+        lookupCall
+      });
+      expect(smartField.value).toBe(null);
+      expect(smartField.displayText).toBe('');
+
+      smartField.setValue(1);
+      expect(smartField.value).toBe(1);
+      expect(smartField.displayText).toBe('');
+
+      smartField.setValue(2);
+      expect(smartField.value).toBe(2);
+      expect(smartField.displayText).toBe('');
+
+      jasmine.clock().tick(300);
+      expect(smartField.value).toBe(2);
+      expect(smartField.displayText).toBe('Bar');
+    });
   });
 
   describe('multiline', () => {


### PR DESCRIPTION
Not every call of SmartField._setValue triggers a new lookup (e.g. null does not require a lookup) and are therefore handled synchronously. A call that needs a lookup will be executed asynchronously and will overwrite a value that has changed in the meantime when the lookup completes.
In order to prevent an old pending lookupCall from overwriting a new value that has been set synchronously the current lookupCall needs to be aborted when the value changes.

360142