### PR TITLE
Desktop: fix cancel all forms

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
@@ -2844,7 +2844,9 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
 
     // if formSet contains only one element simply call doCancel on that form. Using the UnsavedFormChangesForm is not necessary in this case.
     if (!alwaysShowUnsavedChangesForm && formSet.size() == 1) {
-      CollectionUtility.firstElement(formSet).doCancel();
+      IForm form = CollectionUtility.firstElement(formSet);
+      form.activate();
+      form.doCancel();
       return true;
     }
     return continueClosingConsideringUnsavedForms(getUnsavedForms(formSet), false) && internalCloseForms(formSet);

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiTextContributor.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiTextContributor.java
@@ -64,6 +64,8 @@ public class UiTextContributor implements IUiTextContributor {
         "NumberTooSmallMessageX",
         "UnsavedChangesTitle",
         "SaveChangesOfSelectedItems",
+        "CheckAll",
+        "UncheckAll",
         "TheRequestedResourceCouldNotBeFound",
         "FormsCannotBeSaved",
         "NotAllCheckedFormsCanBeSaved",


### PR DESCRIPTION
Split forms to cancel into js forms and remote forms. First cancel all js forms and then the remote forms. This ensures that only one UnsavedFormChangesForm or cancel verification messageBox is visible at a time.
If only one form needs to be canceled, activate it first. This ensures that the cancel verification messageBox is always shown on top of its corresponding form.

359826