### PR TITLE
Page: add summary support

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -9,7 +9,7 @@
  */
 import {
   ButtonTile, ChildModelOf, EnumObject, Event, EventHandler, EventListener, EventMapOf, EventModel, EventSupport, Form, HtmlComponent, icons, InitModelOf, inspector, Menu, MenuBar, menus, ObjectOrChildModel, Outline, PageEventMap,
-  PageModel, PropertyChangeEvent, scout, Table, TableRow, TableRowClickEvent, TileOutlineOverview, TileOverviewForm, TreeNode, Widget
+  PageModel, PropertyChangeEvent, scout, strings, Table, TableRow, TableRowClickEvent, TileOutlineOverview, TileOverviewForm, TreeNode, Widget
 } from '../../../index';
 import $ from 'jquery';
 
@@ -489,16 +489,18 @@ export class Page extends TreeNode implements PageModel {
   }
 
   /**
-   * This function creates the text property of this page. The default implementation returns the
-   * text from the first cell of the given row. It's allowed to ignore the given row entirely, when you override
-   * this function.
+   * This function creates the text property of this page. The default implementation returns the texts of the summary columns of the table or
+   * from the first cell of the given row. It's allowed to ignore the given row entirely, when you override this function.
    */
   computeTextForRow(row: TableRow): string {
-    let text = '';
-    if (row.cells.length >= 1) {
-      text = row.cells[0].text;
+    const summaryColumns = row.getTable().summaryColumns();
+    if (summaryColumns.length) {
+      return strings.join(' ', ...summaryColumns.map(summaryColumn => summaryColumn.cellText(row)));
     }
-    return text;
+    if (row.cells.length >= 1) {
+      return row.cells[0].text;
+    }
+    return '';
   }
 
   /**

--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  arrays, AutoLeafPageWithNodes, EventHandler, Form, FormTableControl, InitModelOf, ObjectOrModel, Page, PageWithTableEventMap, PageWithTableModel, scout, Status, Table, TableAllRowsDeletedEvent, TableReloadEvent, TableRow,
-  TableRowActionEvent, TableRowOrderChangedEvent, TableRowsDeletedEvent, TableRowsInsertedEvent, TableRowsUpdatedEvent
+  arrays, AutoLeafPageWithNodes, EventHandler, Form, FormTableControl, ObjectOrModel, Page, PageWithTableEventMap, PageWithTableModel, scout, Status, Table, TableAllRowsDeletedEvent, TableReloadEvent, TableRow, TableRowActionEvent,
+  TableRowOrderChangedEvent, TableRowsDeletedEvent, TableRowsInsertedEvent, TableRowsUpdatedEvent
 } from '../../../index';
 import $ from 'jquery';
 
@@ -39,10 +39,6 @@ export class PageWithTable extends Page implements PageWithTableModel {
     this._tableRowActionHandler = this._onTableRowAction.bind(this);
     this._tableRowOrderChangeHandler = this._onTableRowOrderChanged.bind(this);
     this._tableDataLoadHandler = this.loadTableData.bind(this);
-  }
-
-  override init(model: InitModelOf<this>) {
-    super.init(model);
   }
 
   protected override _initDetailTable(table: Table) {

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -5671,6 +5671,20 @@ export class Table extends Widget implements TableModel {
   }
 
   /**
+   * @returns all columns marked as primaryKey column (see {@link Column.primaryKey})
+   */
+  primaryKeyColumns(): Column[] {
+    return this.filterColumns(column => column.primaryKey);
+  }
+
+  /**
+   * @returns all columns marked as summary column (see {@link Column.summary})
+   */
+  summaryColumns(): Column[] {
+    return this.filterColumns(column => column.summary);
+  }
+
+  /**
    * @param includeGuiColumns true to also include columns created by the UI (e.g. {@link rowIconColumn} or {@link checkableColumn}). Default is true.
    */
   filterColumns(filter: Predicate<Column<any>>, includeGuiColumns?: boolean): Column<any>[] {

--- a/eclipse-scout-core/src/table/TableRow.ts
+++ b/eclipse-scout-core/src/table/TableRow.ts
@@ -131,7 +131,7 @@ export class TableRow implements TableRowModel, ObjectWithType {
     if (!this.cells?.length) {
       return [];
     }
-    let columns = this.getTable().columns.filter(column => column.primaryKey);
+    let columns = this.getTable().primaryKeyColumns();
     if (!columns.length) {
       columns = this.getTable().columns;
     }

--- a/eclipse-scout-core/src/table/columns/Column.ts
+++ b/eclipse-scout-core/src/table/columns/Column.ts
@@ -721,6 +721,15 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
     this.table.updateRows(this.table.rows);
   }
 
+  setSummary(summary: boolean) {
+    const changed = this.setProperty('summary', summary);
+    if (!changed) {
+      return;
+    }
+
+    this.table.updateRows(this.table.rows);
+  }
+
   setWidth(width: number) {
     let changed = this.setProperty('width', width);
     if (!changed) {

--- a/eclipse-scout-core/test/desktop/outline/pages/PageSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageSpec.ts
@@ -161,6 +161,35 @@ describe('Page', () => {
     }]);
   });
 
+  describe('computeTextForRow', () => {
+
+    it('considers summary columns', () => {
+      const page = scout.create(Page, {parent: outline});
+      const table = tableHelper.createTable(tableHelper.createModel(
+        tableHelper.createModelColumns(5),
+        $.extend(true, [], tableHelper.createModelRows(5, 2), [{cells: ['a', 'b', 'c', 'd', 'e']}, {cells: ['1', '2', '3', '4', '5']}])
+      ));
+      const [rowAbc, row123] = table.rows;
+
+      expect(page.computeTextForRow(rowAbc)).toBe('a');
+      expect(page.computeTextForRow(row123)).toBe('1');
+
+      table.columns[1].setSummary(true);
+      expect(page.computeTextForRow(rowAbc)).toBe('b');
+      expect(page.computeTextForRow(row123)).toBe('2');
+
+      table.columns[4].setSummary(true);
+      expect(page.computeTextForRow(rowAbc)).toBe('b e');
+      expect(page.computeTextForRow(row123)).toBe('2 5');
+
+      table.columns[0].setSummary(true);
+      table.columns[1].setSummary(false);
+      table.columns[3].setSummary(true);
+      expect(page.computeTextForRow(rowAbc)).toBe('a d e');
+      expect(page.computeTextForRow(row123)).toBe('1 4 5');
+    });
+  });
+
   function createAndInsertPage(detailTable: ChildModelOf<Table>, detailForm: ChildModelOf<Form>, parentPage?: Page): PageWithLazyCreationCounter {
     const page = createPage(detailTable, detailForm);
     insertPage(page, parentPage);

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -3546,4 +3546,38 @@ describe('Table', () => {
       expect(table.selectedRows).toEqual([table.rows[1]]);
     });
   });
+
+  describe('primaryKeyColumns', () => {
+
+    it('returns the correct columns', () => {
+      let table = helper.createTable(helper.createModel([], []));
+      expect(table.primaryKeyColumns()).toEqual([]);
+
+      table = helper.createTable(helper.createModel(helper.createModelColumns(3), []));
+      expect(table.primaryKeyColumns()).toEqual([]);
+
+      table = helper.createTable(helper.createModel($.extend(true, [], helper.createModelColumns(3), [{}, {primaryKey: true}, {primaryKey: false}]), []));
+      expect(table.primaryKeyColumns()).toEqual([table.columns[1]]);
+
+      table = helper.createTable(helper.createModel($.extend(true, [], helper.createModelColumns(3), [{primaryKey: true}, {}, {primaryKey: true}]), []));
+      expect(table.primaryKeyColumns()).toEqual([table.columns[0], table.columns[2]]);
+    });
+  });
+
+  describe('summaryColumns', () => {
+
+    it('returns the correct columns', () => {
+      let table = helper.createTable(helper.createModel([], []));
+      expect(table.summaryColumns()).toEqual([]);
+
+      table = helper.createTable(helper.createModel(helper.createModelColumns(3), []));
+      expect(table.summaryColumns()).toEqual([]);
+
+      table = helper.createTable(helper.createModel($.extend(true, [], helper.createModelColumns(3), [{}, {summary: true}, {summary: false}]), []));
+      expect(table.summaryColumns()).toEqual([table.columns[1]]);
+
+      table = helper.createTable(helper.createModel($.extend(true, [], helper.createModelColumns(3), [{summary: true}, {}, {summary: true}]), []));
+      expect(table.summaryColumns()).toEqual([table.columns[0], table.columns[2]]);
+    });
+  });
 });

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/table/JsonColumn.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/table/JsonColumn.java
@@ -76,7 +76,6 @@ public class JsonColumn<T extends IColumn<?>> implements IJsonObject {
     if (getColumn().getInitialWidth() != getColumn().getWidth()) {
       json.put("initialWidth", getColumn().getInitialWidth());
     }
-    json.put("summary", getColumn().isSummary());
     json.put(IColumn.PROP_HORIZONTAL_ALIGNMENT, getColumn().getHorizontalAlignment());
     if (getColumn().isSortActive()) {
       json.put("sortActive", true);

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/json/defaultValues.json
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/json/defaultValues.json
@@ -421,7 +421,6 @@
       "sortActive": false,
       "sortAscending": true,
       "sortIndex": -1,
-      "summary": false,
       "type": "text",
       "uiSortPossible": false,
       "minWidth": 60,


### PR DESCRIPTION
Use all columns marked as summary column while computing the text for a
row. The texts of all cells of summary columns are joined with a
whitespace separating them. If no column is marked as summary column use
the text of the first cell.
Add primaryKeyColumns() and summaryColumns() to Table.
Do not send the summary-flag from the server to the browser as it is not
used in the Scout Classic case.

346791