### PR TITLE
FormController: do not reactivate the removed dialog

### DIFF
--- a/eclipse-scout-core/src/form/FormController.js
+++ b/eclipse-scout-core/src/form/FormController.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -196,8 +196,8 @@ export default class FormController {
       return false;
     }
 
-    dialog.on('remove', () => {
-      let formToActivate = this._findFormToActivateAfterDialogRemove();
+    dialog.on('remove', e => {
+      let formToActivate = this._findFormToActivateAfterDialogRemove(e.source);
       if (formToActivate) {
         desktop._setFormActivated(formToActivate);
       } else {
@@ -221,9 +221,10 @@ export default class FormController {
     }
   }
 
-  _findFormToActivateAfterDialogRemove() {
-    if (this.displayParent.dialogs.length > 0) {
-      return this.displayParent.dialogs[this.displayParent.dialogs.length - 1];
+  _findFormToActivateAfterDialogRemove(removedDialog) {
+    const dialogs = this.displayParent.dialogs.filter(d => d !== removedDialog);
+    if (dialogs.length > 0) {
+      return dialogs[dialogs.length - 1];
     }
     if (this.displayParent instanceof Form && !this.displayParent.detailForm) {
       // activate display parent, but not if it is the detail form

--- a/eclipse-scout-core/test/desktop/DesktopSpec.js
+++ b/eclipse-scout-core/test/desktop/DesktopSpec.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -1293,8 +1293,11 @@ describe('Desktop', () => {
       });
 
       desktop.showForm(view);
+      expect(desktop.activeForm).toBe(view);
+
       outline.selectNode(outline.nodes[0]);
       desktop.bringOutlineToFront();
+      expect(desktop.activeForm).toBeNull();
 
       desktop.activateForm(view);
       outline.deselectAll();
@@ -1396,6 +1399,28 @@ describe('Desktop', () => {
         .always(done);
     });
 
+    it('must not be a removed form', () => {
+      const outline = outlineHelper.createOutlineWithOneDetailForm();
+      const page = outline.nodes[0];
+
+      desktop.setOutline(outline);
+      outline.selectNode(page);
+
+      const form = formHelper.createFormWithOneField({
+        displayHint: Form.DisplayHint.DIALOG,
+        displayParent: page.detailForm
+      });
+
+      desktop.showForm(form);
+      expect(desktop.activeForm).toBe(form);
+
+      outline.selectNode(outline.nodes[1]);
+      desktop.bringOutlineToFront();
+      expect(desktop.activeForm).toBeNull();
+
+      outline.selectNode(page);
+      expect(desktop.activeForm).toBe(form);
+    });
   });
 
   describe('displayStyle', () => {


### PR DESCRIPTION
Consider the recently removed dialog while looking for a form to activate after the dialog removal to prevent it from being reactivated. If there is a dialog and its displayParent is a detailForm of a page and another page is being selected, the detailForm is removed which triggers the removal of the dialog. As the dialog is contained in the detailForms dialogs it needs to be excluded from this list while looking for a new form to activate.

356016