### PR TITLE
TableTileGridMediator: improve types

### DIFF
--- a/eclipse-scout-core/src/table/TableTileGridMediator.ts
+++ b/eclipse-scout-core/src/table/TableTileGridMediator.ts
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AggregateTableControl, arrays, Column, Event, EventHandler, Filter, FilterOrFunction, Group, InitModelOf, ObjectOrChildModel, objects, PropertyChangeEvent, scout, ScrollToOptions, Table, TableAllRowsDeletedEvent, TableFilterAddedEvent,
-  TableFilterRemovedEvent, TableGroupEvent, TableRow, TableRowOrderChangedEvent, TableRowsDeletedEvent, TableRowsInsertedEvent, TableRowsSelectedEvent, TableRowTileMapping, TableTileGridMediatorEventMap, TableTileGridMediatorModel, Tile,
-  TileAccordion, TileActionEvent, TileClickEvent, TileGrid, TileGridLayoutConfig, TileTableHierarchyFilter, Widget
+  AggregateTableControl, arrays, Column, Event, EventHandler, Filter, FilterOrFunction, Group, InitModelOf, ObjectOrChildModel, ObjectOrModel, objects, PropertyChangeEvent, scout, ScrollToOptions, Table, TableAllRowsDeletedEvent,
+  TableFilterAddedEvent, TableFilterRemovedEvent, TableGroupEvent, TableRow, TableRowOrderChangedEvent, TableRowsDeletedEvent, TableRowsInsertedEvent, TableRowsSelectedEvent, TableRowTileMapping, TableTileGridMediatorEventMap,
+  TableTileGridMediatorModel, Tile, TileAccordion, TileActionEvent, TileClickEvent, TileGrid, TileGridLayoutConfig, TileTableHierarchyFilter, Widget
 } from '../index';
 import $ from 'jquery';
 
@@ -98,6 +98,7 @@ export class TableTileGridMediator extends Widget implements TableTileGridMediat
 
     this.table = this.parent;
 
+    this._setTileGridLayoutConfig(this.tileGridLayoutConfig);
     if (!this.tileAccordion) {
       this.tileAccordion = this._createTileAccordion();
       this._installListeners();
@@ -153,8 +154,13 @@ export class TableTileGridMediator extends Widget implements TableTileGridMediat
     }
   }
 
-  setTileGridLayoutConfig(tileGridLayoutConfig: TileGridLayoutConfig) {
+  setTileGridLayoutConfig(tileGridLayoutConfig: ObjectOrModel<TileGridLayoutConfig>) {
     this.setProperty('tileGridLayoutConfig', tileGridLayoutConfig);
+  }
+
+  protected _setTileGridLayoutConfig(tileGridLayoutConfig: ObjectOrModel<TileGridLayoutConfig>) {
+    tileGridLayoutConfig = TileGridLayoutConfig.ensure(tileGridLayoutConfig);
+    this._setProperty('tileGridLayoutConfig', tileGridLayoutConfig);
     if (this.tileAccordion) {
       this.tileAccordion.setTileGridLayoutConfig(tileGridLayoutConfig);
     }

--- a/eclipse-scout-core/src/table/TableTileGridMediatorModel.ts
+++ b/eclipse-scout-core/src/table/TableTileGridMediatorModel.ts
@@ -7,13 +7,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ObjectOrChildModel, Table, TableRowTileMapping, Tile, TileAccordion, TileGridLayoutConfig, WidgetModel} from '../index';
+import {ObjectOrChildModel, ObjectOrModel, Table, TableRowTileMapping, Tile, TileAccordion, TileGridLayoutConfig, WidgetModel} from '../index';
 
 export interface TableTileGridMediatorModel extends WidgetModel {
   parent?: Table;
   tileAccordion?: ObjectOrChildModel<TileAccordion>;
   gridColumnCount?: number;
-  tileGridLayoutConfig?: TileGridLayoutConfig;
+  tileGridLayoutConfig?: ObjectOrModel<TileGridLayoutConfig>;
   withPlaceholders?: boolean;
   tileMappings?: ObjectOrChildModel<TableRowTileMapping>[];
   tiles?: ObjectOrChildModel<Tile>[];

--- a/eclipse-scout-core/src/tile/accordion/TileAccordion.ts
+++ b/eclipse-scout-core/src/tile/accordion/TileAccordion.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  Accordion, arrays, Comparator, Event, EventDelegator, EventHandler, Filter, FilterOrFunction, FilterResult, FilterSupport, Group, InitModelOf, KeyStrokeContext, ObjectOrChildModel, objects, PropertyChangeEvent, scout, TextFilter, Tile,
-  TileAccordionEventMap, TileAccordionLayout, TileAccordionModel, TileAccordionSelectionHandler, TileGrid, TileGridLayout, TileGridLayoutConfig, TileTextFilter
+  Accordion, arrays, Comparator, Event, EventDelegator, EventHandler, Filter, FilterOrFunction, FilterResult, FilterSupport, Group, InitModelOf, KeyStrokeContext, ObjectOrChildModel, ObjectOrModel, objects, PropertyChangeEvent, scout,
+  TextFilter, Tile, TileAccordionEventMap, TileAccordionLayout, TileAccordionModel, TileAccordionSelectionHandler, TileGrid, TileGridLayout, TileGridLayoutConfig, TileTextFilter
 } from '../../index';
 
 export class TileAccordion<TTile extends Tile = Tile> extends Accordion implements TileAccordionModel {
@@ -85,6 +85,7 @@ export class TileAccordion<TTile extends Tile = Tile> extends Accordion implemen
   protected override _init(model: InitModelOf<this>) {
     super._init(model);
     this.setFilters(this.filters);
+    this._setTileGridLayoutConfig(this.tileGridLayoutConfig);
   }
 
   protected override _createKeyStrokeContext(): KeyStrokeContext {
@@ -194,12 +195,16 @@ export class TileAccordion<TTile extends Tile = Tile> extends Accordion implemen
   }
 
   /** @see TileAccordionModel.tileGridLayoutConfig */
-  setTileGridLayoutConfig(layoutConfig: TileGridLayoutConfig) {
+  setTileGridLayoutConfig(layoutConfig: ObjectOrModel<TileGridLayoutConfig>) {
     this.groups.forEach(group => {
       group.body.setLayoutConfig(layoutConfig);
       layoutConfig = group.body.layoutConfig; // May be converted from plain object to TileGridLayoutConfig
     });
     this.setProperty('tileGridLayoutConfig', layoutConfig);
+  }
+
+  protected _setTileGridLayoutConfig(layoutConfig: ObjectOrModel<TileGridLayoutConfig>) {
+    this._setProperty('tileGridLayoutConfig', TileGridLayoutConfig.ensure(layoutConfig));
   }
 
   /** @see TileAccordionModel.withPlaceholders */


### PR DESCRIPTION
Allow a ObjectOrModel<TileGridLayoutConfig> to be passed for the tileGridLayoutConfig property and convert it to a TileGridLayoutConfig in _setTileGridLayoutConfig() if necessary.

362085