### PR TITLE
Scout JS Form: use any instead of object in _load/_save/data

### DIFF
--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -435,7 +435,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
    * Method may be implemented to load the data.
    * By default, a resolved promise containing {@link this.data} is returned.
    */
-  protected _load(): JQuery.Promise<object> {
+  protected _load(): JQuery.Promise<any> {
     return $.resolvedPromise().then(() => {
       return this.data;
     });
@@ -653,7 +653,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
    *
    * The data given to this function is the result of {@link exportData} which was called in advance.
    */
-  protected _save(data: object): JQuery.Promise<void> {
+  protected _save(data: any): JQuery.Promise<void> {
     return $.resolvedPromise();
   }
 

--- a/eclipse-scout-core/src/form/FormModel.ts
+++ b/eclipse-scout-core/src/form/FormModel.ts
@@ -64,7 +64,7 @@ export interface FormModel extends WidgetModel, DisplayParentModel {
    *
    * Default is {}.
    */
-  data?: object;
+  data?: any;
   /**
    * The exclusive key is used by {@link Desktop.createFormExclusive} to check whether a similar form is already open, and if yes, activate that form instead of opening a new one.
    *


### PR DESCRIPTION
Because this.data is typed any too.