### PR TITLE
Widget: change loop in _triggerChildrenOnDetach from forEach to fori

### DIFF
--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -1445,10 +1445,11 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
   }
 
   protected _triggerChildrenOnDetach() {
-    this.children.forEach(child => {
+    for (let i = 0; i < this.children.length; i++) {
+      const child = this.children[i];
       child._onDetach();
       child._triggerChildrenOnDetach();
-    });
+    }
   }
 
   /**


### PR DESCRIPTION
The chromium engine trys to inline the forEach loop in the method Widget._triggerChildrenOnDetach and creates an infinite loop in the engine causing a stack overflow error.
Changing the forEach loop to a fori loop does not change the runtime but prevents the chromium engine from trying to optimize this function.

Also see Chromium issues:
* https://bugs.chromium.org/p/chromium/issues/detail?id=1487583
* https://bugs.chromium.org/p/chromium/issues/detail?id=1480144

362343