### PR TITLE
Form: move error handling out of busy handling

### DIFF
--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -363,7 +363,14 @@ export class Form extends Widget implements FormModel, DisplayParent {
     if (!allowReload && this.formLoaded) {
       return $.resolvedPromise();
     }
-    return this._withBusyHandling(() => this.lifecycle.load());
+    try {
+      return this._withBusyHandling(() => this.lifecycle.load())
+        .catch(error => {
+          return this._handleLoadErrorInternal(error);
+        });
+    } catch (error) {
+      return this._handleLoadErrorInternal(error);
+    }
   }
 
   protected _withBusyHandling<T>(action: () => JQuery.Promise<T>): JQuery.Promise<T> {
@@ -373,6 +380,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
         .always(() => this.setBusy(false));
     } catch (error) {
       this.setBusy(false);
+      throw error;
     }
   }
 
@@ -401,13 +409,10 @@ export class Form extends Widget implements FormModel, DisplayParent {
           this.formLoaded = true;
           this.trigger('load');
         })
-        .catch(error => {
-          this._setFormLoading(false);
-          return this._handleLoadErrorInternal(error);
-        });
+        .always(() => this._setFormLoading(false));
     } catch (error) {
       this._setFormLoading(false);
-      return this._handleLoadErrorInternal(error);
+      throw error;
     }
   }
 
@@ -528,20 +533,21 @@ export class Form extends Widget implements FormModel, DisplayParent {
   }
 
   protected _onLifecycleSave(): JQuery.Promise<void> {
-    return this._withBusyHandling(() => {
-      try {
+    try {
+      return this._withBusyHandling(() => {
         let data = this.exportData();
         return this._save(data)
           .then(() => {
             this.formSaved = true;
             this.setData(data);
             this.trigger('save');
-          })
-          .catch(error => this._handleSaveErrorInternal(error));
-      } catch (error) {
+          });
+      }).catch(error => {
         return this._handleSaveErrorInternal(error);
-      }
-    });
+      });
+    } catch (error) {
+      return this._handleSaveErrorInternal(error);
+    }
   }
 
   /**

--- a/eclipse-scout-core/src/testing/form/FormSpecHelper.ts
+++ b/eclipse-scout-core/src/testing/form/FormSpecHelper.ts
@@ -25,20 +25,32 @@ export class FormSpecHelper {
       return;
     }
     let button = option || MessageBox.Buttons.YES;
+    this.findMessageBoxes().forEach(messageBox => messageBox.trigger('action', {option: button}));
+  }
+
+  findMessageBoxes(): Set<MessageBox> {
+    if (!this.session) {
+      return new Set();
+    }
+
+    const result: Set<MessageBox> = new Set();
+
     if (this.session.$entryPoint) {
-      // close rendered MessageBoxes
+      // collect rendered MessageBoxes
       this.session.$entryPoint
         .find('.messagebox').get()
         .map(domElement => scout.widget(domElement, MessageBox))
         .filter(messageBox => !!messageBox)
-        .forEach(messageBox => messageBox.trigger('action', {option: button}));
+        .forEach(messageBox => result.add(messageBox));
     }
 
-    // close the remaining (possibly not rendered) boxes on the Desktop
+    // collect the remaining (possibly not rendered) boxes on the Desktop
     if (this.session.desktop) {
       this.session.desktop.messageBoxes
-        .forEach(messageBox => messageBox.trigger('action', {option: button}));
+        .forEach(messageBox => result.add(messageBox));
     }
+
+    return result;
   }
 
   createViewWithOneField(model?: FormModel): SpecForm {


### PR DESCRIPTION
The busy handling of the form will set the desktop busy until the given promise completes (resolved or rejected). This might lead to deadlocks if errors occur inside this given promise that are handled by a message box which prevents the promise from completing until a button is clicked. If such a message box is rendered before the busy indicator is rendered, the glass pane of the busy indicator will make it impossible to click any button of the message box, and therefore it is not possible to leave the busy state.
To solve this problem move the error handling out of the scope that is covered by the busy handling. This leads to the busy handling being stopped when an error occurs and therefore the message box is not blocked by a glass pane.

362418