### PR TITLE
Fix MailMessage builder javadoc typo

### DIFF
--- a/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/MailMessage.java
+++ b/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/MailMessage.java
@@ -277,7 +277,7 @@ public class MailMessage {
   }
 
   /**
-   * Adds the attachment.
+   * Adds the inline attachment.
    */
   public MailMessage withInlineAttachment(MailAttachment inlineAttachment) {
     m_inlineAttachments.add(inlineAttachment);


### PR DESCRIPTION
Specify withInlineAttachment method docs to maintain consistency