### PR TITLE
Map properties: improve support for JSON format

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/resources/org/eclipse/scout/rt/platform/config/list-test.properties
+++ b/org.eclipse.scout.rt.platform.test/src/test/resources/org/eclipse/scout/rt/platform/config/list-test.properties
@@ -22,3 +22,7 @@ listWithValidIndices[0]=a
 listWithValidIndices[1]=
 listWithValidIndices[2]=
 listWithValidIndices[3]=b
+listWithSingleEntryText=a
+listWithSingleEntryBoolean=true
+listWithSingleEntryQuotes="a"
+listWithJson={"0": "a", "1": "b"}

--- a/org.eclipse.scout.rt.platform.test/src/test/resources/org/eclipse/scout/rt/platform/config/map-test.properties
+++ b/org.eclipse.scout.rt.platform.test/src/test/resources/org/eclipse/scout/rt/platform/config/map-test.properties
@@ -21,3 +21,6 @@ namespace|mapKey[]=not-a-valid-map-property-2
 namespace1|mapKey[a]=a
 namespace1|mapKey[a]=b
 namespace1|mapKey[c]=c
+map2Key={"one": "one-file-json", "two": "two-file-json", "three": "three-file-json"}
+map2Key[two]=two-file-overwrite
+

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/IJsonPropertyReader.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/IJsonPropertyReader.java
@@ -33,6 +33,10 @@ public interface IJsonPropertyReader {
    * <li><code>null</code> > <code>null</code></li>
    * <li>empty string > empty map
    * </ul>
+   * Calls with a value not representing a JSON map must fail, e.g. arguments such as: a, true, &quot;a&quot;. This is
+   * required to support reading a list property with only a single entry, in which case the reading of the JSON map
+   * must fail to use the fallback instead.
+   * <p>
    * Example:
    *
    * <pre>


### PR DESCRIPTION
JSON format for map properties was so far only supported for environment variables. Now there is support for properties by properties file and system properties too.

364149