### PR TITLE
Notification: Adjust CSS-handling of empty message string

### DIFF
--- a/eclipse-scout-core/src/notification/Notification.less
+++ b/eclipse-scout-core/src/notification/Notification.less
@@ -178,11 +178,7 @@
 
 .notification-message {
   padding-right: 12px;
+  min-height: 12px; // Prevent empty div from collapsing (without &nbsp;)
   #scout.user-select(text);
   #scout.overflow-ellipsis();
-
-  // Prevent empty div from collapsing (without &nbsp;)
-  &::after {
-    content: '\200b'; // U+200B ZERO WIDTH SPACE
-  }
 }


### PR DESCRIPTION
To avoid a collapsing notification box, a zero-width whitespace is inserted into the notification's after pseudo-element. This leads to an empty new line if the notification message is new element as-well. A min-height instead of a zero-width  whitespace is now used.