### PR TITLE
Adds Accept-Language http-header from session for ajax-calls

### DIFF
--- a/eclipse-scout-core/src/App.js
+++ b/eclipse-scout-core/src/App.js
@@ -376,6 +376,9 @@ export default class App {
   _beforeAjaxCall(request) {
     request.setRequestHeader('X-Scout-Correlation-Id', numbers.correlationId());
     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest'); // explicitly add here because jQuery only adds it automatically if it is no crossDomain request
+    if (this.sessions[0]) {
+      request.setRequestHeader('Accept-Language', this.sessions[0].locale.languageTag);
+    }
   }
 
   _loadSessions(options) {


### PR DESCRIPTION
Ensure correct response language for ajax-calls even if no locale- cookie is sent by the browser and the language of the application differs from the one of the browser.

306480