### PR TITLE
Fix possible NPE in ErrorDoRestClientExceptionTransformer

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/proxy/RestClientProxyInvocationTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/proxy/RestClientProxyInvocationTest.java
@@ -111,7 +111,7 @@ public class RestClientProxyInvocationTest {
   @Test
   public void testSyncGetForbiddenEmptyBody() {
     VetoException ve = Assert.assertThrows(VetoException.class, () -> webTargetGet(Status.FORBIDDEN, Content.EMPTY_BODY, Execution.SYNC));
-    assertEquals("Forbidden", ve.getDisplayMessage());
+    assertEquals("REST call failed: 403 Forbidden", ve.getDisplayMessage());
   }
 
   @Test
@@ -123,7 +123,7 @@ public class RestClientProxyInvocationTest {
   @Test
   public void testSyncGetNotFoundEmptyBody() {
     ProcessingException pe = Assert.assertThrows(ProcessingException.class, () -> webTargetGet(Status.NOT_FOUND, Content.EMPTY_BODY, Execution.SYNC));
-    assertEquals("Not Found", pe.getDisplayMessage());
+    assertEquals("REST call failed: 404 Not Found", pe.getDisplayMessage());
   }
 
   @Test
@@ -155,7 +155,7 @@ public class RestClientProxyInvocationTest {
   @Test
   public void testAsyncGetForbiddenEmptyBody() {
     VetoException ve = Assert.assertThrows(VetoException.class, () -> webTargetGet(Status.FORBIDDEN, Content.EMPTY_BODY, Execution.ASYNC));
-    assertEquals("Forbidden", ve.getDisplayMessage());
+    assertEquals("REST call failed: 403 Forbidden", ve.getDisplayMessage());
   }
 
   @Test
@@ -167,7 +167,7 @@ public class RestClientProxyInvocationTest {
   @Test
   public void testAsyncGetNotFoundEmptyBody() {
     ResourceNotFoundException pe = Assert.assertThrows(ResourceNotFoundException.class, () -> webTargetGet(Status.NOT_FOUND, Content.EMPTY_BODY, Execution.ASYNC));
-    assertEquals("Not Found", pe.getDisplayMessage());
+    assertEquals("REST call failed: 404 Not Found", pe.getDisplayMessage());
   }
 
   @Test
@@ -332,7 +332,7 @@ public class RestClientProxyInvocationTest {
       .request()
       .accept(MediaType.APPLICATION_JSON)
       .get(RestClientTestEchoResponse.class));
-    assertEquals("Forbidden", ve.getDisplayMessage());
+    assertEquals("REST call failed: 403 Forbidden", ve.getDisplayMessage());
   }
 
   @Test
@@ -353,7 +353,7 @@ public class RestClientProxyInvocationTest {
       .request()
       .accept(MediaType.APPLICATION_JSON)
       .get(RestClientTestEchoResponse.class));
-    assertEquals("Not Found", pe.getDisplayMessage());
+    assertEquals("REST call failed: 404 Not Found", pe.getDisplayMessage());
   }
 
   @Test
@@ -394,7 +394,7 @@ public class RestClientProxyInvocationTest {
       .get(RestClientTestEchoResponse.class)
       .get());
     assertEquals(AccessForbiddenException.class, ee.getCause().getClass());
-    assertEquals("Forbidden", ((AccessForbiddenException) ee.getCause()).getDisplayMessage());
+    assertEquals("REST call failed: 403 Forbidden", ((AccessForbiddenException) ee.getCause()).getDisplayMessage());
   }
 
   @Test
@@ -421,7 +421,7 @@ public class RestClientProxyInvocationTest {
       .get(RestClientTestEchoResponse.class)
       .get());
     assertEquals(ResourceNotFoundException.class, ee.getCause().getClass());
-    assertEquals("Not Found", ((ResourceNotFoundException) ee.getCause()).getDisplayMessage());
+    assertEquals("REST call failed: 404 Not Found", ((ResourceNotFoundException) ee.getCause()).getDisplayMessage());
   }
 
   @Test
@@ -497,7 +497,7 @@ public class RestClientProxyInvocationTest {
   @Test
   public void testClientInvocationSyncGetEntityForbiddenEmptyBody() {
     VetoException ve = Assert.assertThrows(VetoException.class, () -> clientInvocationGetEntity(Status.FORBIDDEN, Content.EMPTY_BODY, Execution.SYNC));
-    assertEquals("Forbidden", ve.getDisplayMessage());
+    assertEquals("REST call failed: 403 Forbidden", ve.getDisplayMessage());
   }
 
   @Test
@@ -509,7 +509,7 @@ public class RestClientProxyInvocationTest {
   @Test
   public void testClientInvocationSyncGetEntityNotFoundEmptyBody() {
     ProcessingException pe = Assert.assertThrows(ProcessingException.class, () -> clientInvocationGetEntity(Status.NOT_FOUND, Content.EMPTY_BODY, Execution.SYNC));
-    assertEquals("Not Found", pe.getDisplayMessage());
+    assertEquals("REST call failed: 404 Not Found", pe.getDisplayMessage());
   }
 
   @Test
@@ -530,7 +530,7 @@ public class RestClientProxyInvocationTest {
   public void testClientInvocationAsyncGetEntityForbiddenEmptyBody() {
     ExecutionException ee = Assert.assertThrows(ExecutionException.class, () -> clientInvocationGetEntity(Status.FORBIDDEN, Content.EMPTY_BODY, Execution.ASYNC));
     assertEquals(AccessForbiddenException.class, ee.getCause().getClass());
-    assertEquals("Forbidden", ((AccessForbiddenException) ee.getCause()).getDisplayMessage());
+    assertEquals("REST call failed: 403 Forbidden", ((AccessForbiddenException) ee.getCause()).getDisplayMessage());
   }
 
   @Test
@@ -544,7 +544,7 @@ public class RestClientProxyInvocationTest {
   public void testClientInvocationAsyncGetEntityNotFoundEmptyBody() {
     ExecutionException ee = Assert.assertThrows(ExecutionException.class, () -> clientInvocationGetEntity(Status.NOT_FOUND, Content.EMPTY_BODY, Execution.ASYNC));
     assertEquals(ResourceNotFoundException.class, ee.getCause().getClass());
-    assertEquals("Not Found", ((ResourceNotFoundException) ee.getCause()).getDisplayMessage());
+    assertEquals("REST call failed: 404 Not Found", ((ResourceNotFoundException) ee.getCause()).getDisplayMessage());
   }
 
   protected RestClientTestEchoResponse clientInvocationGetEntity(Status status, Content content, Execution execution) throws Exception {
@@ -604,7 +604,7 @@ public class RestClientProxyInvocationTest {
         .buildGet();
 
     VetoException ve = Assert.assertThrows(VetoException.class, () -> invocation.invoke(RestClientTestEchoResponse.class));
-    assertEquals("Forbidden", ve.getDisplayMessage());
+    assertEquals("REST call failed: 403 Forbidden", ve.getDisplayMessage());
   }
 
   @Test
@@ -645,7 +645,7 @@ public class RestClientProxyInvocationTest {
 
     ExecutionException ee = Assert.assertThrows(ExecutionException.class, () -> invocation.submit(RestClientTestEchoResponse.class).get());
     assertEquals(AccessForbiddenException.class, ee.getCause().getClass());
-    assertEquals("Forbidden", ((AccessForbiddenException) ee.getCause()).getDisplayMessage());
+    assertEquals("REST call failed: 403 Forbidden", ((AccessForbiddenException) ee.getCause()).getDisplayMessage());
   }
 
   @Test

--- a/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/client/proxy/ErrorDoRestClientExceptionTransformerTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/client/proxy/ErrorDoRestClientExceptionTransformerTest.java
@@ -57,6 +57,25 @@ public class ErrorDoRestClientExceptionTransformerTest {
   }
 
   @Test
+  public void testWithoutErrorDo() {
+    String message = "mock";
+    RuntimeException mockCause = new RuntimeException(message);
+    ErrorResponse errorResponse = BEANS.get(ErrorResponse.class);
+    RuntimeException actualException = m_exceptionTransformer.transform(mockCause, mockResponse(Status.MOVED_PERMANENTLY, errorResponse));
+    assertProcessingException(ProcessingException.class, mockCause, null, 0, actualException);
+    assertEquals("REST call failed: 301 Moved Permanently [severity=ERROR]", actualException.getMessage());
+    assertEquals(message, actualException.getCause().getMessage());
+  }
+
+  @Test
+  public void testWithoutException() {
+    ErrorResponse errorResponse = BEANS.get(ErrorResponse.class);
+    RuntimeException actualException = m_exceptionTransformer.transform(null, mockResponse(Status.FORBIDDEN, errorResponse));
+    assertProcessingException(AccessForbiddenException.class, null, null, 0, actualException);
+    assertEquals("REST call failed: 403 Forbidden [severity=ERROR]", actualException.getMessage());
+  }
+
+  @Test
   public void testTransformByResponseStatus() {
     RuntimeException mockCause = new RuntimeException("mock");
     int mockCode = 100;
@@ -117,5 +136,6 @@ public class ErrorDoRestClientExceptionTransformerTest {
     assertEquals(expectedCause, actual.getCause());
     assertEquals(expectedTitle, processingException.getStatus().getTitle());
     assertEquals(expectedCode != null ? expectedCode.intValue() : 0, processingException.getStatus().getCode());
+    assertEquals(0, processingException.getSuppressed().length); // nothing should be suppressed
   }
 }


### PR DESCRIPTION
This NPE is not actually rethrown but added as suppressed exception. Nevertheless, it should not happen and is not helpful at all.

It prevents exceptions like this:

`
Forbidden [severity=ERROR, user=usr, calling-thread=http-nio-8180-exec-11, job=jobname]
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain$Chain.continueChain(CallableChain.java:226)
	at org.eclipse.scout.rt.platform.job.internal.ExceptionProcessor.intercept(ExceptionProcessor.java:40)
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain$Chain.continueChain(CallableChain.java:221)
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain$Chain.continueChain(CallableChain.java:226)
	at org.eclipse.scout.rt.platform.transaction.TransactionProcessor.runTxRequiresNew(TransactionProcessor.java:112)
	at org.eclipse.scout.rt.platform.transaction.TransactionProcessor.intercept(TransactionProcessor.java:75)
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain$Chain.continueChain(CallableChain.java:221)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:439)
	at org.eclipse.scout.rt.platform.security.SubjectProcessor.intercept(SubjectProcessor.java:42)
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain$Chain.continueChain(CallableChain.java:221)
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain.call(CallableChain.java:169)
	at org.eclipse.scout.rt.platform.context.RunContext.call(RunContext.java:157)
	at org.eclipse.scout.rt.platform.context.RunContextRunner.intercept(RunContextRunner.java:37)
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain$Chain.continueChain(CallableChain.java:221)
	at org.eclipse.scout.rt.platform.job.internal.CallableChainExceptionHandler.intercept(CallableChainExceptionHandler.java:32)
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain$Chain.continueChain(CallableChain.java:221)
	at org.eclipse.scout.rt.platform.chain.callable.CallableChain.call(CallableChain.java:169)
	at org.eclipse.scout.rt.platform.job.internal.JobFutureTask.lambda$0(JobFutureTask.java:105)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.eclipse.scout.rt.platform.job.internal.JobFutureTask.run(JobFutureTask.java:174)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
	at org.eclipse.scout.rt.platform.job.internal.NamedThreadFactory$1.run(NamedThreadFactory.java:62)
	Suppressed: java.lang.NullPointerException: Cannot invoke "org.eclipse.scout.rt.rest.error.ErrorDo.getMessage()" because "error" is null
		at org.eclipse.scout.rt.rest.client.proxy.ErrorDoRestClientExceptionTransformer.lambda$3(ErrorDoRestClientExceptionTransformer.java:61)
		at org.eclipse.scout.rt.rest.client.proxy.AbstractEntityRestClientExceptionTransformer.safeTransformEntityErrorResponse(AbstractEntityRestClientExceptionTransformer.java:113)
		... 33 common frames omitted
`