### PR TITLE
Fix unnecessary unicode escape sequence

### DIFF
--- a/org.eclipse.scout.json/src/test/java/org/json/JSONStringerTest.java
+++ b/org.eclipse.scout.json/src/test/java/org/json/JSONStringerTest.java
@@ -26,6 +26,7 @@ import junit.framework.TestCase;
  * Changes to the original code:
  * -----------------------------
  * - Applied Scout code formatting rules
+ * - Added @SuppressWarnings("CatchMayIgnoreException")
  *
  * Copyright (c) 2015 BSI Business Systems Integration AG.
  */
@@ -33,6 +34,7 @@ import junit.framework.TestCase;
 /**
  * This black box test was written without inspecting the non-free org.json sourcecode.
  */
+@SuppressWarnings("CatchMayIgnoreException")
 public class JSONStringerTest extends TestCase {
 
   public void testEmptyStringer() {
@@ -237,7 +239,7 @@ public class JSONStringerTest extends TestCase {
     assertEscapedAllWays("]", "]");
     assertEscapedAllWays("\\u0000", "\0");
     assertEscapedAllWays("\\u0019", "\u0019");
-    assertEscapedAllWays(" ", "\u0020");
+    assertEscapedAllWays(" ", " ");
   }
 
   private void assertEscapedAllWays(String escaped, String original) throws JSONException {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTileTableHeader.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTileTableHeader.java
@@ -308,8 +308,8 @@ public abstract class AbstractTileTableHeader extends AbstractGroupBox implement
       for (IColumn col : getTable().getColumns()) {
         if (col.isVisible() && isColumnTypeAllowedForSorting(col)) {
           String colLabel = ObjectUtility.nvl(col.getHeaderCell().getText(), col.getHeaderCell().getTooltipText());
-          lookupRows.add(new LookupRow<>(new ImmutablePair<>(col, true), colLabel + " \u2191"));
-          lookupRows.add(new LookupRow<>(new ImmutablePair<>(col, false), colLabel + " \u2193"));
+          lookupRows.add(new LookupRow<>(new ImmutablePair<>(col, true), colLabel + " ↑")); // U+2191
+          lookupRows.add(new LookupRow<>(new ImmutablePair<>(col, false), colLabel + " ↓")); // U+2193
         }
       }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsForm.java
@@ -85,8 +85,8 @@ import org.slf4j.LoggerFactory;
 public class OrganizeColumnsForm extends AbstractForm implements IOrganizeColumnsForm {
 
   private static final Logger LOG = LoggerFactory.getLogger(OrganizeColumnsForm.class);
-  private static final String UNICODE_ARROW_UP = "\u2191";
-  private static final String UNICODE_ARROW_DOWN = "\u2193";
+  private static final String UNICODE_ARROW_UP = "↑"; // U+2191
+  private static final String UNICODE_ARROW_DOWN = "↓"; // U+2193
   private static final String VISIBLE_DIMENSION_HIERARCHICAL = "dim_hierarchical";
 
   public enum ConfigType {
@@ -221,11 +221,6 @@ public class OrganizeColumnsForm extends AbstractForm implements IOrganizeColumn
         @Order(10)
         @ClassId("f96ddd7f-634b-486b-a4be-fbb69b5162e4")
         public class ProfilesTableField extends AbstractTableField<ProfilesTableField.Table> {
-
-          @Override
-          protected int getConfiguredGridH() {
-            return 3;
-          }
 
           @Override
           protected boolean getConfiguredGridUseUiHeight() {
@@ -610,11 +605,6 @@ public class OrganizeColumnsForm extends AbstractForm implements IOrganizeColumn
         @Order(10)
         @ClassId("eefd05cf-b8b6-4c07-82c9-91aaafe9b8b6")
         public class ColumnsTableField extends AbstractTableField<Table> {
-
-          @Override
-          protected int getConfiguredGridH() {
-            return 3;
-          }
 
           @Override
           protected int getConfiguredGridW() {
@@ -1752,7 +1742,7 @@ public class OrganizeColumnsForm extends AbstractForm implements IOrganizeColumn
         if (col.isGroupingActive()) {
           cellContents.add(HTML.span(TEXTS.get("GroupingAbbreviation")).cssClass("group-symbol"));
         }
-        if (cellContents.size() > 0) {
+        if (CollectionUtility.hasElements(cellContents)) {
           columnsTable.getGroupAndSortColumn().setValue(row, HTML.fragment(cellContents).toHtml());
         }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/numberfield/AbstractNumberField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/numberfield/AbstractNumberField.java
@@ -121,11 +121,11 @@ public abstract class AbstractNumberField<NUMBER extends Number> extends Abstrac
     return CollectionUtility.hashSet(
         '\'', '´', '`', '’', // apostrophe and variations
         ',', '.',
-        "\u00B7".charAt(0), // middle dot
-        "\u0020".charAt(0), // space
-        "\u00A0".charAt(0), // no-break space
-        "\u2009".charAt(0), // thin space
-        "\u202F".charAt(0) // narrow no-break space
+        '·', // U+00B7 middle dot
+        ' ', // U+0020 space
+        ' ', // U+00A0 no-break space
+        ' ', // U+2009 thin space
+        ' ' // U+202F narrow no-break space
     );
   }
 
@@ -560,7 +560,7 @@ public abstract class AbstractNumberField<NUMBER extends Number> extends Abstrac
    *         alpha-numerical characters) or is <code>null</code>
    */
   public static boolean isWithinNumberFormatLimits(DecimalFormat format, String curText, int offset, int replaceLen, String insertText) {
-    if (insertText == null || insertText.length() < 1) {
+    if (insertText == null || insertText.isEmpty()) {
       return true;
     }
 
@@ -616,7 +616,7 @@ public abstract class AbstractNumberField<NUMBER extends Number> extends Abstrac
   public static String createNumberWithinFormatLimits(DecimalFormat format, String curText, int offset, int replaceLen, String insertText) {
     // !! IMPORTANT NOTE: There is also a JavaScript implementation of this method: org/eclipse/scout/rt/ui/rap/form/fields/numberfield/RwtScoutNumberField.js
     // When changing this implementation also consider updating the js version!
-    if (insertText == null || insertText.length() < 1) {
+    if (insertText == null || insertText.isEmpty()) {
       insertText = "";
     }
     StringBuilder result = new StringBuilder();

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/StringUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/StringUtilityTest.java
@@ -119,9 +119,9 @@ public class StringUtilityTest {
     assertEquals("", res1);
     String res2 = StringUtility.join(del1, (String) null);
     assertEquals("", res2);
-    String res3 = StringUtility.join(del1, a, (String) null, c);
+    String res3 = StringUtility.join(del1, a, null, c);
     assertEquals(a + del1 + c, res3);
-    String res4 = StringUtility.join(del1, (String) null, b, c);
+    String res4 = StringUtility.join(del1, null, b, c);
     assertEquals(b + del1 + c, res4);
   }
 
@@ -194,13 +194,7 @@ public class StringUtilityTest {
 
   @Test
   public void testDecompress_umlauts() {
-
-    StringBuilder builder = new StringBuilder();
-    for (int i = 0; i < 100000; i++) {
-      builder.append(CHARACTERS);
-    }
-
-    String original = builder.toString();
+    String original = CHARACTERS.repeat(100000);
     String decompressed = StringUtility.decompress(StringUtility.compress(original));
 
     assertEquals(original, decompressed);
@@ -470,7 +464,7 @@ public class StringUtilityTest {
     assertEquals("0.000000", StringUtility.formatNanos(0L));
     assertEquals("0.000000", StringUtility.formatNanos(-0L));
     assertEquals("0.000001", StringUtility.formatNanos(1L));
-    assertEquals("1.000000", StringUtility.formatNanos((long) (1 * 1000 * 1000)));
+    assertEquals("1.000000", StringUtility.formatNanos(1000 * 1000));
     assertEquals("1.234567", StringUtility.formatNanos(1234567L));
     assertEquals("12.345678", StringUtility.formatNanos(12345678L));
     assertEquals("123.456789", StringUtility.formatNanos(123456789L));
@@ -626,7 +620,7 @@ public class StringUtilityTest {
     assertEquals(0, StringUtility.length(null));
     assertEquals(0, StringUtility.length(""));
     assertEquals(1, StringUtility.length("a"));
-    assertEquals(4, StringUtility.length("a\\ \u00B6"));
+    assertEquals(4, StringUtility.length("a\\ ¶")); // U+00B6 PILCROW SIGN
   }
 
   @Test
@@ -767,7 +761,8 @@ public class StringUtilityTest {
     assertEquals("", StringUtility.removePrefixes("", "prefix"));
 
     assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData"));
-    assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData", null));
+    assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData", (String) null));
+    assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData", (String[]) null));
     assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData", ""));
     assertEquals("CompanyFormData", StringUtility.removePrefixes("CompanyFormData", " "));
 
@@ -786,7 +781,8 @@ public class StringUtilityTest {
     assertEquals(null, StringUtility.removeSuffixes(null, "suffix"));
     assertEquals("", StringUtility.removeSuffixes("", "suffix"));
     assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData"));
-    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData", null));
+    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData", (String) null));
+    assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData", (String[]) null));
     assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData", ""));
     assertEquals("CompanyFormData", StringUtility.removeSuffixes("CompanyFormData", " "));
 

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/nls/NaturalCollatorProvider.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/nls/NaturalCollatorProvider.java
@@ -77,14 +77,14 @@ public class NaturalCollatorProvider {
   }
 
   /**
-   * Extends the rules of an original collator in a way that it sorts spaces (<code>\u0020</code>) and hyphens
-   * (<code>\u002D</code>) before underscores (<code>\u005f</code>).
+   * Extends the rules of an original collator in a way that it sorts spaces (<code> </code>, U+0020) and hyphens
+   * (<code>-</code>, U+002D) before underscores (<code>_</code>, U+005F).
    *
    * @param origRules
    *          original rules
    * @return replaced rules
    */
   protected String replaceRules(String origRules) {
-    return origRules.replaceAll("<'\u005f'", "<'\u0020','\u002D'<'\u005f'");
+    return origRules.replaceAll("<'_'", "<' ','-'<'_'");
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
@@ -477,10 +477,10 @@ public class ApiDocGenerator {
       elements.add(HTML.tag("a").addAttribute("name", r.getAnchor()));
       elements.add(HTML.h2(
           r.getName(),
-          HTML.link("#" + r.getAnchor(), "\u2693\uFE0E") // anchor + "VS15 variant selector = text style"
+              HTML.link("#" + r.getAnchor(), "⚓︎") // U+2693 U+FE0E = anchor + "VS15 variant selector = text style"
               .cssClass("title-link first")
               .addAttribute("title", "Link to this section"),
-          HTML.link("#", "\u2B61") // up arrow
+              HTML.link("#", "⭡") // U+2B61 UPWARDS ARROW
               .cssClass("title-link")
               .addAttribute("title", "Go to top"))
           .cssClass("title"));
@@ -934,7 +934,7 @@ public class ApiDocGenerator {
           .map(type -> type.getTypeClass().getSimpleName() + " " + type.getName())
           .collect(Collectors.joining(", "));
       String ex = "";
-      if (m_exceptionTypes != null && m_exceptionTypes.size() > 0) {
+      if (CollectionUtility.hasElements(m_exceptionTypes)) {
         ex = " throws " + m_exceptionTypes.stream()
             .map(TypeDescriptor::getTypeClass)
             .map(Class::getSimpleName)

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/AbstractIcons.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/AbstractIcons.java
@@ -29,8 +29,8 @@ public abstract class AbstractIcons implements Serializable {
   public static final String Null = "null";
 
   /* default font icons (sans-serif, arial) */
-  public static final String TableSortAsc = "font:\u2191";
-  public static final String TableSortDesc = "font:\u2193";
+  public static final String TableSortAsc = "font:↑"; // U+2191 UPWARDS ARROW
+  public static final String TableSortDesc = "font:↓"; // U+2193 DOWNWARDS ARROW
 
   /* custom icons */
   public static final String ExclamationMarkCircle = "font:\uE001";


### PR DESCRIPTION
Since all source files are now stored as UTF-8, we can safely replace escape sequences with their corresponding unicode symbol.