### PR TITLE
FocusContext: automatically select text content of input fields

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.js
+++ b/eclipse-scout-core/src/focus/FocusContext.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {filters, focusUtils, graphics, keys, Point, scrollbars} from '../index';
+import {filters, focusUtils, graphics, keys, objects, Point, scrollbars} from '../index';
 import $ from 'jquery';
 
 /**
@@ -123,7 +123,9 @@ export default class FocusContext {
       // Don't change the focus here --> will be handled by browser
     } else {
       // Set focus manually to the target element
-      this.validateAndSetFocus(elementToFocus);
+      this.validateAndSetFocus(elementToFocus, null, {
+        selectText: elementToFocus.tagName === 'INPUT'
+      });
       $.suppressEvent(event);
     }
 
@@ -198,6 +200,7 @@ export default class FocusContext {
    *        filter that controls which element should be focused, or null to accept all focusable candidates.
    * @param {object} [options]
    * @param {boolean} [options.preventScroll] prevents scrolling to new focused element (defaults to false)
+   * @param {boolean} [options.selectText] automatically selects the text content of the element if supported (defaults to false)
    */
   validateAndSetFocus(element, filter, options) {
     // Ensure the element to be a child element, or set it to null otherwise.
@@ -244,6 +247,7 @@ export default class FocusContext {
    *        the element to focus, or null to focus the context's first focusable element matching the given filter.
    * @param {object} [options]
    * @param {boolean} [options.preventScroll] prevents scrolling to new focused element (defaults to false)
+   * @param {boolean} [options.selectText] automatically selects the text content of the element if supported (defaults to false)
    */
   _focus(elementToFocus, options) {
     options = options || {};
@@ -286,6 +290,10 @@ export default class FocusContext {
     elementToFocus.focus({
       preventScroll: scout.nvl(options.preventScroll, false)
     });
+    // If requested and possible, select the text content
+    if (options.selectText && objects.isFunction(elementToFocus.select)) {
+      elementToFocus.select();
+    }
 
     $.log.isDebugEnabled() && $.log.debug('Focus set to ' + graphics.debugOutput(elementToFocus));
   }

--- a/eclipse-scout-core/src/focus/FocusManager.js
+++ b/eclipse-scout-core/src/focus/FocusManager.js
@@ -268,6 +268,7 @@ export default class FocusManager {
    *        Use object, boolean is deprecated
    * @param {boolean} [options.preventScroll] prevents scrolling to new focused element (defaults to false)
    * @param {boolean} [options.onlyIfReady] prevents focusing if not ready
+   * @param {boolean} [options.selectText] automatically selects the text content of the element if supported (defaults to false)
    * @return {boolean} true if focus was gained, false otherwise.
    */
   requestFocus(element, filter, options) {

--- a/eclipse-scout-core/test/focus/FocusManagerSpec.js
+++ b/eclipse-scout-core/test/focus/FocusManagerSpec.js
@@ -8,8 +8,8 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {FocusManagerSpecHelper, FormSpecHelper, TableSpecHelper, TreeSpecHelper} from '../../src/testing/index';
-import {Device, FocusRule, focusUtils, scout} from '../../src/index';
+import {FocusManagerSpecHelper, FormSpecHelper} from '../../src/testing/index';
+import {FocusRule, focusUtils, scout} from '../../src/index';
 
 /* global FocusManagerSpecHelper */
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
@@ -35,8 +35,8 @@ describe('scout.FocusManager', () => {
 
   function createDivWithTwoInputs() {
     let $container = session.$entryPoint.makeDiv();
-    $container.appendElement('<input type="text" val="input1" class="input1">');
-    $container.appendElement('<input type="text" val="input2" class="input2">');
+    $container.appendElement('<input type="text" value="input1" class="input1">');
+    $container.appendElement('<input type="text" value="input2" class="input2">');
     return $container;
   }
 
@@ -276,6 +276,50 @@ describe('scout.FocusManager', () => {
       expect(focusManager.evaluateFocusRule($container, null)).toBe(input1);
       expect(focusManager.evaluateFocusRule($container, 'invalid-rule')).toBe('invalid-rule');
       expect(focusManager.evaluateFocusRule($container, input2)).toBe(input2);
+    });
+  });
+
+  describe('focusNextTabbable', () => {
+
+    it('selects text content on focus', () => {
+      let $container = session.$entryPoint.appendDiv();
+      let $input1 = $container.appendElement('<input type="text" value="lorem">');
+      let $input2 = $container.appendElement('<input type="text" value="ipsum">');
+      let $input3 = $container.appendElement('<textarea>dolor</textarea>');
+      let $input4 = $container.appendElement('<div contenteditable="true" tabindex="0">magna</div>');
+
+      focusManager.installFocusContext($container);
+      focusManager.requestFocus($input1[0]);
+      expect(document.activeElement).toBe($input1[0]);
+      // Text not selected initially
+      expect(document.activeElement.selectionStart).toBe(0);
+      expect(document.activeElement.selectionEnd).toBe(0);
+
+      focusManager.focusNextTabbable(document.activeElement);
+      expect(document.activeElement).toBe($input2[0]);
+      // Text selected (because of selectText=true in #focusNextTabbable)
+      expect(document.activeElement.selectionStart).toBe(0);
+      expect(document.activeElement.selectionEnd).toBe(5);
+
+      focusManager.focusNextTabbable(document.activeElement);
+      expect(document.activeElement).toBe($input3[0]);
+      // No text selected (element is not a simple <input> field)
+      expect(document.activeElement.selectionStart).toBe(0);
+      expect(document.activeElement.selectionEnd).toBe(0);
+
+      focusManager.focusNextTabbable(document.activeElement);
+      expect(document.activeElement).toBe($input4[0]);
+      // No text selected (not a HTMLInputField, therefore no 'selectionStart' property)
+      expect(document.activeElement.selectionStart).toBe(undefined);
+      expect(document.activeElement.selectionEnd).toBe(undefined);
+      expect(document.getSelection().getRangeAt(0).startOffset).toBe(0);
+      expect(document.getSelection().getRangeAt(0).endOffset).toBe(0);
+
+      focusManager.focusNextTabbable(document.activeElement);
+      expect(document.activeElement).toBe($input1[0]);
+      // TExt selected (because of selectText=true in #focusNextTabbable)
+      expect(document.activeElement.selectionStart).toBe(0);
+      expect(document.activeElement.selectionEnd).toBe(5);
     });
   });
 });


### PR DESCRIPTION
When tabbing through a form, the browser automatically natively selects the text content of <input> fields. When we intercept the default tabbing order (e.g. because we have reached the end of a focus context and want to wrap around to the beginning), the same behavior should be applied. This is achieved by calling select() after focus().

365935