### PR TITLE
Remove jersey-apache-connector dependency

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.test/pom.xml
+++ b/org.eclipse.scout.rt.rest.jersey.test/pom.xml
@@ -50,10 +50,6 @@
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.connectors</groupId>
-      <artifactId>jersey-apache-connector</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>


### PR DESCRIPTION
Has been replaced with ScoutApacheConnector