### PR TITLE
Add HTTP/2 support to Jetty

### DIFF
--- a/org.eclipse.scout.dev.jetty/pom.xml
+++ b/org.eclipse.scout.dev.jetty/pom.xml
@@ -40,6 +40,15 @@
       <artifactId>jetty-plus</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-server</artifactId>
+    </dependency>
+    <dependency>
+      <!-- alpn implementation, needed to enable HTTP/2 over TLS, see https://xy2401.com/local-docs/java/jetty.9.4.24.v20191120/alpn-chapter.html -->
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-java-server</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.scout.rt</groupId>
       <artifactId>org.eclipse.scout.rt.platform</artifactId>
     </dependency>

--- a/org.eclipse.scout.dev.jetty/src/main/java/org/eclipse/scout/dev/jetty/JettyConfiguration.java
+++ b/org.eclipse.scout.dev.jetty/src/main/java/org/eclipse/scout/dev/jetty/JettyConfiguration.java
@@ -9,8 +9,12 @@
  */
 package org.eclipse.scout.dev.jetty;
 
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.config.AbstractBooleanConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractPortConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractStringConfigProperty;
+import org.eclipse.scout.rt.platform.config.CONFIG;
+import org.eclipse.scout.rt.platform.util.StringUtility;
 
 public final class JettyConfiguration {
 
@@ -46,7 +50,31 @@ public final class JettyConfiguration {
 
     @Override
     public String description() {
-      return "Setting this property enables the jetty https connector. For example 'file:/dev/my-https.jks'";
+      return "Setting this property enables the jetty https connector using this keystore. "
+          + "For example 'classpath:/dev/my-https.jks' or 'file:///C:/Users/usr/Desktop/my-store.jks' or 'C:/Users/usr/Desktop/my-store.jks'.";
+    }
+  }
+
+  /**
+   * @since 24.1
+   */
+  public static class ScoutJettyUseTlsProperty extends AbstractBooleanConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.jetty.useTls";
+    }
+
+    @Override
+    public String description() {
+      return "Specifies if the Jetty server should use TLS. If true, the server must either be started in development mode (then a new self-singed certificate is created automatically),"
+          + "or a Java KeyStore must be configured using property '" + BEANS.get(ScoutJettyKeyStorePathProperty.class).getKey() + "'."
+          + "By default this property is true, if a Java KeyStore has been specified.";
+    }
+
+    @Override
+    public Boolean getDefaultValue() {
+      return StringUtility.hasText(CONFIG.getPropertyValue(ScoutJettyKeyStorePathProperty.class));
     }
   }
 
@@ -61,10 +89,10 @@ public final class JettyConfiguration {
 
     @Override
     public String description() {
-      return "Setting this property to a valid X-500 name will automatically generate a self-signed SSL certificate and store it in the keystore file path specified.\n"
-          + "This property is the X500 name (DN) for which the certificate is issued.\n"
+      return "Specifies the X-500 name to use in the self-signed certificate when starting Jetty in development mode with TLS enabled."
           + "For example 'CN=my-host.my-domain.com,C=US,ST=CA,L=Sunnyvale,O=My Company Inc.'.\n"
-          + "Use in development only!";
+          + "This property is only used in development mode and only if the property '" + BEANS.get(ScoutJettyUseTlsProperty.class).getKey() + "' is true "
+          + "and no existing Java keystore is specified (property '" + BEANS.get(ScoutJettyKeyStorePathProperty.class).getKey() + "').";
     }
   }
 
@@ -94,7 +122,7 @@ public final class JettyConfiguration {
 
     @Override
     public String description() {
-      return "Https private key password. Supports obfuscated values prefixed with 'OBF:'.";
+      return "The password (if any) for the specific key within the key store. Supports obfuscated values prefixed with 'OBF:'.";
     }
   }
 
@@ -109,7 +137,7 @@ public final class JettyConfiguration {
 
     @Override
     public String description() {
-      return "Https certificate alias in keystore.";
+      return "Https certificate alias of the key in the keystore to use.";
     }
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/ICertificateProvider.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/ICertificateProvider.java
@@ -9,11 +9,15 @@
  */
 package org.eclipse.scout.rt.platform.security;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
@@ -30,22 +34,84 @@ public interface ICertificateProvider {
    * @param certificateAlias
    *          is the alias used in the keystore for accessing the certificate, this is not the certificate name (DN)
    * @param x500Name
-   *          or Subject DN or Issuer DN for example "CN=host.domain.com,C=CH,ST=ZH,L=Zurich,O=My Company",
+   *          or Subject DN or Issuer DN. For example "CN=host.domain.com,C=CH,ST=ZH,L=Zurich,O=My Company". X.500 name
+   *          format is:
    *
    *          <pre>
-  X.500 name format is
-  CN: CommonName: host.domain.com
-  C: CountryName: CH
-  S: StateOrProvinceName: ZH
-  L: Locality: Zurich
-  O: Organization: My Company
-  OU: OrganizationalUnit:
+  CN: CommonName: host.domain.com<br>
+  C: CountryName: CH<br>
+  S: StateOrProvinceName: ZH<br>
+  L: Locality: Zurich<br>
+  O: Organization: My Company<br>
+  OU: OrganizationalUnit<br>
    *          </pre>
    *
    * @param storePass
-   *          keystore password
+   *          the password used to unlock the keystore, or {@code null}.
    * @param keyPass
-   *          private key password
+   *          the password to protect the key, or {@code null}.
+   * @param keyBits
+   *          typically 4096
+   * @param validDays
+   *          typically 365 days
+   * @since 22.0
+   */
+  KeyStore createSelfSignedCertificate(String certificateAlias, String x500Name, char[] storePass, char[] keyPass, int keyBits, int validDays);
+
+  /**
+   * Create a self-signed X509 certificate with public key and private key in a JKS keystore.
+   * <p>
+   * Similar to: openssl req -nodes -newkey rsa:4096 -days 3650 -x509 -keyout cert_private.key -out cert_public.pem
+   *
+   * @param certificateAlias
+   *     is the alias used in the keystore for accessing the certificate, this is not the certificate name (DN)
+   * @param x500Name
+   *     or Subject DN or Issuer DN. For example "CN=host.domain.com,C=CH,ST=ZH,L=Zurich,O=My Company". X.500 name
+   *     format is:
+   *
+   *     <pre>
+   *     CN: CommonName: host.domain.com<br>
+   *     C: CountryName: CH<br>
+   *     S: StateOrProvinceName: ZH<br>
+   *     L: Locality: Zurich<br>
+   *     O: Organization: My Company<br>
+   *     OU: OrganizationalUnit<br>
+   *              </pre>
+   * @param storePass
+   *     the password used to unlock the keystore, or {@code null}.
+   * @param keyPass
+   *     the password to protect the key, or {@code null}.
+   * @since 22.0
+   */
+  default KeyStore createSelfSignedCertificate(String certificateAlias, String x500Name, char[] storePass, char[] keyPass) {
+    return createSelfSignedCertificate(certificateAlias, x500Name, storePass, keyPass, 4096, 365);
+  }
+
+  /**
+   * Create a self-signed X509 certificate with public key and private key in a JKS keystore. The Keystore will be
+   * written to the given {@link OutputStream}.
+   * <p>
+   * Similar to: openssl req -nodes -newkey rsa:4096 -days 3650 -x509 -keyout cert_private.key -out cert_public.pem
+   *
+   * @param certificateAlias
+   *          is the alias used in the keystore for accessing the certificate, this is not the certificate name (DN)
+   * @param x500Name
+   *          or Subject DN or Issuer DN. For example "CN=host.domain.com,C=CH,ST=ZH,L=Zurich,O=My Company". X.500 name
+   *          format is:
+   *
+   *          <pre>
+  CN: CommonName: host.domain.com<br>
+  C: CountryName: CH<br>
+  S: StateOrProvinceName: ZH<br>
+  L: Locality: Zurich<br>
+  O: Organization: My Company<br>
+  OU: OrganizationalUnit<br>
+   *          </pre>
+   *
+   * @param storePass
+   *          the password used to unlock the keystore, or {@code null}.
+   * @param keyPass
+   *          the password to protect the key, or {@code null}.
    * @param keyBits
    *          typically 4096
    * @param validDays
@@ -54,14 +120,26 @@ public interface ICertificateProvider {
    *          where to write the generated keystore to. The result is written in java key store file format.
    * @since 22.0
    */
-  void createSelfSignedCertificate(String certificateAlias, String x500Name, char[] storePass, char[] keyPass, int keyBits, int validDays, OutputStream out);
+  default void createSelfSignedCertificate(String certificateAlias, String x500Name, char[] storePass, char[] keyPass, int keyBits, int validDays, OutputStream out) {
+    try {
+      KeyStore ks = createSelfSignedCertificate(certificateAlias, x500Name, storePass, keyPass, keyBits, validDays);
+      ks.store(out, storePass);
+    }
+    catch (IOException | GeneralSecurityException e) {
+      throw new ProcessingException("Error creating self signed certificate with alias '{}'.", certificateAlias, e);
+    }
+  }
 
   /**
-   * Auto-generate a self-signed X509 certificate with public key and private key in a JKS keystore. If the keystore
-   * file already exists, then it is re-used and not created.
+   * If the keyStorePath given already exists, this method does nothing. Otherwise, a new keystore with a self-signed
+   * X509 certificate is created in this file.
    *
    * @param keyStorePath
-   *          must be a valid and writable file path (see {@link Paths#get(String, String...)})
+   *          must be a valid URI pointing to a file on the local file system. E.g.
+   *          file:///C:/Users/usr/Desktop/my-store.jks
+   * @param x500Name
+   *          Must be a valid x500 name (see {@link #createSelfSignedCertificate(String, String, char[], char[])} for
+   *          details).
    * @see #createSelfSignedCertificate(String, String, char[], char[], int, int, OutputStream)
    * @since 22.0
    */
@@ -70,18 +148,16 @@ public interface ICertificateProvider {
       return;
     }
     try {
-      if (keyStorePath.startsWith("file:")) {
-        keyStorePath = keyStorePath.substring(5);
+      Path path = Paths.get(URI.create(keyStorePath));
+      if (Files.exists(path)) {
+        return;
       }
-      Path path = Paths.get(keyStorePath);
-      if (!Files.exists(path)) {
-        try (OutputStream jks = Files.newOutputStream(path)) {
-          createSelfSignedCertificate(certificateAlias, x500Name, storePass, keyPass, 4096, 365, jks);
-        }
+      try (OutputStream jks = new BufferedOutputStream(Files.newOutputStream(path))) {
+        createSelfSignedCertificate(certificateAlias, x500Name, storePass, keyPass, 4096, 365, jks);
       }
     }
     catch (IOException e) {
-      throw new ProcessingException("Could not create self-signed certificate '{}' with X500 name '{}' in {}", certificateAlias, x500Name, keyStorePath, e);
+      throw new ProcessingException("Could not create self-signed certificate '{}' with X500 name '{}' in '{}'.", certificateAlias, x500Name, keyStorePath, e);
     }
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/DefaultExceptionMapper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/DefaultExceptionMapper.java
@@ -13,6 +13,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.ConnectionErrorDetector;
 import org.eclipse.scout.rt.rest.error.ErrorResponseBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +36,12 @@ public class DefaultExceptionMapper extends AbstractExceptionMapper<Exception> {
 
   @Override
   public Response toResponseImpl(Exception exception) {
-    LOG.error("Exception occurred while processing REST request", exception);
+    if (BEANS.get(ConnectionErrorDetector.class).isConnectionError(exception)) {
+      LOG.debug("Connection error occurred while processing REST request", exception);
+    }
+    else {
+      LOG.error("Exception occurred while processing REST request", exception);
+    }
     return createResponse(exception);
   }
 

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/ServletFilterHelper.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/ServletFilterHelper.java
@@ -235,7 +235,8 @@ public class ServletFilterHelper {
   }
 
   /**
-   * Forwards the request to the login.html. In case forwarding would not work, the request will be redirected, see {@link #redirectToLoginFormIfNecessary(HttpServletRequest, HttpServletResponse)}.
+   * Forwards the request to the login.html. In case forwarding would not work, the request will be redirected, see
+   * {@link #redirectToLoginFormIfNecessary(HttpServletRequest, HttpServletResponse)}.
    */
   public void forwardToLoginForm(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
     if (!acceptForwardOrRedirect(req, resp, req.getPathInfo(), true)) {
@@ -250,11 +251,11 @@ public class ServletFilterHelper {
   /**
    * Redirects to /login if forwarding would not work.
    * <p>
-   * Forwarding won't work if the requested path has subfolders because the resources loaded by login.html are addressed
+   * Forwarding won't work if the requested path has sub-folders because the resources loaded by login.html are addressed
    * relatively.
    * <p>
    * Example: if the request url is /folder/file, forwarding to /login.html would correctly return login.html but the
-   * resources (login.js etc) could not be loaded because the location of the browser still is /folder/file. The
+   * resources (login.js etc.) could not be loaded because the location of the browser still is /folder/file. The
    * requests would fail because they expect the resources to be in the root folder (e.g. /login.js) instead of the
    * subfolder (e.g. /folder/login.js).
    */
@@ -313,7 +314,7 @@ public class ServletFilterHelper {
    * javax.servlet.ServletResponse)). This has the same effect as if the user had requested the target location from the
    * beginning.
    * </ul>
-   * If the client expects JSON as response (accept header contains 'application/json'), no redirection happens, but a
+   * If the client expects JSON as response (accept-header contains 'application/json'), no redirection happens, but a
    * JSON timeout message is sent. Also for POST requests no forwarding/redirection will happen but error code 403
    * (forbidden) returned.
    */
@@ -362,7 +363,7 @@ public class ServletFilterHelper {
   }
 
   /**
-   * If the request has a HTTP session attached, the session is invalidated.
+   * If the request has an HTTP session attached, the session is invalidated.
    */
   public void doLogout(HttpServletRequest req) {
     HttpSession session = req.getSession(false);
@@ -377,7 +378,7 @@ public class ServletFilterHelper {
    * {@link ServletFilterHelper#SESSION_ATTRIBUTE_FOR_LOGIN_REDIRECT} is set, a new session is created and the attribute
    * copied to the new session. The next request (which will be the reload request executed by the login page) will read
    * this attribute and return a redirect instruction with the value of the attribute (see
-   * {@link #redirectAfterLogin(HttpServletRequest, HttpServletResponse, ServletFilterHelper)}.
+   * {@link #redirectAfterLogin(HttpServletRequest, HttpServletResponse, ServletFilterHelper)}).
    * <p>
    * If that session attribute is not set, no new session will be created.
    */

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/RemoteServiceInvocationCallable.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/RemoteServiceInvocationCallable.java
@@ -10,7 +10,6 @@
 package org.eclipse.scout.rt.shared.servicetunnel.http;
 
 import java.io.ByteArrayOutputStream;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -18,9 +17,11 @@ import java.net.ConnectException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.context.RunMonitor;
 import org.eclipse.scout.rt.platform.exception.PlatformException;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.util.ConnectionErrorDetector;
 import org.eclipse.scout.rt.platform.util.concurrent.FutureCancelledError;
 import org.eclipse.scout.rt.platform.util.concurrent.ICancellable;
 import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruptedError;
@@ -112,7 +113,7 @@ public class RemoteServiceInvocationCallable implements Callable<ServiceTunnelRe
         LOG.debug("Ignoring IOException for cancelled thread.", e);
         return new ServiceTunnelResponse(new FutureCancelledError("RunMonitor is cancelled.", e));
       }
-      else if (e instanceof EOFException) { // NOSONAR
+      else if (BEANS.get(ConnectionErrorDetector.class).isConnectionError(e)) {
         ISession session = ISession.CURRENT.get();
         if (session == null || session.isStopping() || !session.isActive()) {
           LOG.debug("EOF detected for non-existing/stopping/non-active session.", e);

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -757,6 +757,19 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <!-- This dependency only exists to specify the exclusion. -->
+      <dependency>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>http2-server</artifactId>
+        <version>${jetty.version}</version>
+        <exclusions>
+          <exclusion>
+            <!-- The jetty-servlet-api contains (amongst others) the same classes as jakarta.servlet-api -->
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
       <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>jakarta.activation</artifactId>


### PR DESCRIPTION
In addition to HTTP/1.1 also HTTP/2 is supported with and without TLS.

When using TLS also ALPN is supported which can upgrade an HTTP/1.1 request to an HTTP/2 request if the client supports it.

Furthermore, a new property 'scout.jetty.useTls' is introduced to enable TLS without providing a path to a keystore. In this situation a new self-signed in memory certificate is created on each server startup. The creation of a self-signed certificate is only active in development.

359560