### PR TITLE
FormController: do not register forms twice on their displayParent

### DIFF
--- a/eclipse-scout-core/src/filechooser/FileChooserController.ts
+++ b/eclipse-scout-core/src/filechooser/FileChooserController.ts
@@ -67,7 +67,7 @@ export class FileChooserController {
     if (fileChooser.rendered) {
       return;
     }
-    if (register) {
+    if (register && !arrays.contains(this.displayParent.fileChoosers, fileChooser)) {
       this.displayParent.fileChoosers.push(fileChooser);
     }
 

--- a/eclipse-scout-core/src/form/FormController.ts
+++ b/eclipse-scout-core/src/form/FormController.ts
@@ -139,7 +139,7 @@ export class FormController implements FormControllerModel, ObjectWithType {
     if (view.rendered || view.blockRendering) {
       return;
     }
-    if (register) {
+    if (register && !arrays.contains(this.displayParent.views, view)) {
       if (position !== undefined) {
         arrays.insert(this.displayParent.views, view, position);
       } else {
@@ -181,7 +181,7 @@ export class FormController implements FormControllerModel, ObjectWithType {
       return;
     }
 
-    if (register) {
+    if (register && !arrays.contains(this.displayParent.dialogs, dialog)) {
       this.displayParent.dialogs.push(dialog);
     }
 

--- a/eclipse-scout-core/src/messagebox/MessageBoxController.ts
+++ b/eclipse-scout-core/src/messagebox/MessageBoxController.ts
@@ -67,7 +67,7 @@ export class MessageBoxController {
     if (messageBox.rendered) {
       return;
     }
-    if (register) {
+    if (register && !arrays.contains(this.displayParent.messageBoxes, messageBox)) {
       this.displayParent.messageBoxes.push(messageBox);
     }
     // Use parent's function or (if not implemented) our own.

--- a/eclipse-scout-core/test/filechooser/FileChooserControllerSpec.ts
+++ b/eclipse-scout-core/test/filechooser/FileChooserControllerSpec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {DisplayParent, FileChooser, FileChooserController, scout} from '../../src/index';
+import {FormSpecHelper} from '../../src/testing';
+
+describe('FileChooserController', () => {
+  let session: SandboxSession;
+  let displayParent: DisplayParent;
+  let fileChooserController: FileChooserController;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    displayParent = new FormSpecHelper(session).createFormWithOneField();
+    fileChooserController = new FileChooserController(displayParent, session);
+  });
+
+  describe('registerAndRender', () => {
+
+    it('does not register fileChoosers twice on its displayParent', () => {
+      const fileChooser = scout.create(FileChooser, {
+        parent: displayParent,
+        displayParent
+      });
+
+      expect(displayParent.fileChoosers.length).toBe(0);
+
+      fileChooserController.registerAndRender(fileChooser);
+      expect(displayParent.fileChoosers.length).toBe(1);
+
+      fileChooserController.registerAndRender(fileChooser);
+      expect(displayParent.fileChoosers.length).toBe(1);
+    });
+  });
+});

--- a/eclipse-scout-core/test/form/FormControllerSpec.ts
+++ b/eclipse-scout-core/test/form/FormControllerSpec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {DisplayParent, Form, FormController, scout} from '../../src/index';
+import {FormSpecHelper} from '../../src/testing';
+
+describe('FormController', () => {
+  let session: SandboxSession;
+  let formHelper: FormSpecHelper;
+  let displayParent: DisplayParent;
+  let formController: FormController;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    formHelper = new FormSpecHelper(session);
+    displayParent = formHelper.createFormWithOneField();
+    formController = scout.create(FormController, {displayParent, session});
+  });
+
+  describe('registerAndRender', () => {
+
+    it('does not register views twice on its displayParent', () => {
+      const view = formHelper.createFormWithOneField({
+        parent: displayParent,
+        displayParent,
+        displayHint: Form.DisplayHint.VIEW
+      });
+
+      expect(displayParent.views.length).toBe(0);
+
+      formController.registerAndRender(view);
+      expect(displayParent.views.length).toBe(1);
+
+      formController.registerAndRender(view);
+      expect(displayParent.views.length).toBe(1);
+    });
+
+    it('does not register dialogs twice on its displayParent', () => {
+      const dialog = formHelper.createFormWithOneField({
+        parent: displayParent,
+        displayParent,
+        displayHint: Form.DisplayHint.DIALOG
+      });
+
+      expect(displayParent.dialogs.length).toBe(0);
+
+      formController.registerAndRender(dialog);
+      expect(displayParent.dialogs.length).toBe(1);
+
+      formController.registerAndRender(dialog);
+      expect(displayParent.dialogs.length).toBe(1);
+    });
+  });
+});

--- a/eclipse-scout-core/test/messagebox/MessageBoxControllerSpec.ts
+++ b/eclipse-scout-core/test/messagebox/MessageBoxControllerSpec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {DisplayParent, MessageBox, MessageBoxController, scout} from '../../src/index';
+import {FormSpecHelper} from '../../src/testing';
+
+describe('MessageBoxController', () => {
+  let session: SandboxSession;
+  let displayParent: DisplayParent;
+  let messageBoxController: MessageBoxController;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    displayParent = new FormSpecHelper(session).createFormWithOneField();
+    messageBoxController = new MessageBoxController(displayParent, session);
+  });
+
+  describe('registerAndRender', () => {
+
+    it('does not register messageBoxes twice on its displayParent', () => {
+      const messageBox = scout.create(MessageBox, {
+        parent: displayParent,
+        displayParent
+      });
+
+      expect(displayParent.messageBoxes.length).toBe(0);
+
+      messageBoxController.registerAndRender(messageBox);
+      expect(displayParent.messageBoxes.length).toBe(1);
+
+      messageBoxController.registerAndRender(messageBox);
+      expect(displayParent.messageBoxes.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
A form that is already contained in its displayParents views or dialogs must not be registered again when it is shown.
This happens for example if a JsForm is open and the browser is reloaded. The JsForm will be part of the desktops views on session startup. As the JsForm calls Form.show() after it is loaded the FormController tries to register it a second time on the desktop. If a form is registered multiple times on its displayParent only one occurrence is removed when the form is destroyed. This will break e.g. open exclusive as there might be a matching form which can not be displayed as it is already destroyed.
Add the same logic to FileChooserController and MessageBoxController even if there are no known errors so far.

367169