### PR TITLE
SmartFieldTouchPopup: Delegate lookup events to source smart field

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldTouchPopup.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldTouchPopup.ts
@@ -39,6 +39,10 @@ export class SmartFieldTouchPopup<TValue> extends TouchPopup implements SmartFie
     this.addCssClass('smart-field-touch-popup');
   }
 
+  protected override _initDelegatedEvents(): string[] {
+    return ['prepareLookupCall', 'lookupCallDone'];
+  }
+
   protected override _initWidget(options: SmartFieldTouchPopupModel<TValue>) {
     this._widget = this._createProposalChooser();
     this._widget.on('lookupRowSelected', this._triggerEvent.bind(this));

--- a/eclipse-scout-core/src/popup/TouchPopup.ts
+++ b/eclipse-scout-core/src/popup/TouchPopup.ts
@@ -63,7 +63,9 @@ export class TouchPopup extends Popup {
 
     // clone original touch field
     // original and clone both point to the same popup instance
-    this._field = this._touchField.clone(this._fieldOverrides());
+    this._field = this._touchField.clone(this._fieldOverrides(), {
+      delegateEventsToOriginal: this._initDelegatedEvents()
+    });
     this._touchField.on('propertyChange', this._touchFieldPropertyChangeListener);
     this._initWidget(options);
     this.doneAction = scout.create(Menu, {
@@ -94,6 +96,10 @@ export class TouchPopup extends Popup {
       touchMode: false,
       clearable: ValueField.Clearable.ALWAYS
     };
+  }
+
+  protected _initDelegatedEvents(): string[] {
+    return [];
   }
 
   protected _initWidget(options: TouchPopupModel) {


### PR DESCRIPTION
The SmartField has its own touch popup implementation. Internally, the popup creates a clone of the original SmartField. Until now, any lookup event listeners on the original field have been ignored, as the clone does not delegate the events to the original smart field. This change adjusts this behaviour. The SmartFieldTouchPopup now delegates the events 'prepareLookupCall' and 'lookupCallDone' to the original  smart field.

366351