### PR TITLE
SmartFieldTouchPopup: Delegate lookup events to source smart field

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldTouchPopup.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldTouchPopup.js
@@ -32,6 +32,10 @@ export default class SmartFieldTouchPopup extends TouchPopup {
     this.addCssClass('smart-field-touch-popup');
   }
 
+  _initDelegatedEvents() {
+    return ['prepareLookupCall', 'lookupCallDone'];
+  }
+
   _initWidget(options) {
     this._widget = this._createProposalChooser();
     this._widget.on('lookupRowSelected', this._triggerEvent.bind(this));

--- a/eclipse-scout-core/src/popup/TouchPopup.js
+++ b/eclipse-scout-core/src/popup/TouchPopup.js
@@ -42,7 +42,9 @@ export default class TouchPopup extends Popup {
 
     // clone original touch field
     // original and clone both point to the same popup instance
-    this._field = this._touchField.clone(this._fieldOverrides());
+    this._field = this._touchField.clone(this._fieldOverrides(), {
+      delegateEventsToOriginal: this._initDelegatedEvents()
+    });
     this._touchField.on('propertyChange', this._touchFieldPropertyChangeListener);
     this._initWidget(options);
     this.doneAction = scout.create('Menu', {
@@ -73,6 +75,14 @@ export default class TouchPopup extends Popup {
       touchMode: false,
       clearable: ValueField.Clearable.ALWAYS
     };
+  }
+
+  /**
+   * @return {string[]|[]}
+   * @protected
+   */
+  _initDelegatedEvents() {
+    return [];
   }
 
   _initWidget(options) {

--- a/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.js
+++ b/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.js
@@ -328,6 +328,36 @@ describe('SmartField', () => {
       expect(field.popup._field._tooltip().$container.find('.glasspane').length).toBe(0);
     });
 
+    it('delegates lookup events to original field', () => {
+      let field = createFieldWithLookupCall({
+        touchMode: true
+      });
+      let prepareLookupCallCounter = 0;
+      let lookupCallDoneCounter = 0;
+      let onPrepareLookupCall = () => {
+        prepareLookupCallCounter++;
+      };
+      let onLookupCallDone = () => {
+        lookupCallDoneCounter++;
+      };
+      field.on('prepareLookupCall', onPrepareLookupCall.bind(field));
+      field.on('lookupCallDone', onLookupCallDone.bind(field));
+      field.render();
+      jasmine.clock().tick(500);
+      field.$field.triggerClick();
+      jasmine.clock().tick(500);
+
+      let popup = field.popup;
+      let oldPrepareLookupCallCounter = prepareLookupCallCounter;
+      let oldLookupCallDoneCounter = lookupCallDoneCounter;
+      popup._field.setValue(1);
+      jasmine.clock().tick(500);
+      field.$field.triggerClick();
+
+      expect(prepareLookupCallCounter).toBe(oldPrepareLookupCallCounter + 1);
+      expect(lookupCallDoneCounter).toBe(oldLookupCallDoneCounter + 1);
+    });
+
   });
 
   describe('acceptInput', () => {


### PR DESCRIPTION
The SmartField has its own touch popup implementation. Internally, the popup creates a clone of the original SmartField. Until now, any lookup event listeners on the original field have been ignored, as the clone does not delegate the events to the original smart field. This change adjusts this behaviour. The SmartFieldTouchPopup now delegates the events 'prepareLookupCall' and 'lookupCallDone' to the original  smart field.

366351