### PR TITLE
Tree: fix error in tree event buffer

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTreeNode.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTreeNode.java
@@ -70,6 +70,7 @@ public abstract class AbstractTreeNode implements ITreeNode, ICellObserver, ICon
   private int m_initializing = 0; // >0 is true
   private ITree m_tree;
   private ITreeNode m_parentNode;
+  private ITreeNode m_oldParentNode;
 
   private final Object m_childNodeListLock;
   private final Object m_filteredChildNodesLock;
@@ -788,7 +789,15 @@ public abstract class AbstractTreeNode implements ITreeNode, ICellObserver, ICon
    */
   @Override
   public void setParentNodeInternal(ITreeNode parent) {
+    if (parent == null && m_parentNode != null) {
+      m_oldParentNode = m_parentNode;
+    }
     m_parentNode = parent;
+  }
+
+  @Override
+  public ITreeNode getOldParentNode() {
+    return m_oldParentNode;
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeNode.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeNode.java
@@ -252,6 +252,11 @@ public interface ITreeNode extends IVisibleDimension, IEnabledDimension, IContex
   ITreeNode getParentNode();
 
   /**
+   * @return the parent node before the node was deleted.
+   */
+  ITreeNode getOldParentNode();
+
+  /**
    * @return the immediate parent node if it is of type T, null otherwise
    */
   <T extends ITreeNode> T getParentNode(Class<T> type);

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/TreeEventBuffer.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/TreeEventBuffer.java
@@ -104,7 +104,7 @@ public class TreeEventBuffer extends AbstractEventBuffer<TreeEvent> {
         typesToDelete.addAll(getExpansionRelatedEvents());
       }
       else if ((type == TreeEvent.TYPE_NODES_DELETED || type == TreeEvent.TYPE_ALL_CHILD_NODES_DELETED) && event.hasNodes()) {
-        // Built a set of all nodes that were newly added to the tree.
+        // Build a set of all nodes that were newly added to the tree.
         // (This will only be required when processing delete events, therefore we create it lazily here.)
         if (newNodes == null) {
           newNodes = new HashSet<>();
@@ -620,7 +620,7 @@ public class TreeEventBuffer extends AbstractEventBuffer<TreeEvent> {
         // is a directly inserted node. The nodeToRemove will then not be contained in the insertion
         // event, but because one of its parents was inserted recently, the deletion event is not
         // required anymore (the insertion event does not contain deleted nodes).
-        ITreeNode parentToCheck = nodeToRemove.getParentNode();
+        ITreeNode parentToCheck = ObjectUtility.nvl(nodeToRemove.getParentNode(), nodeToRemove.getOldParentNode());
         while (parentToCheck != null) {
           if (event.containsNode(parentToCheck)) {
             it.remove();
@@ -628,7 +628,7 @@ public class TreeEventBuffer extends AbstractEventBuffer<TreeEvent> {
             updateNodesToRemove(nodeToRemove);
             break;
           }
-          parentToCheck = parentToCheck.getParentNode();
+          parentToCheck = ObjectUtility.nvl(parentToCheck.getParentNode(), parentToCheck.getOldParentNode());
         }
       }
       return m_allNodesToRemove.isEmpty();


### PR DESCRIPTION
Use case:
Two separate data change events reload nodes in the same tree. The first one reloads a parent node.
The second one reloads a child node.
This creates a delete_all_child_nodes event and an insert_nodes event for the parent node (node_a) and the child node (node_b):

delete_all_child_nodes(node_a)
insert_nodes(node_a)

delete_all_child_nodes(node_b)
insert_nodes(node_b)

The tree event buffer should now remove the events for node_b completely because the insert_nodes event of node_a contains the whole subtree, incl. node_b.

Unfortunately, it currently only removes insert_nodes(node_b) event but
 not the delete event which creates an inconsistent state and every
  upcoming event for node_b will fail.
The TreeEventBuffer actually already contains the logic to handle this problem, but does not consider the fact that the link to the parent node is deleted when the node is removed. Hence, the logic only works in the JUnit testcase where the nodes are mocked and the link to the parent node is not removed...

350921