### PR TITLE
Table: error status is being display on wrong cell

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -2093,16 +2093,12 @@ export class Table extends Widget implements TableModel {
   }
 
   protected _showCellErrorForRow(row: TableRow) {
-    let $cells = this.$cellsForRow(row.$row),
-      that = this;
-
-    $cells.each(function(index) {
-      let $cell = $(this);
-      let cell = that.cellByCellIndex(index, row);
+    for (let column of this.visibleColumns()) {
+      let cell = this.cell(column, row);
       if (cell.errorStatus) {
-        that._showCellError(row, $cell, cell.errorStatus);
+        this._showCellError(row, this.$cell(column, row.$row), cell.errorStatus);
       }
-    });
+    }
   }
 
   protected _showCellError(row: TableRow, $cell: JQuery, errorStatus: Status) {


### PR DESCRIPTION
If a table has invisible columns, cells' error status might be displayed on the wrong cell.

367747