### PR TITLE
Bean manager: fix possible deadlock when using GlobalTestingPlatform

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/internal/BeanManagerImplementor.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/internal/BeanManagerImplementor.java
@@ -63,9 +63,9 @@ public class BeanManagerImplementor implements IBeanManager {
   }
 
   protected <T> List<IBean<T>> querySingle(Class<T> beanClazz) {
+    checkAccess();
     m_lock.readLock().lock();
     try {
-      checkAccess();
       @SuppressWarnings("unchecked")
       BeanHierarchy<T> h = m_beanHierarchies.get(beanClazz);
       if (h == null) {


### PR DESCRIPTION
BeanManagerImplementor#checkAccess is called within the read lock of #querySingle, which might cause a deadlock when #registerBean is called concurrently because that one tries to get a write lock. There is no need to call #checkAccess within the read lock, thus move the call outside the lock block.

304920