### PR TITLE
354734 Update jackson to 2.16, adapt to behavioral changes

### DIFF
--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoCollectionDeserializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoCollectionDeserializer.java
@@ -10,6 +10,7 @@
 package org.eclipse.scout.rt.jackson.dataobject;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.function.Supplier;
 
@@ -74,8 +75,17 @@ public class DoCollectionDeserializer<COLLECTION_NODE extends IDoCollection<?, ?
     }
     else {
       // all JSON scalar values are deserialized as bound type (if available) and as fallback as raw object using default jackson typing
-      return ObjectUtility.nvl(m_collectionType.getBindings().getBoundType(0), TypeFactory.unknownType());
+      return ObjectUtility.nvl(m_collectionType.getBindings().getBoundType(0), resolveFallbackListElementType(p));
     }
+  }
+
+  protected ResolvedType resolveFallbackListElementType(JsonParser p) {
+    if (p.getCurrentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+      // deserialize floating point numbers as BigDecimal
+      return TypeFactory.defaultInstance().constructType(BigDecimal.class);
+    }
+    // JSON scalar values are deserialized as raw object using default jackson typing
+    return TypeFactory.unknownType();
   }
 
   @Override

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -124,7 +124,7 @@
     <jetty.version>10.0.15</jetty.version>
     <slf4j.version>2.0.7</slf4j.version>
     <logback.version>1.3.8</logback.version>
-    <jackson.version>2.14.0</jackson.version>
+    <jackson.version>2.16.0</jackson.version>
     <io.netty-version>4.1.94.Final</io.netty-version>
     <apache.tika-version>2.6.0</apache.tika-version>
     <batik.version>1.17</batik.version>


### PR DESCRIPTION
(1) Jackson adapted handling for Optional serialization providing a custom exception message if Optional is being serialized. Scout does not support serialization of Java Optional, therefore adapt test case. See also:
https://github.com/FasterXML/jackson-databind/issues/4082 https://github.com/FasterXML/jackson-databind/commit/d7e77c39ebf477a4b1e8732b3bae9e4d4fd2a994

(2) Jackson adapted handling for untyped deserialization of floating point numbers. Former implementations (before 2.15) deserialized floating point numbers within lists as BigDecimal. Since issue 903 and 3751 numbers are deserialized into the smalles possible Java data type (same behavior as plain numbers not within a JSON list element). Therefore Scout DoCollectionDeserializer was adapted identically to DoEntityDeserializer to enforce using BigDecimal for unknown (raw) number deserialization.

See also:
https://github.com/FasterXML/jackson-core/pull/903 https://github.com/FasterXML/jackson-core/commit/4c957e3ea35e2ba95e00a245394df5b43241918d and
https://github.com/FasterXML/jackson-databind/pull/3751 https://github.com/FasterXML/jackson-databind/commit/23ea48c0abb466aaac2020be802f243f242c4c9c