### PR TITLE
Increase min versions of supported browsers

### DIFF
--- a/eclipse-scout-cli/scripts/webpack-defaults.js
+++ b/eclipse-scout-cli/scripts/webpack-defaults.js
@@ -58,7 +58,7 @@ module.exports = (env, args) => {
       });
   }
 
-  const minimizerTarget = ['firefox69', 'chrome71', 'safari12.1'];
+  const minimizerTarget = ['firefox69', 'chrome71', 'safari13'];
   const babelOptions = {
     compact: false,
     cacheDirectory: true,
@@ -69,7 +69,7 @@ module.exports = (env, args) => {
         targets: {
           firefox: '69',
           chrome: '71',
-          safari: '12.1'
+          safari: '13'
         }
       }]
     ]

--- a/eclipse-scout-core/src/util/Device.ts
+++ b/eclipse-scout-core/src/util/Device.ts
@@ -275,7 +275,7 @@ export class Device implements DeviceModel, ObjectWithType {
     let browsers = Device.Browser;
     return (browser === browsers.CHROME && version >= 71)
       || (browser === browsers.FIREFOX && version >= 69)
-      || (browser === browsers.SAFARI && version >= 12.1);
+      || (browser === browsers.SAFARI && version >= 13);
   }
 
   /**


### PR DESCRIPTION
fetch with keepalive is supported on Safari from version 13 upwards.