### PR TITLE
Activate outline without active form check

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
@@ -1109,7 +1109,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
 
     final IOutline newOutline = resolveOutline(outline);
     if (m_outline == newOutline) {
-      if (m_outline != null && getActiveForm() != null) {
+      if (m_outline != null) { // The active ScoutJS form is not tracked in UI. Active form check removed to support this case.
         m_outline.createDisplayParentRunContext().run(this::fireOutlineContentActivate);
       }
       return;


### PR DESCRIPTION
The active ScoutJS form is not tracked on the UI server. To allow for the outline activation with active ScoutJS form the check for an existing active form is removed.