### PR TITLE
UploadRequestHandler: Switch multipart request handling to servlet api

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -366,14 +366,6 @@ commons-discovery-0.2.jar (0.2)
 
 * License: Apache Software License 1.1
 
-commons-fileupload (1.3.2)
-
-* License: Apache License, 2.0
-
-commons-fileupload (1.3.3)
-
-* License: Apache-2.0
-
 commons-io (2.2)
 
 * License: Apache License, 2.0

--- a/org.eclipse.scout.rt.ui.html/pom.xml
+++ b/org.eclipse.scout.rt.ui.html/pom.xml
@@ -40,10 +40,6 @@
       <groupId>org.eclipse.scout.rt</groupId>
       <artifactId>org.eclipse.scout.json</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-fileupload2-jakarta</artifactId>
-    </dependency>
   </dependencies>
 
   <!-- primarily for license header generation -->

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -594,12 +594,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-fileupload2-jakarta</artifactId>
-        <version>2.0.0-M1</version>    <!-- FIXME PBZ JAKARTA dependency will be removed, see https://github.com/eclipse-scout/scout.rt/pull/817 -->
-      </dependency>
-
-      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.16.0</version>


### PR DESCRIPTION
Java EE servlet API offers access to parts of a multipart/form-data request since Servlet API 3.0. Remove Apache commons-fileupload library and switch UploadRequestHandler to Java EE API.

354734