### PR TITLE
367178 Improve BEANS.get performance, fix 2 concurrency issues

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/internal/BeanHierarchy.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/internal/BeanHierarchy.java
@@ -19,8 +19,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.Order;
@@ -35,15 +33,19 @@ public class BeanHierarchy<T> {
 
   private final Class<T> m_clazz;
   private final List<IBean<T>> m_beans;
-  private final ReadWriteLock m_queryCacheLock;
 
+  /**
+   * Redundant, derived by {@link #m_beans}
+   */
   private List<IBean<T>> m_single;
+  /**
+   * Redundant, derived by {@link #m_beans}
+   */
   private List<IBean<T>> m_all;
 
   public BeanHierarchy(Class<T> clazz) {
     m_clazz = clazz;
     m_beans = new ArrayList<>();
-    m_queryCacheLock = new ReentrantReadWriteLock();
   }
 
   public Class<T> getClazz() {
@@ -98,14 +100,8 @@ public class BeanHierarchy<T> {
   }
 
   protected void invalidate() {
-    m_queryCacheLock.writeLock().lock();
-    try {
-      m_single = null;
-      m_all = null;
-    }
-    finally {
-      m_queryCacheLock.writeLock().unlock();
-    }
+    m_single = null;
+    m_all = null;
   }
 
   /**
@@ -131,104 +127,89 @@ public class BeanHierarchy<T> {
     return sorted;
   }
 
-  @SuppressWarnings({"unchecked", "squid:S1244" /* Floating point numbers should not be tested for equality */})
   protected List<IBean<T>> query(boolean querySingle) {
-    boolean isInitialized = false;
-    m_queryCacheLock.readLock().lock();
-    try {
-      isInitialized = m_single != null && m_all != null;
+    if (m_single == null || m_all == null) {
+      initialize();
     }
-    finally {
-      m_queryCacheLock.readLock().unlock();
-    }
-
-    if (!isInitialized) {
-      m_queryCacheLock.writeLock().lock();
-      try {
-        isInitialized = m_single != null && m_all != null;
-        if (!isInitialized) {
-          List<IBean<T>> list = sortedBeanCopy();
-          //manage replaced beans
-          final Map<Class<?>, IBean<?>> extendsMap = new HashMap<>();//key is replaced by value
-          for (IBean<T> bean : list) {
-            if (bean.hasAnnotation(Replace.class)) {
-              Assertions.assertFalse(bean.getBeanClazz().isInterface(), "@{} annotation not supported on interface: {}.", Replace.class.getSimpleName(), bean);
-              Class<?> superClazz = bean.getBeanClazz().getSuperclass();
-              Assertions.assertNotNull(superClazz, "@{} annotation not supported for bean '{}' because it has no super class.", Replace.class.getSimpleName(), bean);
-              Assertions.assertNotEquals(Object.class, superClazz, "@{} annotation not supported for bean '{}' because it has no super class.", Replace.class.getSimpleName(), bean);
-              Assertions.assertFalse(Modifier.isAbstract(superClazz.getModifiers()), "Cannot replace an abstract super class: {}. Delete this @{} annotation.", bean, Replace.class.getSimpleName());
-
-              IBean<?> existingBean = extendsMap.get(superClazz);
-              if (existingBean == null) {
-                //only add if first to override, respects @Order annotation
-                extendsMap.put(superClazz, bean);
-              }
-              else {
-                // there is no calculation performed on bean orders (typically these are literals).
-                // therefore we accept direct equality check without epsilon.
-                Assertions.assertFalse(orderOf(existingBean) == orderOf(bean),
-                    "Bean '{}' and '{}' replace the same super class and have identical orders. No unique result possible.",
-                    existingBean.getBeanClazz().getName(), bean.getBeanClazz().getName());
-              }
-            }
-          }
-
-          //find most specific version of @Replaced class
-          Class<T> refClazz = m_clazz;
-          while (extendsMap.containsKey(refClazz)) {
-            refClazz = (Class<T>) extendsMap.get(refClazz).getBeanClazz();
-          }
-
-          //remove replaced beans
-          list.removeIf(tiBean -> extendsMap.containsKey(tiBean.getBeanClazz()));
-
-          if (list.isEmpty()) {
-            m_all = Collections.emptyList();
-            m_single = Collections.emptyList();
-          }
-          else {
-            m_all = Collections.unmodifiableList(new ArrayList<>(list));
-
-            IBean<T> exactBean = getExactBean(list, refClazz);
-            if (exactBean != null) {
-              // we have an exact match: use it
-              m_single = Collections.singletonList(exactBean);
-            }
-            else if (!refClazz.isInterface() && !Modifier.isAbstract(refClazz.getModifiers())) {
-              // we queried an specific class (no interface, no abstract class): only exact beans are allowed but we don't have one.
-              m_single = Collections.emptyList();
-            }
-            else if (list.size() == 1) {
-              m_single = Collections.singletonList(list.get(0));
-            }
-            else {
-              //only retain lowest order and if lowest order is same for multiple beans, keep them all, provocating a multiple instance exception on querySingle
-              List<IBean<T>> lowestOrderBeans = new ArrayList<>(list.size());
-              Iterator<IBean<T>> iterator = list.iterator();
-
-              // first bean
-              IBean<T> curBean = iterator.next();
-              double lowestOrder = orderOf(curBean);
-              lowestOrderBeans.add(curBean);
-
-              // all others having the same order
-              while (iterator.hasNext() && orderOf(curBean = iterator.next()) == lowestOrder) {
-                lowestOrderBeans.add(curBean);
-              }
-              m_single = Collections.unmodifiableList(new ArrayList<>(lowestOrderBeans));
-            }
-          }
-        }
-      }
-      finally {
-        m_queryCacheLock.writeLock().unlock();
-      }
-    }
-
     if (querySingle) {
       return m_single;
     }
     return m_all;
+  }
+
+  @SuppressWarnings({"unchecked", "squid:S1244" /* Floating point numbers should not be tested for equality */})
+  protected void initialize() {
+    List<IBean<T>> list = sortedBeanCopy();
+    //manage replaced beans
+    final Map<Class<?>, IBean<?>> extendsMap = new HashMap<>();//key is replaced by value
+    for (IBean<T> bean : list) {
+      if (bean.hasAnnotation(Replace.class)) {
+        Assertions.assertFalse(bean.getBeanClazz().isInterface(), "@{} annotation not supported on interface: {}.", Replace.class.getSimpleName(), bean);
+        Class<?> superClazz = bean.getBeanClazz().getSuperclass();
+        Assertions.assertNotNull(superClazz, "@{} annotation not supported for bean '{}' because it has no super class.", Replace.class.getSimpleName(), bean);
+        Assertions.assertNotEquals(Object.class, superClazz, "@{} annotation not supported for bean '{}' because it has no super class.", Replace.class.getSimpleName(), bean);
+        Assertions.assertFalse(Modifier.isAbstract(superClazz.getModifiers()), "Cannot replace an abstract super class: {}. Delete this @{} annotation.", bean, Replace.class.getSimpleName());
+
+        IBean<?> existingBean = extendsMap.get(superClazz);
+        if (existingBean == null) {
+          //only add if first to override, respects @Order annotation
+          extendsMap.put(superClazz, bean);
+        }
+        else {
+          // there is no calculation performed on bean orders (typically these are literals).
+          // therefore we accept direct equality check without epsilon.
+          Assertions.assertFalse(orderOf(existingBean) == orderOf(bean),
+              "Bean '{}' and '{}' replace the same super class and have identical orders. No unique result possible.",
+              existingBean.getBeanClazz().getName(), bean.getBeanClazz().getName());
+        }
+      }
+    }
+
+    //find most specific version of @Replaced class
+    Class<T> refClazz = m_clazz;
+    while (extendsMap.containsKey(refClazz)) {
+      refClazz = (Class<T>) extendsMap.get(refClazz).getBeanClazz();
+    }
+
+    //remove replaced beans
+    list.removeIf(tiBean -> extendsMap.containsKey(tiBean.getBeanClazz()));
+
+    if (list.isEmpty()) {
+      m_all = Collections.emptyList();
+      m_single = Collections.emptyList();
+    }
+    else {
+      m_all = Collections.unmodifiableList(new ArrayList<>(list));
+
+      IBean<T> exactBean = getExactBean(list, refClazz);
+      if (exactBean != null) {
+        // we have an exact match: use it
+        m_single = Collections.singletonList(exactBean);
+      }
+      else if (!refClazz.isInterface() && !Modifier.isAbstract(refClazz.getModifiers())) {
+        // we queried an specific class (no interface, no abstract class): only exact beans are allowed but we don't have one.
+        m_single = Collections.emptyList();
+      }
+      else if (list.size() == 1) {
+        m_single = Collections.singletonList(list.get(0));
+      }
+      else {
+        //only retain lowest order and if lowest order is same for multiple beans, keep them all, provocating a multiple instance exception on querySingle
+        List<IBean<T>> lowestOrderBeans = new ArrayList<>(list.size());
+        Iterator<IBean<T>> iterator = list.iterator();
+
+        // first bean
+        IBean<T> curBean = iterator.next();
+        double lowestOrder = orderOf(curBean);
+        lowestOrderBeans.add(curBean);
+
+        // all others having the same order
+        while (iterator.hasNext() && orderOf(curBean = iterator.next()) == lowestOrder) {
+          lowestOrderBeans.add(curBean);
+        }
+        m_single = Collections.unmodifiableList(new ArrayList<>(lowestOrderBeans));
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
- After setup, PlatformImplentor.getBeanManager no longer needs a lock
- Removed lock from BeanHierarchy which is guarded and only accessed by BeanManagerImplementor (initialize could now be called concurrently, but cannot cause any harm)
- Add missing lock to BeanManagerImplementor#getAllBeans
- Remove synchronized keyword from BeanManagerImplementor#unregisterBean (does not make sense to use 2 locking variations, other methods use RRWL)

=> under non-initializing circumstances, only 1 lock now remains for BEANS.get, instead of 3. Which saves about 20% access time, says the profiler at least.