### PR TITLE
AbstractRestClientHelper: Validate ContextResolver for duplicated types

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/AbstractRestClientHelperTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/AbstractRestClientHelperTest.java
@@ -10,16 +10,21 @@
  */
 package org.eclipse.scout.rt.rest.jersey.client;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.ext.ContextResolver;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.rest.client.AbstractRestClientHelper;
 import org.eclipse.scout.rt.rest.client.AntiCsrfClientFilter;
 import org.eclipse.scout.rt.rest.client.HttpHeadersRequestFilter;
@@ -28,7 +33,10 @@ import org.eclipse.scout.rt.rest.jackson.ObjectMapperResolver;
 import org.eclipse.scout.rt.rest.jersey.JerseyTestRestClientHelper;
 import org.eclipse.scout.rt.rest.jersey.LanguageAndCorrelationIdRestRequestFilter;
 import org.eclipse.scout.rt.rest.jersey.client.multipart.MultipartMessageBodyWriter;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Various test cases for {@link AbstractRestClientHelper}.
@@ -59,5 +67,39 @@ public class AbstractRestClientHelperTest {
     Client client1 = BEANS.get(RestClientProxyFactory.class).unwrap(restClientHelper.client());
     Client client2 = BEANS.get(RestClientProxyFactory.class).unwrap(restClientHelper.client());
     assertEquals("expect same client instance on multiple calls", client1, client2);
+  }
+
+  @Test
+  public void testDuplicatedContextResolverAsBean() {
+    IBean<?> bean = BeanTestingHelper.get().registerBean(new BeanMetaData(ObjectMapperResolver2.class));
+    try {
+      JerseyTestRestClientHelper restClientHelper = new JerseyTestRestClientHelper();  // use separate instance to force re-init
+      assertThrows(AssertionException.class, () -> restClientHelper.client());
+    }
+    finally {
+      BeanTestingHelper.get().unregisterBean(bean);
+    }
+  }
+
+  @Test
+  public void testDuplicatedContextResolverManualRegister() {
+    JerseyTestRestClientHelper restClientHelper = new JerseyTestRestClientHelperEx();
+    assertThrows(AssertionException.class, () -> restClientHelper.client());
+  }
+
+  static class JerseyTestRestClientHelperEx extends JerseyTestRestClientHelper {
+    @Override
+    protected List<ContextResolver> getContextResolversToRegister() {
+      List<ContextResolver> resolvers = super.getContextResolversToRegister();
+      resolvers.add(new ObjectMapperResolver2());
+      return resolvers;
+    }
+  }
+
+  protected static class ObjectMapperResolver2 implements ContextResolver<ObjectMapper> {
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+      return null;
+    }
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/AbstractRestClientHelper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/AbstractRestClientHelper.java
@@ -30,8 +30,11 @@ import javax.ws.rs.ext.ContextResolver;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IBeanManager;
 import org.eclipse.scout.rt.platform.exception.RemoteSystemUnavailableException;
+import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.LazyValue;
+import org.eclipse.scout.rt.platform.util.StreamUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.eclipse.scout.rt.platform.util.UriBuilder;
 import org.eclipse.scout.rt.rest.client.proxy.IRestClientExceptionTransformer;
 import org.eclipse.scout.rt.rest.client.proxy.RestClientProxyFactory;
@@ -123,9 +126,29 @@ public abstract class AbstractRestClientHelper implements IRestClientHelper {
 
   protected void registerContextResolvers(ClientBuilder clientBuilder) {
     // Context resolver, e.g. resolver for ObjectMapper
-    for (ContextResolver resolver : getContextResolversToRegister()) {
+    for (ContextResolver resolver : validateContextResolvers(getContextResolversToRegister())) {
       clientBuilder.register(resolver);
     }
+  }
+
+  /**
+   * Validates given list of {@link ContextResolver} and checks for resolvers providing a value for the same context resolver type.
+   */
+  protected List<ContextResolver> validateContextResolvers(List<ContextResolver> contextResolvers) {
+    //noinspection ResultOfMethodCallIgnored
+    contextResolvers.stream()
+        .collect(StreamUtility.toMap(
+            r -> getContextResolverType(r),
+            r -> r,
+            (u, v) -> Assertions.fail("Duplicated context resolver for type {}, resolvers: [{}, {}]", getContextResolverType(u), u.getClass(), v.getClass())));
+    return contextResolvers;
+  }
+
+  /**
+   * @return generic type of given {@link ContextResolver}.
+   */
+  protected Class<?> getContextResolverType(ContextResolver contextResolver) {
+    return TypeCastUtility.getGenericsParameterClass(contextResolver.getClass(), ContextResolver.class);
   }
 
   protected void registerRequestFilters(ClientBuilder clientBuilder) {


### PR DESCRIPTION
Add validation to avoid registering multiple ContextResolver instances providing an implementation for the same type (e.g. ObjectMapper).

JAX-RS (Jersey) does not guarantee a defined order when resolving the corresponding ContextResolver unless a priority is used together with the registration.

see also org.eclipse.scout.rt.rest.client.AbstractRestClientHelper.registerContextResolvers

370136