### PR TITLE
Only send GroupBoxes as child fields of TabBoxes to the browser

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/tabbox/AbstractTabBox.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/tabbox/AbstractTabBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -192,7 +192,7 @@ public abstract class AbstractTabBox extends AbstractCompositeField implements I
         result.add((IGroupBox) field);
       }
       else {
-        LOG.warn("Tabboxes only allow instance of IGroupBox as inner fields. '{}' is not instance of IGroupBox!", field.getClass().getName());
+        LOG.warn("TabBoxes only allow instance of IGroupBox as inner fields. '{}' is not instance of IGroupBox!", field.getClass().getName());
       }
     }
     return result;
@@ -249,9 +249,8 @@ public abstract class AbstractTabBox extends AbstractCompositeField implements I
   @Override
   public void removeField(IFormField f) {
     super.removeField(f);
-    // if tabitem (groupbox) is removed from tabbox, we must also reset the selected tab
-    // because otherwise the property would point to a tabitem that is no longer a child
-    // of this tabbox
+    // if TabItem (groupbox) is removed from TabBox, we must also reset the selected tab because otherwise the property
+    // would point to a TabItem that is no longer a child of this TabBox
     if (f == getSelectedTab()) {
       setSelectedTab(findNewSelectedTab(null));
     }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/JsonCompositeField.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/JsonCompositeField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@ import org.eclipse.scout.rt.client.ui.form.fields.ICompositeField;
 import org.eclipse.scout.rt.client.ui.form.fields.IFormField;
 import org.eclipse.scout.rt.ui.html.IUiSession;
 import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
-import org.json.JSONObject;
 
 public class JsonCompositeField<COMPOSITE_FIELD extends ICompositeField, F extends IFormField> extends JsonFormField<COMPOSITE_FIELD> {
 
@@ -31,15 +30,15 @@ public class JsonCompositeField<COMPOSITE_FIELD extends ICompositeField, F exten
   @Override
   protected void initJsonProperties(COMPOSITE_FIELD model) {
     super.initJsonProperties(model);
-    putJsonProperty(new JsonAdapterProperty<COMPOSITE_FIELD>(ICompositeField.PROP_FIELDS, model, getUiSession()) {
+    putJsonProperty(new JsonAdapterProperty<>(ICompositeField.PROP_FIELDS, model, getUiSession()) {
       @Override
       protected JsonAdapterPropertyConfig createConfig() {
         return new JsonAdapterPropertyConfigBuilder().filter(new DisplayableFormFieldFilter<>()).build();
       }
 
       @Override
-      protected List<IFormField> modelValue() {
-        return getModel().getFields();
+      protected List<F> modelValue() {
+        return getModelFields();
       }
 
       @Override
@@ -47,11 +46,6 @@ public class JsonCompositeField<COMPOSITE_FIELD extends ICompositeField, F exten
         return getModelFieldsPropertyName();
       }
     });
-  }
-
-  @Override
-  public JSONObject toJson() {
-    return putAdapterIdsProperty(super.toJson(), getModelFieldsPropertyName(), getModelFields(), new DisplayableFormFieldFilter<>());
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
This prevents 'adapterNotFound' exceptions when manually adding a non groupbox to a TabBox using addField() and then afterwards sending a e.g. property change event for this wrong field.