### PR TITLE
Table: discarded rows should not be added to the decoration buffer

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
@@ -3540,15 +3540,15 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
    */
   @Override
   public void discardRows(Collection<? extends ITableRow> rows) {
+    boolean oldAutoDiscardOnDelete = isAutoDiscardOnDelete();
     try {
       setTableChanging(true);
+      setAutoDiscardOnDelete(true);
       //
-      for (ITableRow row : rows) {
-        row.setStatus(ITableRow.STATUS_INSERTED);
-      }
       deleteRows(rows);
     }
     finally {
+      setAutoDiscardOnDelete(oldAutoDiscardOnDelete);
       setTableChanging(false);
     }
   }
@@ -4053,6 +4053,10 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
   }
 
   private void applyRowValueChanges(Map<Integer, Set<ITableRow>> changes) {
+    // performance quick-check
+    if (changes.isEmpty()) {
+      return;
+    }
     try {
       for (ITableRow tableRow : getRows()) {
         tableRow.setRowChanging(true);
@@ -4075,6 +4079,10 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
 
   @SuppressWarnings("unchecked")
   private void applyRowDecorations(Set<ITableRow> rows) {
+    // performance quick-check
+    if (rows.isEmpty()) {
+      return;
+    }
     try {
       for (ITableRow tableRow : rows) {
         tableRow.setRowChanging(true);


### PR DESCRIPTION
discardRows() uses deleteRows() internally, but additionally sets the table status to INSERTED, so the rows will be discarded instead of just marked as deleted. Calling setStatus() on an InternalTableRow causes the row to be updated. If the table is currently "changing" this update is added to the "decoration buffer". When this buffer is finally processed, the column structure might not match the row data anymore, which can cause errors in execDecorateCell(). To fix this, use the property "autoDiscardOnDelete" to discard rows. It achieves the same result but does not cause the row to be updated unnecessarily.

360881