### PR TITLE
HttpProxy: Improve error and cancel handling

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/AbstractHttpServlet.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/AbstractHttpServlet.java
@@ -14,7 +14,6 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
-import org.eclipse.scout.rt.platform.exception.PlatformException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,7 +126,7 @@ public abstract class AbstractHttpServlet extends HttpServlet {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
       if (!m_valid) {
-        throw new PlatformException("Access to '{}' is not allowed because {} is no longer valid (request has been completed).", method, (m_origin instanceof HttpServletRequest ? "HTTP servlet request" : "HTTP servlet response"));
+        throw new AlreadyInvalidatedException(method, m_origin);
       }
       return method.invoke(m_origin, args);
     }

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/AlreadyInvalidatedException.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/AlreadyInvalidatedException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.commons.servlet;
+
+import java.lang.reflect.Method;
+
+import org.eclipse.scout.rt.platform.exception.PlatformException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Exception thrown by {@link AbstractHttpServlet} when trying to access {@link HttpServletRequest} or
+ * {@link HttpServletResponse} methods after the response has already been completed.
+ */
+public class AlreadyInvalidatedException extends PlatformException {
+
+  private static final long serialVersionUID = -1;
+
+  public AlreadyInvalidatedException(Method method, Object origin) {
+    super("Access to '{}' is not allowed because {} is no longer valid (request has been completed).", method, origin != null ? origin.getClass() : null);
+  }
+}


### PR DESCRIPTION
* Cancel outgoing requests if incoming request time out.
* Ignore error for isCommitted if response is already invalidated.