### PR TITLE
Data Objects: Fix serialization of nested raw attributes

### DIFF
--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
@@ -123,7 +123,10 @@ import org.eclipse.scout.rt.jackson.dataobject.fixture.TestStringHolderPojo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestStringPojo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestSubPojo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestThrowableDo;
+import org.eclipse.scout.rt.jackson.dataobject.fixture.TestTypedUntypedInnerAbsDo;
+import org.eclipse.scout.rt.jackson.dataobject.fixture.TestTypedUntypedInnerDataObjectIfcDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestTypedUntypedInnerDo;
+import org.eclipse.scout.rt.jackson.dataobject.fixture.TestTypedUntypedInnerIfcDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestTypedUntypedOuterDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestVersionedDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestWithEmptyTypeNameDo;
@@ -3843,6 +3846,90 @@ public class JsonDataObjectsSerializationTest {
     // no DO entity, even lenient data object mapper cannot deal with this
     assertThrows(InvalidTypeIdException.class, () -> s_lenientDataObjectMapper.readValue(json, TestItemPojo2.class));
     assertThrows(InvalidTypeIdException.class, () -> s_lenientDataObjectMapper.readValue("{\"_type\":\"Unknown\"}", TestItemPojo.class));
+  }
+
+  @Test
+  public void testSerializeDeserializeNestedRawDoTypes() throws Exception {
+    String inputJson = readResourceAsString("TestNestedRawDo.json");
+    TestNestedRawDo testDo = s_dataObjectMapper.readValue(inputJson, TestNestedRawDo.class);
+
+    DoEntity entity2 = BEANS.get(DoEntity.class);
+    // NOTE: This test-case is not a supposed real-world example. An IId as part of an untyped DoEntity is serialized unqualified and may never be deserialized correctly.
+    entity2.put("iId", FixtureStringId.of("unqualified-string-id-0"));
+    entity2.put("stringId", FixtureStringId.of("unqualified-string-id-0"));
+
+    TestNestedRawDo expected = BEANS.get(TestNestedRawDo.class)
+        .withDoEntity(BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-1"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-1")))
+        .withDoEntity2(entity2)
+        .withIDataObject(BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-2"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-2")))
+        .withIDataObject2(DoList.of(
+            // NOTE: This test-case is not a supposed real-world example. An IId as part of an untyped DoList is serialized unqualified and may never be deserialized correctly.
+            List.of(FixtureStringId.of("unqualified-string-id-3"),
+                FixtureStringId.of("unqualified-string-id-3"))))
+        .withIDoEntity(BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-4"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-4")))
+        .withIDoEntity2(BEANS.get(DoEntityBuilder.class)
+            // NOTE: This test-case is not a supposed real-world example. An IId as part of an untyped IDoEntity is serialized unqualified and may never be deserialized correctly.
+            .put("iId", FixtureStringId.of("unqualified-string-id-5"))
+            .put("stringId", FixtureStringId.of("unqualified-string-id-5")).build())
+        .withITestTypedUntypedInner(BEANS.get(TestTypedUntypedInnerIfcDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-6"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-6"))
+            .withIId2(FixtureStringId.of("qualified-string-id-7"))
+            .withStringId2(FixtureStringId.of("unqualified-string-id-7")))
+        .withAbstractTestTypedUntypedInner(BEANS.get(TestTypedUntypedInnerAbsDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-8"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-8"))
+            .withIId2(FixtureStringId.of("qualified-string-id-9"))
+            .withStringId2(FixtureStringId.of("unqualified-string-id-9")))
+        .withITestTypedUntypedInnerDataObject(BEANS.get(TestTypedUntypedInnerDataObjectIfcDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-10"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-10"))
+            .withIId2(FixtureStringId.of("qualified-string-id-11"))
+            .withStringId2(FixtureStringId.of("unqualified-string-id-11")));
+
+    // assert JSON-equality
+    String json = s_dataObjectMapper.writeValueAsString(testDo);
+    assertJsonEquals("TestNestedRawDo.json", json);
+    json = s_dataObjectMapper.writeValueAsString(expected);
+    assertJsonEquals("TestNestedRawDo.json", json);
+
+    // assert partial Java-equality, excluding untyped attributes, see NOTE above)
+    expected.remove(expected::doEntity2);
+    expected.remove(expected::iDataObject2);
+    expected.remove(expected::iDoEntity2);
+    testDo.remove(testDo::doEntity2);
+    testDo.remove(testDo::iDataObject2);
+    testDo.remove(testDo::iDoEntity2);
+    assertEqualsWithComparisonFailure(expected, testDo);
+  }
+
+  @Test
+  public void testSerializeDeserializeDataObject_DoEntity() throws Exception {
+    IDataObject entity = createTestDo();
+    String json = s_dataObjectMapper.writerFor(IDoEntity.class).writeValueAsString(entity);
+    assertJsonEquals("TestComplexEntityDo.json", json);
+
+    IDataObject marshalled = s_dataObjectMapper.readerFor(IDataObject.class).readValue(json);
+    assertEqualsWithComparisonFailure(entity, marshalled);
+  }
+
+  @Test
+  public void testSerializeDeserializeDataObject_DoList() throws Exception {
+    DoList<TestItemDo> list = new DoList<>();
+    list.add(createTestItemDo("id-1", "string-1"));
+    list.add(createTestItemDo("id-2", "string-2"));
+
+    String json = s_dataObjectMapper.writerFor(DoList.class).writeValueAsString(list);
+    assertJsonEquals("TestItemDoListIDataObject.json", json);
+
+    IDataObject marshalled = s_dataObjectMapper.readerFor(IDataObject.class).readValue(json);
+    assertEqualsWithComparisonFailure(list, marshalled);
   }
 
   // ------------------------------------ common test helper methods ------------------------------------

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/AbstractTestTypedUntypedInnerDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/AbstractTestTypedUntypedInnerDo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
+import org.eclipse.scout.rt.dataobject.id.IId;
+
+public abstract class AbstractTestTypedUntypedInnerDo extends DoEntity {
+
+  public abstract DoValue<FixtureStringId> stringId();
+
+  public abstract DoValue<IId> iId();
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/ITestTypedUntypedInnerDataObjectDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/ITestTypedUntypedInnerDataObjectDo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
+import org.eclipse.scout.rt.dataobject.id.IId;
+
+public interface ITestTypedUntypedInnerDataObjectDo extends IDataObject {
+
+  DoValue<FixtureStringId> stringId();
+
+  DoValue<IId> iId();
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/ITestTypedUntypedInnerDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/ITestTypedUntypedInnerDo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
+import org.eclipse.scout.rt.dataobject.id.IId;
+
+public interface ITestTypedUntypedInnerDo extends IDoEntity {
+
+  DoValue<FixtureStringId> stringId();
+
+  DoValue<IId> iId();
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestNestedRawDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestNestedRawDo.java
@@ -24,12 +24,36 @@ public class TestNestedRawDo extends DoEntity {
     return doValue("doEntity");
   }
 
+  public DoValue<DoEntity> doEntity2() {
+    return doValue("doEntity2");
+  }
+
   public DoValue<IDoEntity> iDoEntity() {
     return doValue("iDoEntity");
   }
 
+  public DoValue<IDoEntity> iDoEntity2() {
+    return doValue("iDoEntity2");
+  }
+
   public DoValue<IDataObject> iDataObject() {
     return doValue("iDataObject");
+  }
+
+  public DoValue<IDataObject> iDataObject2() {
+    return doValue("iDataObject2");
+  }
+
+  public DoValue<ITestTypedUntypedInnerDo> iTestTypedUntypedInner() {
+    return doValue("iTestTypedUntypedInner");
+  }
+
+  public DoValue<ITestTypedUntypedInnerDataObjectDo> iTestTypedUntypedInnerDataObject() {
+    return doValue("iTestTypedUntypedInnerDataObject");
+  }
+
+  public DoValue<AbstractTestTypedUntypedInnerDo> abstractTestTypedUntypedInner() {
+    return doValue("abstractTestTypedUntypedInner");
   }
 
   /* **************************************************************************
@@ -48,6 +72,17 @@ public class TestNestedRawDo extends DoEntity {
   }
 
   @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withDoEntity2(DoEntity doEntity2) {
+    doEntity2().set(doEntity2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public DoEntity getDoEntity2() {
+    return doEntity2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
   public TestNestedRawDo withIDoEntity(IDoEntity iDoEntity) {
     iDoEntity().set(iDoEntity);
     return this;
@@ -59,6 +94,17 @@ public class TestNestedRawDo extends DoEntity {
   }
 
   @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withIDoEntity2(IDoEntity iDoEntity2) {
+    iDoEntity2().set(iDoEntity2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IDoEntity getIDoEntity2() {
+    return iDoEntity2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
   public TestNestedRawDo withIDataObject(IDataObject iDataObject) {
     iDataObject().set(iDataObject);
     return this;
@@ -67,5 +113,49 @@ public class TestNestedRawDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public IDataObject getIDataObject() {
     return iDataObject().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withIDataObject2(IDataObject iDataObject2) {
+    iDataObject2().set(iDataObject2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IDataObject getIDataObject2() {
+    return iDataObject2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withITestTypedUntypedInner(ITestTypedUntypedInnerDo iTestTypedUntypedInner) {
+    iTestTypedUntypedInner().set(iTestTypedUntypedInner);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public ITestTypedUntypedInnerDo getITestTypedUntypedInner() {
+    return iTestTypedUntypedInner().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withITestTypedUntypedInnerDataObject(ITestTypedUntypedInnerDataObjectDo iTestTypedUntypedInnerDataObject) {
+    iTestTypedUntypedInnerDataObject().set(iTestTypedUntypedInnerDataObject);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public ITestTypedUntypedInnerDataObjectDo getITestTypedUntypedInnerDataObject() {
+    return iTestTypedUntypedInnerDataObject().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withAbstractTestTypedUntypedInner(AbstractTestTypedUntypedInnerDo abstractTestTypedUntypedInner) {
+    abstractTestTypedUntypedInner().set(abstractTestTypedUntypedInner);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public AbstractTestTypedUntypedInnerDo getAbstractTestTypedUntypedInner() {
+    return abstractTestTypedUntypedInner().get();
   }
 }

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestTypedUntypedInnerAbsDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestTypedUntypedInnerAbsDo.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
+import org.eclipse.scout.rt.dataobject.id.IId;
+
+import jakarta.annotation.Generated;
+
+@TypeName("scout.TestTypedUntypedInnerAbsDo")
+public class TestTypedUntypedInnerAbsDo extends AbstractTestTypedUntypedInnerDo {
+
+  @Override
+  public DoValue<FixtureStringId> stringId() {
+    return doValue("stringId");
+  }
+
+  @Override
+  public DoValue<IId> iId() {
+    return doValue("iId");
+  }
+
+  public DoValue<FixtureStringId> stringId2() {
+    return doValue("stringId2");
+  }
+
+  public DoValue<IId> iId2() {
+    return doValue("iId2");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerAbsDo withStringId(FixtureStringId stringId) {
+    stringId().set(stringId);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerAbsDo withIId(IId iId) {
+    iId().set(iId);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerAbsDo withStringId2(FixtureStringId stringId2) {
+    stringId2().set(stringId2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureStringId getStringId2() {
+    return stringId2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerAbsDo withIId2(IId iId2) {
+    iId2().set(iId2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IId getIId2() {
+    return iId2().get();
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestTypedUntypedInnerDataObjectIfcDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestTypedUntypedInnerDataObjectIfcDo.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
+import org.eclipse.scout.rt.dataobject.id.IId;
+
+import jakarta.annotation.Generated;
+
+@TypeName("scout.TestTypedUntypedInnerDataObjectIfc")
+public class TestTypedUntypedInnerDataObjectIfcDo extends DoEntity implements ITestTypedUntypedInnerDataObjectDo {
+
+  @Override
+  public DoValue<FixtureStringId> stringId() {
+    return doValue("stringId");
+  }
+
+  @Override
+  public DoValue<IId> iId() {
+    return doValue("iId");
+  }
+
+  public DoValue<FixtureStringId> stringId2() {
+    return doValue("stringId2");
+  }
+
+  public DoValue<IId> iId2() {
+    return doValue("iId2");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerDataObjectIfcDo withStringId(FixtureStringId stringId) {
+    stringId().set(stringId);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureStringId getStringId() {
+    return stringId().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerDataObjectIfcDo withIId(IId iId) {
+    iId().set(iId);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IId getIId() {
+    return iId().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerDataObjectIfcDo withStringId2(FixtureStringId stringId2) {
+    stringId2().set(stringId2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureStringId getStringId2() {
+    return stringId2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerDataObjectIfcDo withIId2(IId iId2) {
+    iId2().set(iId2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IId getIId2() {
+    return iId2().get();
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestTypedUntypedInnerIfcDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestTypedUntypedInnerIfcDo.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
+import org.eclipse.scout.rt.dataobject.id.IId;
+
+import jakarta.annotation.Generated;
+
+@TypeName("scout.TestTypedUntypedInnerIfc")
+public class TestTypedUntypedInnerIfcDo extends DoEntity implements ITestTypedUntypedInnerDo {
+
+  @Override
+  public DoValue<FixtureStringId> stringId() {
+    return doValue("stringId");
+  }
+
+  @Override
+  public DoValue<IId> iId() {
+    return doValue("iId");
+  }
+
+  public DoValue<FixtureStringId> stringId2() {
+    return doValue("stringId2");
+  }
+
+  public DoValue<IId> iId2() {
+    return doValue("iId2");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerIfcDo withStringId(FixtureStringId stringId) {
+    stringId().set(stringId);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureStringId getStringId() {
+    return stringId().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerIfcDo withIId(IId iId) {
+    iId().set(iId);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IId getIId() {
+    return iId().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerIfcDo withStringId2(FixtureStringId stringId2) {
+    stringId2().set(stringId2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureStringId getStringId2() {
+    return stringId2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestTypedUntypedInnerIfcDo withIId2(IId iId2) {
+    iId2().set(iId2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IId getIId2() {
+    return iId2().get();
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestNestedRawDo.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestNestedRawDo.json
@@ -1,0 +1,48 @@
+{
+  "_type" : "TestNestedRaw",
+  "abstractTestTypedUntypedInner" : {
+    "_type" : "scout.TestTypedUntypedInnerAbsDo",
+    "iId" : "scout.FixtureStringId:qualified-string-id-8",
+    "iId2" : "scout.FixtureStringId:qualified-string-id-9",
+    "stringId" : "unqualified-string-id-8",
+    "stringId2" : "unqualified-string-id-9"
+  },
+  "doEntity" : {
+    "_type" : "scout.TestTypedUntypedInner",
+    "iId" : "scout.FixtureStringId:qualified-string-id-1",
+    "stringId" : "unqualified-string-id-1"
+  },
+  "doEntity2" : {
+    "iId" : "unqualified-string-id-0",
+    "stringId" : "unqualified-string-id-0"
+  },
+  "iDataObject" : {
+    "_type" : "scout.TestTypedUntypedInner",
+    "iId" : "scout.FixtureStringId:qualified-string-id-2",
+    "stringId" : "unqualified-string-id-2"
+  },
+  "iDataObject2" : [ "unqualified-string-id-3", "unqualified-string-id-3" ],
+  "iDoEntity" : {
+    "_type" : "scout.TestTypedUntypedInner",
+    "iId" : "scout.FixtureStringId:qualified-string-id-4",
+    "stringId" : "unqualified-string-id-4"
+  },
+  "iDoEntity2" : {
+    "iId" : "unqualified-string-id-5",
+    "stringId" : "unqualified-string-id-5"
+  },
+  "iTestTypedUntypedInner" : {
+    "_type" : "scout.TestTypedUntypedInnerIfc",
+    "iId" : "scout.FixtureStringId:qualified-string-id-6",
+    "iId2" : "scout.FixtureStringId:qualified-string-id-7",
+    "stringId" : "unqualified-string-id-6",
+    "stringId2" : "unqualified-string-id-7"
+  },
+  "iTestTypedUntypedInnerDataObject" : {
+    "_type" : "scout.TestTypedUntypedInnerDataObjectIfc",
+    "iId" : "scout.FixtureStringId:qualified-string-id-10",
+    "iId2" : "scout.FixtureStringId:qualified-string-id-11",
+    "stringId" : "unqualified-string-id-10",
+    "stringId2" : "unqualified-string-id-11"
+  }
+}

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
@@ -23,6 +23,7 @@ import org.eclipse.scout.rt.dataobject.DataObjectInventory;
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoNode;
 import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.IDataObject;
 import org.eclipse.scout.rt.dataobject.IDoCollection;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.IDoEntityContribution;
@@ -121,8 +122,13 @@ public class DoEntitySerializer extends StdSerializer<IDoEntity> {
     }
     else {
       Optional<AttributeType> attributeType = getAttributeType(attributeName);
-      if (attributeType.isPresent() && (!m_context.isLenientMode() || attributeType.get().getJavaType().isTypeOrSuperTypeOf(obj.getClass()))) {
-        // use serialization by typed attribute if a type is present and if lenient, only if type matches (data object might have an invalid structure, e.g. string instead of an enum if deserialized lenient)
+      if (attributeType.isPresent()
+          && (!m_context.isLenientMode() || attributeType.get().getJavaType().isTypeOrSuperTypeOf(obj.getClass()))
+          && !(attributeType.get().getJavaType().isTypeOrSubTypeOf(IDataObject.class))) {
+        // Use serialization by typed attribute if:
+        // (1) an attribute type is present
+        // (2) if lenient mode, only if attribute type matches (data object might have an invalid structure, e.g. string instead of an enum if deserialized lenient)
+        // (3) if attribute type is not a data object type (favor value based serialization for attributes declared as data object or subclasses/subinterfaces)
         serializeTypedAttribute(attributeName, obj, gen, provider, attributeType.get().getJavaType());
       }
       else {


### PR DESCRIPTION
This change fixes serialization of data object with attributes declared using raw data object types (e.g. IDoEntity, DoEntity or IDataObject). Those attributes may have been serialized without type information before this fix.

This change also fixes serialization of data object with attributes declared using own abstract classes/interfaces as attribute type. Attributes of type IIds within those data objects were serialized using untyped serialization instead of typed serialization.

This change also introduces a DataObjectSerializer used when an object of declared type IDataObject is serialized. The serializer itself delegates to an appropriate serializer by value.

370640