### PR TITLE
Update jackson to 2.16, adapt to behavioral changes

### DIFF
--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
@@ -167,7 +167,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 /**
  * Various test cases serializing and deserializing Scout data objects from/to JSON
@@ -1804,6 +1803,24 @@ public class JsonDataObjectsSerializationTest {
   }
 
   @Test
+  public void testSerializeDeserialize_RawEntityWithDouble() throws Exception {
+    DoEntity entity = BEANS.get(DoEntity.class);
+    entity.put("attribute", 45.69);
+    String json = s_dataObjectMapper.writeValueAsString(entity);
+    DoEntity doMarshalled = s_dataObjectMapper.readValue(json, DoEntity.class);
+    assertEquals(new BigDecimal("45.69"), doMarshalled.get("attribute"));
+  }
+
+  @Test
+  public void testSerializeDeserialize_RawEntityWithDoubleList() throws Exception {
+    DoEntity entity = BEANS.get(DoEntity.class);
+    entity.put("attribute", List.of(45.69));
+    String json = s_dataObjectMapper.writeValueAsString(entity);
+    DoEntity doMarshalled = s_dataObjectMapper.readValue(json, DoEntity.class);
+    assertEquals(new BigDecimal("45.69"), doMarshalled.getList("attribute").get(0));
+  }
+
+  @Test
   public void testSerializeDeserialize_TestMapDo() throws Exception {
     TestMapDo mapDo = new TestMapDo();
     Map<String, String> stringStringMap = new HashMap<>();
@@ -3225,27 +3242,28 @@ public class JsonDataObjectsSerializationTest {
     assertArrayEquals(exception.getStackTrace(), marshalled.getException().getStackTrace());
   }
 
+  /**
+   * {@link Optional} is currently not serializable/deserializable using Scout Jackson implementation.
+   */
   @Test
   public void testSerializeDeserializeOptionalDo() throws Exception {
     @SuppressWarnings("unchecked")
     TestOptionalDo optional = BEANS.get(TestOptionalDo.class)
         .withOptString(Optional.empty())
         .withOptStringList(Optional.empty(), Optional.of("foo"));
-    String json = s_dataObjectMapper.writeValueAsString(optional);
 
-    // currently serializable using Scout Jackson implementation, but without values, e.g. useless!
-    assertJsonEquals("TestOptionalDo.json", json);
+    // Expect:
+    // com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 optional type `java.util.Optional<java.lang.String>`
+    // not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" to enable handling
+    JsonMappingException writeException = assertThrows(JsonMappingException.class, () -> s_dataObjectMapper.writeValueAsString(optional));
+    assertTrue("expected InvalidDefinitionException, got " + writeException, writeException instanceof InvalidDefinitionException);
 
-    // currently not deserializable using Scout Jackson implementation
+    // Expect:
+    // com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 optional type `java.util.Optional<java.lang.String>`
+    // not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" to enable handling
+    String json = readResourceAsString("TestOptionalDo.json");
     JsonMappingException exception = assertThrows(JsonMappingException.class, () -> s_dataObjectMapper.readValue(json, TestOptionalDo.class));
-
-    // TODO [23.1] pbz remove when JDK 11 is no longer supported
-    if ("11".equals(System.getProperty("java.specification.version"))) {
-      assertTrue("expected cause UnrecognizedPropertyException, got " + exception.getCause(), exception.getCause() instanceof UnrecognizedPropertyException);
-    }
-    else {
-      assertTrue("expected cause InvalidDefinitionException, got " + exception.getCause(), exception.getCause() instanceof InvalidDefinitionException);
-    }
+    assertTrue("expected InvalidDefinitionException, got " + exception.getCause(), exception.getCause() instanceof InvalidDefinitionException);
   }
 
   @Test

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoCollectionDeserializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoCollectionDeserializer.java
@@ -10,6 +10,7 @@
 package org.eclipse.scout.rt.jackson.dataobject;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.function.Supplier;
 
@@ -74,8 +75,17 @@ public class DoCollectionDeserializer<COLLECTION_NODE extends IDoCollection<?, ?
     }
     else {
       // all JSON scalar values are deserialized as bound type (if available) and as fallback as raw object using default jackson typing
-      return ObjectUtility.nvl(m_collectionType.getBindings().getBoundType(0), TypeFactory.unknownType());
+      return ObjectUtility.nvl(m_collectionType.getBindings().getBoundType(0), resolveFallbackListElementType(p));
     }
+  }
+
+  protected ResolvedType resolveFallbackListElementType(JsonParser p) {
+    if (p.getCurrentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+      // deserialize floating point numbers as BigDecimal
+      return TypeFactory.defaultInstance().constructType(BigDecimal.class);
+    }
+    // JSON scalar values are deserialized as raw object using default jackson typing
+    return TypeFactory.unknownType();
   }
 
   @Override

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -123,7 +123,7 @@
     <jetty.version>10.0.18</jetty.version>
     <slf4j.version>2.0.7</slf4j.version>
     <logback.version>1.3.14</logback.version>
-    <jackson.version>2.14.0</jackson.version>
+    <jackson.version>2.16.1</jackson.version>
     <io.netty-version>4.1.104.Final</io.netty-version>
     <apache.tika-version>2.6.0</apache.tika-version>
     <batik.version>1.17</batik.version>


### PR DESCRIPTION
(1) Jackson adapted handling for Optional serialization providing a custom exception message if Optional is being serialized. Scout does not support serialization of Java Optional, therefore adapt test case. See also:
https://github.com/FasterXML/jackson-databind/issues/4082 https://github.com/FasterXML/jackson-databind/commit/d7e77c39ebf477a4b1e8732b3bae9e4d4fd2a994

(2) Jackson adapted handling for untyped deserialization of floating point numbers. Former implementations (before 2.15) deserialized floating point numbers within lists as BigDecimal. Since issue 903 and 3751 numbers are deserialized into the smalles possible Java data type (same behavior as plain numbers not within a JSON list element). Therefore Scout DoCollectionDeserializer was adapted identically to DoEntityDeserializer to enforce using BigDecimal for unknown (raw) number deserialization.

See also:
https://github.com/FasterXML/jackson-core/pull/903 https://github.com/FasterXML/jackson-core/commit/4c957e3ea35e2ba95e00a245394df5b43241918d and
https://github.com/FasterXML/jackson-databind/pull/3751 https://github.com/FasterXML/jackson-databind/commit/23ea48c0abb466aaac2020be802f243f242c4c9c

354734, 371286