### PR TITLE
Add streaming support to hashing through DigestInput/OutputStream

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/security/LegacySecurityProviderTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/security/LegacySecurityProviderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.security;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
+import org.eclipse.scout.rt.platform.util.Base64Utility;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LegacySecurityProviderTest {
+
+  private static final Charset ENCODING = StandardCharsets.UTF_8;
+
+  @Test
+  public void testCreateHash() {
+    ILegacySecurityProvider securityProvider = BEANS.get(ILegacySecurityProvider.class);
+    final byte[] data = "testdata".getBytes(ENCODING);
+    final byte[] salt = SecurityUtility.createRandomBytes();
+    final byte[] salt2 = SecurityUtility.createRandomBytes();
+    byte[] hash = securityProvider.createHash(data, salt);
+    byte[] hash2 = securityProvider.createHash(data, salt);
+    byte[] hash3 = securityProvider.createHash(data, salt2);
+    byte[] hash4 = securityProvider.createHash(data, salt);
+    byte[] hash5 = securityProvider.createHash(new byte[]{}, salt);
+
+    // ensure null input throws exception
+    boolean nullNotAllowed = false;
+    try {
+      securityProvider.createHash(null, salt);
+    }
+    catch (AssertionException e) {
+      nullNotAllowed = true;
+    }
+    Assert.assertTrue(nullNotAllowed);
+
+    nullNotAllowed = false;
+    try {
+      securityProvider.createHash(null, salt, 1234);
+    }
+    catch (AssertionException e) {
+      nullNotAllowed = true;
+    }
+    Assert.assertTrue(nullNotAllowed);
+
+    // ensure hashing was executed
+    Assert.assertFalse(Arrays.equals(data, hash));
+    Assert.assertFalse(Arrays.equals(data, hash3));
+
+    // ensure different salts matter
+    Assert.assertFalse(Arrays.equals(hash, hash3));
+
+    // ensure same input -> same output
+    Assert.assertArrayEquals(hash, hash2);
+
+    // ensure different input -> different output
+    Assert.assertFalse(Arrays.equals(hash4, hash5));
+
+    // ensure unchanged hashing result compared to legacy security provider
+    Assert.assertArrayEquals(SecurityUtility.hash(data), securityProvider.createHash(new ByteArrayInputStream(data), null, 1));
+  }
+
+  @Test
+  public void testCreateHashStability() {
+    final byte[] data = "my text to hash".getBytes(ENCODING);
+    final byte[] salt = "mycustomsalt".getBytes(ENCODING);
+    Assert.assertEquals("wFxcmwxtdbR1is2XNDHPUfFA9Q60Cnt5geHAfs+LIxn4hxjmSBLbyzNmp9g8MB5Is3NNAs2XzjRN0byuv5mnBg==", Base64Utility.encode(BEANS.get(ILegacySecurityProvider.class).createHash(data, salt)));
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/ILegacySecurityProvider.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/ILegacySecurityProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.security;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
+
+/**
+ * Provider class supporting legacy features for encryption & decryption, hashing and creation of random numbers,
+ * message authentication codes and digital signatures. This class exists only for backward compatibility reasons.
+ * <p>
+ * <b>Important:</b> Do not use this class anymore. Try to use {@link ISecurityProvider} wherever possible.
+ * </p>
+ *
+ * @since 24.1
+ */
+@ApplicationScoped
+public interface ILegacySecurityProvider {
+
+  /**
+   * @see #createHash(InputStream, byte[], int)
+   */
+  default byte[] createHash(byte[] data, byte[] salt) {
+    Assertions.assertNotNull(data, "no data provided");
+    return createHash(new ByteArrayInputStream(data), salt, 3557 /* number of default cycles for backwards compatibility */);
+  }
+
+  /**
+   * Creates a hash for the given data using the given salt.
+   * <p>
+   * <b>Important:</b> For hashing of passwords use {@link ISecurityProvider#createPasswordHash(char[], byte[])}!
+   * </p>
+   * <p><b>Important 2:</b> For "normal" hashing use {@link SecurityUtility#hash(byte[])}</p>
+   *
+   * @param data
+   *     The {@link InputStream} providing the data to hash.
+   * @param salt
+   *     the salt to use or {@code null} if not salt should be used (not recommended!). Use
+   *     {@link ISecurityProvider#createSecureRandomBytes(int)} to generate a random salt per instance.
+   * @param iterations
+   *     the number of hashing iterations. There is always at least one cycle executed.
+   * @return the hash
+   * @throws AssertionException
+   *     If data is {@code null}.
+   * @throws ProcessingException
+   *     If there is an error creating the hash
+   */
+  byte[] createHash(InputStream data, byte[] salt, int iterations);
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/ISecurityProvider.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/ISecurityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,8 @@ package org.eclipse.scout.rt.platform.security;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.DigestInputStream;
+import java.security.DigestOutputStream;
 import java.security.SecureRandom;
 
 import org.eclipse.scout.rt.platform.ApplicationScoped;
@@ -120,24 +122,40 @@ public interface ISecurityProvider {
   KeyPairBytes createKeyPair();
 
   /**
-   * Creates a hash for the given data using the given salt.<br>
-   * <br>
+   * Wraps the specified {@link InputStream} into a digest input stream.
+   * <p>
+   * After the specified input stream has been read, the hash can be accessed by
+   * <code>DigestInputStream.getMessageDigest().digest()</code>.
+   * </p>
+   * <p>
    * <b>Important:</b> For hashing of passwords use {@link #createPasswordHash(char[], byte[])}!
+   * </p>
    *
-   * @param data
+   * @param stream
    *          The {@link InputStream} providing the data to hash.
-   * @param salt
-   *          the salt to use or {@code null} if not salt should be used (not recommended!). Use
-   *          {@link #createSecureRandomBytes(int)} to generate a random salt per instance.
-   * @param iterations
-   *          the number of hashing iterations. There is always at least one cycle executed.
-   * @return the hash
-   * @throws AssertionException
-   *           If data is {@code null}.
+   * @return the digest input stream wrapping the given {@link InputStream}
    * @throws ProcessingException
-   *           If there is an error creating the hash
+   *           If there is an error creating the digest input stream
    */
-  byte[] createHash(InputStream data, byte[] salt, int iterations);
+  DigestInputStream toHashingStream(InputStream stream);
+
+  /**
+   * Wraps the specified {@link OutputStream} into a digest output stream.
+   * <p>
+   * After the specified output stream has been written, the hash can be accessed by
+   * <code>DigestInputStream.getMessageDigest().digest()</code>.
+   * </p>
+   * <p>
+   * <b>Important:</b> For hashing of passwords use {@link #createPasswordHash(char[], byte[])}!
+   * </p>
+   *
+   * @param stream
+   *          The {@link OutputStream} providing the data to hash.
+   * @return the digest output stream wrapping the given {@link OutputStream}
+   * @throws ProcessingException
+   *           If there is an error creating the digest output stream
+   */
+  DigestOutputStream toHashingStream(OutputStream stream);
 
   /**
    * Creates a hash for the given password.<br>

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/SunSecurityProvider.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/SunSecurityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,8 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.security.DigestInputStream;
+import java.security.DigestOutputStream;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -69,7 +71,7 @@ import org.eclipse.scout.rt.platform.util.Base64Utility;
  * @since 6.1
  */
 @Order(5500)
-public class SunSecurityProvider implements ISecurityProvider {
+public class SunSecurityProvider implements ISecurityProvider, ILegacySecurityProvider {
 
   /**
    * Buffer size for {@link InputStream} read.
@@ -307,6 +309,28 @@ public class SunSecurityProvider implements ISecurityProvider {
     byte[] rnd = new byte[numBytes];
     createSecureRandom().nextBytes(rnd);
     return rnd;
+  }
+
+  @Override
+  public DigestInputStream toHashingStream(InputStream stream) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance(getDigestAlgorithm(), getDigestAlgorithmProvider());
+      return new DigestInputStream(stream, digest);
+    }
+    catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+      throw new ProcessingException("Unable to hash.", e);
+    }
+  }
+
+  @Override
+  public DigestOutputStream toHashingStream(OutputStream stream) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance(getDigestAlgorithm(), getDigestAlgorithmProvider());
+      return new DigestOutputStream(stream, digest);
+    }
+    catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+      throw new ProcessingException("Unable to hash.", e);
+    }
   }
 
   @Override

--- a/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationRegistry.java
+++ b/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -490,6 +490,6 @@ public class UiNotificationRegistry {
    * @return the hash of the current node id. Because it will be sent to the UI and may contain the name of the server, a hash is used instead of the plain node id.
    */
   public String currentNodeId() {
-    return Base64Utility.encode(SecurityUtility.hash(NodeId.current().toString().getBytes(), "UiNotificationRegistrySalt".getBytes()));
+    return Base64Utility.encode(SecurityUtility.hash(NodeId.current().toString().getBytes()));
   }
 }


### PR DESCRIPTION
Additionally move SecurityUtility.hash(byte[] data, byte[] salt) to new ILegacySecurityProvider. This method exists only for backward compatibility reasons.

370862