### PR TITLE
Multipart request handling in UiServlet: Unlimited upload as default

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiHtmlConfigProperties.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiHtmlConfigProperties.java
@@ -197,7 +197,7 @@ public final class UiHtmlConfigProperties {
 
     @Override
     public String getKey() {
-      return "scout.uiServletMultipartConfig";
+      return "scout.ui.servletMultipartConfig";
     }
 
     @Override
@@ -205,8 +205,8 @@ public final class UiHtmlConfigProperties {
       return String.format("Multipart configuration for inbound servlet.\n"
               + "Map property with the keys as follows:\n"
               + "- %s: the directory location where files will be stored temporarily (default: temp directory)\n"
-              + "- %s: the maximum size allowed in MB for uploaded files (default: %d MB) \n"
-              + "- %s: the maximum size allowed in MB for multipart/form-data requests (default: %d MB) \n"
+              + "- %s: the maximum size allowed in MB for uploaded files, -1 means unlimited (default: %d MB) \n"
+              + "- %s: the maximum size allowed in MB for multipart/form-data requests, -1 means unlimited (default: %d MB) \n"
               + "- %s: the size threshold in MB after which files will written to disk (default: %d MB) \n",
           LOCATION,
           MAX_FILE_SIZE, getDefaultMaxFileSizeMB(),
@@ -229,11 +229,11 @@ public final class UiHtmlConfigProperties {
     }
 
     protected long getDefaultMaxFileSizeMB() {
-      return 50; // 50 MB
+      return -1; // unlimited (limited on field base by org.eclipse.scout.rt.ui.html.res.IUploadable)
     }
 
     protected long getDefaultMaxRequestSizeMB() {
-      return 100; // 100 MB
+      return -1; // unlimited (limited on field base by org.eclipse.scout.rt.ui.html.res.IUploadable)
     }
 
     protected int getDefaultFileSizeThresholdMB() {


### PR DESCRIPTION
Java EE servlet API offers access to parts of a multipart/form-data
request since Servlet API 3.0. The former used Apache commons-fileupload
library allowed unlimited upload of data as default behavior. Provide
a default MultipartConfigElement with unlimited upload limit as basis
for UiServlet registrations by applications.

In practice the upload size is limited by IUploadable and the
corresponding implementations in various JSON form fields,
see getConfiguredMaximumUploadSize() implementations for default
value for each field:
e.g. AbstractFileChooserField.getConfiguredMaximumUploadSize

354734