### PR TITLE
Applications: add migration guide/tutorials

### DIFF
--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.image/pom.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.image/pom.xml
@@ -33,7 +33,6 @@
                 <image>${docker.java.image}</image>
               </from>
               <container>
-                <entrypoint>INHERIT</entrypoint>
                 <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
                 <ports>
                   <port>8080</port>

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -10,7 +10,6 @@
 
   <artifactId>${rootArtifactId}</artifactId>
   <packaging>pom</packaging>
-  <name>${displayName}</name>
 
   <properties>
     <jdk.source.version>${javaVersion}</jdk.source.version>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.image/pom.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.image/pom.xml
@@ -34,7 +34,6 @@
                 <image>${docker.java.image}</image>
               </from>
               <container>
-                <entrypoint>INHERIT</entrypoint>
                 <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
                 <ports>
                   <port>8080</port>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.image/pom.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.image/pom.xml
@@ -34,7 +34,6 @@
                 <image>${docker.java.image}</image>
               </from>
               <container>
-                <entrypoint>INHERIT</entrypoint>
                 <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
                 <ports>
                   <port>8080</port>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.image/src/main/resources/config.properties
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.image/src/main/resources/config.properties
@@ -6,7 +6,7 @@ scout.application.name=${displayName}
 scout.application.version=${symbol_dollar}{project.version}
 
 $symbol_pound$symbol_pound$symbol_pound Service tunnel
-scout.backendUrl=http://localhost:8080
+${symbol_pound}scout.backendUrl must be set via environment variable
 scout.auth.privateKey=changeme
 
 $symbol_pound$symbol_pound$symbol_pound Security

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -10,7 +10,6 @@
 
   <artifactId>${rootArtifactId}</artifactId>
   <packaging>pom</packaging>
-  <name>${displayName}</name>
 
   <properties>
     <${groupId}.${rootArtifactId}.version>${project.version}</${groupId}.${rootArtifactId}.version>


### PR DESCRIPTION
Add detailed description of how to migrate from the old module structure (.war) to the new one (.app.zip/.app.image) including replacement of web.xml. Add tutorial on how to deploy with shell scripts as service and by using docker images.

369376