### PR TITLE
Add workaround for jquery 3.7.1 focus regression

### DIFF
--- a/eclipse-scout-core/src/jquery/jquery-scout-types.ts
+++ b/eclipse-scout-core/src/jquery/jquery-scout-types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -549,6 +549,11 @@ declare global {
      * @returns true if the current element has the class 'selected', false if not.
      */
     isSelected(): boolean;
+
+    /**
+     * Focuses the element if it is focusable.
+     */
+    focus(): this;
 
     /**
      * Toggles the class 'disabled'. Also toggles 'disabled' attribute for elements that support it (see http://www.w3.org/TR/html5/disabled-elements.html)

--- a/eclipse-scout-core/src/jquery/jquery-scout.js
+++ b/eclipse-scout-core/src/jquery/jquery-scout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1504,6 +1504,20 @@ $.fn.onPassive = function(eventType, handler) {
 $.fn.offPassive = function(eventType, handler) {
   let options = events.passiveOptions();
   this[0].removeEventListener(eventType, handler, options);
+  return this;
+};
+
+/**
+ * Focuses the element if it is focusable.
+ *
+ * The focus function of jQuery triggers a focus event instead of focusing the element (since 3.7.1 even if the element is not focusable).
+ * Because that is not the expected behavior, this replacement calls the native focus function.
+ */
+$.fn.focus = function() {
+  if (this.length === 0) {
+    return this;
+  }
+  this[0].focus();
   return this;
 };
 


### PR DESCRIPTION
Calling $elem.focus() now triggers a focusin event even if the element is not focusable. This did not happen with 3.7.0.

According to jsdoc, the function is deprecated and actually just triggers a focus event when called without parameters which is quite unexpected.
Unfortunately, there is no other jQuery function to really focus an element. That is why it is used for this purpose in our code base.

To fix it, the jQuery focus function is now replaced and just calls the native focus function.

370308