### PR TITLE
Tree: fix setting of inital tree values

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -301,19 +301,6 @@ export class Tree extends Widget implements TreeModel {
   }
 
   /**
-   * @internal
-   */
-  _postInitNodes() {
-    Tree.visitNodes((node: TreeNode, parentNode: TreeNode) => {
-      // Check all children, in when autoCheckChildren is true
-      if (node.checked && this.autoCheckChildren) {
-        this.checkNodes(node.childNodes, {checked: true});
-      }
-      this._updateMarkChildrenChecked(node);
-    }, this.nodes, null);
-  }
-
-  /**
    * @param autoCheckChildren
    */
   setAutoCheckChildren(autoCheckChildren: boolean) {
@@ -381,10 +368,7 @@ export class Tree extends Widget implements TreeModel {
       this.checkedNodes.push(node);
     }
     this._initTreeNodeInternal(node, parentNode);
-    if (this.initialized) {
-      // Only execute, when Tree has already been initialized
-      this._updateMarkChildrenChecked(node);
-    }
+    this._updateMarkChildrenChecked(node);
     node.initialized = true;
   }
 

--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -301,6 +301,19 @@ export class Tree extends Widget implements TreeModel {
   }
 
   /**
+   * @internal
+   */
+  _postInitNodes() {
+    Tree.visitNodes((node: TreeNode, parentNode: TreeNode) => {
+      // Check all children, in when autoCheckChildren is true
+      if (node.checked && this.autoCheckChildren) {
+        this.checkNodes(node.childNodes, {checked: true});
+      }
+      this._updateMarkChildrenChecked(node);
+    }, this.nodes, null);
+  }
+
+  /**
    * @param autoCheckChildren
    */
   setAutoCheckChildren(autoCheckChildren: boolean) {
@@ -368,7 +381,10 @@ export class Tree extends Widget implements TreeModel {
       this.checkedNodes.push(node);
     }
     this._initTreeNodeInternal(node, parentNode);
-    this._updateMarkChildrenChecked(node);
+    if (this.initialized) {
+      // Only execute, when Tree has already been initialized
+      this._updateMarkChildrenChecked(node);
+    }
     node.initialized = true;
   }
 

--- a/eclipse-scout-core/src/tree/TreeAdapter.ts
+++ b/eclipse-scout-core/src/tree/TreeAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,10 @@ export class TreeAdapter extends ModelAdapter {
   constructor() {
     super();
     this._addRemoteProperties(['displayStyle']);
+  }
+
+  override _postCreateWidget() {
+    this.widget._postInitNodes();
   }
 
   protected _sendNodesSelected(nodeIds: string[], debounceSend: boolean) {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
@@ -1440,6 +1440,20 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
     }
   }
 
+  @Override
+  public void setAllNodesChecked(boolean checked) {
+    IDepthFirstTreeVisitor<ITreeNode> v = new DepthFirstTreeVisitor<>() {
+      @Override
+      public TreeVisitResult preVisit(ITreeNode element, int level, int index) {
+        if (element.isChecked() != checked) {
+          setNodeChecked(element, checked);
+        }
+        return TreeVisitResult.CONTINUE;
+      }
+    };
+    visitTree(v);
+  }
+
   /**
    * Recursively checks/unchecks the subtree of <code>parent</code>.
    */

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITree.java
@@ -406,6 +406,8 @@ public interface ITree extends IWidget, IDNDSupport, IStyleable, IAppLinkCapable
 
   void setNodesChecked(List<ITreeNode> nodes, boolean checked, boolean enabledNodesOnly, boolean forceUpdateNode);
 
+  void setAllNodesChecked(boolean checked);
+
   boolean isNodeChecked(ITreeNode node);
 
   int getNodeStatus(ITreeNode node);


### PR DESCRIPTION
When initial values are set and autoCheckChildNodes is enabled, children were not updated. In the init function, no events can be triggered, because the TreeAdapter has not yet attached its widget. Because of this, the updates are performed in the _postCreateWidget function.

363033