### PR TITLE
Tree: ensure child nodes of a checked parent are checked initially

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
@@ -1440,6 +1440,20 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
     }
   }
 
+  @Override
+  public void setAllNodesChecked(boolean checked) {
+    IDepthFirstTreeVisitor<ITreeNode> v = new DepthFirstTreeVisitor<>() {
+      @Override
+      public TreeVisitResult preVisit(ITreeNode element, int level, int index) {
+        if (element.isChecked() != checked) {
+          setNodeChecked(element, checked);
+        }
+        return TreeVisitResult.CONTINUE;
+      }
+    };
+    visitTree(v);
+  }
+
   /**
    * Recursively checks/unchecks the subtree of <code>parent</code>.
    */

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITree.java
@@ -406,6 +406,8 @@ public interface ITree extends IWidget, IDNDSupport, IStyleable, IAppLinkCapable
 
   void setNodesChecked(List<ITreeNode> nodes, boolean checked, boolean enabledNodesOnly, boolean forceUpdateNode);
 
+  void setAllNodesChecked(boolean checked);
+
   boolean isNodeChecked(ITreeNode node);
 
   int getNodeStatus(ITreeNode node);


### PR DESCRIPTION
With the new autoCheckChildNodes behaviour, Java does not check the children anymore when a parent node is checked. Instead, it is done by
 JS and notified back to Java afterward.
This behavior does not work when nodes are checked before the tree is sent to JS.
In the init function, no events can be triggered, because the TreeAdapter has not yet attached its widget.
Because of this, the updates are performed in the _postCreateWidget function.

363033