### PR TITLE
HTTP-Proxy: Prevent doubled encoding of query parameters

### DIFF
--- a/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxyTest.java
+++ b/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxyTest.java
@@ -142,8 +142,7 @@ public class HttpProxyTest {
         "/lorem", null, options);
     testRewriteUrlInternal("http://internal.example.com:1234/api/lorem?ipsum",
         "/lorem", "ipsum", new HttpProxyRequestOptions());
-    testRewriteUrlInternal("http://internal.example.com:1234/api/lorem?foo=%25bar%25",
-        "/lorem", "foo=%bar%", new HttpProxyRequestOptions());
+    testRewriteUrlInternal("http://internal.example.com:1234/api/lorem?foo=%25bar%25+lorem+ipsum", "/lorem", "foo=%25bar%25+lorem+ipsum", new HttpProxyRequestOptions());
   }
 
   protected void testRewriteUrlInternal(String expectedResult, String pathInfo, String queryString, HttpProxyRequestOptions options) {

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxy.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxy.java
@@ -252,7 +252,8 @@ public class HttpProxy {
       pathInfo = pathInfo.substring(1);
     }
     uriBuilder.addPath(pathInfo);
-    uriBuilder.queryString(req.getQueryString());
+    // Decoding URL since req.getQueryString method doesn't decode it. The query string gets encoded again when creating the URI.
+    uriBuilder.queryString(IOUtility.urlDecode(req.getQueryString()));
     return uriBuilder.createURI();
   }
 


### PR DESCRIPTION
Due to a recent change, query parameters were encoded twice inside HttpProxy#rewriteUrl. In this change we undo this doubled encoding.

372285