### PR TITLE
UiSession: warn when model theme is not valid

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiSession.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiSession.java
@@ -418,7 +418,14 @@ public class UiSession implements IUiSession {
     // Ensure the model theme is valid, otherwise it could result in an endless reload loop
     String validTheme = UiThemeHelper.get().validateTheme(modelTheme);
     if (!ObjectUtility.equals(validTheme, modelTheme)) {
-      LOG.info("Model theme ({}) is not valid, switching to a valid one ({})", modelTheme, validTheme);
+      if (modelTheme == null) {
+        // Initial assignment
+        LOG.debug("No model theme set, using a default value ({})", validTheme);
+      }
+      else {
+        // Invalid theme
+        LOG.warn("Model theme ({}) is not valid, switching to a valid one ({})", modelTheme, validTheme);
+      }
       modelTheme = validTheme;
     }
 


### PR DESCRIPTION
Automatically assigning a theme when the model theme is not set is a valid case (user has no specific setting). Therefore, this is only logged on level DEBUG. However, if a theme is set explicitly but is not valid, a message with level WARNING is logged.

270127