### PR TITLE
UiSession: don't throw error on concurrent dispose

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/IDesktopUIFacade.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/IDesktopUIFacade.java
@@ -52,7 +52,7 @@ public interface IDesktopUIFacade {
   void fireGuiAttached();
 
   /**
-   * GUI fires this event when the application/workbench is closing
+   * GUI fires this event when the UiSession is disposing.
    */
   void fireGuiDetached();
 


### PR DESCRIPTION
Model may trigger events during detaching desktop.
Example: HybridManager disposes widgets that trigger JsonAdapterProperty#disposeObsoleteAdapters
If UiSession is disposed at the same time there will be ConcurrentModificationException of the m_ownedAdapters member.

Solution is to make sure desktop is detached after the ui session is completely disposed so that there are no model listeners attached anymore.

373116