### PR TITLE
Data Objects: Fix serialization of nested raw attributes (list & map)

### DIFF
--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
@@ -84,6 +84,7 @@ import org.eclipse.scout.rt.jackson.dataobject.fixture.TestDuplicatedAttributeDo
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestElectronicAddressDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestEmptyObject;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestEntityWithArrayDoValueDo;
+import org.eclipse.scout.rt.jackson.dataobject.fixture.TestEntityWithAttributesWithoutTypeNameDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestEntityWithDoValueOfObjectDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestEntityWithGenericValuesDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestEntityWithIIdDo;
@@ -105,6 +106,7 @@ import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemPojo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestItemPojo2;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestMapDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestMixedRawBigIntegerDo;
+import org.eclipse.scout.rt.jackson.dataobject.fixture.TestNestedListRawDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestNestedRawDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestOptionalDo;
 import org.eclipse.scout.rt.jackson.dataobject.fixture.TestPersonDo;
@@ -1640,6 +1642,38 @@ public class JsonDataObjectsSerializationTest {
     assertJsonEquals("TestCollectionsIDoEntity.json", json);
   }
 
+  @Test
+  public void testSerializeDeserialize_CollectionsIDoEntityDoWithoutTypename() throws Exception {
+    List<IDoEntity> entities = List.of(
+        BEANS.get(TestWithoutTypeNameDo.class).withId("foo"),
+        BEANS.get(TestWithoutTypeNameSubclassDo.class).withId("bar"),
+        BEANS.get(TestWithoutTypeNameSubclassWithTypeNameDo.class).withId("baz"));
+
+    TestCollectionsIDoEntityDo entity = BEANS.get(TestCollectionsIDoEntityDo.class)
+        .withDoEntityAttribute(entities.get(0))
+        .withDoEntityDoListAttribute(entities)
+        .withDoEntityCollectionAttribute(entities)
+        .withDoEntityListAttribute(new ArrayList<>(entities));
+    String json = s_dataObjectMapper.writeValueAsString(entity);
+    assertJsonEquals("TestCollectionsIDoEntityWithoutTypename.json", json);
+  }
+
+  @Test
+  public void testSerializeDeserialize_EntityWithAttributeWithoutTypename() throws Exception {
+    TestEntityWithAttributesWithoutTypeNameDo entity = BEANS.get(TestEntityWithAttributesWithoutTypeNameDo.class)
+        .withListAttribute(
+            BEANS.get(TestWithoutTypeNameDo.class).withId("withoutName1"),
+            BEANS.get(TestWithoutTypeNameSubclassDo.class).withId("withoutName2"),
+            BEANS.get(TestWithoutTypeNameSubclassWithTypeNameDo.class).withId("withName3"))
+        .withValueAttribute(BEANS.get(TestWithoutTypeNameDo.class).withId("withName4"));
+    String json = s_dataObjectMapper.writeValueAsString(entity);
+    assertJsonEquals("TestEntityWithAttributesWithoutTypeName1.json", json);
+
+    entity.withValueAttribute(BEANS.get(TestWithoutTypeNameSubclassWithTypeNameDo.class).withId("withName5"));
+    json = s_dataObjectMapper.writeValueAsString(entity);
+    assertJsonEquals("TestEntityWithAttributesWithoutTypeName2.json", json);
+  }
+
   // ------------------------------------ DoEntity with collections test cases ------------------------------------
 
   @Test
@@ -1849,6 +1883,16 @@ public class JsonDataObjectsSerializationTest {
     stringAbstractDoMap.put("doAbstractKey1", BEANS.get(TestElectronicAddressDo.class).withId("elecAddress").withEmail("foo@bar.de"));
     stringAbstractDoMap.put("doAbstractKey2", BEANS.get(TestPhysicalAddressDo.class).withId("physicAddress").withCity("Example"));
     mapDo.withStringDoAbstractAddressMapAttribute(stringAbstractDoMap);
+
+    Map<String, IDoEntity> stringIDoEntityMap = new HashMap<>();
+    stringIDoEntityMap.put("iDoEntityKey1", createTestItemDo("1", "foo"));
+    stringIDoEntityMap.put("iDoEntityKey2", createTestItemDo("2", "bar"));
+    mapDo.withStringIDoEntityMapAttribute(stringIDoEntityMap);
+
+    Map<String, DoEntity> stringDoEntityMap = new HashMap<>();
+    stringDoEntityMap.put("doEntityKey1", createTestItemDo("1", "foo"));
+    stringDoEntityMap.put("doEntityKey2", createTestItemDo("2", "bar"));
+    mapDo.withStringDoEntityMapAttribute(stringDoEntityMap);
 
     Map<Double, TestItemDo> doubleDoMap = new HashMap<>();
     doubleDoMap.put(1.11, createTestItemDo("item-key5", "value5"));
@@ -3891,7 +3935,27 @@ public class JsonDataObjectsSerializationTest {
             .withIId(FixtureStringId.of("qualified-string-id-10"))
             .withStringId(FixtureStringId.of("unqualified-string-id-10"))
             .withIId2(FixtureStringId.of("qualified-string-id-11"))
-            .withStringId2(FixtureStringId.of("unqualified-string-id-11")));
+            .withStringId2(FixtureStringId.of("unqualified-string-id-11")))
+        .withStringDoEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-12"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-13"))))
+        .withStringIDoEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-14"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-15"))))
+        .withStringIDataObjectEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-16"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-17"))))
+        .withStringITestTypedUntypedInnerEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerIfcDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-18"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-19"))))
+        .withStringITestTypedUntypedInnerDataObjectEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerDataObjectIfcDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-20"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-21"))))
+        .withStringAbstractTestTypedUntypedInnerEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerAbsDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-22"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-23"))
+            .withIId2(FixtureStringId.of("qualified-string-id-24"))
+            .withStringId2(FixtureStringId.of("unqualified-string-id-25"))));
 
     // assert JSON-equality
     String json = s_dataObjectMapper.writeValueAsString(testDo);
@@ -3899,7 +3963,89 @@ public class JsonDataObjectsSerializationTest {
     json = s_dataObjectMapper.writeValueAsString(expected);
     assertJsonEquals("TestNestedRawDo.json", json);
 
-    // assert partial Java-equality, excluding untyped attributes, see NOTE above)
+    // assert partial Java-equality, excluding untyped attributes, see NOTE above
+    expected.remove(expected::doEntity2);
+    expected.remove(expected::iDataObject2);
+    expected.remove(expected::iDoEntity2);
+    testDo.remove(testDo::doEntity2);
+    testDo.remove(testDo::iDataObject2);
+    testDo.remove(testDo::iDoEntity2);
+    assertEqualsWithComparisonFailure(expected, testDo);
+  }
+
+  @Test
+  public void testSerializeDeserializeNestedListRawDoTypes() throws Exception {
+    String inputJson = readResourceAsString("TestNestedListRawDo.json");
+    TestNestedListRawDo testDo = s_dataObjectMapper.readValue(inputJson, TestNestedListRawDo.class);
+
+    DoEntity entity2 = BEANS.get(DoEntity.class);
+    // NOTE: This test-case is not a supposed real-world example. An IId as part of an untyped DoEntity is serialized unqualified and may never be deserialized correctly.
+    entity2.put("iId", FixtureStringId.of("unqualified-string-id-0"));
+    entity2.put("stringId", FixtureStringId.of("unqualified-string-id-0"));
+
+    @SuppressWarnings("unchecked")
+    TestNestedListRawDo expected = BEANS.get(TestNestedListRawDo.class)
+        .withDoEntity(BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-1"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-1")))
+        .withDoEntity2(entity2)
+        .withIDataObject(BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-2"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-2")))
+        .withIDataObject2(DoList.of(
+            // NOTE: This test-case is not a supposed real-world example. An IId as part of an untyped DoList is serialized unqualified and may never be deserialized correctly.
+            List.of(FixtureStringId.of("unqualified-string-id-3"),
+                FixtureStringId.of("unqualified-string-id-3"))))
+        .withIDoEntity(BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-4"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-4")))
+        .withIDoEntity2(BEANS.get(DoEntityBuilder.class)
+            // NOTE: This test-case is not a supposed real-world example. An IId as part of an untyped IDoEntity is serialized unqualified and may never be deserialized correctly.
+            .put("iId", FixtureStringId.of("unqualified-string-id-5"))
+            .put("stringId", FixtureStringId.of("unqualified-string-id-5")).build())
+        .withITestTypedUntypedInner(BEANS.get(TestTypedUntypedInnerIfcDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-6"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-6"))
+            .withIId2(FixtureStringId.of("qualified-string-id-7"))
+            .withStringId2(FixtureStringId.of("unqualified-string-id-7")))
+        .withAbstractTestTypedUntypedInner(BEANS.get(TestTypedUntypedInnerAbsDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-8"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-8"))
+            .withIId2(FixtureStringId.of("qualified-string-id-9"))
+            .withStringId2(FixtureStringId.of("unqualified-string-id-9")))
+        .withITestTypedUntypedInnerDataObject(BEANS.get(TestTypedUntypedInnerDataObjectIfcDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-10"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-10"))
+            .withIId2(FixtureStringId.of("qualified-string-id-11"))
+            .withStringId2(FixtureStringId.of("unqualified-string-id-11")))
+        .withStringDoEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-12"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-13"))))
+        .withStringIDoEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-14"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-15"))))
+        .withStringIDataObjectEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-16"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-17"))))
+        .withStringITestTypedUntypedInnerEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerIfcDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-18"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-19"))))
+        .withStringITestTypedUntypedInnerDataObjectEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerDataObjectIfcDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-20"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-21"))))
+        .withStringAbstractTestTypedUntypedInnerEntityMap(Map.of("one", BEANS.get(TestTypedUntypedInnerAbsDo.class)
+            .withIId(FixtureStringId.of("qualified-string-id-22"))
+            .withStringId(FixtureStringId.of("unqualified-string-id-23"))
+            .withIId2(FixtureStringId.of("qualified-string-id-24"))
+            .withStringId2(FixtureStringId.of("unqualified-string-id-25"))));
+
+    // assert JSON-equality
+    String json = s_dataObjectMapper.writeValueAsString(testDo);
+    assertJsonEquals("TestNestedListRawDo.json", json);
+    json = s_dataObjectMapper.writeValueAsString(expected);
+    assertJsonEquals("TestNestedListRawDo.json", json);
+
+    // assert partial Java-equality, excluding untyped attributes, see NOTE above
     expected.remove(expected::doEntity2);
     expected.remove(expected::iDataObject2);
     expected.remove(expected::iDoEntity2);

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestEntityWithAttributesWithoutTypeNameDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestEntityWithAttributesWithoutTypeNameDo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoList;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Test {@link DoEntity} with attributes of DO type using no TypeName.
+ */
+@TypeName("TestEntityWithAttributesWithoutTypeName")
+public class TestEntityWithAttributesWithoutTypeNameDo extends DoEntity {
+
+  public DoValue<TestWithoutTypeNameDo> valueAttribute() {
+    return doValue("valueAttribute");
+  }
+
+  public DoList<TestWithoutTypeNameDo> listAttribute() {
+    return doList("listAttribute");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestEntityWithAttributesWithoutTypeNameDo withValueAttribute(TestWithoutTypeNameDo valueAttribute) {
+    valueAttribute().set(valueAttribute);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestWithoutTypeNameDo getValueAttribute() {
+    return valueAttribute().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestEntityWithAttributesWithoutTypeNameDo withListAttribute(Collection<? extends TestWithoutTypeNameDo> listAttribute) {
+    listAttribute().updateAll(listAttribute);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestEntityWithAttributesWithoutTypeNameDo withListAttribute(TestWithoutTypeNameDo... listAttribute) {
+    listAttribute().updateAll(listAttribute);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<TestWithoutTypeNameDo> getListAttribute() {
+    return listAttribute().get();
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestMapDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestMapDo.java
@@ -15,12 +15,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
-import jakarta.annotation.Generated;
-
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.TypeName;
+
+import jakarta.annotation.Generated;
 
 @TypeName("TestMap")
 public class TestMapDo extends DoEntity {
@@ -52,6 +52,10 @@ public class TestMapDo extends DoEntity {
 
   public DoValue<Map<String, IDoEntity>> stringIDoEntityMapAttribute() {
     return doValue("stringIDoEntityMapAttribute");
+  }
+
+  public DoValue<Map<String, DoEntity>> stringDoEntityMapAttribute() {
+    return doValue("stringDoEntityMapAttribute");
   }
 
   public DoValue<IDoEntity> iDoEntityAttribute() {
@@ -150,6 +154,17 @@ public class TestMapDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public Map<String, IDoEntity> getStringIDoEntityMapAttribute() {
     return stringIDoEntityMapAttribute().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestMapDo withStringDoEntityMapAttribute(Map<String, DoEntity> stringDoEntityMapAttribute) {
+    stringDoEntityMapAttribute().set(stringDoEntityMapAttribute);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, DoEntity> getStringDoEntityMapAttribute() {
+    return stringDoEntityMapAttribute().get();
   }
 
   @Generated("DoConvenienceMethodsGenerator")

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestNestedListRawDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestNestedListRawDo.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.jackson.dataobject.fixture;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoList;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.TypeName;
+
+import jakarta.annotation.Generated;
+
+@TypeName("TestNestedListRaw")
+public class TestNestedListRawDo extends DoEntity {
+
+  public DoList<DoEntity> doEntity() {
+    return doList("doEntity");
+  }
+
+  public DoList<DoEntity> doEntity2() {
+    return doList("doEntity2");
+  }
+
+  public DoList<IDoEntity> iDoEntity() {
+    return doList("iDoEntity");
+  }
+
+  public DoList<IDoEntity> iDoEntity2() {
+    return doList("iDoEntity2");
+  }
+
+  public DoList<IDataObject> iDataObject() {
+    return doList("iDataObject");
+  }
+
+  public DoList<IDataObject> iDataObject2() {
+    return doList("iDataObject2");
+  }
+
+  public DoList<ITestTypedUntypedInnerDo> iTestTypedUntypedInner() {
+    return doList("iTestTypedUntypedInner");
+  }
+
+  public DoList<ITestTypedUntypedInnerDataObjectDo> iTestTypedUntypedInnerDataObject() {
+    return doList("iTestTypedUntypedInnerDataObject");
+  }
+
+  public DoList<AbstractTestTypedUntypedInnerDo> abstractTestTypedUntypedInner() {
+    return doList("abstractTestTypedUntypedInner");
+  }
+
+  public DoValue<Map<String, DoEntity>> stringDoEntityMap() {
+    return doValue("stringDoEntityMap");
+  }
+
+  public DoList<Map<String, IDoEntity>> stringIDoEntityMap() {
+    return doList("stringIDoEntityMap");
+  }
+
+  public DoList<Map<String, IDataObject>> stringIDataObjectEntityMap() {
+    return doList("stringIDataObjectEntityMap");
+  }
+
+  public DoList<Map<String, ITestTypedUntypedInnerDo>> stringITestTypedUntypedInnerEntityMap() {
+    return doList("stringITestTypedUntypedInnerEntityMap");
+  }
+
+  public DoList<Map<String, ITestTypedUntypedInnerDataObjectDo>> stringITestTypedUntypedInnerDataObjectEntityMap() {
+    return doList("stringITestTypedUntypedInnerDataObjectEntityMap");
+  }
+
+  public DoList<Map<String, AbstractTestTypedUntypedInnerDo>> stringAbstractTestTypedUntypedInnerEntityMap() {
+    return doList("stringAbstractTestTypedUntypedInnerEntityMap");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withDoEntity(Collection<? extends DoEntity> doEntity) {
+    doEntity().updateAll(doEntity);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withDoEntity(DoEntity... doEntity) {
+    doEntity().updateAll(doEntity);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<DoEntity> getDoEntity() {
+    return doEntity().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withDoEntity2(Collection<? extends DoEntity> doEntity2) {
+    doEntity2().updateAll(doEntity2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withDoEntity2(DoEntity... doEntity2) {
+    doEntity2().updateAll(doEntity2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<DoEntity> getDoEntity2() {
+    return doEntity2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withIDoEntity(Collection<? extends IDoEntity> iDoEntity) {
+    iDoEntity().updateAll(iDoEntity);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withIDoEntity(IDoEntity... iDoEntity) {
+    iDoEntity().updateAll(iDoEntity);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<IDoEntity> getIDoEntity() {
+    return iDoEntity().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withIDoEntity2(Collection<? extends IDoEntity> iDoEntity2) {
+    iDoEntity2().updateAll(iDoEntity2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withIDoEntity2(IDoEntity... iDoEntity2) {
+    iDoEntity2().updateAll(iDoEntity2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<IDoEntity> getIDoEntity2() {
+    return iDoEntity2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withIDataObject(Collection<? extends IDataObject> iDataObject) {
+    iDataObject().updateAll(iDataObject);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withIDataObject(IDataObject... iDataObject) {
+    iDataObject().updateAll(iDataObject);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<IDataObject> getIDataObject() {
+    return iDataObject().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withIDataObject2(Collection<? extends IDataObject> iDataObject2) {
+    iDataObject2().updateAll(iDataObject2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withIDataObject2(IDataObject... iDataObject2) {
+    iDataObject2().updateAll(iDataObject2);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<IDataObject> getIDataObject2() {
+    return iDataObject2().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withITestTypedUntypedInner(Collection<? extends ITestTypedUntypedInnerDo> iTestTypedUntypedInner) {
+    iTestTypedUntypedInner().updateAll(iTestTypedUntypedInner);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withITestTypedUntypedInner(ITestTypedUntypedInnerDo... iTestTypedUntypedInner) {
+    iTestTypedUntypedInner().updateAll(iTestTypedUntypedInner);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<ITestTypedUntypedInnerDo> getITestTypedUntypedInner() {
+    return iTestTypedUntypedInner().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withITestTypedUntypedInnerDataObject(Collection<? extends ITestTypedUntypedInnerDataObjectDo> iTestTypedUntypedInnerDataObject) {
+    iTestTypedUntypedInnerDataObject().updateAll(iTestTypedUntypedInnerDataObject);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withITestTypedUntypedInnerDataObject(ITestTypedUntypedInnerDataObjectDo... iTestTypedUntypedInnerDataObject) {
+    iTestTypedUntypedInnerDataObject().updateAll(iTestTypedUntypedInnerDataObject);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<ITestTypedUntypedInnerDataObjectDo> getITestTypedUntypedInnerDataObject() {
+    return iTestTypedUntypedInnerDataObject().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withAbstractTestTypedUntypedInner(Collection<? extends AbstractTestTypedUntypedInnerDo> abstractTestTypedUntypedInner) {
+    abstractTestTypedUntypedInner().updateAll(abstractTestTypedUntypedInner);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withAbstractTestTypedUntypedInner(AbstractTestTypedUntypedInnerDo... abstractTestTypedUntypedInner) {
+    abstractTestTypedUntypedInner().updateAll(abstractTestTypedUntypedInner);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<AbstractTestTypedUntypedInnerDo> getAbstractTestTypedUntypedInner() {
+    return abstractTestTypedUntypedInner().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringDoEntityMap(Map<String, DoEntity> stringDoEntityMap) {
+    stringDoEntityMap().set(stringDoEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, DoEntity> getStringDoEntityMap() {
+    return stringDoEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringIDoEntityMap(Collection<? extends Map<String, IDoEntity>> stringIDoEntityMap) {
+    stringIDoEntityMap().updateAll(stringIDoEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringIDoEntityMap(Map<String, IDoEntity>... stringIDoEntityMap) {
+    stringIDoEntityMap().updateAll(stringIDoEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<Map<String, IDoEntity>> getStringIDoEntityMap() {
+    return stringIDoEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringIDataObjectEntityMap(Collection<? extends Map<String, IDataObject>> stringIDataObjectEntityMap) {
+    stringIDataObjectEntityMap().updateAll(stringIDataObjectEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringIDataObjectEntityMap(Map<String, IDataObject>... stringIDataObjectEntityMap) {
+    stringIDataObjectEntityMap().updateAll(stringIDataObjectEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<Map<String, IDataObject>> getStringIDataObjectEntityMap() {
+    return stringIDataObjectEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringITestTypedUntypedInnerEntityMap(Collection<? extends Map<String, ITestTypedUntypedInnerDo>> stringITestTypedUntypedInnerEntityMap) {
+    stringITestTypedUntypedInnerEntityMap().updateAll(stringITestTypedUntypedInnerEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringITestTypedUntypedInnerEntityMap(Map<String, ITestTypedUntypedInnerDo>... stringITestTypedUntypedInnerEntityMap) {
+    stringITestTypedUntypedInnerEntityMap().updateAll(stringITestTypedUntypedInnerEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<Map<String, ITestTypedUntypedInnerDo>> getStringITestTypedUntypedInnerEntityMap() {
+    return stringITestTypedUntypedInnerEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringITestTypedUntypedInnerDataObjectEntityMap(Collection<? extends Map<String, ITestTypedUntypedInnerDataObjectDo>> stringITestTypedUntypedInnerDataObjectEntityMap) {
+    stringITestTypedUntypedInnerDataObjectEntityMap().updateAll(stringITestTypedUntypedInnerDataObjectEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringITestTypedUntypedInnerDataObjectEntityMap(Map<String, ITestTypedUntypedInnerDataObjectDo>... stringITestTypedUntypedInnerDataObjectEntityMap) {
+    stringITestTypedUntypedInnerDataObjectEntityMap().updateAll(stringITestTypedUntypedInnerDataObjectEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<Map<String, ITestTypedUntypedInnerDataObjectDo>> getStringITestTypedUntypedInnerDataObjectEntityMap() {
+    return stringITestTypedUntypedInnerDataObjectEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringAbstractTestTypedUntypedInnerEntityMap(Collection<? extends Map<String, AbstractTestTypedUntypedInnerDo>> stringAbstractTestTypedUntypedInnerEntityMap) {
+    stringAbstractTestTypedUntypedInnerEntityMap().updateAll(stringAbstractTestTypedUntypedInnerEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedListRawDo withStringAbstractTestTypedUntypedInnerEntityMap(Map<String, AbstractTestTypedUntypedInnerDo>... stringAbstractTestTypedUntypedInnerEntityMap) {
+    stringAbstractTestTypedUntypedInnerEntityMap().updateAll(stringAbstractTestTypedUntypedInnerEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<Map<String, AbstractTestTypedUntypedInnerDo>> getStringAbstractTestTypedUntypedInnerEntityMap() {
+    return stringAbstractTestTypedUntypedInnerEntityMap().get();
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestNestedRawDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestNestedRawDo.java
@@ -9,13 +9,15 @@
  */
 package org.eclipse.scout.rt.jackson.dataobject.fixture;
 
-import jakarta.annotation.Generated;
+import java.util.Map;
 
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.IDataObject;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.TypeName;
+
+import jakarta.annotation.Generated;
 
 @TypeName("TestNestedRaw")
 public class TestNestedRawDo extends DoEntity {
@@ -54,6 +56,30 @@ public class TestNestedRawDo extends DoEntity {
 
   public DoValue<AbstractTestTypedUntypedInnerDo> abstractTestTypedUntypedInner() {
     return doValue("abstractTestTypedUntypedInner");
+  }
+
+  public DoValue<Map<String, DoEntity>> stringDoEntityMap() {
+    return doValue("stringDoEntityMap");
+  }
+
+  public DoValue<Map<String, IDoEntity>> stringIDoEntityMap() {
+    return doValue("stringIDoEntityMap");
+  }
+
+  public DoValue<Map<String, IDataObject>> stringIDataObjectEntityMap() {
+    return doValue("stringIDataObjectEntityMap");
+  }
+
+  public DoValue<Map<String, ITestTypedUntypedInnerDo>> stringITestTypedUntypedInnerEntityMap() {
+    return doValue("stringITestTypedUntypedInnerEntityMap");
+  }
+
+  public DoValue<Map<String, ITestTypedUntypedInnerDataObjectDo>> stringITestTypedUntypedInnerDataObjectEntityMap() {
+    return doValue("stringITestTypedUntypedInnerDataObjectEntityMap");
+  }
+
+  public DoValue<Map<String, AbstractTestTypedUntypedInnerDo>> stringAbstractTestTypedUntypedInnerEntityMap() {
+    return doValue("stringAbstractTestTypedUntypedInnerEntityMap");
   }
 
   /* **************************************************************************
@@ -157,5 +183,71 @@ public class TestNestedRawDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public AbstractTestTypedUntypedInnerDo getAbstractTestTypedUntypedInner() {
     return abstractTestTypedUntypedInner().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withStringDoEntityMap(Map<String, DoEntity> stringDoEntityMap) {
+    stringDoEntityMap().set(stringDoEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, DoEntity> getStringDoEntityMap() {
+    return stringDoEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withStringIDoEntityMap(Map<String, IDoEntity> stringIDoEntityMap) {
+    stringIDoEntityMap().set(stringIDoEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, IDoEntity> getStringIDoEntityMap() {
+    return stringIDoEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withStringIDataObjectEntityMap(Map<String, IDataObject> stringIDataObjectEntityMap) {
+    stringIDataObjectEntityMap().set(stringIDataObjectEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, IDataObject> getStringIDataObjectEntityMap() {
+    return stringIDataObjectEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withStringITestTypedUntypedInnerEntityMap(Map<String, ITestTypedUntypedInnerDo> stringITestTypedUntypedInnerEntityMap) {
+    stringITestTypedUntypedInnerEntityMap().set(stringITestTypedUntypedInnerEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, ITestTypedUntypedInnerDo> getStringITestTypedUntypedInnerEntityMap() {
+    return stringITestTypedUntypedInnerEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withStringITestTypedUntypedInnerDataObjectEntityMap(Map<String, ITestTypedUntypedInnerDataObjectDo> stringITestTypedUntypedInnerDataObjectEntityMap) {
+    stringITestTypedUntypedInnerDataObjectEntityMap().set(stringITestTypedUntypedInnerDataObjectEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, ITestTypedUntypedInnerDataObjectDo> getStringITestTypedUntypedInnerDataObjectEntityMap() {
+    return stringITestTypedUntypedInnerDataObjectEntityMap().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public TestNestedRawDo withStringAbstractTestTypedUntypedInnerEntityMap(Map<String, AbstractTestTypedUntypedInnerDo> stringAbstractTestTypedUntypedInnerEntityMap) {
+    stringAbstractTestTypedUntypedInnerEntityMap().set(stringAbstractTestTypedUntypedInnerEntityMap);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Map<String, AbstractTestTypedUntypedInnerDo> getStringAbstractTestTypedUntypedInnerEntityMap() {
+    return stringAbstractTestTypedUntypedInnerEntityMap().get();
   }
 }

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestCollectionsIDoEntityWithoutTypename.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestCollectionsIDoEntityWithoutTypename.json
@@ -1,0 +1,30 @@
+{
+  "_type" : "TestCollectionsIDoEntity",
+  "doEntityAttribute" : {
+    "id" : "foo"
+  },
+  "doEntityCollectionAttribute" : [ {
+    "id" : "foo"
+  }, {
+    "id" : "bar"
+  }, {
+    "_type" : "TestWithoutTypeNameSubclassWithTypename",
+    "id" : "baz"
+  } ],
+  "doEntityDoListAttribute" : [ {
+    "id" : "foo"
+  }, {
+    "id" : "bar"
+  }, {
+    "_type" : "TestWithoutTypeNameSubclassWithTypename",
+    "id" : "baz"
+  } ],
+  "doEntityListAttribute" : [ {
+    "id" : "foo"
+  }, {
+    "id" : "bar"
+  }, {
+    "_type" : "TestWithoutTypeNameSubclassWithTypename",
+    "id" : "baz"
+  } ]
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithAttributesWithoutTypeName1.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithAttributesWithoutTypeName1.json
@@ -1,0 +1,14 @@
+{
+  "_type" : "TestEntityWithAttributesWithoutTypeName",
+  "listAttribute" : [ {
+    "id" : "withoutName1"
+  }, {
+    "id" : "withoutName2"
+  }, {
+    "_type" : "TestWithoutTypeNameSubclassWithTypename",
+    "id" : "withName3"
+  } ],
+  "valueAttribute" : {
+    "id" : "withName4"
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithAttributesWithoutTypeName2.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestEntityWithAttributesWithoutTypeName2.json
@@ -1,0 +1,15 @@
+{
+  "_type" : "TestEntityWithAttributesWithoutTypeName",
+  "listAttribute" : [ {
+    "id" : "withoutName1"
+  }, {
+    "id" : "withoutName2"
+  }, {
+    "_type" : "TestWithoutTypeNameSubclassWithTypename",
+    "id" : "withName3"
+  } ],
+  "valueAttribute" : {
+    "_type" : "TestWithoutTypeNameSubclassWithTypename",
+    "id" : "withName5"
+  }
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestMapDo.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestMapDo.json
@@ -36,6 +36,18 @@
       "id" : "elecAddress"
     }
   },
+  "stringDoEntityMapAttribute" : {
+    "doEntityKey1" : {
+      "_type" : "TestItem",
+      "id" : "1",
+      "stringAttribute" : "foo"
+    },
+    "doEntityKey2" : {
+      "_type" : "TestItem",
+      "id" : "2",
+      "stringAttribute" : "bar"
+    }
+  },
   "stringDoTestItemMapAttribute" : {
     "doKey1" : {
       "_type" : "TestItem",
@@ -48,6 +60,18 @@
       "stringAttribute" : "value4"
     },
     "doKey3" : null
+  },
+  "stringIDoEntityMapAttribute" : {
+    "iDoEntityKey2" : {
+      "_type" : "TestItem",
+      "id" : "2",
+      "stringAttribute" : "bar"
+    },
+    "iDoEntityKey1" : {
+      "_type" : "TestItem",
+      "id" : "1",
+      "stringAttribute" : "foo"
+    }
   },
   "stringMapStringMapStringListTestItemDoMapAttribute" : {
     "complex1" : {

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestNestedListRawDo.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestNestedListRawDo.json
@@ -1,51 +1,51 @@
 {
-  "_type" : "TestNestedRaw",
-  "abstractTestTypedUntypedInner" : {
+  "_type" : "TestNestedListRaw",
+  "abstractTestTypedUntypedInner" : [ {
     "_type" : "scout.TestTypedUntypedInnerAbsDo",
     "iId" : "scout.FixtureStringId:qualified-string-id-8",
     "iId2" : "scout.FixtureStringId:qualified-string-id-9",
     "stringId" : "unqualified-string-id-8",
     "stringId2" : "unqualified-string-id-9"
-  },
-  "doEntity" : {
+  } ],
+  "doEntity" : [ {
     "_type" : "scout.TestTypedUntypedInner",
     "iId" : "scout.FixtureStringId:qualified-string-id-1",
     "stringId" : "unqualified-string-id-1"
-  },
-  "doEntity2" : {
+  } ],
+  "doEntity2" : [ {
     "iId" : "unqualified-string-id-0",
     "stringId" : "unqualified-string-id-0"
-  },
-  "iDataObject" : {
+  } ],
+  "iDataObject" : [ {
     "_type" : "scout.TestTypedUntypedInner",
     "iId" : "scout.FixtureStringId:qualified-string-id-2",
     "stringId" : "unqualified-string-id-2"
-  },
-  "iDataObject2" : [ "unqualified-string-id-3", "unqualified-string-id-3" ],
-  "iDoEntity" : {
+  } ],
+  "iDataObject2" : [ [ "unqualified-string-id-3", "unqualified-string-id-3" ] ],
+  "iDoEntity" : [ {
     "_type" : "scout.TestTypedUntypedInner",
     "iId" : "scout.FixtureStringId:qualified-string-id-4",
     "stringId" : "unqualified-string-id-4"
-  },
-  "iDoEntity2" : {
+  } ],
+  "iDoEntity2" : [ {
     "iId" : "unqualified-string-id-5",
     "stringId" : "unqualified-string-id-5"
-  },
-  "iTestTypedUntypedInner" : {
+  } ],
+  "iTestTypedUntypedInner" : [ {
     "_type" : "scout.TestTypedUntypedInnerIfc",
     "iId" : "scout.FixtureStringId:qualified-string-id-6",
     "iId2" : "scout.FixtureStringId:qualified-string-id-7",
     "stringId" : "unqualified-string-id-6",
     "stringId2" : "unqualified-string-id-7"
-  },
-  "iTestTypedUntypedInnerDataObject" : {
+  } ],
+  "iTestTypedUntypedInnerDataObject" : [ {
     "_type" : "scout.TestTypedUntypedInnerDataObjectIfc",
     "iId" : "scout.FixtureStringId:qualified-string-id-10",
     "iId2" : "scout.FixtureStringId:qualified-string-id-11",
     "stringId" : "unqualified-string-id-10",
     "stringId2" : "unqualified-string-id-11"
-  },
-  "stringAbstractTestTypedUntypedInnerEntityMap" : {
+  } ],
+  "stringAbstractTestTypedUntypedInnerEntityMap" : [ {
     "one" : {
       "_type" : "scout.TestTypedUntypedInnerAbsDo",
       "iId" : "scout.FixtureStringId:qualified-string-id-22",
@@ -53,7 +53,7 @@
       "stringId" : "unqualified-string-id-23",
       "stringId2" : "unqualified-string-id-25"
     }
-  },
+  } ],
   "stringDoEntityMap" : {
     "one" : {
       "_type" : "scout.TestTypedUntypedInner",
@@ -61,32 +61,32 @@
       "stringId" : "unqualified-string-id-13"
     }
   },
-  "stringIDataObjectEntityMap" : {
+  "stringIDataObjectEntityMap" : [ {
     "one" : {
       "_type" : "scout.TestTypedUntypedInner",
       "iId" : "scout.FixtureStringId:qualified-string-id-16",
       "stringId" : "unqualified-string-id-17"
     }
-  },
-  "stringIDoEntityMap" : {
+  } ],
+  "stringIDoEntityMap" : [ {
     "one" : {
       "_type" : "scout.TestTypedUntypedInner",
       "iId" : "scout.FixtureStringId:qualified-string-id-14",
       "stringId" : "unqualified-string-id-15"
     }
-  },
-  "stringITestTypedUntypedInnerDataObjectEntityMap" : {
+  } ],
+  "stringITestTypedUntypedInnerDataObjectEntityMap" : [ {
     "one" : {
       "_type" : "scout.TestTypedUntypedInnerDataObjectIfc",
       "iId" : "scout.FixtureStringId:qualified-string-id-20",
       "stringId" : "unqualified-string-id-21"
     }
-  },
-  "stringITestTypedUntypedInnerEntityMap" : {
+  } ],
+  "stringITestTypedUntypedInnerEntityMap" : [ {
     "one" : {
       "_type" : "scout.TestTypedUntypedInnerIfc",
       "iId" : "scout.FixtureStringId:qualified-string-id-18",
       "stringId" : "unqualified-string-id-19"
     }
-  }
+  } ]
 }

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DataObjectAnnotationIntrospector.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DataObjectAnnotationIntrospector.java
@@ -9,7 +9,7 @@
  */
 package org.eclipse.scout.rt.jackson.dataobject;
 
-import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.IDataObject;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
 
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
 
 /**
- * Jackson {@link AnnotationIntrospector} implementation adding type resolver for all {@link IDoEntity} data object
+ * Jackson {@link AnnotationIntrospector} implementation adding type resolver for all {@link IDataObject} data object
  * instances.
  */
 @Bean
@@ -40,7 +40,7 @@ public class DataObjectAnnotationIntrospector extends JacksonAnnotationIntrospec
 
   @Override
   public TypeResolverBuilder<?> findTypeResolver(MapperConfig<?> config, AnnotatedClass ac, JavaType baseType) {
-    if (IDoEntity.class.isAssignableFrom(ac.getRawType())) {
+    if (IDataObject.class.isAssignableFrom(ac.getRawType())) {
       if (m_moduleContext.isSuppressTypeAttribute()) {
         return StdTypeResolverBuilder.noTypeInfoBuilder();
       }


### PR DESCRIPTION
This change fixes serialization of data object with DoList or DoValue<Map> attributes declared using raw data object types (e.g. IDoEntity, DoEntity or IDataObject).
Those attributes may have been serialized without type information before this fix.

This change also fixes serialization of data object with attributes declared using own abstract classes/interfaces as attribute type. Attributes of type IIds within those data objects were serialized using untyped serialization instead of typed serialization.

371681