### PR TITLE
Initialize last poll timestamp when starting the poller job

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/clientnotification/ClientNotificationPoller.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/clientnotification/ClientNotificationPoller.java
@@ -84,6 +84,7 @@ public class ClientNotificationPoller {
   }
 
   protected void startPoller() {
+    touch(); // reset timestamp of last poll request to eliminate timing issues (poller must run before liveness check)
     m_pollerFuture = Jobs.schedule(new P_NotificationPoller(this::touch), Jobs.newInput()
         .withRunContext(createRunContext())
         .withName(ClientNotificationPoller.class.getSimpleName()));


### PR DESCRIPTION
This prevents the timing issue where the liveness checker is executed before the poller job runs for the first time.

363614