### PR TITLE
HttpProxy: Fix log message for custom request headers

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxy.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxy.java
@@ -237,7 +237,7 @@ public class HttpProxy {
     }
     for (Entry<String, String> header : customHeaders.entrySet()) {
       httpReq.getHeaders().set(header.getKey(), header.getValue());
-      LOG.trace("Added custom request header: {}: {}", header.getValue(), header.getValue());
+      LOG.trace("Added custom request header: {}: {}", header.getKey(), header.getValue());
     }
   }
 


### PR DESCRIPTION
Do not log getValue twice, instead log getKey and getValue