### PR TITLE
Scout Archetypes: remove docker.java.image.registry

### DIFF
--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -23,10 +23,9 @@
     <docker.app.image.registry>localhost:5000</docker.app.image.registry> <!-- set a desired registry before using profile exec.docker.image (e.g. registry.hub.docker.com/yourusername) -->
     <docker.app.image.tag>${versionWithoutSnapshot}-latest</docker.app.image.tag>
     <!-- java source image (pull) -->
-    <docker.java.image.registry>docker.io</docker.java.image.registry>
     <docker.java.image.name>eclipse-temurin</docker.java.image.name>
     <docker.java.image.tag>17-jdk-jammy</docker.java.image.tag>
-    <docker.java.image>${docker.java.image.registry}/${docker.java.image.name}:${docker.java.image.tag}</docker.java.image>
+    <docker.java.image>${docker.java.image.name}:${docker.java.image.tag}</docker.java.image>
   </properties>
 
   <modules>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -22,10 +22,9 @@
     <docker.app.image.registry>localhost:5000</docker.app.image.registry> <!-- set a desired registry before using profile exec.docker.image (e.g. registry.hub.docker.com/yourusername) -->
     <docker.app.image.tag>${versionWithoutSnapshot}-latest</docker.app.image.tag>
     <!-- java source image (pull) -->
-    <docker.java.image.registry>docker.io</docker.java.image.registry>
     <docker.java.image.name>eclipse-temurin</docker.java.image.name>
     <docker.java.image.tag>17-jdk-jammy</docker.java.image.tag>
-    <docker.java.image>${docker.java.image.registry}/${docker.java.image.name}:${docker.java.image.tag}</docker.java.image>
+    <docker.java.image>${docker.java.image.name}:${docker.java.image.tag}</docker.java.image>
   </properties>
 
   <modules>


### PR DESCRIPTION
Seems to required authentication when used with Google JIB. If using an own registry, prefix the docker.java.image.name with it, e.g. <docker.java.image.name>my-docker-mirror.local/eclipse-temurin</docker.java.image.name>