### PR TITLE
ProposalField: fix validation errors

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
@@ -170,6 +170,12 @@ export default class ProposalField extends SmartField {
   }
 
   _acceptInput(sync, searchText, searchTextEmpty, searchTextChanged, selectedLookupRow) {
+    if (this.touchMode) {
+      $.log.isDebugEnabled() && $.log.debug('(ProposalField#_acceptInput) Always send acceptInput for touch field');
+      this._inputAccepted(true, !!selectedLookupRow);
+      return;
+    }
+
     // Do nothing when search text is equals to the text of the current lookup row
     if (!selectedLookupRow && this.lookupRow && this.lookupRow.text === searchText) {
       $.log.isDebugEnabled() && $.log.debug('(ProposalField#_acceptInput) unchanged: text is equals. Close popup');

--- a/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {objects, scout, SmartField, strings} from '../../../index';
+import {objects, SmartField, strings} from '../../../index';
 import $ from 'jquery';
 
 export default class ProposalField extends SmartField {
@@ -69,7 +69,15 @@ export default class ProposalField extends SmartField {
   }
 
   _formatValue(value) {
-    return scout.nvl(value, '');
+    if (objects.isNullOrUndefined(value)) {
+      return '';
+    }
+
+    if (this.lookupRow) {
+      return this._formatLookupRow(this.lookupRow);
+    }
+
+    return value;
   }
 
   _validateValue(value) {
@@ -161,12 +169,11 @@ export default class ProposalField extends SmartField {
    */
   _copyValuesFromField(otherField) {
     if (this.lookupRow !== otherField.lookupRow) {
-      this.setLookupRow(otherField.lookupRow);
+      this._setLookupRow(otherField.lookupRow); // only set property lookup
     }
     this.setErrorStatus(otherField.errorStatus);
-    if (this.value !== otherField.value) {
-      this.setValue(otherField.value);
-    }
+    this.setDisplayText(otherField.displayText);
+    this.setValue(otherField.value);
   }
 
   _acceptInput(sync, searchText, searchTextEmpty, searchTextChanged, selectedLookupRow) {
@@ -176,8 +183,8 @@ export default class ProposalField extends SmartField {
       return;
     }
 
-    // Do nothing when search text is equals to the text of the current lookup row
-    if (!selectedLookupRow && this.lookupRow && this.lookupRow.text === searchText) {
+    // Do nothing when search text did not change and is equals to the text of the current lookup row
+    if (!searchTextChanged && !selectedLookupRow && this.lookupRow && this.lookupRow.text === searchText) {
       $.log.isDebugEnabled() && $.log.debug('(ProposalField#_acceptInput) unchanged: text is equals. Close popup');
       this._inputAccepted(false);
       return;

--- a/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/ProposalField.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -163,6 +163,7 @@ export default class ProposalField extends SmartField {
     if (this.lookupRow !== otherField.lookupRow) {
       this.setLookupRow(otherField.lookupRow);
     }
+    this.setErrorStatus(otherField.errorStatus);
     if (this.value !== otherField.value) {
       this.setValue(otherField.value);
     }

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -232,12 +232,6 @@ export default class SmartField extends ValueField {
     this._flushLookupStatus();
     this._clearPendingLookup();
 
-    if (this.touchMode) {
-      $.log.isDebugEnabled() && $.log.debug('(SmartField#acceptInput) Always send acceptInput for touch field');
-      this._inputAccepted();
-      return;
-    }
-
     return this._acceptInput(sync, searchText, searchTextEmpty, searchTextChanged, selectedLookupRow);
   }
 
@@ -287,6 +281,11 @@ export default class SmartField extends ValueField {
    * @param [sync] optional boolean value (default: false), when set to true acceptInput is not allowed to start an asynchronous lookup for text search
    */
   _acceptInput(sync, searchText, searchTextEmpty, searchTextChanged, selectedLookupRow) {
+    if (this.touchMode) {
+      $.log.isDebugEnabled() && $.log.debug('(SmartField#_acceptInput) Always send acceptInput for touch field');
+      this._inputAccepted();
+      return;
+    }
 
     let unchanged = false;
     if (this.removing) {

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldTouchPopup.js
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldTouchPopup.js
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2014-2018 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {scout, TouchPopup} from '../../../index';
+import {objects, scout, TouchPopup} from '../../../index';
+import $ from 'jquery';
 
 /**
  * Info: this class must have the same interface as SmartFieldPopup. That's why there's some
@@ -18,12 +19,14 @@ export default class SmartFieldTouchPopup extends TouchPopup {
 
   constructor() {
     super();
+    this._initialFieldState = null;
   }
 
   _init(options) {
     options.withFocusContext = false;
     options.smartField = options.parent; // alias for parent (required by proposal chooser)
     super._init(options);
+    this._initialFieldState = this._getFieldState();
 
     this.setLookupResult(options.lookupResult);
     this.setStatus(options.status);
@@ -40,6 +43,11 @@ export default class SmartFieldTouchPopup extends TouchPopup {
     this._widget = this._createProposalChooser();
     this._widget.on('lookupRowSelected', this._triggerEvent.bind(this));
     this._widget.on('activeFilterSelected', this._triggerEvent.bind(this));
+  }
+
+  _getFieldState() {
+    const {value, displayText, errorStatus, lookupRow} = this._field;
+    return $.extend(true, {}, {value, displayText, errorStatus, lookupRow});
   }
 
   _createProposalChooser() {
@@ -107,6 +115,9 @@ export default class SmartFieldTouchPopup extends TouchPopup {
   }
 
   _beforeClosePopup(event) {
+    if (objects.equalsRecursive(this._initialFieldState, this._getFieldState())) {
+      return;
+    }
     this.smartField.acceptInputFromField(this._field);
   }
 }

--- a/eclipse-scout-core/src/testing/form/fields/smartfield/proposalFieldSpecHelper.js
+++ b/eclipse-scout-core/src/testing/form/fields/smartfield/proposalFieldSpecHelper.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+
+import {ProposalField} from '../../../../index';
+
+export async function testProposalFieldInputs(field, inputs, touchMode, callbacks) {
+  field.touchMode = touchMode;
+  field.render();
+
+  callbacks = $.extend({
+    beforeInput: (input) => {
+    },
+    afterInput: (input) => {
+    },
+    afterSelectLookupRow: (text, lookupRow) => {
+    },
+    afterAcceptCustomText: (text) => {
+    }
+  }, callbacks);
+
+  for (const inputOrText of inputs) {
+    const input = ensureInput(inputOrText);
+    const {text, lookup} = input;
+
+    callbacks.beforeInput(input);
+
+    if (lookup) {
+      const lookupRow = await selectLookupRow(field, text);
+      callbacks.afterSelectLookupRow(text, lookupRow);
+    } else {
+      await acceptCustomText(field, text);
+      callbacks.afterAcceptCustomText(text);
+    }
+
+    callbacks.afterInput(input);
+  }
+}
+
+export function ensureInput(inputOrText) {
+  return typeof inputOrText === 'string' ? {text: inputOrText} : inputOrText;
+}
+
+export async function acceptCustomText(field, text) {
+  if (field.touchMode) {
+    // touchMode opens a popup with a field and a done-menu
+    const popup = await openPopup(field);
+    popup._field.$field.val(text);
+    popup._field.acceptInput();
+    popup.doneAction.doAction();
+  } else {
+    field.$field.val(text);
+    field.acceptInput();
+  }
+}
+
+export async function selectLookupRow(field, text) {
+  // find row for text
+  const popup = await openPopup(field);
+  const proposalChooser = field.touchMode ? popup._widget : popup.proposalChooser;
+  const table = proposalChooser.model;
+  const row = table.rows.find(r => r.cells[0].text === text);
+
+  // trigger row mousedown and mouseup
+  row.$row.triggerMouseDown();
+  row.$row.triggerMouseUp();
+
+  return row.lookupRow;
+}
+
+export async function openPopup(field) {
+  field.$field.focus();
+  await field.openPopup(true);
+  const popup = field.popup;
+  popup.animateRemoval = false;
+  return popup;
+}
+
+export function createSpecProposalField() {
+  return new SpecProposalField();
+}
+
+class SpecProposalField extends ProposalField {
+  acceptInput(sync) {
+    this._acceptInputEnabled = true; // accept all inputs, no need for a timeout
+    return super.acceptInput(sync);
+  }
+}
+
+export default {
+  testProposalFieldInputs,
+  ensureInput,
+  acceptCustomText,
+  selectLookupRow,
+  openPopup,
+  createSpecProposalField
+}

--- a/eclipse-scout-core/src/testing/index.js
+++ b/eclipse-scout-core/src/testing/index.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2010-2020 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -23,6 +23,7 @@ export {default as TableSpecHelper} from './table/TableSpecHelper';
 export {default as FormSpecHelper} from './form/FormSpecHelper';
 export {default as CloneSpecHelper} from './form/fields/CloneSpecHelper';
 export {default as TestBeanField} from './form/fields/beanfield/TestBeanField';
+export {default as proposalFieldSpecHelper} from './form/fields/smartfield/proposalFieldSpecHelper';
 export {default as TabBoxSpecHelper} from './form/fields/tabbox/TabBoxSpecHelper';
 export {default as OutlineSpecHelper} from './desktop/outline/OutlineSpecHelper';
 export {default as DummyLookupCall} from './lookup/DummyLookupCall';

--- a/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldAdapterSpec.js
+++ b/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldAdapterSpec.js
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+import {ObjectFactory, scout, Status} from '../../../../src/index';
+import {proposalFieldSpecHelper} from '../../../../src/testing';
+
+describe('ProposalFieldAdapter', () => {
+
+  let session, field, modelAdapter;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    ObjectFactory.get().register('SpecProposalField', () => proposalFieldSpecHelper.createSpecProposalField());
+
+    field = scout.create('SpecProposalField', {parent: session.desktop});
+    linkWidgetAndAdapter(field, 'ProposalFieldAdapter');
+    modelAdapter = field.modelAdapter;
+    field.setLookupCall(scout.create('StaticLookupCall', {
+      session: field.session,
+      data: [
+        ['foo', 'foo'],
+        ['bar', 'bar']
+      ]
+    }));
+  });
+
+  afterEach(() => {
+    ObjectFactory.get().unregister('SpecProposalField');
+  });
+
+  describe('acceptInput-event contains correct data', () => {
+    let spy;
+
+    beforeEach(() => {
+      spy = spyOn(modelAdapter, '_send');
+    });
+
+    // some > foo > bar
+
+    it('write \'some\' > write \'foo\' > write \'bar\' (touchMode: false, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['some', 'foo', 'bar'],
+        false,
+        false));
+
+    it('write \'some\' > write \'foo\' > write \'bar\' (touchMode: true, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['some', 'foo', 'bar'],
+        true,
+        false));
+
+    it('write \'some\' > write \'foo\' > write \'bar\' (touchMode: false, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['some', 'foo', 'bar'],
+        false,
+        true));
+
+    it('write \'some\' > write \'foo\' > write \'bar\' (touchMode: true, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['some', 'foo', 'bar'],
+        true,
+        true));
+
+    // foo > some > bar
+
+    it('write \'foo\' > write \'some\' > write \'bar\' (touchMode: false, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'some', 'bar'],
+        false,
+        false));
+
+    it('write \'foo\' > write \'some\' > write \'bar\' (touchMode: true, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'some', 'bar'],
+        true,
+        false));
+
+    it('write \'foo\' > write \'some\' > write \'bar\' (touchMode: false, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'some', 'bar'],
+        false,
+        true));
+
+    it('write \'foo\' > write \'some\' > write \'bar\' (touchMode: true, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'some', 'bar'],
+        true,
+        true));
+
+    // foo > bar > some
+
+    it('write \'foo\' > write \'bar\' > write \'some\' (touchMode: false, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'bar', 'some'],
+        false,
+        false));
+
+    it('write \'foo\' > write \'bar\' > write \'some\' (touchMode: true, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'bar', 'some'],
+        true,
+        false));
+
+    it('write \'foo\' > write \'bar\' > write \'some\' (touchMode: false, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'bar', 'some'],
+        false,
+        true));
+
+    it('write \'foo\' > write \'bar\' > write \'some\' (touchMode: true, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'bar', 'some'],
+        true,
+        true));
+
+    // foo > bar > some > thing
+
+    it('lookup \'foo\' > lookup \'bar\' > write \'some\' > write \'thing\' (touchMode: false, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'some', 'thing'],
+        false,
+        false));
+
+    it('lookup \'foo\' > lookup \'bar\' > write \'some\' > write \'thing\' (touchMode: true, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'some', 'thing'],
+        true,
+        false));
+
+    it('lookup \'foo\' > lookup \'bar\' > write \'some\' > write \'thing\' (touchMode: false, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'some', 'thing'],
+        false,
+        true));
+
+    it('lookup \'foo\' > lookup \'bar\' > write \'some\' > write \'thing\' (touchMode: true, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'some', 'thing'],
+        true,
+        true));
+
+    // some > thing > foo > bar
+
+    it('write \'some\' > write \'thing\' > lookup \'foo\' > lookup \'bar\' (touchMode: false, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['some', 'thing', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+        false,
+        false));
+
+    it('write \'some\' > write \'thing\' > lookup \'foo\' > lookup \'bar\' (touchMode: true, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['some', 'thing', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+        true,
+        false));
+
+    it('write \'some\' > write \'thing\' > lookup \'foo\' > lookup \'bar\' (touchMode: false, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['some', 'thing', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+        false,
+        true));
+
+    it('write \'some\' > write \'thing\' > lookup \'foo\' > lookup \'bar\' (touchMode: true, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['some', 'thing', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+        true,
+        true));
+
+    // foo > bar > foo > bar
+
+    it('lookup \'foo\' > lookup \'bar\' > write \'foo\' > write \'bar\' (touchMode: false, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'foo', 'bar'],
+        false,
+        false));
+
+    it('lookup \'foo\' > lookup \'bar\' > write \'foo\' > write \'bar\' (touchMode: true, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'foo', 'bar'],
+        true,
+        false));
+
+    it('lookup \'foo\' > lookup \'bar\' > write \'foo\' > write \'bar\' (touchMode: false, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'foo', 'bar'],
+        false,
+        true));
+
+    it('lookup \'foo\' > lookup \'bar\' > write \'foo\' > write \'bar\' (touchMode: true, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'foo', 'bar'],
+        true,
+        true));
+
+    it('write \'foo\' > write \'bar\' > lookup \'foo\' > lookup \'bar\' (touchMode: false, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'bar', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+        false,
+        false));
+
+    it('write \'foo\' > write \'bar\' > lookup \'foo\' > lookup \'bar\' (touchMode: true, withErrorStatus: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'bar', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+        true,
+        false));
+
+    it('write \'foo\' > write \'bar\' > lookup \'foo\' > lookup \'bar\' (touchMode: false, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'bar', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+        false,
+        true));
+
+    it('write \'foo\' > write \'bar\' > lookup \'foo\' > lookup \'bar\' (touchMode: true, withErrorStatus: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'bar', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+        true,
+        true));
+
+    async function testProposalFieldInputs(inputs, touchMode, withErrorStatus) {
+      const callbacks = {
+        afterInput: (input) => {
+          const {text} = input;
+          expect(field.value).toBe(text);
+          expect(field.errorStatus).toBeNull();
+        },
+        afterSelectLookupRow: (text, lookupRow) => expectAcceptInputEvent(text, lookupRow),
+        afterAcceptCustomText: (text) => expectAcceptInputEvent(text)
+      };
+
+      if (withErrorStatus) {
+        callbacks.beforeInput = (input) => field.setErrorStatus(Status.warning('I am a WARNING!'));
+      }
+
+      await proposalFieldSpecHelper.testProposalFieldInputs(field, inputs, touchMode, callbacks);
+    }
+
+    function expectAcceptInputEvent(text, lookupRow) {
+      const displayText = text;
+      const value = text;
+      let eventData = {displayText, value, errorStatus: null};
+      if (lookupRow) {
+        eventData = {...eventData, lookupRow};
+      }
+      expect(spy).toHaveBeenCalledWith('acceptInput', jasmine.objectContaining(eventData), jasmine.anything());
+    }
+  });
+});

--- a/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldSpec.js
+++ b/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldSpec.js
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2010-2019 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
-import {scout, Status} from '../../../../src/index';
+import {ObjectFactory, scout, Status} from '../../../../src/index';
+import {proposalFieldSpecHelper} from '../../../../src/testing';
 
 describe('ProposalField', () => {
 
@@ -156,5 +157,424 @@ describe('ProposalField', () => {
     expect(field.errorStatus.containsStatus(Status)).toBe(true);
     field._acceptInput(false, 'Bar', false, true, null);
     expect(field.getErrorStatus).toBeUndefined();
+  });
+
+  describe('displayText, value, errorStatus and lookupRow are always in a consistent state', () => {
+
+    beforeEach(() => {
+      jasmine.clock().uninstall();
+      ObjectFactory.get().register('SpecProposalField', () => proposalFieldSpecHelper.createSpecProposalField());
+      field = scout.create('SpecProposalField', {
+        parent: session.desktop,
+        lookupCall: {
+          objectType: 'StaticLookupCall',
+          data: [
+            ['ok', 'ok'],
+            ['warning', 'warning'],
+            ['throw', 'throw'],
+            ['no error', 'no error']
+          ]
+        }
+      });
+      field.addValidator(value => {
+        field.clearErrorStatus();
+
+        if ('ok' === value) {
+          field.setErrorStatus(Status.ok({message: 'This has severity OK.'}));
+          return value;
+        }
+
+        if ('warning' === value) {
+          field.setErrorStatus(Status.warning({message: 'This has severity WARNING.'}));
+          return value;
+        }
+
+        if ('throw' === value) {
+          throw 'This is an exception.';
+        }
+
+        return value;
+      });
+    });
+
+    afterEach(() => {
+      ObjectFactory.get().unregister('SpecProposalField');
+    });
+
+    // foo > ok > foo > ok
+
+    it('write \'foo\' > write \'ok\' > write \'foo\' > write \'ok\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'ok', 'foo', 'ok'],
+        false));
+
+    it('write \'foo\' > write \'ok\' > write \'foo\' > write \'ok\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'ok', 'foo', 'ok'],
+        true));
+
+    it('write \'foo\' > lookup \'ok\' > write \'foo\' > lookup \'ok\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', {text: 'ok', lookup: true}, 'foo', {text: 'ok', lookup: true}],
+        false));
+
+    it('write \'foo\' > lookup \'ok\' > write \'foo\' > lookup \'ok\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', {text: 'ok', lookup: true}, 'foo', {text: 'ok', lookup: true}],
+        true));
+
+    // no error > ok > no error > ok
+
+    it('write \'no error\' > lookup \'ok\' > write \'no error\' > lookup \'ok\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['no error', {text: 'ok', lookup: true}, 'no error', {text: 'ok', lookup: true}],
+        false));
+
+    it('write \'no error\' > lookup \'ok\' > write \'no error\' > lookup \'ok\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['no error', {text: 'ok', lookup: true}, 'no error', {text: 'ok', lookup: true}],
+        true));
+
+    it('lookup \'no error\' > lookup \'ok\' > lookup \'no error\' > lookup \'ok\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'no error', lookup: true}, {text: 'ok', lookup: true}, {text: 'no error', lookup: true}, {text: 'ok', lookup: true}],
+        false));
+
+    it('lookup \'no error\' > lookup \'ok\' > lookup \'no error\' > lookup \'ok\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'no error', lookup: true}, {text: 'ok', lookup: true}, {text: 'no error', lookup: true}, {text: 'ok', lookup: true}],
+        true));
+
+    // foo > throw > foo > throw
+
+    it('write \'foo\' > write \'throw\' > write \'foo\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'throw', 'foo', 'throw'],
+        false));
+
+    it('write \'foo\' > write \'throw\' > write \'foo\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', 'throw', 'foo', 'throw'],
+        true));
+
+    it('write \'foo\' > lookup \'throw\' > write \'foo\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['foo', {text: 'throw', lookup: true}, 'foo', {text: 'throw', lookup: true}],
+        false));
+
+    it('write \'foo\' > lookup \'throw\' > write \'foo\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['foo', {text: 'throw', lookup: true}, 'foo', {text: 'throw', lookup: true}],
+        true));
+
+    // no error > throw > no error > throw
+
+    it('write \'no error\' > lookup \'throw\' > write \'no error\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['no error', {text: 'throw', lookup: true}, 'no error', {text: 'throw', lookup: true}],
+        false));
+
+    it('write \'no error\' > lookup \'throw\' > write \'no error\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['no error', {text: 'throw', lookup: true}, 'no error', {text: 'throw', lookup: true}],
+        true));
+
+    it('lookup \'no error\' > lookup \'throw\' > lookup \'no error\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'no error', lookup: true}, {text: 'throw', lookup: true}, {text: 'no error', lookup: true}, {text: 'throw', lookup: true}],
+        false));
+
+    it('lookup \'no error\' > lookup \'throw\' > lookup \'no error\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'no error', lookup: true}, {text: 'throw', lookup: true}, {text: 'no error', lookup: true}, {text: 'throw', lookup: true}],
+        true));
+
+    // ok > throw > ok > throw
+
+    it('write \'ok\' > write \'throw\' > write \'ok\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', 'ok', 'throw'],
+        false));
+
+    it('write \'ok\' > write \'throw\' > write \'ok\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', 'ok', 'throw'],
+        true));
+
+    it('write \'ok\' > write \'throw\' > write \'ok\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', 'ok', {text: 'throw', lookup: true}],
+        false));
+
+    it('write \'ok\' > write \'throw\' > write \'ok\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', 'ok', {text: 'throw', lookup: true}],
+        true));
+
+    it('write \'ok\' > write \'throw\' > lookup \'ok\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', {text: 'ok', lookup: true}, 'throw'],
+        false));
+
+    it('write \'ok\' > write \'throw\' > lookup \'ok\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', {text: 'ok', lookup: true}, 'throw'],
+        true));
+
+    it('write \'ok\' > write \'throw\' > lookup \'ok\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', {text: 'ok', lookup: true}, {text: 'throw', lookup: true}],
+        false));
+
+    it('write \'ok\' > write \'throw\' > lookup \'ok\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', {text: 'ok', lookup: true}, {text: 'throw', lookup: true}],
+        true));
+
+    it('write \'ok\' > lookup \'throw\' > write \'ok\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, 'ok', 'throw'],
+        false));
+
+    it('write \'ok\' > lookup \'throw\' > write \'ok\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, 'ok', 'throw'],
+        true));
+
+    it('write \'ok\' > lookup \'throw\' > write \'ok\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, 'ok', {text: 'throw', lookup: true}],
+        false));
+
+    it('write \'ok\' > lookup \'throw\' > write \'ok\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, 'ok', {text: 'throw', lookup: true}],
+        true));
+
+    it('write \'ok\' > lookup \'throw\' > lookup \'ok\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, {text: 'ok', lookup: true}, 'throw'],
+        false));
+
+    it('write \'ok\' > lookup \'throw\' > lookup \'ok\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, {text: 'ok', lookup: true}, 'throw'],
+        true));
+
+    it('write \'ok\' > lookup \'throw\' > lookup \'ok\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, {text: 'ok', lookup: true}, {text: 'throw', lookup: true}],
+        false));
+
+    it('write \'ok\' > lookup \'throw\' > lookup \'ok\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, {text: 'ok', lookup: true}, {text: 'throw', lookup: true}],
+        true));
+
+    it('lookup \'ok\' > write \'throw\' > write \'ok\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', 'ok', 'throw'],
+        false));
+
+    it('lookup \'ok\' > write \'throw\' > write \'ok\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', 'ok', 'throw'],
+        true));
+
+    it('lookup \'ok\' > write \'throw\' > write \'ok\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', 'ok', {text: 'throw', lookup: true}],
+        false));
+
+    it('lookup \'ok\' > write \'throw\' > write \'ok\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', 'ok', {text: 'throw', lookup: true}],
+        true));
+
+    it('lookup \'ok\' > write \'throw\' > lookup \'ok\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', {text: 'ok', lookup: true}, 'throw'],
+        false));
+
+    it('lookup \'ok\' > write \'throw\' > lookup \'ok\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', {text: 'ok', lookup: true}, 'throw'],
+        true));
+
+    it('lookup \'ok\' > write \'throw\' > lookup \'ok\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', {text: 'ok', lookup: true}, {text: 'throw', lookup: true}],
+        false));
+
+    it('lookup \'ok\' > write \'throw\' > lookup \'ok\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', {text: 'ok', lookup: true}, {text: 'throw', lookup: true}],
+        true));
+
+    it('lookup \'ok\' > lookup \'throw\' > write \'ok\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, 'ok', 'throw'],
+        false));
+
+    it('lookup \'ok\' > lookup \'throw\' > write \'ok\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, 'ok', 'throw'],
+        true));
+
+    it('lookup \'ok\' > lookup \'throw\' > write \'ok\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, 'ok', {text: 'throw', lookup: true}],
+        false));
+
+    it('lookup \'ok\' > lookup \'throw\' > write \'ok\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, 'ok', {text: 'throw', lookup: true}],
+        true));
+
+    it('lookup \'ok\' > lookup \'throw\' > lookup \'ok\' > write \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, {text: 'ok', lookup: true}, 'throw'],
+        false));
+
+    it('lookup \'ok\' > lookup \'throw\' > lookup \'ok\' > write \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, {text: 'ok', lookup: true}, 'throw'],
+        true));
+
+    it('lookup \'ok\' > lookup \'throw\' > lookup \'ok\' > lookup \'throw\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, {text: 'ok', lookup: true}, {text: 'throw', lookup: true}],
+        false));
+
+    it('lookup \'ok\' > lookup \'throw\' > lookup \'ok\' > lookup \'throw\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, {text: 'ok', lookup: true}, {text: 'throw', lookup: true}],
+        true));
+
+    // ok > throw > warning
+
+    it('write \'ok\' > write \'throw\' > write \'warning\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', 'warning'],
+        false));
+
+    it('write \'ok\' > write \'throw\' > write \'warning\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', 'warning'],
+        true));
+
+    it('write \'ok\' > write \'throw\' > lookup \'warning\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', {text: 'warning', lookup: true}],
+        false));
+
+    it('write \'ok\' > write \'throw\' > lookup \'warning\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', 'throw', {text: 'warning', lookup: true}],
+        true));
+
+    it('write \'ok\' > lookup \'throw\' > write \'warning\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, 'warning'],
+        false));
+
+    it('write \'ok\' > lookup \'throw\' > write \'warning\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, 'warning'],
+        true));
+
+    it('write \'ok\' > lookup \'throw\' > lookup \'warning\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, {text: 'warning', lookup: true}],
+        false));
+
+    it('write \'ok\' > lookup \'throw\' > lookup \'warning\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        ['ok', {text: 'throw', lookup: true}, {text: 'warning', lookup: true}],
+        true));
+
+    it('lookup \'ok\' > write \'throw\' > write \'warning\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', 'warning'],
+        false));
+
+    it('lookup \'ok\' > write \'throw\' > write \'warning\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', 'warning'],
+        true));
+
+    it('lookup \'ok\' > write \'throw\' > lookup \'warning\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', {text: 'warning', lookup: true}],
+        false));
+
+    it('lookup \'ok\' > write \'throw\' > lookup \'warning\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, 'throw', {text: 'warning', lookup: true}],
+        true));
+
+    it('lookup \'ok\' > lookup \'throw\' > write \'warning\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, 'warning'],
+        false));
+
+    it('lookup \'ok\' > lookup \'throw\' > write \'warning\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, 'warning'],
+        true));
+
+    it('lookup \'ok\' > lookup \'throw\' > lookup \'warning\' (touchMode: false)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, {text: 'warning', lookup: true}],
+        false));
+
+    it('lookup \'ok\' > lookup \'throw\' > lookup \'warning\' (touchMode: true)', async () =>
+      await testProposalFieldInputs(
+        [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, {text: 'warning', lookup: true}],
+        true));
+
+    async function testProposalFieldInputs(inputs, touchMode) {
+      await proposalFieldSpecHelper.testProposalFieldInputs(field, inputs, touchMode, {
+        afterInput: (input) => {
+          const {text, lookup} = input;
+
+          // displayText always equals text
+          expect(field.displayText).toBe(text);
+
+          // value equals text iff there is no validation error (see validator)
+          if ('throw' === text) {
+            expect(field.value).not.toBe(text);
+          } else {
+            expect(field.value).toBe(text);
+          }
+
+          // correct errorStatus is set (see validator)
+          if ('ok' === text) {
+            expect(field.errorStatus).not.toBeNull();
+            expect(field.errorStatus.severity).toBe(Status.Severity.OK);
+            expect(field.errorStatus.message).toBe('This has severity OK.');
+          } else if ('warning' === text) {
+            expect(field.errorStatus).not.toBeNull();
+            expect(field.errorStatus.severity).toBe(Status.Severity.WARNING);
+            expect(field.errorStatus.message).toBe('This has severity WARNING.');
+          } else if ('throw' === text) {
+            expect(field.errorStatus).not.toBeNull();
+            expect(field.errorStatus.severity).toBe(Status.Severity.ERROR);
+            expect(field.errorStatus.message).toBe('This is an exception.');
+          } else {
+            expect(field.errorStatus).toBeNull();
+          }
+
+          // lookupRow is set and contains the correct values iff a lookupRow was selected
+          if (lookup) {
+            expect(field.lookupRow).not.toBeNull();
+            expect(field.lookupRow.text).toBe(text);
+            expect(field.lookupRow.key).toBe(text);
+          } else {
+            expect(field.lookupRow).toBeNull();
+          }
+        }
+      });
+    }
   });
 });

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/smartfield/JsonProposalField.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/smartfield/JsonProposalField.java
@@ -1,24 +1,20 @@
 /*
- * Copyright (c) 2014-2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 package org.eclipse.scout.rt.ui.html.json.form.fields.smartfield;
 
-import org.eclipse.scout.rt.client.ui.form.fields.IValueField;
 import org.eclipse.scout.rt.client.ui.form.fields.smartfield.IProposalField;
-import org.eclipse.scout.rt.client.ui.form.fields.smartfield.ISmartField;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.ui.html.IUiSession;
 import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
-import org.eclipse.scout.rt.ui.html.json.JsonEvent;
 import org.eclipse.scout.rt.ui.html.json.JsonProperty;
-import org.json.JSONObject;
 
 public class JsonProposalField<VALUE, MODEL extends IProposalField<VALUE>> extends JsonSmartField<VALUE, MODEL> {
 
@@ -60,25 +56,4 @@ public class JsonProposalField<VALUE, MODEL extends IProposalField<VALUE>> exten
   protected void setValueFromUI(Object value) {
     getModel().getUIFacade().setValueAsStringFromUI((String) value);
   }
-
-  @Override
-  protected void handleUiAcceptInput(JsonEvent event) {
-    JSONObject data = event.getData();
-    if (data.has(IValueField.PROP_DISPLAY_TEXT)) {
-      this.handleUiDisplayTextChange(data);
-    }
-    if (data.has(IValueField.PROP_ERROR_STATUS)) {
-      this.handleUiErrorStatusChange(data);
-    }
-    // The difference to the smart-field is that the proposal-field
-    // can receive lookup-row and value in a single event. For instance:
-    // lookupRow=null, value=Foo (in case a custom text has been set)
-    if (data.has(ISmartField.PROP_LOOKUP_ROW)) {
-      this.handleUiLookupRowChange(data);
-    }
-    if (data.has(IValueField.PROP_VALUE)) {
-      handleUiValueChange(data);
-    }
-  }
-
 }


### PR DESCRIPTION
ProposalField: fix custom text in touch mode while error status present

Problem: If there is an error status present on the proposal field it
will be mirrored to the field in the touch popup. When the value of the
field in the touch popup changes, its error status is cleared. If this
value change happens because a custom text was entered, the error status
of the main proposal field will not be cleared. The SmartFieldAdapter
will not send the value to the server if there is an error status
present on the field. Therefore, the value in the model on the server
never changes.

This problem only occurs in the touch mode when entering a custom text.
When a lookup row is selected, the error status will always be cleared
regardless of the touch mode. If a custom text is entered in the desktop
mode, the error status will also be cleared.

Therefore, add the error status to the properties that are copied from
the touch popups field to the main proposal field. This leads to the
error status being cleared for all different ways the proposal fields
value can be changed and therefore, the new value will be sent to the
server, where it is updated in the model.

369873

------------------------------------------------------------------------

ProposalField: always send the correct acceptInput event

The ProposalField can accept customText, i.e. a value with no
corresponding lookupRow. If the triggered acceptInput-event of the
ProposalField is marked with acceptByLookupRow the event sent to the
server contains a lookupRow property. Ensure that there is no lookupRow
property in an event for a custom text in order to make handling of a
lookupRow property with value null obsolete.

369873

------------------------------------------------------------------------

ProposalField: fix validation errors

If a potential value that is not accepted by the validator of a
ProposalField is passed to the field, the display text needs to change
while the value stays the same.
If this value comes from a selected lookupRow, the lookupRow will be set
and therefore, the formatting needs to consider it.
If this value comes from a touch popup, there are several things that
need to be considered:
* The lookupRow must not trigger any value changed logic, as setting a
  value that does not pass validation will reset the value to the
  previous one. Otherwise, if the new lookupRow is null it will set the
  value of the field to null and therefore the reset-logic after a
  failed validation resets the value to null as the former value is
  already lost.
* The displayText needs to be set without exception, as it can differ
  from the value. Consider the value 'info' for which a validator adds
  an error status with severity info and another value 'throw' for which
  the validation fails. Switching between these two values will never
  change the value, it will always stay 'info'. But what needs to change
  are the displayText and the error status. Therefore, the value needs
  to be set again when switching from 'throw' back to 'info' as the
  validator needs to run in order to add the info-error status. The
  displayText needs to be set to support the 'info'>'throw' case as
  setting a value 'throw' will never change the displayText it needs to
  be transferred explicitly from the touch popup.
* The value needs to be set without exception, even if it is identical
  to the current value. See example for displayText.

To support the 'throw' > 'info' case from the previous example correctly
for Scout Classic, an input needs to be accepted and all listeners need
to be informed if the search text changed to the text of the current
lookupRow. Consider the previous example and the inputs "lookup 'info'" >
"lookup 'throw'" > "write 'info'". While writing 'info', the 'info'
lookupRow is still present and the searchText changes from 'throw' to
'info' and therefore, the listener in the adapter needs to be triggered
in order to validate 'info' again on the ui server.

369873

------------------------------------------------------------------------

ProposalField: fix open and close touch popup multiple times

If the touch popup of a SmartField or ProposalField is opened and closed
multiple times without changing the value, the properties value,
displayText, errorStatus and lookupRow of the corresponding field need
to stay unchanged. These properties are copied from the original field
to the field in the touch popup. Therefore, save the initial state of
these properties and compare them before closing the popup to detect
whether the popup was changed or not.
It is not sufficient to mark the field in the touch popup as saved and
check if it was touched before closing as there might be validators that
throw exceptions on some values. Consider two values 'ok' and 'error'
and a validator that throws an error if 'error' is selected. When
switching between these two the value of the ProposalField will always
be 'ok' but the displayText will change. Marking the field in the touch
popup as saved and checking if it was touched will only consider the
value which has not changed in this example and there would be no update
of the original field and the resulting errorStatus will be
inconsistent.

369873