### PR TITLE
Throw error when Karma config is invalid

### DIFF
--- a/eclipse-scout-cli/bin/scout-scripts.js
+++ b/eclipse-scout-cli/bin/scout-scripts.js
@@ -106,7 +106,7 @@ function runKarma(configFileName, headless, args) {
   }
 
   // load config
-  const karmaConfig = cfg.parseConfig(configFilePath, args);
+  const karmaConfig = cfg.parseConfig(configFilePath, args, {throwErrors: true});
   if (autoSetupHeadlessConfig) {
     // only executed if headless and no specific CI config file is found: use headless defaults
     karmaConfig.set({


### PR DESCRIPTION
When Karma encounters an error during parsing of the configuration, it simply ends the process. Because logs are off by default, it is therefore not easily possible to find the cause of the problem. By passing the argument "throwErrors: true" explicitly, we can instruct Karma to throw an error instead.

351426