### PR TITLE
Chart: fix missing datalabels after detach/attach

### DIFF
--- a/eclipse-scout-chart/src/chart/AbstractChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/AbstractChartRenderer.js
@@ -9,7 +9,7 @@
  *     BSI Business Systems Integration AG - initial API and implementation
  */
 
-import {arrays} from '@eclipse-scout/core';
+import {arrays, objects} from '@eclipse-scout/core';
 
 export default class AbstractChartRenderer {
 
@@ -84,14 +84,16 @@ export default class AbstractChartRenderer {
    *          property is ignored when chart.config.options.animation.duration is <code>0</code>!
    */
   render(requestAnimation) {
-    this.animationDuration = requestAnimation ? this.chart.config.options.animation.duration : 0;
     if (!this.validate() || !this.chart.rendered) {
       return;
     }
+    const configAnimationDuration = this.chart.config.options.animation.duration;
+    this.setAnimationDuration(requestAnimation ? configAnimationDuration : 0);
     this.rendering = true;
     this._render();
     this.rendering = false;
     this.rendered = true;
+    this.setAnimationDuration(configAnimationDuration);
   }
 
   _render() {
@@ -118,11 +120,13 @@ export default class AbstractChartRenderer {
       this.render(requestAnimation);
       return;
     }
-    this.animationDuration = requestAnimation ? this.chart.config.options.animation.duration : 0;
     if (!this.validate() || !this.isDataUpdatable()) {
       return;
     }
+    const configAnimationDuration = this.chart.config.options.animation.duration;
+    this.setAnimationDuration(requestAnimation ? configAnimationDuration : 0);
     this._updateData();
+    this.setAnimationDuration(configAnimationDuration);
   }
 
   _updateData() {
@@ -144,18 +148,39 @@ export default class AbstractChartRenderer {
     this.render(false);
   }
 
+  setAnimationDuration(animationDuration) {
+    if (objects.equals(this.animationDuration, animationDuration)) {
+      return;
+    }
+
+    this._setAnimationDuration(animationDuration);
+    if (this.rendered) {
+      this._renderAnimationDuration();
+    }
+  }
+
+  _setAnimationDuration(animationDuration) {
+    this.animationDuration = animationDuration;
+  }
+
+  _renderAnimationDuration() {
+    // nop
+  }
+
   /**
    * @param requestAnimation
    *          Whether animations should be used while removing the chart. Note that his
    *          property is ignored when chart.config.options.animation.duration is <code>0</code>!
    */
   remove(requestAnimation, afterRemoveFunc) {
-    this.animationDuration = requestAnimation && this.chart.config.options.animation.duration;
+    const configAnimationDuration = this.chart.config.options.animation.duration;
+    this.setAnimationDuration(requestAnimation && configAnimationDuration);
     if (this.animationDuration && this.rendered) {
       this._removeAnimated(afterRemoveFunc);
     } else {
       this._remove(afterRemoveFunc);
     }
+    this.setAnimationDuration(configAnimationDuration);
   }
 
   _remove(afterRemoveFunc) {

--- a/eclipse-scout-chart/src/chart/AbstractChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/AbstractChartRenderer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -131,6 +131,10 @@ export default class AbstractChartRenderer {
 
   isDataUpdatable() {
     return false;
+  }
+
+  isDetachSupported() {
+    return true;
   }
 
   refresh() {

--- a/eclipse-scout-chart/src/chart/Chart.js
+++ b/eclipse-scout-chart/src/chart/Chart.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -111,7 +111,15 @@ export default class Chart extends Widget {
 
   _renderOnAttach() {
     super._renderOnAttach();
-    this._updateChartOptsWhileNotAttached.splice(0).forEach(opts => this.updateChart($.extend(true, {}, opts, {debounce: true})));
+    const updateChartOptsWhileNotAttached = this._updateChartOptsWhileNotAttached.splice(0);
+    if (!this.chartRenderer?.isDetachSupported()) {
+      // the chartRenderer does not support detach => recreate it
+      this._updateChartRenderer();
+      if (!updateChartOptsWhileNotAttached.length) {
+        updateChartOptsWhileNotAttached.push({requestAnimation: true});
+      }
+    }
+    updateChartOptsWhileNotAttached.forEach(opts => this.updateChart($.extend(true, {}, opts, {debounce: true})));
   }
 
   _remove() {

--- a/eclipse-scout-chart/src/chart/Chart.js
+++ b/eclipse-scout-chart/src/chart/Chart.js
@@ -93,7 +93,7 @@ export default class Chart extends Widget {
     this.htmlComp.setLayout(new ChartLayout(this));
 
     // !!! Do _not_ update the chart here, because usually the container size
-    // !!! is not correct anyways during the render phase. The ChartLayout
+    // !!! is not correct anyway during the render phase. The ChartLayout
     // !!! will eventually call updateChart() when the layout is validated.
   }
 
@@ -115,9 +115,8 @@ export default class Chart extends Widget {
     if (!this.chartRenderer?.isDetachSupported()) {
       // the chartRenderer does not support detach => recreate it
       this._updateChartRenderer();
-      if (!updateChartOptsWhileNotAttached.length) {
-        updateChartOptsWhileNotAttached.push({requestAnimation: true});
-      }
+      updateChartOptsWhileNotAttached.forEach(opts => delete opts.requestAnimation);
+      updateChartOptsWhileNotAttached.push({requestAnimation: false});
     }
     updateChartOptsWhileNotAttached.forEach(opts => this.updateChart($.extend(true, {}, opts, {debounce: true})));
   }
@@ -193,7 +192,7 @@ export default class Chart extends Widget {
       delete oldConfigWithNewData.data;
     }
 
-    // the label map is technically part of the config, but it is handled as data. Therefore it is excluded from this check.
+    // the label map is technically part of the config, but it is handled as data. Therefore, it is excluded from this check.
     let transferLabelMap = (source, target, identifier) => {
       if (!source || !target || !identifier) {
         return;

--- a/eclipse-scout-chart/src/chart/ChartJsRenderer.js
+++ b/eclipse-scout-chart/src/chart/ChartJsRenderer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -486,6 +486,12 @@ export default class ChartJsRenderer extends AbstractChartRenderer {
 
   isDataUpdatable() {
     return true;
+  }
+
+  isDetachSupported() {
+    // chart.js removes the animation-listeners onProgress and onComplete on detach and does not add them again on attach
+    // these listeners are needed for the datalabels => this renderer does not support detach
+    return false;
   }
 
   refresh() {

--- a/eclipse-scout-chart/src/chart/VennChartRenderer.js
+++ b/eclipse-scout-chart/src/chart/VennChartRenderer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023 BSI Business Systems Integration AG.
+ * Copyright (c) 2010-2024 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,6 +80,8 @@ export default class VennChartRenderer extends AbstractSvgChartRenderer {
     }
 
     // Final callback
+    // In the case of 3 circles, draw will be called async after render is completed. Therefore, the current animationDuration needs to be set again when _draw is finally called.
+    const animationDurationRender = this.animationDuration;
     let draw = function() {
       this.readyToDraw = true;
       if (!this.$svg.isAttached()) {
@@ -87,7 +89,10 @@ export default class VennChartRenderer extends AbstractSvgChartRenderer {
         return;
       }
       this.readyToDraw = false;
+      const animationDuration = this.animationDuration;
+      this.setAnimationDuration(animationDurationRender);
       this._draw(true, true);
+      this.setAnimationDuration(animationDuration);
     }.bind(this);
 
     // save callback if user navigated away while calculating and _draw is not executed.


### PR DESCRIPTION
chart.js removes the animation-listeners onProgress and onComplete on detach and does not add them again on attach. These listeners are needed for the datalabels. Removing them results in missing datalabels or datalabels that are displayed on segments that are too small. Add a flag to the chart renderer if detach is supported. If not the Chart will recreate its renderer on attach.

362731