### PR TITLE
BrowserField: fix CSP report-uri

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/UriUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/UriUtilityTest.java
@@ -109,4 +109,27 @@ public class UriUtilityTest {
     assertEquals(UriUtility.hashCode(a), UriUtility.hashCode(b));
   }
 
+  @Test
+  public void testToBaseUri() {
+    assertNull(UriUtility.toBaseUri(null));
+
+    assertEquals("https://localhost/", UriUtility.toBaseUri(UriUtility.toUri("https://localhost")));
+    assertEquals("http://localhost:8080/", UriUtility.toBaseUri(UriUtility.toUri("http://localhost:8080")));
+    assertEquals("http://localhost:8080/", UriUtility.toBaseUri(UriUtility.toUri("http://localhost:8080/?debug=true#base")));
+    assertEquals("https://my.app.example.com/", UriUtility.toBaseUri(UriUtility.toUri("https://my.app.example.com")));
+    assertEquals("https://example.com/", UriUtility.toBaseUri(UriUtility.toUri("https://example.com/my-app")));
+    assertEquals("https://example.com/my-app/", UriUtility.toBaseUri(UriUtility.toUri("https://example.com/my-app/")));
+    assertEquals("https://example.com/my-app/", UriUtility.toBaseUri(UriUtility.toUri("https://example.com/my-app/index.html")));
+    assertEquals("https://example.com/my-app/", UriUtility.toBaseUri(UriUtility.toUri("https://example.com/my-app/index.html#sec-login")));
+    assertEquals("https://example.com/my-app/", UriUtility.toBaseUri(UriUtility.toUri("https://example.com/my-app/search?type=0&q=a/b")));
+
+    assertEquals("/", UriUtility.toBaseUri(UriUtility.toUri("?type=0&q=a/b")));
+    assertEquals("/", UriUtility.toBaseUri(UriUtility.toUri("#")));
+    assertEquals("http/", UriUtility.toBaseUri(UriUtility.toUri("http")));
+    assertEquals("https://example.org/foo/", UriUtility.toBaseUri(UriUtility.toUri("https://example.org/foo//")));
+    assertEquals("https://example.org/foo/", UriUtility.toBaseUri(UriUtility.toUri("https://example.org/foo//bar")));
+    assertEquals("https://example.org/foo:/", UriUtility.toBaseUri(UriUtility.toUri("https://example.org/foo://bar")));
+    assertEquals("foo://bar://baz:/", UriUtility.toBaseUri(UriUtility.toUri("foo://bar://baz://")));
+    assertEquals("foo:bar/", UriUtility.toBaseUri(UriUtility.toUri("foo:bar?baz#qux")));
+  }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/UriUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/UriUtility.java
@@ -305,4 +305,46 @@ public final class UriUtility {
   public static int hashCode(URL a) {
     return Objects.hashCode(a == null ? null : a.toString());
   }
+
+  /**
+   * Returns the "base URI" for the given URI. If the argument is {@code null}, {@code null} is returned.
+   * Otherwise, a string is returned that always ends with a {@code "/"} character. Filename, query parameters and
+   * fragment are automatically removed.
+   * <p>
+   * Examples:
+   * <ul>
+   * <li>http://localhost:8080 → http://localhost:8080/
+   * <li>https://www.example.org/public/my-app/index.html?debug=true → https://www.example.org/public/my-app/
+   * </ul>
+   */
+  @SuppressWarnings("JavadocLinkAsPlainText")
+  public static String toBaseUri(URI uri) {
+    if (uri == null) {
+      return null;
+    }
+
+    String baseUri = uri.toString();
+
+    // Remove query part
+    int index = baseUri.indexOf('?');
+    if (index != -1) {
+      baseUri = baseUri.substring(0, index);
+    }
+
+    // Remove fragment part
+    index = baseUri.indexOf('#');
+    if (index != -1) {
+      baseUri = baseUri.substring(0, index);
+    }
+
+    // Remove everything after the last slash (the file part), except if it is part of the scheme:// part
+    index = baseUri.lastIndexOf('/');
+    if (index != -1 && index != baseUri.indexOf("://") + 2) {
+      baseUri = baseUri.substring(0, index); // remove the last slash and everything after that
+      baseUri = baseUri.replaceAll("/+$", ""); // remove additional trailing slashes
+    }
+
+    // Add a single trailing slash again
+    return baseUri + "/";
+  }
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/browserfield/BrowserFieldContentHttpResponseInterceptor.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/browserfield/BrowserFieldContentHttpResponseInterceptor.java
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.UriUtility;
 import org.eclipse.scout.rt.server.commons.servlet.ContentSecurityPolicy;
 import org.eclipse.scout.rt.server.commons.servlet.HttpClientInfo;
 import org.eclipse.scout.rt.server.commons.servlet.HttpServletControl;
@@ -35,15 +36,22 @@ public class BrowserFieldContentHttpResponseInterceptor implements IHttpResponse
   public void intercept(HttpServletRequest req, HttpServletResponse resp) {
     ContentSecurityPolicy csp = BEANS.get(ContentSecurityPolicy.class).appendScriptSrc("'unsafe-inline'");
 
-    // Bug in Chrome: CSP 'self' is not interpreted correctly in sandboxed iframes, see https://bugs.chromium.org/p/chromium/issues/detail?id=443444
-    // Workaround: Add resolved URI to image and style CSP directive to allow loading of images and styles from same origin as nested iframe in browser field
     HttpClientInfo httpClientInfo = HttpClientInfo.get(req);
-    if (httpClientInfo.isWebkit()) {
-      String resolvedSelfUri = m_browserUri.toString();
-      csp
-          .appendImgSrc(resolvedSelfUri)
-          .appendStyleSrc(resolvedSelfUri);
+    String baseUri = UriUtility.toBaseUri(m_browserUri);
+
+    if (baseUri != null) {
+      // Normally, the csp report url is relative. Because documents inside the browser field are
+      // loaded from a "/dynamic/..." URL, the relative url has to be converted to an absolute url.
+      csp.withReportUri(baseUri + HttpServletControl.CSP_REPORT_URL);
+
+      // Bug in Chrome: CSP 'self' is not interpreted correctly in sandboxed iframes, see https://bugs.chromium.org/p/chromium/issues/detail?id=443444
+      // Workaround: Add resolved URI to image and style CSP directive to allow loading of images and styles from same origin as nested iframe in browser field
+      if (httpClientInfo.isWebkit()) {
+        csp.appendImgSrc(baseUri);
+        csp.appendStyleSrc(baseUri);
+      }
     }
+
     String cspToken = csp.toToken();
     if (httpClientInfo.isMshtml()) {
       resp.setHeader(HttpServletControl.HTTP_HEADER_CSP_LEGACY, cspToken);


### PR DESCRIPTION
If a browser field is used to display a document, the report-uri cannot be relative, because the dynamic URL has a different base than the application. Instead, use the browserUri from the client session to create an absolute URL.

290376