### PR TITLE
Action: show tooltip even if action is disabled

### DIFF
--- a/eclipse-scout-core/src/action/Action.ts
+++ b/eclipse-scout-core/src/action/Action.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -290,11 +290,10 @@ export class Action extends Widget implements ActionModel {
   }
 
   protected _shouldInstallTooltip(): boolean {
-    let show = this.tooltipText && this.enabledComputed;
-    if (!this.showTooltipWhenSelected && this.selected) {
-      show = false;
+    if (this.selected && !this.showTooltipWhenSelected) {
+      return false;
     }
-    return show;
+    return !!this.tooltipText;
   }
 
   /** @see ActionModel.tabbable */

--- a/eclipse-scout-core/test/action/ActionSpec.ts
+++ b/eclipse-scout-core/test/action/ActionSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Action, keys, scout} from '../../src/index';
+import {Action, keys, scout, Tooltip, tooltips} from '../../src/index';
 import {JQueryTesting} from '../../src/testing';
 
 describe('Action', () => {
@@ -138,6 +138,46 @@ describe('Action', () => {
       expect(selected).toBe(false);
     });
 
+  });
+
+  describe('tooltipText', () => {
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    it('is shown on mouseover after a short delay ', () => {
+      let action = scout.create(Action, {
+        parent: session.desktop,
+        tooltipText: 'tooltip'
+      });
+      action.render();
+      JQueryTesting.triggerMouseEnter(action.$container);
+      expect(action.findChild(Tooltip)).toBeFalsy();
+
+      jasmine.clock().tick(tooltips.DEFAULT_TOOLTIP_DELAY - 100);
+      expect(action.findChild(Tooltip)).toBeFalsy();
+
+      jasmine.clock().tick(100);
+      expect(action.findChild(Tooltip).rendered).toBe(true);
+    });
+
+    it('is shown even if action is disabled', () => {
+      let action = scout.create(Action, {
+        parent: session.desktop,
+        tooltipText: 'tooltip',
+        enabled: false
+      });
+      action.render();
+      JQueryTesting.triggerMouseEnter(action.$container);
+      expect(action.findChild(Tooltip)).toBeFalsy();
+
+      jasmine.clock().tick(tooltips.DEFAULT_TOOLTIP_DELAY);
+      expect(action.findChild(Tooltip).rendered).toBe(true);
+    });
   });
 
   describe('aria properties', () => {


### PR DESCRIPTION
Currently, it is not possible to show a tooltip explaining why an action is disabled because tooltips are only shown if the action is enabled. This is different to buttons or form fields where the tooltip is always shown.
This is a limitation and inconsistent, so now the tooltip is always shown.

It could be helpful for existing actions with tooltips as well, to let the user know what a disabled action would do, if it was enabled.

If it turns out that this is not the expected behavior, we could add a property similar to `showTooltipWhenSelected` called
 `showTooltipWhenDisabled`.

362354