### PR TITLE
Planner: fix cannot read properties of null (reading 'elementFromPoint')

### DIFF
--- a/eclipse-scout-core/src/planner/Planner.ts
+++ b/eclipse-scout-core/src/planner/Planner.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -344,22 +344,25 @@ export class Planner extends Widget implements PlannerModel {
 
     this.startRow = selectedResource;
     this.lastRow = this.startRow;
-    this._select(true);
+    this._select();
 
     // add event handlers
-    this._resourceTitleMousemoveHandler = this._onResourceTitleMousemove.bind(this, event);
-    this._$body.document()
-      .on('mousemove', this._resourceTitleMousemoveHandler)
-      .one('mouseup', this._onDocumentMouseUp.bind(this));
+    this._removeMouseMoveHandlers();
+    if (this.multiSelect) {
+      this._resourceTitleMousemoveHandler = this._onResourceTitleMousemove.bind(this);
+      this._$body.document()
+        .on('mousemove', this._resourceTitleMousemoveHandler)
+        .one('mouseup', this._onDocumentMouseUp.bind(this));
+    }
   }
 
-  protected _onResourceTitleMousemove(mousedownEvent: JQuery.MouseDownEvent, event: JQuery.MouseMoveEvent<Document>) {
+  protected _onResourceTitleMousemove(event: JQuery.MouseMoveEvent<Document>) {
     let lastRow = this._findRow(event.pageY);
     if (lastRow) {
       this.lastRow = lastRow;
     }
 
-    this._select(true);
+    this._select();
   }
 
   protected _onResourceTitleContextMenu(event: JQuery.ContextMenuEvent) {
@@ -983,6 +986,7 @@ export class Planner extends Widget implements PlannerModel {
     }
 
     // add event handlers
+    this._removeMouseMoveHandlers();
     this._cellMousemoveHandler = this._onCellMousemove.bind(this, event);
     this._$body.document()
       .on('mousemove', this._cellMousemoveHandler)
@@ -999,7 +1003,7 @@ export class Planner extends Widget implements PlannerModel {
     this.lastRange = this.startRange;
 
     // draw
-    this._select(true);
+    this._select();
     this._rangeSelectionStarted = true;
   }
 
@@ -1038,7 +1042,7 @@ export class Planner extends Widget implements PlannerModel {
       this.lastRange = lastRange;
     }
 
-    this._select(true);
+    this._select();
   }
 
   protected _onResizeMouseDown(event: JQuery.MouseDownEvent): boolean {
@@ -1061,6 +1065,7 @@ export class Planner extends Widget implements PlannerModel {
 
     this._$body.addClass('col-resize');
 
+    this._removeMouseMoveHandlers();
     this._resizeMousemoveHandler = this._onResizeMousemove.bind(this);
     this._$body.document()
       .on('mousemove', this._resizeMousemoveHandler)


### PR DESCRIPTION
Can be reproduced as follows:
1. Press mouse down on a resource
2. Press alt-tab and release mouse button
3. Press mouse down on a resource again
4. Remove planner and move mouse

Problem is that the mouse move handler is not released after alt-tab. Solution is to always remove the move handler before it is added again so that Planner.remove() will remove the latest handler.

Other adjusmtents (not relevant for the bugfix).
- select(true) -> select() because true is the default
- resource title mouse move and up handlers are only necessary in multi select mode

347428