### PR TITLE
StringField: reposition 'disabled copy overlay' when scrollbars change

### DIFF
--- a/eclipse-scout-core/src/form/fields/stringfield/StringField.js
+++ b/eclipse-scout-core/src/form/fields/stringfield/StringField.js
@@ -309,6 +309,11 @@ export default class StringField extends BasicField {
    * @override
    */
   _renderDisplayText() {
+    if (this.multilineText && this.$disabledCopyOverlay) {
+      // Changing the value might change the visibility of the scrollbars -> overlay size needs to be adjusted
+      this.invalidateLayoutTree(false);
+    }
+
     if (this.inputObfuscated && this.focused) {
       // If a new display text is set (e.g. because value in model changed) and field is focused,
       // do not display new display text but clear content (as in _onFieldFocus).


### PR DESCRIPTION
When the $disabledCopyOverlay is visible and the input field is a <textarea>, the form field layout positions the overlay such that it does not cover the scrollbars (otherwise they would not be usable). When the scrollbars change visibility when the text content changes, the position of the overlay has to be adjusted dynamically.

368547