### PR TITLE
Tree: center tooltip on node text

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.js
+++ b/eclipse-scout-core/src/tree/Tree.js
@@ -1255,7 +1255,23 @@ export default class Tree extends Widget {
       text: this._nodeTooltipText.bind(this),
       arrowPosition: 50,
       arrowPositionUnit: '%',
-      nativeTooltip: !Device.get().isCustomEllipsisTooltipPossible()
+      nativeTooltip: !Device.get().isCustomEllipsisTooltipPossible(),
+      originProducer: $anchor => {
+        // Measure entire node
+        let origin = graphics.offsetBounds($anchor);
+
+        // Measure text (disable flex-grow to get only the necessary text width)
+        let $text = $anchor.children('.text');
+        let oldStyle = $text.attr('style');
+        $text.css('flex-grow', '0');
+        let textOffsetBounds = graphics.offsetBounds($text);
+        $text.attrOrRemove('style', oldStyle);
+
+        // Use text bounds for horizontal axis
+        origin.x = textOffsetBounds.x;
+        origin.width = Math.min(100, textOffsetBounds.width);
+        return origin;
+      }
     });
   }
 


### PR DESCRIPTION
Because a tree node is stretched over the entire width of the tree, centering the tooltip on the node can feel weird, because the arrow points to an empty space. The user expects the tooltip to point to the text. By providing a custom "originProducer" function, we can measure the visible width of the node label.

The vertical alignment was not changed.

327222