### PR TITLE
Table.ts: Prevent row invalidation during mouse down event

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -741,9 +741,12 @@ export class Table extends Widget implements TableModel {
       this._mouseDownColumn = null;
     });
     this.setContextColumn(this._columnAtX(event.pageX));
-    this.selectionHandler.onMouseDown(event);
-    let isRightClick = event.which === 3;
+    // The row referenced by this._$mouseDownRow might become invalid in the onMouseDown event (e.g. if the event removes all rows).
+    // Hence, we put the row aside before the event.
     let row = this._$mouseDownRow.data('row') as TableRow;
+    this.selectionHandler.onMouseDown(event);
+    this._$mouseDownRow = row.$row;
+    let isRightClick = event.which === 3;
 
     let $target = $(event.target);
     // handle expansion

--- a/eclipse-scout-core/test/table/HierarchicalTableSpec.ts
+++ b/eclipse-scout-core/test/table/HierarchicalTableSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {arrays, Column, ColumnUserFilter, HierarchicalTableAccessibilityRenderer, Table, TableRow, TableRowModel} from '../../src/index';
-import {SpecTable, TableSpecHelper} from '../../src/testing/index';
+import {JQueryTesting, SpecTable, TableSpecHelper} from '../../src/testing/index';
 import $ from 'jquery';
 
 describe('HierarchicalTableSpec', () => {
@@ -906,6 +906,23 @@ describe('HierarchicalTableSpec', () => {
       table.collapseRow(table.rootRows[0]);
       table.rows[1].$row.stop(false, true); // Complete animation
       expect(table.$rows().length).toBe(1);
+    });
+
+    it('can expand rows during mouse down event', () => {
+      let model = helper.createModelFixture(1, 2);
+      let table = helper.createTable(model);
+      let rows = [
+        {cells: ['child0_row0'], parentRow: table.rows[0]},
+        {cells: ['child1_row0'], parentRow: table.rows[1]}
+      ];
+      table.insertRows(rows);
+      table.render();
+      table.on('rowsSelected', event => table.expandAll());
+      JQueryTesting.triggerMouseDown(table.rows[0].$row);
+
+      for (let i = 0; i < 4; ++i) {
+        expect(table.rows[i].expanded).toBe(true);
+      }
     });
   });
 

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -2323,6 +2323,16 @@ describe('Table', () => {
       verifyMouseMoveSelectionIsDisabled(model, table, true);
     });
 
+    it('can delete all rows during mouse down event', () => {
+      let model = helper.createModelFixture(2, 4);
+      let table = helper.createTable(model);
+      table.render();
+      table.on('rowsSelected', event => table.deleteAllRows());
+      expect(() => {
+        JQueryTesting.triggerMouseDown(table.rows[0].$row);
+      }).not.toThrow();
+    });
+
     function verifyMouseMoveSelectionIsDisabled(model, table, selectionMovable) {
       table.render();
 


### PR DESCRIPTION
Inside the mouse down event another event might be triggered which invalidates the chosen table row. We put the row aside such that we can check some properties of it later on.
Note that this change only fixes the problem when the other event is
 triggered inside the mouseDown method of the selectionHandler. Other
 places are ignored with this change.

375082