### PR TITLE
PopupWindow: don't fail if a form that was never shown is closed

### DIFF
--- a/eclipse-scout-core/src/desktop/DesktopFormController.js
+++ b/eclipse-scout-core/src/desktop/DesktopFormController.js
@@ -163,14 +163,13 @@ export default class DesktopFormController extends FormController {
    */
   _removePopupWindow(form) {
     let popupWindow = form.popupWindow;
-    if (!popupWindow) {
-      throw new Error('Form has no popupWindow reference');
+    if (popupWindow) {
+      delete form.popupWindow;
+      arrays.remove(this._popupWindows, popupWindow);
     }
-    delete form.popupWindow;
-    arrays.remove(this._popupWindows, popupWindow);
     if (form.rendered) {
       form.remove();
-      popupWindow.close();
+      popupWindow?.close();
     }
   }
 


### PR DESCRIPTION
Can be reproduced as follows
- Create a form with display hint = 'popup_window'
- Open the form
- Close the form using form.close() or form.hide()
- Close or hide the form again -> throws an error

Can also be reproduced if the form is closed programmatically after the opening failed (e.g. due to a popup blocker).

354487