### PR TITLE
Tree: improve tooltip position

### DIFF
--- a/eclipse-scout-core/src/desktop/navigation/DesktopNavigationLayout.ts
+++ b/eclipse-scout-core/src/desktop/navigation/DesktopNavigationLayout.ts
@@ -45,9 +45,7 @@ export class DesktopNavigationLayout extends AbstractLayout {
       if (viewButtonBoxWidth === 0 && outline && outline.$title) {
         // If there is no view button box, the outline title will be moved up.
         // If there is no outline title, the tool box will take the whole width (else case)
-        outline.$title.addClass('measure');
         let outlineTitleWidth = graphics.prefSize(outline.$title).width;
-        outline.$title.removeClass('measure');
         toolBoxSize = new Dimension(containerSize.width - outlineTitleWidth, 0) // height is set by css
           .subtract(toolBox.htmlComp.margins());
       } else {

--- a/eclipse-scout-core/src/layout/graphics.ts
+++ b/eclipse-scout-core/src/layout/graphics.ts
@@ -142,8 +142,12 @@ export const graphics = {
 
   /**
    * Returns the preferred size of $elem.
-   * Precondition: $elem and it's parents must not be hidden (display: none. Visibility: hidden would be ok
-   * because in this case the browser reserves the space the element would be using).
+   *
+   * Precondition: $elem and its parents must not be hidden ('display: none' - other styles like 'visibility: hidden'
+   * or 'opacity: 0' would be ok because in this case the browser reserves the space the element would be using).
+   *
+   * The `style` and `class` properties are temporarily altered to allow the element to assume its "natural size".
+   * A marker CSS class `measure` is added that can be used to reset element-specific CSS constraints (e.g. flexbox).
    *
    * @param $elem
    *          the jQuery element to measure
@@ -180,6 +184,7 @@ export const graphics = {
     }
 
     let oldStyle = $elem.attr('style');
+    let oldClass = $elem.attr('class');
     let oldScrollLeft = $elem.scrollLeft();
     let oldScrollTop = $elem.scrollTop();
 
@@ -208,6 +213,7 @@ export const graphics = {
     }
 
     // modify properties which prevent reading the preferred size
+    $elem.addClass('measure');
     $elem.css(cssProperties);
 
     // measure
@@ -220,6 +226,7 @@ export const graphics = {
 
     // reset the modified style attribute
     $elem.attrOrRemove('style', oldStyle);
+    $elem.attrOrRemove('class', oldClass);
     $elem.scrollLeft(oldScrollLeft);
     $elem.scrollTop(oldScrollTop);
 

--- a/eclipse-scout-core/src/tree/Tree.less
+++ b/eclipse-scout-core/src/tree/Tree.less
@@ -119,6 +119,10 @@
     display: inline-block;
     flex-grow: 1;
     #scout.overflow-ellipsis-nowrap();
+
+    &.measure {
+      flex-grow: 0;
+    }
   }
 
   & > .icon {


### PR DESCRIPTION
A tree node is always as wide as the entire tree. By default, tooltips are displayed at the center of the anchor. In the case of tree nodes, the tooltip may therefore point to an empty space in the middle of the tree.

By providing a custom "origin producer" function, the tooltip position can be adjusted such that it points to the center of the text (or the icon if the node has no text).

graphics.prefSize() now adds a marker CSS class 'measure' while measuring to allow elements to assume their natural size.

327222