### PR TITLE
Popup: run scheduled post validate layout functions on open

### DIFF
--- a/eclipse-scout-core/src/popup/Popup.ts
+++ b/eclipse-scout-core/src/popup/Popup.ts
@@ -285,7 +285,7 @@ export class Popup extends Widget implements PopupModel {
     if (this._openLater) {
       return;
     }
-    this.revalidateLayout();
+    this.revalidateLayoutTree(false);
     this.position();
   }
 
@@ -693,7 +693,7 @@ export class Popup extends Widget implements PopupModel {
     if (this.scrollType === 'position') {
       this.position();
     } else if (this.scrollType === 'layoutAndPosition') {
-      this.revalidateLayout();
+      this.revalidateLayoutTree(false);
       this.position();
     } else if (this.scrollType === 'remove') {
       this.close();
@@ -1033,7 +1033,7 @@ export class Popup extends Widget implements PopupModel {
     if (needsLayouting) {
       let currentAnimateResize = this.animateResize;
       this.animateResize = false;
-      this.revalidateLayout();
+      this.revalidateLayoutTree(false);
       this.animateResize = currentAnimateResize;
       if (this.withFocusContext) {
         this.session.focusManager.validateFocus();
@@ -1073,7 +1073,7 @@ export class Popup extends Widget implements PopupModel {
     this.setProperty('$anchor', $anchor);
     if (this.rendered) {
       this._attachAnchorHandlers();
-      this.revalidateLayout();
+      this.revalidateLayoutTree(false);
       if (!this.animateResize) { // PopupLayout will move it -> don't break move animation
         this.position();
       }

--- a/eclipse-scout-core/test/popup/PopupSpec.ts
+++ b/eclipse-scout-core/test/popup/PopupSpec.ts
@@ -1395,5 +1395,21 @@ describe('Popup', () => {
       expect(popup.rendered).toBe(true);
     });
 
+    it('executes post validate functions on open', () => {
+      let scheduledValidateFunctionCalled = false;
+      session.layoutValidator.schedulePostValidateFunction(() => {
+        scheduledValidateFunctionCalled = true;
+      });
+      session.desktop.validateLayoutTree();
+      spyOn(session.desktop.htmlComp, 'validateLayout').and.callThrough();
+      let popup = scout.create(Popup, {
+        parent: session.desktop
+      });
+      popup.open();
+      expect(popup.rendered).toBe(true);
+      expect(popup.htmlComp.valid).toBe(true);
+      expect(scheduledValidateFunctionCalled).toBe(true);
+      expect(session.desktop.htmlComp.validateLayout).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
When a popup is opened, the layout needs to be revalidated. This should be done via layout validator, so scheduled postValidateFunctions are executed.

Example:
The TableHeaderMenu is a popup that displays a table to filter the column values (FilterSupport). The background color of the filter field in this table needs to be updated, depending on the number of selected table rows. Because this is scheduled before the widget is fully rendered, a postValidateFunction is registered on the layoutValidator. If only the popup layout is revalidated, this function is never executed, because the layout validator is not involved. To fix this, use revalidateLayoutTree() instead of revalidateLayout(). The argument 'false' is not required, because a popup is always a validate root.

369849