### PR TITLE
Removed duplicate utility function getFileExtension

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/FileUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/FileUtilityTest.java
@@ -38,6 +38,7 @@ public class FileUtilityTest {
   private static final String FILE_NAME = "fooBar.txt";
   private static final String FILE_NAME_MULTIPLE_DOTS = "foo.bar.txt";
   private static final String FILE_NAME_NO_EXT = "fooBar";
+  private static final String FILE_NAME_ONLY_DOT = "fooBar";
   private static final String PLATFORM_PATH = "org/eclipse/scout/rt/platform/";
 
   @Test
@@ -96,7 +97,9 @@ public class FileUtilityTest {
   public void testGetFileExtension_String() {
     assertEquals(TEXT_EXT, FileUtility.getFileExtension(FILE_NAME));
     assertEquals(TEXT_EXT, FileUtility.getFileExtension(FILE_NAME_MULTIPLE_DOTS));
+    assertNull(FileUtility.getFileExtension(FILE_NAME_ONLY_DOT));
     assertNull(FileUtility.getFileExtension(FILE_NAME_NO_EXT));
+    assertNull(FileUtility.getFileExtension(""));
     assertNull(FileUtility.getFileExtension((String) null));
   }
 
@@ -104,7 +107,9 @@ public class FileUtilityTest {
   public void testGetFileExtension_File() {
     assertEquals(TEXT_EXT, FileUtility.getFileExtension(new File(FILE_NAME)));
     assertEquals(TEXT_EXT, FileUtility.getFileExtension(new File(FILE_NAME_MULTIPLE_DOTS)));
+    assertNull(FileUtility.getFileExtension(new File(FILE_NAME_ONLY_DOT)));
     assertNull(FileUtility.getFileExtension(new File(FILE_NAME_NO_EXT)));
+    assertNull(FileUtility.getFileExtension(new File("")));
     assertNull(FileUtility.getFileExtension((File) null));
   }
 
@@ -319,4 +324,3 @@ public class FileUtilityTest {
     assertEquals("foo.bar", FileUtility.getFileName("\\folder\\subfolder\\foo.bar", true));
   }
 }
-

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/IOUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/IOUtilityTest.java
@@ -171,17 +171,6 @@ public class IOUtilityTest {
   }
 
   @Test
-  public void testFileExtension() {
-    assertEquals("temp", IOUtility.getFileExtension("Test.temp"));
-    assertEquals("temp", IOUtility.getFileExtension("Test.xy.temp"));
-    assertEquals("temp", IOUtility.getFileExtension(".temp"));
-    assertEquals("", IOUtility.getFileExtension("Test."));
-    assertEquals("", IOUtility.getFileExtension("."));
-    assertNull(IOUtility.getFileExtension(""));
-    assertNull(IOUtility.getFileExtension(null));
-  }
-
-  @Test
   public void testDeleteDirectory() throws IOException {
     File tempFile = File.createTempFile("tempFile", "tmp");
     File tempDir = new File(tempFile.getParent(), "FileUtilityTestTempDir");

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/IOUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/IOUtility.java
@@ -862,22 +862,6 @@ public final class IOUtility {
   }
 
   /**
-   * @return the extension of the file
-   */
-  public static String getFileExtension(String filename) {
-    if (filename == null) {
-      return null;
-    }
-    int i = filename.lastIndexOf('.');
-    if (i < 0) {
-      return null;
-    }
-    else {
-      return filename.substring(i + 1);
-    }
-  }
-
-  /**
    * @return the path of the file without its name
    */
   public static String getFilePath(String filepath) {


### PR DESCRIPTION
The IOUtility and the FileUtility class both implement the getFileExtension method. The occurrence in the IOUtility was removed.

323620