### PR TITLE
Harmonize revalidation of layout

### DIFF
--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -449,7 +449,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
 
   /**
    * Method may be implemented to load the data.
-   * By default, a resolved promise containing {@link this.data} is returned.
+   * By default, a resolved promise containing {@link data} is returned.
    */
   protected _load(): JQuery.Promise<any> {
     return $.resolvedPromise().then(() => {
@@ -499,14 +499,14 @@ export class Form extends Widget implements FormModel, DisplayParent {
   }
 
   /**
-   * Imports the {@link this.data} to the form.
+   * Imports {@link data} to the form.
    */
   importData() {
     // NOP
   }
 
   /**
-   * Exports the form to {@link this.data}.
+   * Exports the form to {@link data}.
    */
   exportData(): any {
     return null;
@@ -1471,7 +1471,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
     let layout = this.htmlComp.layout as DialogLayout,
       shrinkEnabled = layout.shrinkEnabled;
     layout.shrinkEnabled = true;
-    this.revalidateLayoutTree();
+    this.revalidateLayoutTree(false);
     this.position();
     layout.shrinkEnabled = shrinkEnabled;
   }

--- a/eclipse-scout-core/src/form/FormController.ts
+++ b/eclipse-scout-core/src/form/FormController.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -340,7 +340,7 @@ export class FormController implements FormControllerModel, ObjectWithType {
   }
 
   protected _layoutDialog(dialog: Form) {
-    dialog.htmlComp.validateLayout();
+    dialog.revalidateLayoutTree(false);
     dialog.position();
 
     // If not validated anew, focus on single-button forms is not gained.

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldLayout.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldLayout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,8 +33,8 @@ export class SmartFieldLayout extends FormFieldLayout {
     let popup = this._smartField.popup;
     if (popup && popup.rendered) {
       // Make sure the popup is correctly layouted and positioned
+      popup.revalidateLayoutTree(false);
       popup.position();
-      popup.validateLayout();
     }
   }
 }

--- a/eclipse-scout-core/test/desktop/DesktopSpec.ts
+++ b/eclipse-scout-core/test/desktop/DesktopSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -2375,7 +2375,6 @@ describe('Desktop', () => {
     });
   });
 
-
   describe('views', () => {
     let formModel = {
       objectType: Form,
@@ -2498,7 +2497,6 @@ describe('Desktop', () => {
       desktop.views[0].close();
       expect(desktop.selectedViewTabs.size).toBe(0);
     });
-
 
     it('allows to select a specific outline based view on startup', () => {
       session = sandboxSession({
@@ -2703,6 +2701,16 @@ describe('Desktop', () => {
     });
 
     it('orders overlays relative to their context', () => {
+      // Add some CSS styles for "overlay" elements to prevent errors when running this test on a headless browser
+      // that only provides a small screen (e.g. 800x600). Without these styles, certain elements are automatically
+      // hidden because they are outside the viewport.
+      $('#sandbox').append($(`
+          <style>
+            .desktop { position: absolute; left: 0; top: 0; width: 200px; height: 200px; }
+            .form, .popup, .tooltip { position: absolute; min-width: 50px; min-height: 50px; max-width: 50px; max-height: 50px; }
+          </style>
+      `));
+
       let desktop = session.desktop;
       desktop.render(session.$entryPoint);
 


### PR DESCRIPTION
Widgets that reposition themselves needs to revalidate their layout. This should be done via revalidateLayoutTree(false), because otherwise, scheduled post validate functions are not executed.

369849