### PR TITLE
Scout archetype: avoid warnings during .app.zip build

### DIFF
--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.zip/src/assembly/assembly.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.zip/src/assembly/assembly.xml
@@ -11,9 +11,7 @@
     <dependencySet>
       <outputDirectory>/lib</outputDirectory>
       <unpack>false</unpack>
-      <excludes>
-        <exclude>${project.groupId}:${project.artifactId}</exclude>
-      </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
   </dependencySets>
 

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.zip/src/assembly/assembly.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.zip/src/assembly/assembly.xml
@@ -11,9 +11,7 @@
     <dependencySet>
       <outputDirectory>/lib</outputDirectory>
       <unpack>false</unpack>
-      <excludes>
-        <exclude>${project.groupId}:${project.artifactId}</exclude>
-      </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
   </dependencySets>
 

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.zip/src/assembly/assembly.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.zip/src/assembly/assembly.xml
@@ -11,9 +11,7 @@
     <dependencySet>
       <outputDirectory>/lib</outputDirectory>
       <unpack>false</unpack>
-      <excludes>
-        <exclude>${project.groupId}:${project.artifactId}</exclude>
-      </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
   </dependencySets>
 


### PR DESCRIPTION
Warnings present before:
- [WARNING] Cannot include project artifact: org.eclipse.scout.apps:helloscout.ui.html.app.zip:pom:1.0.0-SNAPSHOT; it doesn't have an associated file or directory.
- [WARNING] The following patterns were never triggered in this artifact exclusion filter: 'org.eclipse.scout.apps:helloscout.ui.html.app.zip'

374997