### PR TITLE
Locale switch must not replace texts

### DIFF
--- a/eclipse-scout-cli/scripts/webpack-defaults.js
+++ b/eclipse-scout-cli/scripts/webpack-defaults.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -557,7 +557,7 @@ function getModuleName() {
  * Keep imports to the excludedFolder.
  * @param {string} newImport new name of the replaced import, typically the module name
  * @param {string} excludedFolder imports to that folder won't be replaced
- * @return a function that should be added to the webpack externals
+ * @returns a function that should be added to the webpack externals
  */
 function rewriteIndexImports(newImport, excludedFolder) {
   return ({context, request, contextInfo}, callback) => {

--- a/eclipse-scout-core/src/code/CodeType.ts
+++ b/eclipse-scout-core/src/code/CodeType.ts
@@ -57,7 +57,7 @@ export class CodeType<TCodeId = string, TCode extends Code<TCodeId> = Code<TCode
 
   /**
    * Override this method and add additional properties which should not be validated to be present after CodeType init.
-   * @return A Set with all public properties (fields) of this CodeType which do _not_ point to a nested Code instance.
+   * @returns A Set with all public properties (fields) of this CodeType which do _not_ point to a nested Code instance.
    */
   protected _getPublicNonCodeProperties(): Set<string> {
     return new Set(['id', 'objectType', 'modelClass', 'iconId', 'hierarchical', 'maxLevel', 'codeMap']);
@@ -123,7 +123,7 @@ export class CodeType<TCodeId = string, TCode extends Code<TCodeId> = Code<TCode
   /**
    * Gets the codes of this CodeType.
    * @param rootOnly true if only the root Codes should be returned. The default value is false.
-   * @return the root Codes of this CodeType if rootOnly is true and all Codes recursively otherwise.
+   * @returns the root Codes of this CodeType if rootOnly is true and all Codes recursively otherwise.
    */
   codes(rootOnly?: boolean): TCode[] {
     if (!rootOnly) {
@@ -143,7 +143,7 @@ export class CodeType<TCodeId = string, TCode extends Code<TCodeId> = Code<TCode
   /**
    * Gets the Code with given id. All codes recursively are searched.
    * @param codeId The Code id to search
-   * @return The Code with given id or null.
+   * @returns The Code with given id or null.
    */
   get(codeId: TCodeId): TCode {
     return this.codeMap.get(codeId);

--- a/eclipse-scout-core/src/code/codes.ts
+++ b/eclipse-scout-core/src/code/codes.ts
@@ -53,7 +53,7 @@ export const codes = {
 
   /**
    * Adds the given CodeType models to the registry. Existing entries with the same ids are overwritten.
-   * @return The registered CodeType instances.
+   * @returns The registered CodeType instances.
    */
   add(codeTypes: ObjectOrModel<CodeType<any, any, any>> | ObjectOrModel<CodeType<any, any, any>>[]): CodeType<any, any, any>[] {
     let registeredCodeTypes = [];
@@ -81,7 +81,7 @@ export const codes = {
   /**
    * Gets the CodeType with given id or Class.
    * @param codeTypeIdOrClassRef The CodeType id or Class
-   * @return The CodeType instance or undefined if not found.
+   * @returns The CodeType instance or undefined if not found.
    */
   get<T extends CodeType<any>>(codeTypeIdOrClassRef: string | (new() => T)): T {
     if (typeof codeTypeIdOrClassRef === 'string') {

--- a/eclipse-scout-core/src/desktop/Desktop.ts
+++ b/eclipse-scout-core/src/desktop/Desktop.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -211,7 +211,7 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
     // a listener on the desktop in their init phase, they access the desktop by calling 'this.session.desktop'
     // that's why we need this instance as early as possible. When that happens they access a desktop which is
     // not yet fully initialized. But anyway, it's already possible to attach a listener, for instance.
-    // Because of this line of code here, we don't have to set the variable in App.js, after the desktop has been
+    // Because of this line of code here, we don't have to set the variable in App.ts, after the desktop has been
     // created. Also note that Scout Java uses a different pattern to solve the same problem, there a VirtualDesktop
     // is used during initialization. When initialization is done, all registered listeners on the virtual desktop
     // are copied to the real desktop instance.
@@ -376,7 +376,7 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
   }
 
   /**
-   * @return true if the desktop has a busy indicator active.
+   * @returns true if the desktop has a busy indicator active.
    */
   get busy(): boolean {
     return this.busySupport.isBusy();

--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -595,7 +595,7 @@ export class Form extends Widget implements FormModel, DisplayParent {
 
   /**
    * Default error handler for {@link _load}, {@link _save} and {@link _postLoad}. May be overridden by subclasses.
-   * @return A promise that resolves when the error is handled.
+   * @returns A promise that resolves when the error is handled.
    */
   protected _handleError(error: any): JQuery.Promise<void> {
     const errorHandler = App.get().errorHandler;

--- a/eclipse-scout-core/src/session/Locale.ts
+++ b/eclipse-scout-core/src/session/Locale.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -51,9 +51,14 @@ export class Locale implements LocaleModel {
     }
   }
 
+  /**
+   * Creates a new {@link Locale} based on given input. If no input is given, the default Locale is returned (en-US).
+   * @param locale The locale or null for the default locale.
+   * @returns the given Locale, a new Locale based on the model given or the default Locale if the input is null.
+   */
   static ensure(locale?: Locale | InitModelOf<Locale>): Locale {
     if (!locale) {
-      return locale as Locale;
+      return new Locale(Locale.DEFAULT);
     }
     if (locale instanceof Locale) {
       return locale;

--- a/eclipse-scout-core/src/status/NotificationBadgeStatus.ts
+++ b/eclipse-scout-core/src/status/NotificationBadgeStatus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,7 @@ export class NotificationBadgeStatus extends Status {
   }
 
   /**
-   * @return {NotificationBadgeStatus} a clone of this Status instance.
+   * @returns {NotificationBadgeStatus} a clone of this Status instance.
    */
   override clone(): Status {
     let modelClone = $.extend({}, this);

--- a/eclipse-scout-core/src/testing/JasmineScout.ts
+++ b/eclipse-scout-core/src/testing/JasmineScout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -176,7 +176,7 @@ window.createSimpleModel = <T>(objectType, session, id) => {
 window.mostRecentJsonRequest = () => {
   let req = jasmine.Ajax.requests.mostRecent();
   if (req) {
-    return $.parseJSON(req.params);
+    return JSON.parse(req.params);
   }
 };
 

--- a/eclipse-scout-core/src/testing/scoutMatchers.ts
+++ b/eclipse-scout-core/src/testing/scoutMatchers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -79,7 +79,7 @@ export const jasmineScoutMatchers = {
       for (let i = 0; i < expected.length; i++) {
         // Prototype may be Event. If that's the case we need to convert, otherwise equals will fail
         if (Object.getPrototypeOf(expected[i]) !== Object.prototype) {
-          expected[i] = $.parseJSON(JSON.stringify(expected[i]));
+          expected[i] = JSON.parse(JSON.stringify(expected[i]));
         }
 
         result.pass = result.pass && util.contains(actualEvents, expected[i]);
@@ -113,7 +113,7 @@ export const jasmineScoutMatchers = {
       for (let i = 0; i < expected.length; i++) {
         // Prototype may be Event. If that's the case we need to convert, otherwise equals will fail
         if (Object.getPrototypeOf(expected[i]) !== Object.prototype) {
-          expected[i] = $.parseJSON(JSON.stringify(expected[i]));
+          expected[i] = JSON.parse(JSON.stringify(expected[i]));
         }
       }
 

--- a/eclipse-scout-core/src/text/texts.ts
+++ b/eclipse-scout-core/src/text/texts.ts
@@ -101,7 +101,7 @@ export const texts = {
   /**
    * Returns the (modifiable) TextMap for the given language tag.
    * If no TextMap exists for the languageTag given, a new empty map is created.
-   * @return the TextMap for the given languageTag. Never returns null or undefined.
+   * @returns the TextMap for the given languageTag. Never returns null or undefined.
    */
   get(languageTag: string): TextMap {
     let textMap: TextMap = texts._get(languageTag);

--- a/eclipse-scout-core/src/text/texts.ts
+++ b/eclipse-scout-core/src/text/texts.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,7 +53,7 @@ export const texts = {
   },
 
   /**
-   * Links the texts of the given languageTag to make parent lookup possible (e.g. look first in de-CH, then in de, then in default)
+   * Links the texts of the given languageTag to make parent lookup possible (e.g. look first in de-CH, then in de, then in default).
    */
   link(languageTag: string) {
     let tags = texts.createOrderedLanguageTags(languageTag);
@@ -63,13 +63,13 @@ export const texts = {
       if (!textMap) {
         // If there are no texts for the given tag, create an empty Texts object for linking purpose
         textMap = new TextMap();
-        texts.put(tag, textMap);
+        texts._put(tag, textMap);
       }
       if (child) {
         child.setParent(textMap);
       }
       child = textMap;
-    }, this);
+    });
   },
 
   /**
@@ -100,6 +100,8 @@ export const texts = {
 
   /**
    * Returns the (modifiable) TextMap for the given language tag.
+   * If no TextMap exists for the languageTag given, a new empty map is created.
+   * @return the TextMap for the given languageTag. Never returns null or undefined.
    */
   get(languageTag: string): TextMap {
     let textMap: TextMap = texts._get(languageTag);
@@ -123,8 +125,9 @@ export const texts = {
   /**
    * Registers the text map for the given locale.
    * If there already is a text map registered for that locale, it will be replaced, meaning existing texts for that locale are deleted.
+   * @internal
    */
-  put(languageTag: string, textMap: TextMap) {
+  _put(languageTag: string, textMap: TextMap) {
     texts.textsByLocale[languageTag] = textMap;
   },
 

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonRepository.ts
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonRepository.ts
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 import {App, Person, PersonRestriction, Repository} from '../index';
 import {App as ScoutApp, scout} from '@eclipse-scout/core';
 
@@ -22,7 +31,7 @@ export class PersonRepository extends Repository {
   /**
    * Gets all persons.
    * @param restriction Restriction which persons to fetch
-   * @return The persons matching the restriction
+   * @returns The persons matching the restriction
    */
   list(restriction: PersonRestriction): JQuery.Promise<Person[]> {
     return this._list(restriction);


### PR DESCRIPTION
A locale switch may also contain a new text map. This text map should
not completely replace the existing one, as other texts might have been
added (e.g. by user code or CodeTypes). Instead, the new text map should
extend the existing texts as it is already done in
Session#_processStartupResponse().

376033