### PR TITLE
DateFormat: fix prediction on February 29

### DIFF
--- a/eclipse-scout-core/src/text/DateFormat.ts
+++ b/eclipse-scout-core/src/text/DateFormat.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -135,7 +135,7 @@ export class DateFormat {
           let startYear = (parseContext.startDate || new Date()).getFullYear();
           // Construct a new year using the startYear's century and the entered 'short year'
           let year = Number(
-            strings.padZeroLeft(startYear, 4).substr(0, 2) +
+            strings.padZeroLeft(startYear, 4).substring(0, 2) +
             strings.padZeroLeft(match, 2));
           // Ensure max. 50 years distance between 'startYear' and 'year'
           let distance = year - startYear;
@@ -639,7 +639,7 @@ export class DateFormat {
         },
         parseRegExp: /^([+|-]\d{4})(.*)$/,
         applyMatchFunction: (parseContext, match, acceptedTerm) => {
-          let offset = Number(match.substr(1, 2)) * 60 + Number(match.substr(3, 2));
+          let offset = Number(match.substring(1, 3)) * 60 + Number(match.substring(3, 5));
           if (match.charAt(0) === '-') {
             offset *= -1;
           }
@@ -733,7 +733,7 @@ export class DateFormat {
   protected _createConstantStringParseFunction(term: string): (parseContext: DateFormatParseContext) => boolean {
     return parseContext => {
       if (strings.startsWith(parseContext.inputString, term)) {
-        parseContext.inputString = parseContext.inputString.substr(term.length);
+        parseContext.inputString = parseContext.inputString.substring(term.length);
         parseContext.parsedPattern += term;
         return true;
       }
@@ -901,7 +901,7 @@ export class DateFormat {
     let validMonth = scout.nvl(dateInfo.month, startDate.getMonth());
     let validYear = scout.nvl(dateInfo.year, startDate.getFullYear());
     // When user entered the day but not (yet) the month, adjust month if possible to propose a valid date
-    if (dateInfo.day && !dateInfo.month) {
+    if (dateInfo.day && !numbers.isNumber(dateInfo.month)) {
       // If day "31" does not exist in the proposed month, use the next month
       if (dateInfo.day === 31) {
         let monthsWithThirtyOneDays = [0, 2, 4, 6, 7, 9, 11];
@@ -917,8 +917,8 @@ export class DateFormat {
     }
 
     // ensure valid day for selected month for dateInfo without day
-    if (!dateInfo.day && dateInfo.month) {
-      let lastOfMonth = dates.shift(new Date(validYear, dateInfo.month + 1, 1), 0, 0, -1);
+    if (!dateInfo.day && (numbers.isNumber(dateInfo.month) || dateInfo.year)) {
+      let lastOfMonth = dates.shift(new Date(validYear, validMonth + 1, 1), 0, 0, -1);
       validDay = Math.min(lastOfMonth.getDate(), startDate.getDate());
     }
 
@@ -1054,6 +1054,7 @@ export interface DateFormatOptions {
 
 export interface DateFormatMatchInfo {
   year?: string;
+  /** one-based (January = '1') */
   month?: string;
   week?: string;
   day?: string;
@@ -1068,6 +1069,7 @@ export interface DateFormatMatchInfo {
 
 export interface DateFormatDateInfo {
   year?: number;
+  /** zero-based (January = 0) */
   month?: number;
   day?: number;
   hours?: number;

--- a/eclipse-scout-core/test/text/DateFormatSpec.ts
+++ b/eclipse-scout-core/test/text/DateFormatSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -118,9 +118,7 @@ describe('DateFormat', () => {
       pattern = 'yyyy-MM-ddTHH:mm:ss.SSSZ';
       dateFormat = new DateFormat(locale, pattern);
       expect(dateFormat.format(date)).toBe('2014-03-21T13:01:00.000' + timeZone);
-
     });
-
   });
 
   describe('parse', () => {
@@ -194,7 +192,6 @@ describe('DateFormat', () => {
       let refDate = dates.create('2017-01-01 12:00:05.123');
       refDate.setMinutes(refDate.getMinutes() - refDate.getTimezoneOffset() - 6 * 60);
       expect(dateFormat.parse('2017-01-01T12:00:05.123-0600').getTime()).toBe(refDate.getTime());
-
     });
   });
 
@@ -284,6 +281,15 @@ describe('DateFormat', () => {
 
         result = dateFormat.analyze('32', dates.create('2016-04-01'));
         expect(result.predictedDate).toBe(null);
+
+        result = dateFormat.analyze('2', dates.create('2024-02-29'));
+        expect(dateFormat.format(result.predictedDate)).toBe('02.02.2024');
+
+        result = dateFormat.analyze('3', dates.create('2024-02-29'));
+        expect(dateFormat.format(result.predictedDate)).toBe('03.02.2024');
+
+        result = dateFormat.analyze('30', dates.create('2024-02-29'));
+        expect(dateFormat.format(result.predictedDate)).toBe('30.03.2024');
       });
 
       it('proposes valid dates for pattern MM.yyyy', () => {
@@ -309,6 +315,32 @@ describe('DateFormat', () => {
 
         let result = dateFormat.analyze('2017', dates.create('2016-02-29'));
         expect(dateFormat.format(result.predictedDate)).toBe('2017');
+      });
+
+      it('proposes valid dates for pattern yyyy-MM', () => {
+        let pattern = 'yyyy-MM';
+        let dateFormat = new DateFormat(locale, pattern);
+
+        let result = dateFormat.analyze('17-2', dates.create('2017-03-31'));
+        expect(dateFormat.format(result.predictedDate)).toBe('2017-02');
+
+        result = dateFormat.analyze('17-4', dates.create('2017-03-31'));
+        expect(dateFormat.format(result.predictedDate)).toBe('2017-04');
+
+        result = dateFormat.analyze('17-5', dates.create('2017-03-31'));
+        expect(dateFormat.format(result.predictedDate)).toBe('2017-05');
+
+        result = dateFormat.analyze('17-5', dates.create('2017-03-10'));
+        expect(dateFormat.format(result.predictedDate)).toBe('2017-05');
+
+        result = dateFormat.analyze('2', dates.create('2024-02-29')); // feb-29 does not exist in 2002 -> should still predict february
+        expect(dateFormat.format(result.predictedDate)).toBe('2002-02');
+
+        result = dateFormat.analyze('24', dates.create('2024-02-29'));
+        expect(dateFormat.format(result.predictedDate)).toBe('2024-02');
+
+        result = dateFormat.analyze('2-3', dates.create('2024-02-29'));
+        expect(dateFormat.format(result.predictedDate)).toBe('2002-03');
       });
 
       it('proposes valid times', () => {
@@ -350,5 +382,4 @@ describe('DateFormat', () => {
       });
     });
   });
-
 });


### PR DESCRIPTION
When the reference date is February 29 and format pattern starts with 'yyyy' and the user enters '2', the year 2002 is predicted. Day and month are inherited from the reference date, but because 2002 is not a leap year, that day does not exist. The runtime automatically "fixes" the date to March 1, but the user (and the jasmine spec) expects the month to still be February.

There is already some code that limits the predicted day to the entered month. The same can be done when the year is entered.

Additional improvements:
- To determine if a month was entered (i.e. is set on the 'dateInfo' object), checking for falsyness is not always correct, because the month property is zero-based (0 = January). numbers.isNumber() is now used instead.
- Add jsdoc specifying the start index of the 'month' property.
- Replace the deprecated string method substr() with substring(). https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

376459