### PR TITLE
Notification: further improve handling of empty message

### DIFF
--- a/eclipse-scout-core/src/desktop/notification/DesktopNotification.less
+++ b/eclipse-scout-core/src/desktop/notification/DesktopNotification.less
@@ -201,7 +201,7 @@
   }
 
   // Prevent empty div from collapsing (without &nbsp;)
-  &::after {
+  &:empty::after {
     content: '\200b'; // U+200B ZERO WIDTH SPACE
   }
 }

--- a/eclipse-scout-core/src/notification/Notification.less
+++ b/eclipse-scout-core/src/notification/Notification.less
@@ -178,7 +178,11 @@
 
 .notification-message {
   padding-right: 12px;
-  min-height: 12px; // Prevent empty div from collapsing (without &nbsp;)
   #scout.user-select(text);
   #scout.overflow-ellipsis();
+
+  // Prevent empty div from collapsing (without &nbsp;)
+  &:empty::after {
+    content: '\200b'; // U+200B ZERO WIDTH SPACE
+  }
 }


### PR DESCRIPTION
The CSS selector ':empty' matches elements without content. It can be used to only inject an ::after element when the notification is empty (to prevent it from collapsing). If there is content (e.g. a text or an entire <div>), the ::after element is not active and will not interfere with the content. This prevents an unwanted empty line after content with 'display: block' without needing to set a minimal height.

376567