### PR TITLE
Maven build: only add phase binding for Google Jib on active profile

### DIFF
--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.image/pom.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app.image/pom.xml
@@ -12,41 +12,35 @@
   <!-- Application leaf module with dependencies only relevant for docker image build including config.properties/logback.xml -->
   <artifactId>${rootArtifactId}.app.image</artifactId>
 
-  <profiles>
-    <profile>
-      <!--  set property docker.app.image.registry before activating profile -->
-      <id>exec.docker.image</id>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.google.cloud.tools</groupId>
-            <artifactId>jib-maven-plugin</artifactId>
-            <configuration>
-              <to>
-                <image>${docker.app.image.registry}/${simpleArtifactName}</image>
-                <tags>
-                  <tag>${docker.app.image.tag}</tag>
-                </tags>
-              </to>
-              <from>
-                <image>${docker.java.image}</image>
-              </from>
-              <container>
-                <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
-                <ports>
-                  <port>8080</port>
-                </ports>
-                <environment>
-                  <scout_app_port>8080</scout_app_port>
-                </environment>
-              </container>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+  <build>
+    <plugins>
+      <plugin>
+        <!-- Google Jib goal 'build' is bound to phase 'package' via profile 'exec.docker.image' -->
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>${docker.app.image.registry}/${simpleArtifactName}</image>
+            <tags>
+              <tag>${docker.app.image.tag}</tag>
+            </tags>
+          </to>
+          <from>
+            <image>${docker.java.image}</image>
+          </from>
+          <container>
+            <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
+            <ports>
+              <port>8080</port>
+            </ports>
+            <environment>
+              <scout_app_port>8080</scout_app_port>
+            </environment>
+          </container>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <dependency>

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -70,6 +70,30 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <!--  set property docker.app.image.registry before activating profile -->
+      <id>exec.docker.image</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <!-- phase binding required for .app.image module to build and publish docker image -->
+              <groupId>com.google.cloud.tools</groupId>
+              <artifactId>jib-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>build</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 
   <build>
@@ -81,20 +105,6 @@
             <overWriteReleases>false</overWriteReleases>
             <overWriteSnapshots>true</overWriteSnapshots>
           </configuration>
-        </plugin>
-
-        <plugin>
-          <!-- required for .app.image module to build and publish docker image -->
-          <groupId>com.google.cloud.tools</groupId>
-          <artifactId>jib-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>build</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.image/pom.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.server.app.image/pom.xml
@@ -13,41 +13,35 @@
   <!-- Application leaf module with dependencies only relevant for docker image build including config.properties/logback.xml -->
   <artifactId>${rootArtifactId}.${artifactId}</artifactId>
 
-  <profiles>
-    <profile>
-      <!--  set property docker.app.image.registry before activating profile -->
-      <id>exec.docker.image</id>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.google.cloud.tools</groupId>
-            <artifactId>jib-maven-plugin</artifactId>
-            <configuration>
-              <to>
-                <image>${docker.app.image.registry}/${simpleArtifactName}-server</image>
-                <tags>
-                  <tag>${docker.app.image.tag}</tag>
-                </tags>
-              </to>
-              <from>
-                <image>${docker.java.image}</image>
-              </from>
-              <container>
-                <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
-                <ports>
-                  <port>8080</port>
-                </ports>
-                <environment>
-                  <scout_app_port>8080</scout_app_port>
-                </environment>
-              </container>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+  <build>
+    <plugins>
+      <plugin>
+        <!-- Google Jib goal 'build' is bound to phase 'package' via profile 'exec.docker.image' -->
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>${docker.app.image.registry}/${simpleArtifactName}-server</image>
+            <tags>
+              <tag>${docker.app.image.tag}</tag>
+            </tags>
+          </to>
+          <from>
+            <image>${docker.java.image}</image>
+          </from>
+          <container>
+            <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
+            <ports>
+              <port>8080</port>
+            </ports>
+            <environment>
+              <scout_app_port>8080</scout_app_port>
+            </environment>
+          </container>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <dependency>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.image/pom.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html.app.image/pom.xml
@@ -13,41 +13,35 @@
   <!-- Application leaf module with dependencies only relevant for docker image build including config.properties/logback.xml -->
   <artifactId>${rootArtifactId}.${artifactId}</artifactId>
 
-  <profiles>
-    <profile>
-      <!--  set property docker.app.image.registry before activating profile -->
-      <id>exec.docker.image</id>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.google.cloud.tools</groupId>
-            <artifactId>jib-maven-plugin</artifactId>
-            <configuration>
-              <to>
-                <image>${docker.app.image.registry}/${simpleArtifactName}-ui</image>
-                <tags>
-                  <tag>${docker.app.image.tag}</tag>
-                </tags>
-              </to>
-              <from>
-                <image>${docker.java.image}</image>
-              </from>
-              <container>
-                <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
-                <ports>
-                  <port>8080</port>
-                </ports>
-                <environment>
-                  <scout_app_port>8080</scout_app_port>
-                </environment>
-              </container>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+  <build>
+    <plugins>
+      <plugin>
+        <!-- Google Jib goal 'build' is bound to phase 'package' via profile 'exec.docker.image' -->
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>${docker.app.image.registry}/${simpleArtifactName}-ui</image>
+            <tags>
+              <tag>${docker.app.image.tag}</tag>
+            </tags>
+          </to>
+          <from>
+            <image>${docker.java.image}</image>
+          </from>
+          <container>
+            <mainClass>org.eclipse.scout.rt.app.Application</mainClass>
+            <ports>
+              <port>8080</port>
+            </ports>
+            <environment>
+              <scout_app_port>8080</scout_app_port>
+            </environment>
+          </container>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <dependency>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -66,27 +66,31 @@
         </plugins>
       </build>
     </profile>
-  </profiles>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <!-- required for .app.image module to build and publish docker image -->
-          <groupId>com.google.cloud.tools</groupId>
-          <artifactId>jib-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>build</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+    <profile>
+      <!--  set property docker.app.image.registry before activating profile -->
+      <id>exec.docker.image</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <!-- phase binding required for .app.image module to build and publish docker image -->
+              <groupId>com.google.cloud.tools</groupId>
+              <artifactId>jib-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>build</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Google Jib builds the docker image and requires additional configuration (e.g. valid registry to push images to). A build via root pom.xml involving all modules must be executable. Therefore, Google Jib must only be triggered for the .app.image modules if profile 'exec.docker.image' is active. This is achieved by binding the Google Jib goal 'build' to the 'package' phase only if the profile 'exec.docker.image' is active. This enables to avoid profile checks within the .app.image modules itself.

375115