### PR TITLE
GroupBoxLayout: use pixel based layout for notification

### DIFF
--- a/eclipse-scout-core/src/form/fields/groupbox/GroupBoxLayout.js
+++ b/eclipse-scout-core/src/form/fields/groupbox/GroupBoxLayout.js
@@ -81,14 +81,12 @@ export default class GroupBoxLayout extends AbstractLayout {
 
     let notificationHeight = 0;
     if (this.groupBox.notification) {
-      setWidthForStatus(this.groupBox.notification.$container, statusWidth);
-
+      let notificationMargin = this.groupBox.notification.htmlComp.margins();
       let notificationPrefSize = this.groupBox.notification.htmlComp.prefSize({
-        widthHint: containerSize.width - statusWidth,
-        includeMargin: true
+        widthHint: containerSize.width - statusWidth
       });
       this.groupBox.notification.htmlComp.setSize(notificationPrefSize);
-      notificationHeight = notificationPrefSize.height;
+      notificationHeight = notificationPrefSize.height + notificationMargin.vertical();
     }
 
     gbBodySize = containerSize.subtract(htmlGbBody.margins());

--- a/eclipse-scout-core/src/notification/Notification.js
+++ b/eclipse-scout-core/src/notification/Notification.js
@@ -43,7 +43,6 @@ export default class Notification extends Widget {
     this.$content = this.$container.appendDiv('notification-content');
     this.$messageText = this.$content.appendDiv('notification-message');
     this.htmlComp = HtmlComponent.install(this.$container, this.session);
-    this.htmlComp.pixelBasedSizing = false;
   }
 
   _remove() {


### PR DESCRIPTION
To fix the calculation of the notification size in a group box, the notification layout was previously changed to pixelBasedSizing=false. This works for the group box layout, but potentially breaks other uses of the 'Notification' widget. To prevent this, the notification layout was changed back to pixelBasedSizing=true. The group box layout was updated accordingly to measure and set the correct size in pixels. Because the width is now always set explicitly, it is no longer necessary to adjust it for the status width using a calc() expression.

367904