### PR TITLE
JsonMessageRequestHandler: prevent double logout

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonMessageRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonMessageRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -183,13 +183,8 @@ public class JsonMessageRequestHandler extends AbstractUiServletRequestHandler {
       // because the poller-induced "heart beat" mechanism would stop. Therefore, if the lock cannot be acquired,
       // an empty response is sent back to the UI.
       if (!uiSession.uiSessionLock().tryLock()) {
-        if (uiSession.isDisposed()) {
-          handleUiSessionDisposed(httpServletResponse, uiSession, jsonRequest);
-        }
-        else {
-          LOG.debug("Creating empty response [{}, #{}, #ACK {}]", "CER_HJR", jsonRequest.getSequenceNo(), jsonRequest.getAckSequenceNo());
-          writeJsonResponse(httpServletResponse, m_jsonRequestHelper.createEmptyResponse());
-        }
+        LOG.debug("Creating empty response [{}, #{}, #ACK {}]", "CER_HJR", jsonRequest.getSequenceNo(), jsonRequest.getAckSequenceNo());
+        writeJsonResponse(httpServletResponse, m_jsonRequestHelper.createEmptyResponse());
         return;
       }
     }


### PR DESCRIPTION
When the ?poll request cannot acquire the ui session lock, another user request is currently being processed. Because the model is not accessible, an empty response is returned. This was recently changed to return a "session terminated" message if the ui session is disposed. While this sounds sensible, it can lead to problems because the "session terminated" message also contains a redirect url. If the browser applies this redirect, while the other request is still being processed, unpredictable effects can happen, especially if the second response _also_ eventually causes a redirect. Depending on the kind of authentication filter, the second redirect does no longer work and the user will see a blank page or an error message.

To fix this, the previous change was partially inverted. Instead of sending a "session terminated" message when the ui session is disposed, an empty response is sent in any case where the ui session lock could not be acquired.

376896