### PR TITLE
JsonMessageRequestHandler: prevent double logout

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonMessageRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonMessageRequestHandler.java
@@ -190,20 +190,15 @@ public class JsonMessageRequestHandler extends AbstractUiServletRequestHandler {
       // the corresponding response from the history. This would normally be done in UiSession#processJsonRequest,
       // but without lock we have to do it manually. Otherwise, we send back an empty response.
       if (!uiSession.uiSessionLock().tryLock()) {
-        if (uiSession.isDisposed()) {
-          handleUiSessionDisposed(httpServletResponse, uiSession, jsonRequest);
+        JSONObject response = uiSession.getAlreadyProcessedResponse(jsonRequest);
+        if (response != null) {
+          LOG.info("Request #{} was already processed. Sending back response from history.", jsonRequest.getSequenceNo());
         }
         else {
-          JSONObject response = uiSession.getAlreadyProcessedResponse(jsonRequest);
-          if (response != null) {
-            LOG.info("Request #{} was already processed. Sending back response from history.", jsonRequest.getSequenceNo());
-          }
-          else {
-            LOG.debug("Creating empty response [{}, #{}, #ACK {}]", "CER_HJR", jsonRequest.getSequenceNo(), jsonRequest.getAckSequenceNo());
-            response = m_jsonRequestHelper.createEmptyResponse();
-          }
-          writeJsonResponse(httpServletResponse, response);
+          LOG.debug("Creating empty response [{}, #{}, #ACK {}]", "CER_HJR", jsonRequest.getSequenceNo(), jsonRequest.getAckSequenceNo());
+          response = m_jsonRequestHelper.createEmptyResponse();
         }
+        writeJsonResponse(httpServletResponse, response);
         return;
       }
     }


### PR DESCRIPTION
When the ?poll request cannot acquire the ui session lock, another user request is currently being processed. Because the model is not accessible, an empty response is returned. This was recently changed to return a "session terminated" message if the ui session is disposed. While this sounds sensible, it can lead to problems because the "session terminated" message also contains a redirect url. If the browser applies this redirect, while the other request is still being processed, unpredictable effects can happen, especially if the second response _also_ eventually causes a redirect. Depending on the kind of authentication filter, the second redirect does no longer work and the user will see a blank page or an error message.

To fix this, the previous change was partially inverted. Instead of sending a "session terminated" message when the ui session is disposed, an empty response is sent in any case where the ui session lock could not be acquired.

376896