### PR TITLE
Device: fix unwanted tablet mode for Firefox on Windows 11

### DIFF
--- a/eclipse-scout-core/src/util/Device.ts
+++ b/eclipse-scout-core/src/util/Device.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -261,11 +261,15 @@ export class Device implements DeviceModel, ObjectWithType {
   }
 
   /**
-   * The best way we have to detect a Microsoft Surface Tablet in table mode is to check if
-   * the scrollbar width is 0 pixel. In desktop mode the scrollbar width is > 0 pixel.
+   * Checks if the device is running Windows 10 or later in "tablet mode". We assume that this is the case when the
+   * _primary_ input mechanism consists of a pointing device of limited accuracy, such as a finger on a touchscreen.
+   *
+   * In Windows 11, the "tablet mode" cannot be explicitly set by the user. Instead, it is automatically turned on
+   * when the keyboard is detached. When the device is docked, the touchscreen can still be used, but it is no longer
+   * the primary input mechanism.
    */
   isWindowsTabletMode(): boolean {
-    return Device.System.WINDOWS === this.system && this.systemVersion >= 10 && this.scrollbarWidth === 0;
+    return Device.System.WINDOWS === this.system && this.systemVersion >= 10 && window.matchMedia('(pointer: coarse)').matches;
   }
 
   /**

--- a/eclipse-scout-core/test/util/DeviceSpec.ts
+++ b/eclipse-scout-core/test/util/DeviceSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -54,12 +54,28 @@ describe('Device', () => {
   describe('isWindowsTabletMode', () => {
 
     it('returns true if system is windows and scrollbarWidth is 0', () => {
-      Device.get().scrollbarWidth = 0;
       Device.get().system = Device.System.WINDOWS;
       Device.get().systemVersion = 10.0;
-      expect(Device.get().isWindowsTabletMode()).toBe(true);
-    });
+      let origMatchMedia = window.matchMedia;
+      try {
+        // Patch native "matchMedia" function to simulate different device capabilities
+        let matches = false;
+        window.matchMedia = (mediaQuery: string) => {
+          return {
+            matches: matches
+          } as MediaQueryList;
+        };
+        expect(Device.get().isWindowsTabletMode()).toBe(false);
 
+        matches = true;
+        expect(Device.get().isWindowsTabletMode()).toBe(true);
+
+        Device.get().system = Device.System.UNKNOWN;
+        expect(Device.get().isWindowsTabletMode()).toBe(false);
+      } finally {
+        window.matchMedia = origMatchMedia;
+      }
+    });
   });
 
   describe('user agent parsing', () => {


### PR DESCRIPTION
Firefox on Windows 11 always uses "pretty" (floating) scrollbars that have a width of 0. Because Device#isWindowsTabletMode() assumes that a width of 0 indicates that the "tablet mode" is active, Firefox users on Windows 11 always get the tablet version of the application, even when they are using a normal desktop computer.

To fix this, the implementation of isWindowsTableMode() is changed. Instead of checking the scrollbar width, a media query is used to identify the type of the _primary_ input method.
- A normal desktop computer or a convertible in "desktop mode" uses a mouse cursor as primary input method, which is reported as 'fine'.
- A touch-only device or a convertible in "tablet mode" does not have a mouse. Therefore, the primary input method is reported as 'coarse'.

Note that Windows 11 no longer provides an option to manually activate or deactivate the "tablet mode". Instead, the mode is automatically activated or deactivated when the device is docked or undocked.

363875