### PR TITLE
Table: fix tooltip position when rows are updated

### DIFF
--- a/eclipse-scout-core/src/tooltip/Tooltip.ts
+++ b/eclipse-scout-core/src/tooltip/Tooltip.ts
@@ -213,10 +213,6 @@ export class Tooltip extends Widget implements TooltipModel {
     this.setProperty('text', text);
   }
 
-  setSeverity(severity: StatusSeverity) {
-    this.setProperty('severity', severity);
-  }
-
   protected _renderText() {
     let text = this.text || '';
     if (this.htmlEnabled) {
@@ -230,6 +226,18 @@ export class Tooltip extends Widget implements TooltipModel {
     if (!this.rendering) {
       this.position();
     }
+  }
+
+  setHtmlEnabled(htmlEnabled: boolean) {
+    this.setProperty('htmlEnabled', htmlEnabled);
+  }
+
+  protected _renderHtmlEnabled() {
+    this._renderText();
+  }
+
+  setSeverity(severity: StatusSeverity) {
+    this.setProperty('severity', severity);
   }
 
   protected _renderSeverity() {
@@ -284,6 +292,17 @@ export class Tooltip extends Widget implements TooltipModel {
       this.$container.cssLeft('').cssTop('');
       this.position();
     }
+  }
+
+  set$Anchor($anchor: JQuery) {
+    if ($anchor?.[0] === this.$anchor?.[0]) { // compare DOM elements
+      return;
+    }
+    this.setProperty('$anchor', $anchor);
+  }
+
+  protected _render$anchor() {
+    this.position();
   }
 
   position() {

--- a/eclipse-scout-core/src/tooltip/TooltipSupport.ts
+++ b/eclipse-scout-core/src/tooltip/TooltipSupport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -89,6 +89,10 @@ export class TooltipSupport {
     this._destroyTooltip();
   }
 
+  get tooltip(): Tooltip {
+    return this._tooltip;
+  }
+
   protected _onMouseEnter(event: MouseEnterEvent) {
     let $comp = $(event.currentTarget);
 
@@ -134,21 +138,25 @@ export class TooltipSupport {
       return; // removed in the meantime (this method is called using setTimeout)
     }
     let text = this._text($comp);
-    if (!text) {
-      return; // treat undefined and no text as no tooltip
+    if (!text) { // treat undefined and no text as no tooltip
+      this._destroyTooltip();
+      return;
     }
 
+    let $anchor = this._options.$anchor || $comp;
     let htmlEnabled = this._htmlEnabled($comp);
 
     if (this._tooltip && this._tooltip.rendered) {
       // update existing tooltip
+      this._tooltip.set$Anchor($anchor);
+      this._tooltip.setHtmlEnabled(htmlEnabled);
       this._tooltip.setText(text);
       this._tooltip.setSeverity(this._options.severity);
       this._tooltip.setMenus(this._options.menus);
     } else {
       // create new tooltip
       let options = $.extend({}, this._options, {
-        $anchor: this._options.$anchor || $comp,
+        $anchor: $anchor,
         text: text,
         htmlEnabled: htmlEnabled
       });


### PR DESCRIPTION
When a cell tooltip is open while the row is updated, the tooltip is updated because the new row might have a different tooltip text. Because the tooltip support reuses the same tooltip instance, the $anchor has to be updated as well. Otherwise, the position will be wrong, because the old cell div is no longer in the DOM.

Certain other properties also need to be updated on the existing tooltip instance. For example, if the text is set to an empty string, the tooltip should be closed.

377024