### PR TITLE
App: don't set language header for ajax calls until session is ready

### DIFF
--- a/eclipse-scout-core/src/App.js
+++ b/eclipse-scout-core/src/App.js
@@ -376,7 +376,7 @@ export default class App {
   _beforeAjaxCall(request) {
     request.setRequestHeader('X-Scout-Correlation-Id', numbers.correlationId());
     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest'); // explicitly add here because jQuery only adds it automatically if it is no crossDomain request
-    if (this.sessions[0]) {
+    if (this.sessions[0] && this.sessions[0].ready) {
       request.setRequestHeader('Accept-Language', this.sessions[0].locale.languageTag);
     }
   }


### PR DESCRIPTION
The startup request should use the default 'Accept-Language' header set by the browser. The session locale is only used after the session is fully initialized. Otherwise, the startup request would always be called with 'en_US' (Locale.DEFAULT) instead of the browser language.

377400