### PR TITLE
strings: truncateText must not fail if a number is passed

### DIFF
--- a/eclipse-scout-core/src/util/strings.ts
+++ b/eclipse-scout-core/src/util/strings.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -411,7 +411,7 @@ export const strings = {
     if (!measureText) {
       measureText = text => ({width: (text || '').length});
     }
-    text = text.trim();
+    text = strings.asString(text).trim();
     let textWidth = measureText(text).width;
     if (textWidth <= horizontalSpace) {
       return text;

--- a/eclipse-scout-core/test/util/stringsSpec.ts
+++ b/eclipse-scout-core/test/util/stringsSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -480,6 +480,10 @@ describe('strings', () => {
       expect(strings.truncateText(loremIpsum, 120, measureText)).toBe(loremIpsum);
       expect(strings.truncateText(loremIpsum, 100, measureText)).toBe('Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dol...');
       expect(strings.truncateText(loremIpsum, 0, measureText)).toBe(loremIpsum);
+    });
+
+    it('does not fail if a number is passed', () => {
+      expect(strings.truncateText(1234567 as any, 5)).toBe('12...');
     });
   });
 });


### PR DESCRIPTION
ChartTableControl works with numeric labels even though chart expects strings.
truncateText on 23.2 did not fail if there was enough space because in that case trim() was not called.
Now trim() is called before measureText() which causes the error. Because there may be other existing code that calls the function with a number, it can now work with numbers.

376764