### PR TITLE
Session: don't reload page on upload errors

### DIFF
--- a/eclipse-scout-core/src/session/Session.ts
+++ b/eclipse-scout-core/src/session/Session.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1054,11 +1054,13 @@ export class Session extends EventEmitter implements SessionModel, ModelAdapterL
       boxOptions.header = this.optText('ui.UnsafeUpload', boxOptions.header);
       boxOptions.body = this.optText('ui.UnsafeUploadMsg', boxOptions.body);
       boxOptions.yesButtonText = this.optText('ui.Ok', 'Ok');
+      boxOptions.yesButtonAction = null; // NOP
       isFatalError = false; // unsafe upload allows the application to continue
     } else if (jsonError.code === Session.JsonResponseError.REJECTED_UPLOAD) {
       boxOptions.header = this.optText('ui.RejectedUpload', boxOptions.header);
       boxOptions.body = this.optText('ui.RejectedUploadMsg', boxOptions.body);
       boxOptions.yesButtonText = this.optText('ui.Ok', 'Ok');
+      boxOptions.yesButtonAction = null; // NOP
       isFatalError = false; // rejected upload allows the application to continue
     }
     this.showFatalMessage(boxOptions, jsonError.code + '');


### PR DESCRIPTION
Errors during the uploading of files allow the application to continue. The default yes button action reloads the page, which is not necessary in this case. To skip the reload, the button action is remove. (This was already the case in 22.0, but somehow got lost during the TS migration.)