### PR TITLE
FilterSupport: update background color on 'render' event

### DIFF
--- a/eclipse-scout-core/src/filter/FilterSupport.ts
+++ b/eclipse-scout-core/src/filter/FilterSupport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -119,7 +119,7 @@ export class FilterSupport<TElem extends FilterElement> extends WidgetSupport {
     this._filterField.$field.attr('tabindex', -1);
 
     if (!this.widget.rendered) {
-      this.widget.session.layoutValidator.schedulePostValidateFunction(this._updateFilterFieldBackgroundColor.bind(this));
+      this.widget.one('render', event => this._updateFilterFieldBackgroundColor());
     } else {
       this._updateFilterFieldBackgroundColor();
     }

--- a/eclipse-scout-core/test/widget/FilterSupportSpec.ts
+++ b/eclipse-scout-core/test/widget/FilterSupportSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ describe('FilterSupport', () => {
 
     elements: Element[];
     filters: Filter<Element>[];
-    filterSupport: FilterSupport<Element> & { _filterField: StringField };
+    filterSupport: FilterSupport<Element> & { _filterField: StringField; _updateFilterFieldBackgroundColor: () => void };
     textFilterEnabled: boolean;
     filteredElementsDirty: boolean;
 
@@ -385,6 +385,40 @@ describe('FilterSupport', () => {
         };
 
       testTextFilter(somePropertyFilterFunc, idIsPrimeFilterFunc);
+    });
+  });
+
+  describe('filter field', () => {
+
+    let $div1, $div2, $div3;
+
+    beforeEach(() => {
+      $div1 = session.$entryPoint.appendDiv().css('background-color', 'red');
+      $div2 = $div1.appendDiv();
+      $div3 = $div2.appendDiv().css('background-color', 'blue');
+    });
+
+    it('updates the background-color when filter field is rendered initially', () => {
+      let widget = createWidget({elements: createElements()});
+      let updateBgSpy = spyOn(widget.filterSupport, '_updateFilterFieldBackgroundColor').and.callThrough();
+      widget.setTextFilterEnabled(true); // <-- before widget.render()
+
+      expect(updateBgSpy).toHaveBeenCalledTimes(0);
+      widget.render($div3);
+      expect(updateBgSpy).toHaveBeenCalledTimes(1);
+      expect(widget.filterSupport._filterField.$container.css('--filter-field-background-color')).toBe($div3.css('background-color'));
+    });
+
+    it('updates the background-color when filter field is rendered later', () => {
+      let widget = createWidget({elements: createElements()});
+      let updateBgSpy = spyOn(widget.filterSupport, '_updateFilterFieldBackgroundColor').and.callThrough();
+
+      expect(updateBgSpy).toHaveBeenCalledTimes(0);
+      widget.render($div2);
+      expect(updateBgSpy).toHaveBeenCalledTimes(0);
+      widget.setTextFilterEnabled(true); // <-- after widget.render()
+      expect(updateBgSpy).toHaveBeenCalledTimes(1);
+      expect(widget.filterSupport._filterField.$container.css('--filter-field-background-color')).toBe($div1.css('background-color'));
     });
   });
 });


### PR DESCRIPTION
When the filter field is rendered while the parent widget is also currently being rendered, the determination of the background color has to be postponed until after the DOM is ready. This was previously done by scheduling a "post validate layout" function. However, this function might not be executed on time. For example, when a popup is opened, only the PopupLayout is validated, not the entire layout tree. To fix this, a listener for the 'render' event is attached to the widget. This event is fired independent of the layout. It is enough to determine the background color, because it only depends on the DOM structure, not on the size and layout information.

369849