### PR TITLE
Chart: add color mode

### DIFF
--- a/eclipse-scout-chart/src/chart/Chart.ts
+++ b/eclipse-scout-chart/src/chart/Chart.ts
@@ -150,6 +150,7 @@ export class Chart extends Widget implements ChartModel {
       type: Chart.Type.PIE,
       options: {
         autoColor: true,
+        colorMode: ChartColorMode.AUTO,
         colorScheme: colorSchemes.ColorSchemeId.DEFAULT,
         transparent: false,
         maxSegments: 5,
@@ -418,6 +419,7 @@ export type ChartConfig = Partial<Omit<ChartConfiguration, 'type'>> & {
   type: ChartType;
   options?: {
     autoColor?: boolean;
+    colorMode?: ChartColorMode;
     colorScheme?: ColorScheme | string;
     transparent?: boolean;
     maxSegments?: number;
@@ -471,6 +473,24 @@ export type ChartConfig = Partial<Omit<ChartConfiguration, 'type'>> & {
 export type ChartType = EnumObject<typeof Chart.Type>;
 export type ChartPosition = EnumObject<typeof Chart.Position>;
 export type NumberFormatter = (label: number | string, defaultFormatter: (label: number | string) => string) => string;
+
+/**
+ * Determines what parts of the chart data is colored with the same colors.
+ */
+export enum ChartColorMode {
+  /**
+   * Uses one of the other options depending on the chart type.
+   */
+  AUTO = 'auto',
+  /**
+   * Uses a different color for each dataset.
+   */
+  DATASET = 'dataset',
+  /**
+   * Uses a different color for each datapoint in a dataset but the n-th datapoint in each dataset will be colored using the same color.
+   */
+  DATA = 'data'
+}
 
 export type ClickObject = {
   datasetIndex: number;

--- a/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
+++ b/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AbstractChartRenderer, Chart, chartJsDateAdapter} from '../index';
+import {AbstractChartRenderer, Chart, ChartColorMode, chartJsDateAdapter} from '../index';
 import {
   _adapters as chartJsAdapters, ActiveElement, ArcElement, BarElement, BubbleDataPoint, CartesianScaleOptions, Chart as ChartJs, ChartArea, ChartConfiguration, ChartDataset, ChartEvent, ChartType as ChartJsType, Color, DefaultDataPoint,
   FontSpec, LegendElement, LegendItem, LegendOptions, LinearScaleOptions, PointElement, PointHoverOptions, RadialLinearScaleOptions, Scale, ScatterDataPoint, TooltipCallbacks, TooltipItem, TooltipLabelStyle, TooltipModel, TooltipOptions
@@ -1656,7 +1656,13 @@ export class ChartJsRenderer extends AbstractChartRenderer {
       type = config.type,
       autoColor = config.options && config.options.autoColor,
       checkable = config.options && config.options.checkable,
-      multipleColorsPerDataset = autoColor && scout.isOneOf(type, Chart.Type.PIE, Chart.Type.DOUGHNUT, Chart.Type.POLAR_AREA),
+      colorMode = config.options && config.options.colorMode,
+      multipleColorsPerDataset = autoColor && (
+        colorMode === ChartColorMode.DATASET
+          ? false
+          : colorMode === ChartColorMode.DATA
+            ? true
+            : scout.isOneOf(type, Chart.Type.PIE, Chart.Type.DOUGHNUT, Chart.Type.POLAR_AREA)),
       colors = {
         backgroundColors: [],
         borderColors: [],

--- a/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/ChartConfig.java
+++ b/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/ChartConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,7 @@ public class ChartConfig implements IChartConfig {
   protected static final String OPTIONS = "options";
   protected static final String PLUGINS = combine(OPTIONS, "plugins");
   protected static final String AUTO_COLOR = combine(OPTIONS, "autoColor");
+  protected static final String COLOR_MODE = combine(OPTIONS, "colorMode");
   protected static final String COLOR_SCHEME = combine(OPTIONS, "colorScheme");
   protected static final String TRANSPARENT = combine(OPTIONS, "transparent");
   protected static final String MAX_SEGMENTS = combine(OPTIONS, "maxSegments");
@@ -435,6 +436,21 @@ public class ChartConfig implements IChartConfig {
   @Override
   public boolean isAutoColor() {
     return BooleanUtility.nvl((Boolean) getProperty(AUTO_COLOR));
+  }
+
+  @Override
+  public IChartConfig withColorMode(ColorMode colorMode) {
+    return withProperty(COLOR_MODE, colorMode != null ? colorMode.getValue() : null);
+  }
+
+  @Override
+  public IChartConfig removeColorMode() {
+    return removeProperty(COLOR_MODE);
+  }
+
+  @Override
+  public ColorMode getColorMode() {
+    return ColorMode.parse((String) getProperty(COLOR_MODE));
   }
 
   @Override

--- a/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/ColorMode.java
+++ b/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/ColorMode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.chart.shared.data.basic.chart;
+
+import java.util.stream.Stream;
+
+/**
+ * Determines what parts of the chart data is colored with the same colors.
+ */
+public enum ColorMode {
+  /**
+   * Uses one of the other options depending on the chart type.
+   */
+  AUTO("auto"),
+  /**
+   * Uses a different color for each dataset.
+   */
+  DATASET("dataset"),
+  /**
+   * Uses a different color for each datapoint in a dataset but the n-th datapoint in each dataset will be colored using the same color.
+   */
+  DATA("data");
+
+  private final String m_value;
+
+  ColorMode(String value) {
+    m_value = value;
+  }
+
+  public String getValue() {
+    return m_value;
+  }
+
+  public static ColorMode parse(String value) {
+    return Stream.of(values())
+        .filter(colorMode -> colorMode.getValue().equals(value))
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Utility method returning the "opposite" color mode for this mode.
+   */
+  public ColorMode toggle() {
+    switch (this) {
+      case DATASET:
+        return DATA;
+      case DATA:
+        return DATASET;
+      default:
+        return this; // unknown mode cannot be toggled
+    }
+  }
+}

--- a/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/IChartConfig.java
+++ b/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/IChartConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -132,6 +132,12 @@ public interface IChartConfig extends Serializable {
   IChartConfig removeAutoColor();
 
   boolean isAutoColor();
+
+  IChartConfig withColorMode(ColorMode colorMode);
+
+  IChartConfig removeColorMode();
+
+  ColorMode getColorMode();
 
   IChartConfig withColorScheme(IColorScheme colorScheme);
 


### PR DESCRIPTION
If a chart uses autoColor, the colorMode determines what parts of the chart data is colored with the same colors:
* DATASET uses a different color for each dataset.
* DATA uses a different color for each datapoint in a dataset but the n-th datapoint in each dataset will be colored using the same color.
* AUTO uses one of the other options depending on the chart type.

328459