### PR TITLE
Data Objects: Retain UnknownId as past of TypedId-deserialization

### DIFF
--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/id/TestEntityWithUnknownTypedIdDo.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/id/TestEntityWithUnknownTypedIdDo.json
@@ -1,0 +1,6 @@
+{
+  "_type" : "scout.TestEntityWithTypedId",
+  "iid" : "scout.unknown1:foo;8fa211b0-fd83-42cb-96c9-1942e274ce79",
+  "stringId" : "scout.unknown2:foo",
+  "uuId" : "scout.unknown3:8fa211b0-fd83-42cb-96c9-1942e274ce79"
+}

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/id/TestEntityWithUnknownTypedIdInvalidFormatDo.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/id/TestEntityWithUnknownTypedIdInvalidFormatDo.json
@@ -1,0 +1,6 @@
+{
+  "_type" : "scout.TestEntityWithTypedId",
+  "iid" : "foo;8fa211b0-fd83-42cb-96c9-1942e274ce79",
+  "stringId" : "foo",
+  "uuId" : "8fa211b0-fd83-42cb-96c9-1942e274ce79"
+}

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/ScoutDataObjectSerializerProvider.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/ScoutDataObjectSerializerProvider.java
@@ -132,7 +132,7 @@ public class ScoutDataObjectSerializerProvider implements IDataObjectSerializerP
       }
     }
     else if (TypedId.class.isAssignableFrom(rawClass)) {
-      return new TypedIdDeserializer();
+      return new TypedIdDeserializer(moduleContext);
     }
 
     return null;

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/id/TypedIdDeserializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/id/TypedIdDeserializer.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import org.eclipse.scout.rt.dataobject.id.IId;
 import org.eclipse.scout.rt.dataobject.id.IdCodec;
 import org.eclipse.scout.rt.dataobject.id.TypedId;
+import org.eclipse.scout.rt.jackson.dataobject.ScoutDataObjectModuleContext;
 import org.eclipse.scout.rt.platform.util.LazyValue;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -27,16 +28,21 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 public class TypedIdDeserializer extends StdDeserializer<TypedId<IId>> {
   private static final long serialVersionUID = 1L;
 
+  protected final ScoutDataObjectModuleContext m_moduleContext;
   protected final LazyValue<IdCodec> m_idCodec = new LazyValue<>(IdCodec.class);
 
-  public TypedIdDeserializer() {
+  public TypedIdDeserializer(ScoutDataObjectModuleContext moduleContext) {
     super(TypedId.class);
+    m_moduleContext = moduleContext;
   }
 
   @Override
   public TypedId<IId> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
     String rawValue = p.getText();
     try {
+      if (m_moduleContext.isLenientMode()) {
+        return TypedId.of(m_idCodec.get().fromQualifiedLenient(rawValue));
+      }
       return TypedId.of(m_idCodec.get().fromQualified(rawValue));
     }
     catch (RuntimeException e) {


### PR DESCRIPTION
In order to allow a value migration to mutate IdTypeName of an id wrapped into a TypedId the TypedIdDeserializer must retain the UnknownId when deserializing in lenient mode.

379569