### PR TITLE
Support CAST and INTERVAL in classical SqlFormatter

### DIFF
--- a/org.eclipse.scout.rt.server.jdbc.test/src/test/java/org/eclipse/scout/rt/server/jdbc/parsers/sql/SqlFormatterTest.java
+++ b/org.eclipse.scout.rt.server.jdbc.test/src/test/java/org/eclipse/scout/rt/server/jdbc/parsers/sql/SqlFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,6 +34,15 @@ public class SqlFormatterTest {
     check("select-case1.sql");
     check("select-case2.sql");
     check("select-case3.sql");
+  }
+
+  @Test
+  public void testSelectCast() throws Exception {
+    check("select-cast1.sql");
+    check("select-cast2.sql");
+    check("select-cast3.sql");
+    check("select-cast4.sql");
+    check("select-cast5.sql");
   }
 
   @Test

--- a/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast1.sql
+++ b/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast1.sql
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+SELECT DV.VALUE0 AS KEY,
+          DV.VALUE1,
+          CAST( DV.VALUE2 AS INT ) + 10 AS VALUE2 ,
+          DV.VALUE3
+FROM TABLE1 D, TABLE2 DV
+WHERE DV.ACTIVE = 1

--- a/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast2.sql
+++ b/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast2.sql
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+UPDATE TABLE1 AS T
+SET LOCKED_BY_ID = :b__0,
+    VERSION      = CAST((VERSION + 1) AS BIGINT)
+WHERE T.ID = :b__1
+  AND T.LOCKED_BY_ID IS NULL
+  AND T.VERSION = :b__2

--- a/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast3.sql
+++ b/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast3.sql
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+SELECT DV.VALUE0 AS KEY
+FROM TABLE2 DV
+WHERE DV.ACTIVE = 1
+  AND ( CAST ( DATE_TRUNC ( 'DAY'
+    , CAST ( EVT_END AS TIMESTAMP ) ) AS TIMESTAMP ) + ( 1 ) * INTERVAL '1 day' ) <= STATEMENT_TIMESTAMP ( )
+INTO :resultHolder

--- a/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast4.sql
+++ b/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast4.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+SELECT DV.VALUE0 AS KEY
+FROM TABLE2 DV
+WHERE DV.ACTIVE = 1
+  AND EVT_START BETWEEN ( CAST ( STATEMENT_TIMESTAMP ( ) AS TIMESTAMP ) + ( - 1 ) * INTERVAL '1 hour' )
+  AND STATEMENT_TIMESTAMP ( )
+UNION
+SELECT DW.COLUMN_NR
+FROM TABLE2 DW
+WHERE DW.COLUMN_NR = :idNrs

--- a/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast5.sql
+++ b/org.eclipse.scout.rt.server.jdbc.test/src/test/resources/org/eclipse/scout/rt/server/jdbc/parsers/sql/select-cast5.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+select value_0 as key
+from table2
+where active = 1
+  and coalesce (
+    ( state_expiry )
+    , ( ( cast ( cast ( statement_timestamp ( ) as date ) as timestamp ) + ( 1 ) * interval '1 day' ) )
+  )
+    > cast ( statement_timestamp ( ) as date )
+  and state_no = 1

--- a/org.eclipse.scout.rt.server.jdbc/src/main/java/org/eclipse/scout/rt/server/jdbc/parsers/sql/SqlFormatter.java
+++ b/org.eclipse.scout.rt.server.jdbc/src/main/java/org/eclipse/scout/rt/server/jdbc/parsers/sql/SqlFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,24 +37,6 @@ import org.eclipse.scout.rt.server.jdbc.parsers.sql.SqlParserToken.Unparsed;
 
 /**
  * see {@link SqlParser}
- *
- * <pre>
- * <code>
- * Statement = SingleStatement (UnionToken SingleStatement)* (Unparsed)?
- * SingleStatement = Part+
- * Part = PartToken ListExpr
- * ListExpr = OrExpr (ListSeparator OrExpr)*
- * OrExpr = AndExpr (BinaryOp['OR'] AndExpr)*
- * AndExpr = MathExpr (BinaryOp['AND'] MathExpr)*
- * MathExpr = _simpleExpr (BinaryOp _simpleExpr)*
- * _simpleExpr = UnaryPrefixExpr | MinusExpr | Atom
- * UnaryPrefixExpr = UnaryPrefix Atom
- * MinusExpr = BinaryOp['-'] Atom
- * Atom= (BracketExpr | Statement | OrExpr | FunExpr | Name | Text | BinaryOp['*']) (OuterJoinToken)? (Name["AS"])? (Name[alias])?
- * BracketExpr = OpenBracketToken (Statement | ListExpr) CloseBracketToken
- * FunExpr = Name BracketExpr
- * </code>
- * </pre>
  */
 public class SqlFormatter {
 

--- a/org.eclipse.scout.rt.server.jdbc/src/main/java/org/eclipse/scout/rt/server/jdbc/parsers/sql/SqlParserToken.java
+++ b/org.eclipse.scout.rt.server.jdbc/src/main/java/org/eclipse/scout/rt/server/jdbc/parsers/sql/SqlParserToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -123,6 +123,18 @@ final class SqlParserToken {
   }
 
   public static class PartToken extends AbstractToken {
+  }
+
+  public static class CastExpr extends AbstractToken {
+  }
+
+  public static class CastToken extends AbstractToken {
+  }
+
+  public static class IntervalToken extends AbstractToken {
+  }
+
+  public static class IntervalExpr extends AbstractToken {
   }
 
   public static class UnaryPrefix extends AbstractToken {


### PR DESCRIPTION
Support CAST and INTERVAL in classical SqlFormatter

Added support for CAST and INTERVAL clauses to the
SqlFormatter class.

Examples:
CAST ( t.COLUMN_1 AS NUMBER)
INTERVAL '1 day'

This change does not affect the SQLService at all
and is thus a low impact change improving
effectiveness and productivity of logging done with
the SqlFormatter.