### PR TITLE
Primary sort order for IDoValueMigrationHandler

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventoryTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventoryTest.java
@@ -34,6 +34,7 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureRawOn
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureTypedOnlyStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypeFixtureDoValueMigrationHandler_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStructureMigrationHandler_2;
@@ -103,7 +104,8 @@ public class DataObjectMigrationInventoryTest {
             // registration order here is relevant for test method testValueMigrationHandlersOrdered
             new RoomSizeFixtureDoValueMigrationHandler_2(),
             new RoomTypeFixtureDoValueMigrationHandler_2(),
-            new HouseTypeFixtureDoValueMigrationHandler_2()));
+            new HouseTypeFixtureDoValueMigrationHandler_2(),
+            new OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2()));
   }
 
   /**
@@ -140,7 +142,7 @@ public class DataObjectMigrationInventoryTest {
    * Validates internal structure of inventory ({@link DataObjectMigrationInventory#m_orderedVersions}.
    */
   @Test
-  public void testOrdered() {
+  public void testOrderedVersions() {
     assertEquals(
         Arrays.asList(
             AlfaFixture_1.VERSION, BravoFixture_1.VERSION, CharlieFixture_1.VERSION, DeltaFixture_1.VERSION,
@@ -317,7 +319,7 @@ public class DataObjectMigrationInventoryTest {
   }
 
   @Test
-  public void testGetMigrationHandlers() {
+  public void testGetStructureMigrationHandlers() {
     assertThrows(AssertionException.class, () -> s_inventory.getStructureMigrationHandlers(null));
     assertThrows(AssertionException.class, () -> s_inventory.getStructureMigrationHandlers(AlfaFixture_7.VERSION)); // no registered
 
@@ -362,19 +364,24 @@ public class DataObjectMigrationInventoryTest {
   public void testValueMigrationHandlersOrdered() {
     // all value migration handlers, ordered (see initialization of s_inventory)
     List<IDoValueMigrationHandler<?>> valueMigrationHandlers = s_inventory.getValueMigrationHandlers();
-    assertEquals(3, valueMigrationHandlers.size());
-    assertEquals(RoomTypeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(0).id());
+    assertEquals(4, valueMigrationHandlers.size());
+
+    // untyped value migration handler before regular migrations (because of primary sort order)
+    assertEquals(OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2.ID, valueMigrationHandlers.get(0).id());
+
+    // regular migration handlers
+    assertEquals(RoomTypeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(1).id());
     // HouseTypeFixtureDoValueMigrationHandler_2 after RoomTypeFixtureDoValueMigrationHandler_2 because of registration order (same type version)
-    assertEquals(HouseTypeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(1).id());
+    assertEquals(HouseTypeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(2).id());
     // RoomSizeFixtureDoValueMigrationHandler_2 after HouseTypeFixtureDoValueMigrationHandler_2 because of type version (registration order is overridden)
-    assertEquals(RoomSizeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(2).id());
+    assertEquals(RoomSizeFixtureDoValueMigrationHandler_2.ID, valueMigrationHandlers.get(3).id());
   }
 
   /**
    * Register two value migration handlers with identical ID -> exception expected
    */
   @Test
-  public void voidTestDuplicateValueMigrationIds() {
+  public void testDuplicateValueMigrationIds() {
     PlatformException exception = assertThrows(PlatformException.class, () -> new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace()),
         Arrays.asList(

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorValueMigrationTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorValueMigrationTest.java
@@ -37,7 +37,7 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDoVal
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypeFixtureDoValueMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypeFixtureStringId;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseTypesFixture;
-import org.eclipse.scout.rt.dataobject.migration.fixture.house.OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler;
+import org.eclipse.scout.rt.dataobject.migration.fixture.house.OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureAlwaysAcceptDoValueMigrationHandler_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PetFixtureDoValueMigrationHandler_3;
@@ -92,7 +92,7 @@ public class DataObjectMigratorValueMigrationTest {
             new CustomerGenderFixtureDoValueMigrationHandler_2(),
             new HouseTypeFixtureDoValueMigrationHandler_2(),
             new HouseFixtureDoValueMigrationHandler_1(),
-            new OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler()));
+            new OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2()));
 
     TEST_BEANS.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(TestDataObjectMigrationInventory.class, inventory).withReplace(true)));
 
@@ -611,5 +611,23 @@ public class DataObjectMigratorValueMigrationTest {
     assertTrue(result.isChanged());
     assertTrue(result.getDataObject().getId() instanceof HouseTypeFixtureStringId);
     assertEquals("foo", result.getDataObject().getId().unwrap());
+  }
+
+  /**
+   * Testcase for IdTypeName renaming from 'charlieFixture.OldHouseTypeFixtureStringId' to
+   * 'charlieFixture.HouseTypeFixtureStringId' followed by a typed value migration for HouseTypeFixtureStringId.
+   * <p>
+   * Setup EntityWithIdFixtureDo using raw data object mapper.
+   * <p>
+   * Sort order of value migration handlers is relevant: HouseTypeFixtureDoValueMigrationHandler_2 is applied
+   * <i>after</i> OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2, despite a lower type version.
+   */
+  @Test
+  public void testValueMigrationOrder() {
+    IDoEntity entity = (IDoEntity) BEANS.get(IDataObjectMapper.class).readValueRaw("{\"_type\" : \"EntityWithIdFixture\", \"id\" : \"charlieFixture.OldHouseTypeFixtureStringId:house\"}");
+    DataObjectMigratorResult<EntityWithIdFixtureDo> result = s_migrator.migrateDataObject(s_migrationContext, entity, EntityWithIdFixtureDo.class);
+    assertTrue(result.isChanged());
+    assertTrue(result.getDataObject().getId() instanceof HouseTypeFixtureStringId);
+    assertEquals(HouseTypesFixture.DETACHED_HOUSE, result.getDataObject().getId());
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2.java
@@ -14,12 +14,12 @@ import org.eclipse.scout.rt.dataobject.id.UnknownId;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueUntypedMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
 
 /**
  * Migration handler migrating former OldHouseTypeFixtureStringId instances to {@link HouseTypeFixtureStringId}.
  */
-public class OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler extends AbstractDoValueUntypedMigrationHandler<UnknownId> {
+public class OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2 extends AbstractDoValueUntypedMigrationHandler<UnknownId> {
 
   public static final DoValueMigrationId ID = DoValueMigrationId.of("543df71a-e095-499c-a684-2d4e5604a391");
 
@@ -30,7 +30,9 @@ public class OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler extends A
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return CharlieFixture_1.class;
+    // Type version DeltaFixture_2 is after CharlieFixture_2 and therefore HouseTypeFixtureDoValueMigrationHandler_2.
+    // But untyped value migrations will always be applied before regular value migrations, based on the primary sort order.
+    return DeltaFixture_2.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoValueMigrationHandler.java
@@ -22,6 +22,11 @@ import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
  */
 public abstract class AbstractDoValueMigrationHandler<T> extends AbstractDoValueUntypedMigrationHandler<T> {
 
+  @Override
+  public double primarySortOrder() {
+    return DEFAULT_PRIMARY_SORT_ORDER;
+  }
+
   /**
    * Note: A default data object value migration is not allowed to change the type {@code T} of the value. Use
    * {@link AbstractDoValueUntypedMigrationHandler} to change the type of the migrated value.

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoValueUntypedMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractDoValueUntypedMigrationHandler.java
@@ -19,7 +19,7 @@ import org.eclipse.scout.rt.platform.util.TypeCastUtility;
  * based on the class generic type and supporting {@link Class} of {@link ITypeVersion} instead of
  * {@link NamespaceVersion}.
  * <p>
- * This rename migration handler allows to rename the type name and therefore change the type of the migrated value
+ * This untyped migration handler allows to rename the type name and therefore change the type of the migrated value
  * from {@code T} to {@link Object}.
  */
 public abstract class AbstractDoValueUntypedMigrationHandler<T> implements IDoValueMigrationHandler<T> {
@@ -28,6 +28,11 @@ public abstract class AbstractDoValueUntypedMigrationHandler<T> implements IDoVa
 
   protected AbstractDoValueUntypedMigrationHandler() {
     m_typeVersion = BEANS.get(typeVersionClass()).getVersion();
+  }
+
+  @Override
+  public double primarySortOrder() {
+    return UNTYPED_PRIMARY_SORT_ORDER;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventory.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventory.java
@@ -220,7 +220,9 @@ public class DataObjectMigrationInventory {
     allValueMigrationHandlers.forEach(handler -> validateValueMigrationHandler(handler, validatedValueMigrationHandlers));
     // Primary sort order by type version, secondary sort order provided by bean manager (order annotation and fully qualified class name).
     allValueMigrationHandlers.stream()
-        .sorted(Comparator.comparing(IDoValueMigrationHandler::typeVersion, m_comparator))
+        .sorted(Comparator
+            .comparingDouble((IDoValueMigrationHandler<?> handler) -> handler.primarySortOrder())
+            .thenComparing(IDoValueMigrationHandler::typeVersion, m_comparator))
         .forEach(handler -> m_valueMigrationHandlers.put(handler.id(), handler));
   }
 

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoValueMigrationHandler.java
@@ -36,8 +36,9 @@ import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
  * constants from the current code base, i.e. they are never refactored, if the code base changes).
  * <p>
  * Value migration handlers are always applied <i>after</i> all {@link IDoStructureMigrationHandler} have been applied.
- * Value migrations are applied in a specific order, defined by the given {@link #typeVersion()}. Migration handlers
- * with the same type version are applied in the order provided by the bean manager.
+ * Value migrations are applied in a specific order, defined by the given {@link #primarySortOrder()} and
+ * {@link #typeVersion()}. Migration handlers with the same primary sort order and type version are applied in the order
+ * provided by the bean manager.
  * <p>
  * Value migration handlers <i>must be idempotent</i>, i.e. the result of a given migration must not change, even if the
  * migration is applied multiple times. In general, value migrations are applied <i>exactly once</i>, as the system
@@ -139,6 +140,20 @@ import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 public interface IDoValueMigrationHandler<T> {
 
   /**
+   * Primary sort order for untyped value migrations, used by {@link AbstractDoValueUntypedMigrationHandler}.
+   *
+   * @see #primarySortOrder()
+   */
+  double UNTYPED_PRIMARY_SORT_ORDER = 1000.0;
+
+  /**
+   * Default primary sort order used by {@link AbstractDoValueMigrationHandler}.
+   *
+   * @see #primarySortOrder()
+   */
+  double DEFAULT_PRIMARY_SORT_ORDER = 2000.0;
+
+  /**
    * Unique identifier for this value migration handler.
    */
   DoValueMigrationId id();
@@ -153,7 +168,18 @@ public interface IDoValueMigrationHandler<T> {
   Class<T> valueClass();
 
   /**
-   * Type version used for sorting.
+   * Primary sort order used for sorting. The primary sort order can be used to group different types of value migration
+   * handlers. Secondary sort order is by {@link #typeVersion()}.
+   * <p>
+   * Example: Untyped DO value migrations (see {@link AbstractDoValueUntypedMigrationHandler}) use
+   * {@link #UNTYPED_PRIMARY_SORT_ORDER} and are always applied before regular migration handlers
+   * ({@link AbstractDoValueMigrationHandler}) using {@link #DEFAULT_PRIMARY_SORT_ORDER}).
+   */
+  double primarySortOrder();
+
+  /**
+   * Type version used for sorting. Primary sort order is by {@link #primarySortOrder()}, secondary sort order is by
+   * type version.
    * <p>
    * The type version defined on a value migration is used to obtain a sort order over all value migrations, including
    * value migrations from other namespaces. Value migrations are always applied after all structure migrations have


### PR DESCRIPTION
Untyped data object value migration handlers need to be applied before regular value migrations because they may convert typed values to the expected target type. A typical use case is conversion from UnknownId to a typed target ID in case of renaming a type ID name.

A primary sort order is introduced to allow (primary) sorting independent of the type version (which is used for secondary sorting). The primary sort order can be used to group different types of value migrations.

Regular value migrations (i.e. sub-classes of
AbstractDoValueMigrationHandler use
IDoValueMigrationHandler.DEFAULT_PRIMARY_SORT_ORDER and are applied after untyped value migrations (i.e. sub-classes of AbstractDoValueUntypedMigrationHandler) which use
IDoValueMigrationHandler.UNTYPED_PRIMARY_SORT_ORDER

379569