### PR TITLE
Add bootstrap rest mocks for jasmine specs

### DIFF
--- a/eclipse-scout-core/src/App.ts
+++ b/eclipse-scout-core/src/App.ts
@@ -67,7 +67,7 @@ export interface AppBootstrapOptions {
   configUrl?: string | string[];
   /**
    * Custom functions that needs to be executed while bootstrapping.
-   * All custom and default bootrappers need to finish successfully before the app will proceed with the initialization.
+   * All custom and default bootstrappers need to finish successfully before the app will proceed with the initialization.
    */
   bootstrappers?: (() => JQuery.Promise<void>)[];
 }
@@ -90,11 +90,11 @@ export class App extends EventEmitter {
    * Adds a function that needs to be executed while bootstrapping.
    * @see AppModel.bootstrappers
    */
-  static addBootstrapper(bootrapper: () => JQuery.Promise<void>) {
-    if (bootstrappers.indexOf(bootrapper) > -1) {
+  static addBootstrapper(bootstrapper: () => JQuery.Promise<void>) {
+    if (bootstrappers.indexOf(bootstrapper) > -1) {
       throw new Error('Bootstrapper is already registered.');
     }
-    bootstrappers.push(bootrapper);
+    bootstrappers.push(bootstrapper);
   }
 
   static get(): App {

--- a/eclipse-scout-core/src/RemoteApp.ts
+++ b/eclipse-scout-core/src/RemoteApp.ts
@@ -19,7 +19,7 @@ export class RemoteApp extends App {
 
   protected override _defaultBootstrappers(options: AppBootstrapOptions): (() => JQuery.Promise<void>)[] {
     return super._defaultBootstrappers(options).concat(
-      this._defaultValuesBootrapper(),
+      this._defaultValuesBootstrapper(),
       this._configPropertiesBootstrapper(options)
     );
   }
@@ -32,7 +32,7 @@ export class RemoteApp extends App {
     return config.bootstrapSystem.bind(config);
   }
 
-  protected _defaultValuesBootrapper(): () => JQuery.Promise<void> {
+  protected _defaultValuesBootstrapper(): () => JQuery.Promise<void> {
     return defaultValues.bootstrap.bind(defaultValues);
   }
 

--- a/eclipse-scout-core/src/testing/JasmineScout.ts
+++ b/eclipse-scout-core/src/testing/JasmineScout.ts
@@ -8,9 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AdapterData, App, arrays, Desktop, FullModelOf, HtmlEnvironment, InitModelOf, JsonErrorResponse, ModelAdapter, ModelOf, ObjectFactory, RemoteEvent, RemoteRequest, RemoteResponse, scout, Session, SessionStartupResponse, Widget, WidgetModel
+  AdapterData, App, arrays, Desktop, FullModelOf, HtmlEnvironment, InitModelOf, JsonErrorResponse, ModelAdapter, ModelOf, ObjectFactory, PermissionCollectionType, RemoteEvent, RemoteRequest, RemoteResponse, scout, Session,
+  SessionStartupResponse, Widget, WidgetModel
 } from '../index';
-import {jasmineScoutMatchers, LocaleSpecHelper, TestingApp} from './index';
+import {jasmineScoutMatchers, JasmineScoutUtil, LocaleSpecHelper, TestingApp} from './index';
 import 'jasmine-jquery';
 import $ from 'jquery';
 
@@ -261,14 +262,22 @@ export const JasmineScout = {
 
     context.keys().forEach(context);
   },
+
   startApp(App: new() => App) {
     // App initialization uses promises which are executed asynchronously
     // -> Use the clock to make sure all promise callbacks are executed before any test starts.
     jasmine.clock().install();
+    jasmine.Ajax.install();
 
     new App().init();
 
     jasmine.clock().tick(1000);
+
+    jasmine.Ajax.uninstall();
     jasmine.clock().uninstall();
   }
 };
+
+JasmineScoutUtil.mockRestCall('api/permissions', {type: PermissionCollectionType.ALL});
+JasmineScoutUtil.mockRestCall('api/codes', {});
+JasmineScoutUtil.mockRestCall('api/parameters', []);

--- a/eclipse-scout-core/src/testing/TestingApp.ts
+++ b/eclipse-scout-core/src/testing/TestingApp.ts
@@ -11,7 +11,7 @@ import {App, AppBootstrapOptions, Device, InitModelOf, RemoteApp, Session} from 
 
 export class TestingApp extends RemoteApp {
 
-  protected override _defaultValuesBootrapper(): () => JQuery.Promise<void> {
+  protected override _defaultValuesBootstrapper(): () => JQuery.Promise<void> {
     // nop for testing
     return null;
   }

--- a/eclipse-scout-core/src/testing/index.ts
+++ b/eclipse-scout-core/src/testing/index.ts
@@ -14,8 +14,8 @@ import {ObjectFactory} from '../index';
 import * as self from './index';
 
 export * from './TestingApp';
-export * from './JasmineScout';
 export * from './JasmineScoutUtil';
+export * from './JasmineScout';
 export * from './text/LocaleSpecHelper';
 export * from './menu/MenuSpecHelper';
 export * from './security/accessSpecHelper';


### PR DESCRIPTION
The app used during jasmine specs does its own bootstrapping. If e.g. codes need to be loaded during the bootstrapping phase it is now possible to add a static response for the rest call that loads the codes.