### PR TITLE
HealthCheckerTest: Fix flip/flop

### DIFF
--- a/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/healthcheck/HealthCheckerTest.java
+++ b/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/healthcheck/HealthCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -73,6 +73,7 @@ public class HealthCheckerTest {
   protected void awaitDone(IFuture future) {
     if (future != null) {
       future.awaitDoneAndGet();
+      future.awaitFinished(5, TimeUnit.SECONDS);
     }
   }
 


### PR DESCRIPTION
There is a really short time frame where a future is already DONE (e.g. awaitDone has returned already) but the future is not yet FINISHED (e.g. another checkHealth call may not return result of previous call future).