### PR TITLE
CellEditorPopup: ignore key stroke when cell editor opens a form

### DIFF
--- a/eclipse-scout-core/src/filechooser/FileChooser.ts
+++ b/eclipse-scout-core/src/filechooser/FileChooser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -182,7 +182,10 @@ export class FileChooser extends Widget implements FileChooserModel {
 
   protected _setDisplayParent(displayParent: DisplayParent) {
     this._setProperty('displayParent', displayParent);
-    if (displayParent) {
+
+    // Overwrite the parent with the displayParent, unless the displayParent is a descendant of the parent.
+    // This is necessary to automatically remove this element when the display parent is removed.
+    if (displayParent && !displayParent.isOrHas(this.parent)) {
       this.setParent(this.findDesktop().computeParentForDisplayParent(displayParent));
     }
   }

--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -1454,7 +1454,9 @@ export class Form extends Widget implements FormModel, DisplayParent {
     }
     this._setProperty('displayParent', displayParent);
 
-    if (displayParent) {
+    // Overwrite the parent with the displayParent, unless the displayParent is a descendant of the parent.
+    // This is necessary to automatically remove this element when the display parent is removed.
+    if (displayParent && !displayParent.isOrHas(this.parent)) {
       this.setParent(this.findDesktop().computeParentForDisplayParent(displayParent));
     }
   }

--- a/eclipse-scout-core/src/messagebox/MessageBox.ts
+++ b/eclipse-scout-core/src/messagebox/MessageBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -312,7 +312,10 @@ export class MessageBox extends Widget implements MessageBoxModel {
 
   protected _setDisplayParent(displayParent: DisplayParent) {
     this._setProperty('displayParent', displayParent);
-    if (displayParent) {
+
+    // Overwrite the parent with the displayParent, unless the displayParent is a descendant of the parent.
+    // This is necessary to automatically remove this element when the display parent is removed.
+    if (displayParent && !displayParent.isOrHas(this.parent)) {
       this.setParent(this.findDesktop().computeParentForDisplayParent(displayParent));
     }
   }

--- a/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
+++ b/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
@@ -264,13 +264,8 @@ export class CellEditorPopup<TValue> extends Popup implements CellEditorPopupMod
     // would be a form that is opened from within the popup. To identify these kind of elements, we additionally
     // check the widget hierarchy.
     let target = widgets.get($target);
-    while (target) {
-      if (target === this.cell.field) {
-        return false; // event target belongs to the cell editor popup -> don't close the popup
-      }
-      // Follow 'owner' hierarchy instead of 'parent' hierarchy because the parent of a form is automatically
-      // overwritten with the display parent (see Form#_setDisplayParent).
-      target = target.owner;
+    if (this.cell.field.isOrHas(target)) {
+      return false; // event target belongs to the cell editor popup -> don't close the popup
     }
 
     return true;

--- a/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
+++ b/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,7 +9,7 @@
  */
 import {
   AbstractLayout, Cell, CellEditorCancelEditKeyStroke, CellEditorCompleteEditKeyStroke, CellEditorPopupLayout, CellEditorPopupModel, CellEditorTabKeyStroke, Column, EventHandler, events, FormField, graphics, InitModelOf, KeyStroke,
-  KeyStrokeManagerKeyStrokeEvent, Point, Popup, Rectangle, scout, SomeRequired, Table, TableRow, TableRowOrderChangedEvent, ValueField
+  KeyStrokeManagerKeyStrokeEvent, Point, Popup, Rectangle, scout, SomeRequired, Table, TableRow, TableRowOrderChangedEvent, ValueField, widgets
 } from '../../index';
 import $ from 'jquery';
 
@@ -255,10 +255,24 @@ export class CellEditorPopup<TValue> extends Popup implements CellEditorPopupMod
     if (!this.session.keyStrokeManager.invokeAcceptInputOnActiveValueField(event.keyStroke, event.keyStrokeContext)) {
       return false;
     }
-    if (this.$container.isOrHas(event.keyStrokeContext.$getScopeTarget())) {
+    let $target = event.keyStrokeContext.$getScopeTarget();
+    if (this.$container.isOrHas($target)) {
       // Don't interfere with keystrokes of the popup or children of the popup (otherwise pressing enter would close both the popup and the form at once)
       return false;
     }
+    // Not all elements created by the popup are necessarily descendants of the cell editor popup. An example
+    // would be a form that is opened from within the popup. To identify these kind of elements, we additionally
+    // check the widget hierarchy.
+    let target = widgets.get($target);
+    while (target) {
+      if (target === this.cell.field) {
+        return false; // event target belongs to the cell editor popup -> don't close the popup
+      }
+      // Follow 'owner' hierarchy instead of 'parent' hierarchy because the parent of a form is automatically
+      // overwritten with the display parent (see Form#_setDisplayParent).
+      target = target.owner;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
When a keystroke is triggered on a descendant of the cell editor field, the cell editor popup should not be closed. This should also work if the cell editor opens a form, which is not rendered within the cell editor popup's $container.

Consider a cell editor that opens a form that also has an editable column. If the inner cell editor is closed with Enter, the outer cell editor popup should _not_ be completed automatically.

Instead of checking if the key stroke's scope target is part of the $container, we also check the widget hierarchy of the scope target. If it belongs to the cell editor, we don't trigger completeEdit().

378432