### PR TITLE
Desktop: prevent unwanted browser scrolling outside the desktop

### DIFF
--- a/eclipse-scout-core/src/desktop/Desktop.less
+++ b/eclipse-scout-core/src/desktop/Desktop.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
   left: 0;
   bottom: 0;
   right: 0;
+  overflow: clip; // prevent unwanted scrolling on modern browsers
 
   &:focus {
     outline: none;


### PR DESCRIPTION
If a form is moved (partially) outside the desktop bounds and one of fields receives the focus, the browser will try to the field into view. This will happen even when the scrollbars are disabled (overflow: hidden), which is confusing for the user, because they cannot manually scroll back to the top. While the automatic scrolling can be prevented when setting the focus programmatically (preventScroll=true), the standard browser behavior for focusable fields cannot be changed.

By setting the overflow property to 'clip' instead of 'hidden', we can effectively disable the scrolling entirely for the desktop DIV. This does not affect the application (because scrolling is always done on inner components anyway) but prevents the browser from auto-scrolling the desktop to focused elements.

380833