### PR TITLE
LoginBox: prevent cut-off box on very narrow screens

### DIFF
--- a/eclipse-scout-core/src/box/Box.less
+++ b/eclipse-scout-core/src/box/Box.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,6 @@
   position: absolute;
   height: 75%;
   width: 100%;
-  margin: @box-margin-y 0;
 
   & > .wrapper {
     display: table-cell;
@@ -31,7 +30,7 @@
   border-radius: @border-radius-large;
   background-color: @popup-background-color;
   max-width: @box-width;
-  margin: 0 auto;
+  margin: @box-margin-y auto;
   padding: 45px 95px 50px 95px;
   #scout.drop-shadow(0, 20px, 50px, 0, 0.2);
   font-size: @box-font-size;

--- a/eclipse-scout-core/src/login/LoginBox.less
+++ b/eclipse-scout-core/src/login/LoginBox.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -93,6 +93,8 @@
 
 .login-body,
 .logout-body {
+  overflow: auto;
+
   & > .box-background-elements.box-background-elements-fadeout {
     #scout.animation(nop 0.05s);
   }


### PR DESCRIPTION
When the available vertical space is smaller than the login/logout box, the entire document should be scrollable. The 'overflow' property was therefore changed to 'auto'. The margin was moved from the box to the box-content, so it will not be ignored when scrolling is needed. The position of the background elements was set to 'fixed', so they will not scroll.

380262