### PR TITLE
JsonOutline: filter default values for "Page"

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutline.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutline.java
@@ -31,6 +31,7 @@ import org.eclipse.scout.rt.ui.html.IUiSession;
 import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
 import org.eclipse.scout.rt.ui.html.json.InspectorInfo;
 import org.eclipse.scout.rt.ui.html.json.JsonDataObjectHelper;
+import org.eclipse.scout.rt.ui.html.json.JsonObjectUtility;
 import org.eclipse.scout.rt.ui.html.json.JsonProperty;
 import org.eclipse.scout.rt.ui.html.json.form.fields.JsonAdapterProperty;
 import org.eclipse.scout.rt.ui.html.json.form.fields.JsonAdapterPropertyConfig;
@@ -196,6 +197,7 @@ public class JsonOutline<OUTLINE extends IOutline> extends JsonTree<OUTLINE> {
       json.put(PROP_COMPACT_ROOT, page.isCompactRoot());
     }
     BEANS.get(InspectorInfo.class).put(getUiSession(), json, page);
+    JsonObjectUtility.filterDefaultValues(json, "Page");
     return json;
   }
 


### PR DESCRIPTION
Default values for tree nodes of type "Page" were defined in defaultValues.json, but never applied. This caused some properties to always be transferred, even if they are identical in most cases. For example: compactRoot=false