### PR TITLE
Planner: Fix nullPointer when layouting hierarchical menus

### DIFF
--- a/eclipse-scout-core/src/planner/Planner.ts
+++ b/eclipse-scout-core/src/planner/Planner.ts
@@ -1341,6 +1341,10 @@ export class Planner extends Widget implements PlannerModel {
     this._updateMenuBar();
   }
 
+  protected _removeMenus() {
+    // menubar takes care of removal
+  }
+
   protected _updateMenuBar() {
     let menuItems = this._filterMenus([Planner.MenuType.EmptySpace, Planner.MenuType.Resource, Planner.MenuType.Activity, Planner.MenuType.Range], false, true);
     this.menuBar.setMenuItems(menuItems);


### PR DESCRIPTION
When the menu property is updated with the same value after the initialization, a null pointer exception occurs when layouting hierarchical menus. This is because the menu gets removed, but not rendered again. The equals check in Widget#setPropertyInternal and MenuBar#setMenuItems are not the same. This change prevents the removal of the menus.

384547