### PR TITLE
PropertiesHelper: Add 'importenv' key for importing variable files

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/config/PropertiesHelperTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/config/PropertiesHelperTest.java
@@ -41,6 +41,8 @@ public class PropertiesHelperTest {
   private static final String PLACEHOLDER_IMPORT_PROPS = "classpath:org/eclipse/scout/rt/platform/config/placeholder-imp.properties";
   private static final String LIST_PROPS = "classpath:org/eclipse/scout/rt/platform/config/list-test.properties";
   private static final String DOTPROPERTY_PROPS = "classpath:org/eclipse/scout/rt/platform/config/dotproperty-test.properties";
+  private static final String ENV_FILE_PROPS = "classpath:org/eclipse/scout/rt/platform/config/envfile-test.properties";
+  private static final String IMPORTENV_PROPS = "classpath:org/eclipse/scout/rt/platform/config/importenv-test.properties";
 
   private static final String USER_HOME_KEY = "user.home";
   private static final String USER_HOME_VALUE = System.getProperty("user.home");
@@ -510,6 +512,18 @@ public class PropertiesHelperTest {
     finally {
       System.clearProperty("import");
     }
+  }
+
+  @Test
+  public void testEnvFile(){
+    PropertiesHelper h = new PropertiesHelper(new ConfigPropertyProvider(HELPER_CONFIG_PROPS), new ConfigPropertyProvider(ENV_FILE_PROPS));
+    assertEquals("atestValueb", h.getProperty("keyWithPlaceholderFromImport"));
+  }
+
+  @Test
+  public void testImportEnv() {
+    PropertiesHelper h = new PropertiesHelper(new ConfigPropertyProvider(HELPER_CONFIG_PROPS), new ConfigPropertyProvider(IMPORTENV_PROPS));
+    assertEquals("atestValueb", h.getProperty("keyWithPlaceholderFromImport"));
   }
 
   @Test

--- a/org.eclipse.scout.rt.platform.test/src/test/resources/org/eclipse/scout/rt/platform/config/envfile-test.properties
+++ b/org.eclipse.scout.rt.platform.test/src/test/resources/org/eclipse/scout/rt/platform/config/envfile-test.properties
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+stringVar=aStringVarValue
+intVar=50
+
+# otherwise non-existing key in helper-test.properties
+otherKey=testValue

--- a/org.eclipse.scout.rt.platform.test/src/test/resources/org/eclipse/scout/rt/platform/config/importenv-test.properties
+++ b/org.eclipse.scout.rt.platform.test/src/test/resources/org/eclipse/scout/rt/platform/config/importenv-test.properties
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# recursion
+importenv[0]=classpath:org/eclipse/scout/rt/platform/config/importenv-test.properties
+
+# values
+importenv[1]=classpath:org/eclipse/scout/rt/platform/config/envfile-test.properties

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/ConfigPropertyValidator.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/ConfigPropertyValidator.java
@@ -33,6 +33,7 @@ public class ConfigPropertyValidator implements IConfigurationValidator {
   @PostConstruct
   public void init() {
     m_specialValidKeys.add(PropertiesHelper.IMPORT_KEY);// 'import' key should be accepted although there is no IConfigProperty class for this key.
+    m_specialValidKeys.add(PropertiesHelper.IMPORTENV_KEY);
   }
 
   protected Map<String, IConfigProperty<?>> getAllConfigProperties() {

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/ConfigUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/ConfigUtility.java
@@ -67,7 +67,8 @@ public final class ConfigUtility {
    * values are not checked in any {@link IConfigurationValidator}.
    * <p>
    * A variable file is passed to the java process using the system property
-   * <code>-Dscout.env=file:/path/to/my/launch.properties</code>
+   * <code>-Dscout.env=file:/path/to/my/launch.properties</code>. Alternatively such a file may be imported using the
+   * special key <code>importenv</code>.
    * <p>
    * Example content of such a launch.properties assuming it is placed in the root of the eclipse workspace resp. the
    * root of the IntelliJ project folder.


### PR DESCRIPTION
This allows importing variable files using the special key 'importenv'.

Contrary to the existing 'import' key, this does not add the entries as config properties and the values are not checked by any IConfigurationValidator.

This is useful to allow importing another variable file from within a variable files, such as the one passed in via -Dscout.env. E.g.:
importenv[0]=anotherfile.properties

or with a relative path:
importenv[1]=${CURRENT_DIR}/somefile.properties

383208