### PR TITLE
Charts: fix numeric tick labels

### DIFF
--- a/eclipse-scout-chart/src/table/controls/ChartTableControl.js
+++ b/eclipse-scout-chart/src/table/controls/ChartTableControl.js
@@ -749,7 +749,9 @@ export default class ChartTableControl extends TableControl {
         let label,
           keyX = xAxis[x];
         if (xAxis.column instanceof NumberColumn) {
-          label = keyX;
+          // the axis will format numbers as two digit decimals and null/undefined as the text '-empty-' or something similar
+          // only pass null/undefined to the axis as we want to leave the number format to the chart but need the '-empty-' string
+          label = objects.isNullOrUndefined(keyX) ? xAxis.format(keyX) : keyX;
         } else {
           label = this._handleIconLabel(xAxis.format(keyX), xAxis, iconClasses);
         }


### PR DESCRIPTION
chart.js creates a CategoryScale if labels are set directly on the data. The CategoryScale itself registers a ticks callback which is overridden if the labels need to be reformatted. The original callback calls CategoryScale.getLabelForValue. If the formatters are passed as bound functions there is no access to the scale and therefore, no access to CategoryScale.getLabelForValue. Therefore, pass the formatter functions wrapped in an unbound function that extracts the renderer and the scale. This function then calls the formatter as it was bound to the renderer and passes the scale as an argument. The formatters then use the scale to call CategoryScale.getLabelForValue before custom formatting. Fix empty label for numeric columns in ChartTableControl.

379927