### PR TITLE
TileGrid: invalidateLayout not always called anymore on tile insertion

### DIFF
--- a/eclipse-scout-core/src/tile/TileGrid.ts
+++ b/eclipse-scout-core/src/tile/TileGrid.ts
@@ -423,12 +423,19 @@ export class TileGrid<TTile extends Tile = Tile> extends Widget implements TileG
   }
 
   protected _renderInsertTiles(tiles: (TTile | PlaceholderTile)[]) {
-    if (!this.animateTileInsertion) {
-      return;
+    if (this.animateTileInsertion) {
+      this._animateInsertTiles(tiles);
     }
-    tiles.forEach(tile => {
+    if (!this.htmlComp.layouting) {
+      // no need to invalidate when tile placeholders are added or removed while layouting
+      this.invalidateLayoutTree();
+    }
+  }
+
+  protected _animateInsertTiles(tiles: (TTile | PlaceholderTile)[]) {
+    for (let tile of tiles) {
       if (!tile.rendered) {
-        return;
+        continue;
       }
       tile.$container.addClass('before-animate-insert');
       // Wait until the layout animation is done before animating the insert operation.
@@ -442,11 +449,6 @@ export class TileGrid<TTile extends Tile = Tile> extends Widget implements TileG
           }
         }
       });
-    });
-
-    if (!this.htmlComp.layouting) {
-      // no need to invalidate when tile placeholders are added or removed while layouting
-      this.invalidateLayoutTree();
     }
   }
 


### PR DESCRIPTION
This happens since 4040e057cd2e04ef235b988fa06378b2fc9888ee.