### PR TITLE
SplitBox: focus border of fields inside the split box not visible

### DIFF
--- a/eclipse-scout-core/src/form/fields/splitbox/SplitBox.less
+++ b/eclipse-scout-core/src/form/fields/splitbox/SplitBox.less
@@ -17,8 +17,11 @@
 
     & > .first-field,
     & > .second-field {
-      overflow: hidden;
       position: absolute;
+      #scout.overflow-clip();
+      // Ensure focus border of elements inside the field is always visible
+      // Use @split-box-y-splitter-padding instead of (@focus-box-shadow-size to remove whitespace between splitter and field completely, at least for y splitter
+      overflow-clip-margin: @split-box-y-splitter-padding;
 
       &.collapsed {
         display: none;

--- a/eclipse-scout-core/src/style/mixins.less
+++ b/eclipse-scout-core/src/style/mixins.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -391,6 +391,12 @@
   .overflow-nowrap() {
     overflow: hidden;
     white-space: nowrap;
+  }
+
+  .overflow-clip() {
+    // clip is not supported for Safari < 16 -> it will be ignored and fall back to hidden
+    overflow: hidden;
+    overflow: clip;
   }
 
   .white-space-nowrap() {


### PR DESCRIPTION
The split box may contain a focusable field that uses a focus glow (#scout.focus-border()), e.g. TreeField, Button etc. Because split box sets overflow: hidden, the glow won't be fully visible. Overflow: hidden is necessary if the content has a min size and won't shrink anymore even if the splitter is moved further.

With the new overflow: clip property it is possible to define a clip-margin to show the focus glow.
Unfortunately, Safari does not support the clip-margin yet https://bugs.webkit.org/show_bug.cgi?id=236153

384244