### PR TITLE
JsonHybridManager: prevent unnecessary 'hybridWidgetEvent'

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/JsonHybridManager.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/JsonHybridManager.java
@@ -128,6 +128,7 @@ public class JsonHybridManager<T extends HybridManager> extends AbstractJsonProp
     switch (event.getType()) {
       case HybridEvent.TYPE_EVENT:
         addActionEvent("hybridEvent", createJsonHybridEvent(event));
+        break;
       case HybridEvent.TYPE_WIDGET_EVENT:
         addActionEvent("hybridWidgetEvent", createJsonHybridEvent(event));
         break;


### PR DESCRIPTION
Add missing break statement in switch block. Otherwise, all hybrid events will generate an additional action event of type 'hybridWidgetEvent' in addition to the normal 'hybridEvent' action event.