### PR TITLE
Embedded forms: never show form on open

### DIFF
--- a/eclipse-scout-core/src/form/FormMenu.ts
+++ b/eclipse-scout-core/src/form/FormMenu.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -89,6 +89,7 @@ export class FormMenu extends Menu implements FormMenuModel {
   }
 
   protected _adaptForm(form: Form) {
+    form.setShowOnOpen(false);
     form.setDisplayHint(Form.DisplayHint.VIEW);
     form.setModal(false);
     form.setClosable(false);

--- a/eclipse-scout-core/src/form/fields/wrappedform/WrappedFormField.ts
+++ b/eclipse-scout-core/src/form/fields/wrappedform/WrappedFormField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,24 +53,23 @@ export class WrappedFormField extends FormField implements WrappedFormFieldModel
     }
     if (innerForm) {
       innerForm.on('destroy', this._formDestroyHandler);
+      this._adaptForm(innerForm);
     }
     this._setProperty('innerForm', innerForm);
   }
 
-  /**
-   * Will also be called by model adapter on property change event
-   */
+  protected _adaptForm(form: Form) {
+    form.setShowOnOpen(false);
+    form.setDisplayHint(Form.DisplayHint.VIEW);
+    form.setModal(false);
+    form.setClosable(false); // Disable close key stroke
+    form.rootGroupBox?.setMenuBarPosition(GroupBox.MenuBarPosition.BOTTOM);
+    form.renderInitialFocusEnabled = this.initialFocusEnabled;
+  }
+
   protected _renderInnerForm() {
     if (!this.innerForm) {
       return;
-    }
-
-    this.innerForm.setDisplayHint(Form.DisplayHint.VIEW); // by definition, an inner form is a view.
-    this.innerForm.setModal(false); // by definition, an inner form is not modal.
-    this.innerForm.setClosable(false); // Disable close key stroke
-    this.innerForm.renderInitialFocusEnabled = this.initialFocusEnabled; // do not render initial focus of form if disabled.
-    if (this.innerForm.rootGroupBox) {
-      this.innerForm.rootGroupBox.setMenuBarPosition(GroupBox.MenuBarPosition.BOTTOM);
     }
 
     this.innerForm.render();
@@ -79,7 +78,9 @@ export class WrappedFormField extends FormField implements WrappedFormFieldModel
     this.innerForm.invalidateLayoutTree();
 
     // required because active element is lost when 'addField' is called.
-    this._renderInitialFocusEnabled();
+    if (this.innerForm.renderInitialFocusEnabled) {
+      this.innerForm.renderInitialFocus();
+    }
   }
 
   protected _removeInnerForm() {
@@ -94,9 +95,10 @@ export class WrappedFormField extends FormField implements WrappedFormFieldModel
     this._setInnerForm(null);
   }
 
-  protected _renderInitialFocusEnabled() {
-    if (this.innerForm && this.initialFocusEnabled) {
-      this.innerForm.renderInitialFocus();
+  setInitialFocusEnabled(initialFocusEnabled: boolean) {
+    this.setProperty('initialFocusEnabled', initialFocusEnabled);
+    if (this.innerForm) {
+      this.innerForm.renderInitialFocusEnabled = this.initialFocusEnabled;
     }
   }
 }

--- a/eclipse-scout-core/src/form/fields/wrappedform/WrappedFormFieldEventMap.ts
+++ b/eclipse-scout-core/src/form/fields/wrappedform/WrappedFormFieldEventMap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,4 +11,5 @@ import {Form, FormFieldEventMap, PropertyChangeEvent} from '../../../index';
 
 export interface WrappedFormFieldEventMap extends FormFieldEventMap {
   'propertyChange:innerForm': PropertyChangeEvent<Form>;
+  'propertyChange:initialFocusEnabled': PropertyChangeEvent<boolean>;
 }

--- a/eclipse-scout-core/src/form/fields/wrappedform/WrappedFormFieldModel.ts
+++ b/eclipse-scout-core/src/form/fields/wrappedform/WrappedFormFieldModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@ export interface WrappedFormFieldModel extends FormFieldModel {
   innerForm?: ObjectOrChildModel<Form>;
   /**
    * true if the inner form should request the initial focus once loaded, false if not.
+   *
    * Default is false.
    */
   initialFocusEnabled?: boolean;

--- a/eclipse-scout-core/src/table/controls/FormTableControl.ts
+++ b/eclipse-scout-core/src/table/controls/FormTableControl.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ export class FormTableControl extends TableControl implements FormTableControlMo
 
     // Tab box gets a special style if it is the first field in the root group box
     let rootGroupBox = this.form.rootGroupBox;
-    if (rootGroupBox.controls[0] instanceof TabBox) {
+    if (rootGroupBox && rootGroupBox.controls[0] instanceof TabBox) {
       rootGroupBox.controls[0].$container.addClass('in-table-control');
     }
 
@@ -85,11 +85,12 @@ export class FormTableControl extends TableControl implements FormTableControlMo
   }
 
   protected _adaptForm(form: Form) {
-    form.rootGroupBox.setMenuBarPosition(GroupBox.MenuBarPosition.BOTTOM);
+    form.setShowOnOpen(false);
     form.setDisplayHint(Form.DisplayHint.VIEW);
     form.setModal(false);
-    form.setAskIfNeedSave(false);
     form.setClosable(false);
+    form.setAskIfNeedSave(false);
+    form.rootGroupBox?.setMenuBarPosition(GroupBox.MenuBarPosition.BOTTOM);
   }
 
   override onControlContainerOpened() {


### PR DESCRIPTION
If form.open() is called for embedded forms
(wrapped form field, form menu etc.), which happens for example for JsForms, it must not be shown by the desktop because the container is responsible to render the embedded form. If the desktop tries to show the form, it would change the displayParent and therefore also the parent which must be avoided.

383085