### PR TITLE
Fix transaction-handling for client-notifications without piggy-back

### DIFF
--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryTest.java
@@ -268,8 +268,10 @@ public class ClientNotificationRegistryTest {
   }
 
   private void commit() {
-    ITransaction.CURRENT.get().commitPhase1();
-    ITransaction.CURRENT.get().commitPhase2();
+    ITransaction transaction = ITransaction.CURRENT.get();
+    transaction.commitPhase1();
+    transaction.commitPhase2();
+    transaction.release();
   }
 
   private List<ClientNotificationMessage> consumeNoWait(ClientNotificationRegistry reg, NodeId nodeId) {

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/security/AccessControlServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/security/AccessControlServiceTest.java
@@ -100,7 +100,9 @@ public class AccessControlServiceTest {
   }
 
   private void commit() {
-    ITransaction.CURRENT.get().commitPhase2();
+    ITransaction transaction = ITransaction.CURRENT.get();
+    transaction.commitPhase2();
+    transaction.release();
   }
 
   private void assertSingleNotification() {


### PR DESCRIPTION
If we cannot 'piggy-back' the notifications to the current request (e.g. for rest-calls), we hold the notifications back until the transaction is released to ensure the notifications are sent after all transaction-members are committed.

386675