### PR TITLE
SmartField: don't trigger unnecessary event for cssClass

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
@@ -1523,14 +1523,14 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
 
   protected _setLookupRow(lookupRow: LookupRow<TValue>) {
     // remove css classes from old lookup-row
-    if (this.lookupRow) {
+    if (this.lookupRow?.cssClass) {
       this.removeCssClass(this.lookupRow.cssClass);
     }
 
     this._setProperty('lookupRow', lookupRow);
 
     // add css classes from new lookup-row
-    if (lookupRow) {
+    if (lookupRow?.cssClass) {
       this.addCssClass(lookupRow.cssClass);
     }
   }


### PR DESCRIPTION
If a lookupRow is selected, a propertyChange event is triggered because
 cssClass changes from null to ''

This is unnecessary and also triggers invalidateLayoutTree which may have undesired consequences, e.g. a dialog to be resized if a lookup row is selected in a SmartField of an ellipsis menu popup.

388328