### PR TITLE
UiNotifications: add publishOverCluster-property to options

### DIFF
--- a/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationPutOptions.java
+++ b/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationPutOptions.java
@@ -12,6 +12,14 @@ package org.eclipse.scout.rt.api.uinotification;
 public class UiNotificationPutOptions {
   private Boolean m_transactional;
   private Long m_timeout;
+  private Boolean m_publishOverCluster;
+
+  public UiNotificationPutOptions copy() {
+    return new UiNotificationPutOptions()
+        .withTransactional(getTransactional())
+        .withTimeout(getTimeout())
+        .withPublishOverCluster(getPublishOverCluster());
+  }
 
   /**
    * @param timeout
@@ -27,6 +35,11 @@ public class UiNotificationPutOptions {
     return m_timeout;
   }
 
+  /**
+   * @param transactional
+   *          Whether the notification should be put into the registry only if the current transaction is committed
+   *          successfully or not. Default is {@code true}.
+   */
   public UiNotificationPutOptions withTransactional(Boolean transactional) {
     m_transactional = transactional;
     return this;
@@ -36,7 +49,34 @@ public class UiNotificationPutOptions {
     return m_transactional;
   }
 
+  /**
+   * @param publishOverCluster
+   *          Whether the notification is published to all other cluster nodes or not. Default is {@code true}.
+   */
+  public UiNotificationPutOptions withPublishOverCluster(Boolean publishOverCluster) {
+    m_publishOverCluster = publishOverCluster;
+    return this;
+  }
+
+  public Boolean getPublishOverCluster() {
+    return m_publishOverCluster;
+  }
+
+  /*
+   * factory methods
+   */
+
+  /**
+   * Creates an {@link UiNotificationPutOptions} instance with {@code transactional = false}.
+   */
   public static UiNotificationPutOptions noTransaction() {
     return new UiNotificationPutOptions().withTransactional(false);
+  }
+
+  /**
+   * Creates an {@link UiNotificationPutOptions} instance with {@code publishOverCluster = false}.
+   */
+  public static UiNotificationPutOptions noClusterSync() {
+    return new UiNotificationPutOptions().withPublishOverCluster(false);
   }
 }

--- a/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationTransactionMember.java
+++ b/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationTransactionMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,12 +13,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.scout.rt.platform.transaction.AbstractTransactionMember;
+import org.eclipse.scout.rt.platform.util.ImmutablePair;
+import org.eclipse.scout.rt.platform.util.Pair;
 
 public class UiNotificationTransactionMember extends AbstractTransactionMember {
 
   public static final String TRANSACTION_MEMBER_ID = "uiNotification.transactionMemberId";
 
-  private final List<UiNotificationMessageDo> m_messages = new ArrayList<>();
+  private final List<Pair<UiNotificationMessageDo, UiNotificationPutOptions>> m_messages = new ArrayList<>();
   private final UiNotificationRegistry m_registry;
 
   public UiNotificationTransactionMember(UiNotificationRegistry registry) {
@@ -41,14 +43,14 @@ public class UiNotificationTransactionMember extends AbstractTransactionMember {
     return !m_messages.isEmpty();
   }
 
-  public void addNotification(UiNotificationMessageDo message) {
-    m_messages.add(message);
+  public void addNotification(UiNotificationMessageDo message, UiNotificationPutOptions options) {
+    m_messages.add(ImmutablePair.of(message, options));
   }
 
   @Override
   public void commitPhase2() {
-    for (UiNotificationMessageDo message : m_messages) {
-      m_registry.putInternal(message);
+    for (Pair<UiNotificationMessageDo, UiNotificationPutOptions> message : m_messages) {
+      m_registry.putInternal(message.getLeft(), message.getRight());
     }
     m_messages.clear();
   }

--- a/org.eclipse.scout.rt.uinotification/src/test/resources/META-INF/scout.xml
+++ b/org.eclipse.scout.rt.uinotification/src/test/resources/META-INF/scout.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<scout>
+</scout>


### PR DESCRIPTION
The publishOverCluster property ca be used to explicitly publish a notification over all cluster nodes or not. The