### PR TITLE
Make Switch._renderActivated() null-safe

### DIFF
--- a/eclipse-scout-core/src/switch/Switch.ts
+++ b/eclipse-scout-core/src/switch/Switch.ts
@@ -101,7 +101,7 @@ export class Switch extends Widget implements SwitchModel {
   }
 
   protected _renderActivated() {
-    this.$button.toggleClass('activated', this.activated);
+    this.$button.toggleClass('activated', !!this.activated);
   }
 
   setLabel(label: string) {
@@ -176,7 +176,7 @@ export class Switch extends Widget implements SwitchModel {
   protected _renderTabbable() {
     let tabbable = this.tabbable && this.enabledComputed && !Device.get().supportsOnlyTouch();
     this.$container.setTabbable(tabbable);
-    this.$container.toggleClass('unfocusable', tabbable);
+    this.$container.toggleClass('unfocusable', !!tabbable);
   }
 
   protected _onSwitchMouseDown(event: JQuery.MouseDownEvent) {

--- a/eclipse-scout-core/test/switch/SwitchSpec.ts
+++ b/eclipse-scout-core/test/switch/SwitchSpec.ts
@@ -51,4 +51,14 @@ describe('Switch', () => {
       expect(switch_.activated).toBe(true);
     });
   });
+
+  it('renders activated = null as not activated', () => {
+    let switch_ = scout.create(Switch, {
+      parent: session.desktop
+    });
+    switch_.render();
+    switch_.setActivated(false);
+    switch_.setActivated(null);
+    expect(switch_.$button).not.toHaveClass('activated');
+  });
 });


### PR DESCRIPTION
jQuery .toggleClass expects a boolean, but this.activated might be null under certain circumstances.