### PR TITLE
Synchronize inactive codes to the UI, return active only by default

### DIFF
--- a/eclipse-scout-core/src/code/Code.ts
+++ b/eclipse-scout-core/src/code/Code.ts
@@ -117,16 +117,19 @@ export class Code<TCodeId> implements ObjectWithType {
 
   /**
    * Visits all children of this Code recursively without visiting this Code itself.
+   *
+   * By default, only active child codes are visited. To visit inactive child codes as well, set the `activeOnly` argument to false.
    */
-  visitChildren(visitor: TreeVisitor<Code<TCodeId>>): boolean | TreeVisitResult {
-    for (let i = 0; i < this.children.length; i++) {
-      let child = this.children[i];
+  visitChildren(visitor: TreeVisitor<Code<TCodeId>>, activeOnly = true): boolean | TreeVisitResult {
+    let children = activeOnly ? this.children.filter(child => child.active) : this.children;
+    for (let i = 0; i < children.length; i++) {
+      let child = children[i];
       let visitResult = visitor(child);
       if (visitResult === true || visitResult === TreeVisitResult.TERMINATE) {
         return TreeVisitResult.TERMINATE;
       }
       if (visitResult !== TreeVisitResult.SKIP_SUBTREE) {
-        visitResult = child.visitChildren(visitor);
+        visitResult = child.visitChildren(visitor, activeOnly);
         if (visitResult === true || visitResult === TreeVisitResult.TERMINATE) {
           return TreeVisitResult.TERMINATE;
         }

--- a/eclipse-scout-core/src/code/CodeLookupCall.ts
+++ b/eclipse-scout-core/src/code/CodeLookupCall.ts
@@ -52,7 +52,7 @@ export class CodeLookupCall<TCodeId> extends StaticLookupCall<TCodeId> {
       if (!predicate || predicate(lookupRow)) {
         lookupRows.push(lookupRow);
       }
-    });
+    }, false);
     return lookupRows;
   }
 

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/common/code/mapping/CodeTypeToDoFunctionTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/common/code/mapping/CodeTypeToDoFunctionTest.java
@@ -25,6 +25,7 @@ import org.eclipse.scout.rt.shared.services.common.code.ICodeType;
 import org.junit.Test;
 
 public class CodeTypeToDoFunctionTest {
+
   @Test
   public void testConvert() {
     assertNull(convert(null));
@@ -38,15 +39,17 @@ public class CodeTypeToDoFunctionTest {
     assertTrue(codeTypeDo.isHierarchical());
     assertEquals("text", codeTypeDo.getTexts().get(NlsLocale.get().toLanguageTag()));
     assertEquals("TestFixture", codeTypeDo.getObjectType());
-    assertEquals(1, codeTypeDo.codes().size());
-    assertCodeDo(codeTypeDo.codes().get(0));
+    assertEquals(3, codeTypeDo.codes().size());
+    assertCodeDo10(codeTypeDo.codes().get(0));
+    assertCodeDo20(codeTypeDo.codes().get(1));
+    assertCodeDo30(codeTypeDo.codes().get(2));
   }
 
   protected CodeTypeDo convert(ICodeType<?, ?> codeType) {
     return BEANS.get(ToDoFunctionHelper.class).toDo(codeType, ICodeTypeToDoFunction.class);
   }
 
-  protected void assertCodeDo(CodeDo codeDo) {
+  protected void assertCodeDo10(CodeDo codeDo) {
     assertEquals("10", codeDo.getId());
     assertTrue(codeDo.getActive());
     assertFalse(codeDo.isEnabled());
@@ -63,6 +66,32 @@ public class CodeTypeToDoFunctionTest {
     assertEquals("testObjectType", codeDo.getObjectType());
     assertEquals(0, codeDo.getSortCode().intValue());
     assertEquals(1, codeDo.children().size());
+  }
+
+  protected void assertCodeDo20(CodeDo codeDo) {
+    assertEquals("20", codeDo.getId());
+    assertTrue(codeDo.getActive());
+    assertEquals(1, codeDo.children().size());
+    assertCodeDo201(codeDo.children().get(0));
+  }
+
+  protected void assertCodeDo201(CodeDo codeDo) {
+    assertEquals("201", codeDo.getId());
+    assertFalse(codeDo.getActive());
+    assertEquals(0, codeDo.children().size());
+  }
+
+  protected void assertCodeDo30(CodeDo codeDo) {
+    assertEquals("30", codeDo.getId());
+    assertFalse(codeDo.getActive());
+    assertEquals(1, codeDo.children().size());
+    assertCodeDo301(codeDo.children().get(0));
+  }
+
+  protected void assertCodeDo301(CodeDo codeDo) {
+    assertEquals("301", codeDo.getId());
+    assertFalse(codeDo.getActive()); // Automatically set to false by AbstractCodeTypeWithGeneric#loadCodes
+    assertEquals(0, codeDo.children().size());
   }
 
   @ObjectType("TestFixture")
@@ -170,7 +199,7 @@ public class CodeTypeToDoFunctionTest {
       @Order(1000)
       public static class ConvertTestChildCode extends AbstractCode<Long> {
         private static final long serialVersionUID = 1L;
-        public static final long ID = 1000L;
+        public static final long ID = 101L;
 
         @Override
         public Long getId() {
@@ -186,6 +215,60 @@ public class CodeTypeToDoFunctionTest {
       @Override
       public Long getId() {
         return null;
+      }
+    }
+
+    @Order(3000)
+    public static class ConvertTestCodeWithChildCodes extends AbstractCode<Long> {
+      private static final long serialVersionUID = 1L;
+      public static final long ID = 20L;
+
+      @Override
+      public Long getId() {
+        return ID;
+      }
+
+      @Order(1000)
+      public static class InactiveConvertTestCode extends AbstractCode<Long> {
+        private static final long serialVersionUID = 1L;
+        public static final long ID = 201L;
+
+        @Override
+        public Long getId() {
+          return ID;
+        }
+
+        @Override
+        protected boolean getConfiguredActive() {
+          return false;
+        }
+      }
+    }
+
+    @Order(4000)
+    public static class InactiveConvertTestCodeWithChildCodes extends AbstractCode<Long> {
+      private static final long serialVersionUID = 1L;
+      public static final long ID = 30L;
+
+      @Override
+      public Long getId() {
+        return ID;
+      }
+
+      @Override
+      protected boolean getConfiguredActive() {
+        return false;
+      }
+
+      @Order(1000)
+      public static class ConvertTestChildCode extends AbstractCode<Long> {
+        private static final long serialVersionUID = 1L;
+        public static final long ID = 301L;
+
+        @Override
+        public Long getId() {
+          return ID;
+        }
       }
     }
   }

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/lookup/fixture/LegacyCodeLookupCall.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/lookup/fixture/LegacyCodeLookupCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.shared.services.common.code.ICode;
@@ -30,6 +31,7 @@ import org.eclipse.scout.rt.shared.services.lookup.LookupRow;
  *
  * @see CodeLookupCallTest
  */
+@IgnoreBean // constructor with arguments
 public class LegacyCodeLookupCall<CODE_ID_TYPE> extends LocalLookupCall<CODE_ID_TYPE> implements Serializable {
   private static final long serialVersionUID = 0L;
 

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/mapping/AbstractCodeToDoFunction.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/mapping/AbstractCodeToDoFunction.java
@@ -127,7 +127,7 @@ public abstract class AbstractCodeToDoFunction<EXPLICIT_SOURCE extends ICode<?>,
   }
 
   protected List<? extends ICode<?>> getChildCodesToConvert(EXPLICIT_SOURCE code) {
-    return code.getChildCodes();
+    return code.getChildCodes(false);
   }
 
   /**

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/mapping/AbstractCodeTypeToDoFunction.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/mapping/AbstractCodeTypeToDoFunction.java
@@ -74,7 +74,7 @@ public abstract class AbstractCodeTypeToDoFunction<EXPLICIT_SOURCE extends ICode
   }
 
   protected List<? extends ICode<?>> getCodesToConvert(EXPLICIT_SOURCE codeType) {
-    return codeType.getCodes();
+    return codeType.getCodes(false);
   }
 
   /**


### PR DESCRIPTION
Codes of a code type can be active or inactive. When a code type is marked with @ApiExposed, the corresponding codes are automatically transferred to the UI.

Previously, only active codes were synchronized. To allow the UI to resolve IDs of inactive codes, they have to be synchronized as well. Because existing code should not behave differently, CodeType#codes still only returns active codes by default. To also return inactive codes, the option {activeOnly: true} should be set.

Likewise, the method CodeType#visitChildren will only visit active codes, unless the argument activeOnly=true is passed explicitly.