### PR TITLE
Add white background color in light theme

### DIFF
--- a/eclipse-scout-core/src/style/colors.less
+++ b/eclipse-scout-core/src/style/colors.less
@@ -83,7 +83,7 @@
 @application-loading01-color: fade(@accent-color-3, 90%);
 @application-loading02-color: @palette-green-3;
 @background-color: @palette-white;
-@body-background-color: transparent;
+@body-background-color: @palette-white;
 @border-color: @palette-gray-4;
 @control-background-color: transparent;
 @control-border-color: fade(@palette-black, 23%); // Fade to make it work on white as well on darker background. A little more intense than the regular border color to show the control is interactive.


### PR DESCRIPTION
Some features (e.g. the filter field) are looking for a background color of their parents. If there is no background-color a default is used which can not fit for both light and dark theme. Therefore, ensure that at least the body has a background color set that matches the theme.

388715