### PR TITLE
HttpProxy: Fix cookie support

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxy.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxy.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
@@ -27,10 +28,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,6 +44,9 @@ import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.apache.hc.client5.http.ContextBuilder;
+import org.apache.hc.client5.http.cookie.Cookie;
+import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -63,14 +68,17 @@ import org.apache.hc.core5.http.support.AbstractRequestBuilder;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.config.CONFIG;
+import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.exception.ExceptionHandler;
 import org.eclipse.scout.rt.platform.job.internal.JobManager;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.IOUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.platform.util.concurrent.IRunnable;
 import org.eclipse.scout.rt.server.commons.servlet.HttpProxyConfigProperties.HttpProxyAsyncHttpClientManagerConfigProperty;
 import org.eclipse.scout.rt.server.commons.servlet.HttpProxyConfigProperties.HttpProxyAsyncTimeoutConfigProperty;
+import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.http.async.AbstractAsyncHttpClientManager;
 import org.eclipse.scout.rt.shared.http.async.DefaultAsyncHttpClientManager;
 import org.slf4j.Logger;
@@ -88,13 +96,15 @@ public class HttpProxy {
   private String m_remoteBaseUrl;
   private final List<IHttpHeaderFilter> m_requestHeaderFilters;
   private final List<IHttpHeaderFilter> m_responseHeaderFilters;
+  private final CookieStore m_defaultCookieStore;
   private Executor m_blockingOperationExecutor;
-  private Supplier<HttpClientContext> m_httpClientContextSupplier;
+  private Function<ContextBuilder, HttpClientContext> m_httpClientContextInterceptor;
 
   public HttpProxy() {
     m_httpClientManager = BEANS.get(CONFIG.getPropertyValue(HttpProxyAsyncHttpClientManagerConfigProperty.class));
     m_requestHeaderFilters = new ArrayList<>();
     m_responseHeaderFilters = new ArrayList<>();
+    m_defaultCookieStore = initializeDefaultCookieStore();
   }
 
   @PostConstruct
@@ -137,6 +147,27 @@ public class HttpProxy {
     m_responseHeaderFilters.add(new HttpHeaderNameFilter(null));
 
     m_blockingOperationExecutor = createBlockingOperationExecutor();
+  }
+
+  /**
+   * Return the (already initialized) {@link #m_defaultCookieStore}; may be null.
+   */
+  public CookieStore getDefaultCookieStore() {
+    return m_defaultCookieStore;
+  }
+
+  /**
+   * Create the cookie store instance used just for this {@link HttpProxy} instance.
+   */
+  protected CookieStore initializeDefaultCookieStore() {
+    return m_httpClientManager.getCookieStore();
+  }
+
+  /**
+   * @see SpecificSessionCookieStore
+   */
+  protected CookieStore createSpecificSessionCookieStore(ISession session) {
+    return new SpecificSessionCookieStore(session);
   }
 
   protected ExecutorService createBlockingOperationExecutor() {
@@ -231,8 +262,28 @@ public class HttpProxy {
   }
 
   protected HttpContext createHttpContext() {
-    Supplier<HttpClientContext> httpClientContextSupplier = getHttpClientContextSupplier();
-    return httpClientContextSupplier != null ? httpClientContextSupplier.get() : HttpClientContext.create();
+    ContextBuilder contextBuilder = ContextBuilder.create();
+
+    // cookie store
+    ISession currentSession = ISession.CURRENT.get();
+    CookieStore defaultCookieStore = getDefaultCookieStore();
+    if (defaultCookieStore != null) {
+      if (currentSession != null) {
+        contextBuilder.useCookieStore(createSpecificSessionCookieStore(currentSession));
+      }
+      else {
+        contextBuilder.useCookieStore(defaultCookieStore);
+      }
+    }
+
+    // apply additional settings using interceptor
+    Function<ContextBuilder, HttpClientContext> httpClientContextInterceptor = getHttpClientContextInterceptor();
+    if (httpClientContextInterceptor != null) {
+      return httpClientContextInterceptor.apply(contextBuilder);
+    }
+
+    // create context
+    return contextBuilder.build();
   }
 
   /**
@@ -512,15 +563,17 @@ public class HttpProxy {
     return m_blockingOperationExecutor;
   }
 
-  public Supplier<HttpClientContext> getHttpClientContextSupplier() {
-    return m_httpClientContextSupplier;
+  public Function<ContextBuilder, HttpClientContext> getHttpClientContextInterceptor() {
+    return m_httpClientContextInterceptor;
   }
 
   /**
-   * Create a supplier for {@link HttpClientContext} which is called upon each request.
+   * Create a supplier for {@link HttpClientContext} which is called upon each request. The function will be called with
+   * a pre-filled {@link ContextBuilder} and returns a {@link HttpClientContext} (maybe using
+   * {@link ContextBuilder#build()} or even a different one).
    */
-  public HttpProxy withHttpClientContextSupplier(Supplier<HttpClientContext> httpClientContextSupplier) {
-    m_httpClientContextSupplier = httpClientContextSupplier;
+  public HttpProxy withHttpClientContextSupplier(Function<ContextBuilder, HttpClientContext> httpClientContextSupplier) {
+    m_httpClientContextInterceptor = httpClientContextSupplier;
     return this;
   }
 
@@ -669,5 +722,47 @@ public class HttpProxy {
         asyncContext.complete();
       }
     };
+  }
+
+  /**
+   * Cookie store which uses {@link #getDefaultCookieStore()} with all operations run for the specified {@link ISession}.
+   * May be used if async threads access the cookie store where {@link ISession#CURRENT} is not set correctly.
+   */
+  private class SpecificSessionCookieStore implements CookieStore {
+
+    private ISession m_session;
+
+    public SpecificSessionCookieStore(ISession session) {
+      m_session = session;
+    }
+
+    @Override
+    public void addCookie(Cookie cookie) {
+      runWithSession(() -> getDefaultCookieStore().addCookie(cookie));
+    }
+
+    @Override
+    public List<Cookie> getCookies() {
+      return callWithSession(getDefaultCookieStore()::getCookies);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean clearExpired(Date date) {
+      return callWithSession(() -> getDefaultCookieStore().clearExpired(date));
+    }
+
+    @Override
+    public void clear() {
+      runWithSession(getDefaultCookieStore()::clear);
+    }
+
+    private void runWithSession(IRunnable runnable) {
+      RunContexts.copyCurrent(true).withThreadLocal(ISession.CURRENT, m_session).run(runnable);
+    }
+
+    private <R> R callWithSession(Callable<R> callable) {
+      return RunContexts.copyCurrent(true).withThreadLocal(ISession.CURRENT, m_session).call(callable);
+    }
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/AbstractAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/AbstractAsyncHttpClientManager.java
@@ -10,7 +10,9 @@
 package org.eclipse.scout.rt.shared.http.async;
 
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
+import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
@@ -18,6 +20,8 @@ import org.eclipse.scout.rt.platform.IPlatform.State;
 import org.eclipse.scout.rt.platform.IPlatformListener;
 import org.eclipse.scout.rt.platform.PlatformEvent;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.util.LazyValue;
+import org.eclipse.scout.rt.shared.http.ApacheMultiSessionCookieStore;
 
 /**
  * <p>
@@ -48,9 +52,37 @@ public abstract class AbstractAsyncHttpClientManager<BUILDER> implements IPlatfo
    */
   protected volatile CloseableHttpAsyncClient m_client;
 
+  /**
+   *
+   */
+  protected LazyValue<ApacheMultiSessionCookieStore> m_cookieStore = new LazyValue<>(ApacheMultiSessionCookieStore.class);
+
   public CloseableHttpAsyncClient getClient() {
     init();
     return m_client;
+  }
+
+  public ApacheMultiSessionCookieStore getCookieStore() {
+    return m_cookieStore.get();
+  }
+
+  /**
+   * Return a function to be called to install a {@link CookieStore}; return null if not supported/no store should be
+   * installed.
+   */
+  protected abstract BiConsumer<BUILDER, CookieStore> getInstallCookieStoreBiConsumer();
+
+  protected void installMultiSessionCookieStore(BUILDER builder) {
+    BiConsumer<BUILDER, CookieStore> installCookieStoreBiConsumer = getInstallCookieStoreBiConsumer();
+    if (installCookieStoreBiConsumer == null) {
+      return;
+    }
+
+    ApacheMultiSessionCookieStore cookieStore = getCookieStore();
+    if (cookieStore == null) {
+      return;
+    }
+    installCookieStoreBiConsumer.accept(builder, cookieStore);
   }
 
   /**
@@ -72,6 +104,7 @@ public abstract class AbstractAsyncHttpClientManager<BUILDER> implements IPlatfo
     }
 
     BUILDER builder = createBuilder();
+    installMultiSessionCookieStore(builder);
     interceptCreateClient(builder);
 
     m_client = createClient(builder);

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
@@ -10,8 +10,10 @@
 package org.eclipse.scout.rt.shared.http.async;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.DefaultClientConnectionReuseStrategy;
 import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
@@ -59,7 +61,6 @@ public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManage
   protected void interceptCreateClient(HttpAsyncClientBuilder builder) {
     // see very similar code in org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory.newHttpTransport(IHttpTransportManager), unfortunately there is no common interface
     installConfigurableProxySelector(builder);
-    installMultiSessionCookieStore(builder);
 
     setConnectionKeepAliveAndRetrySettings(builder);
 
@@ -71,9 +72,9 @@ public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManage
     builder.setRoutePlanner(new SystemDefaultRoutePlanner(BEANS.get(ConfigurableProxySelector.class)));
   }
 
-  protected void installMultiSessionCookieStore(HttpAsyncClientBuilder builder) {
-    // see very similar code in org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory.installMultiSessionCookieStore(HttpClientBuilder), unfortunately there is no common interface
-    builder.setDefaultCookieStore(BEANS.get(ApacheMultiSessionCookieStore.class));
+  @Override
+  protected BiConsumer<HttpAsyncClientBuilder, CookieStore> getInstallCookieStoreBiConsumer() {
+    return (builder, cookieStore) -> builder.setDefaultCookieStore(cookieStore);
   }
 
   protected void setConnectionKeepAliveAndRetrySettings(HttpAsyncClientBuilder builder) {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/H2AsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/H2AsyncHttpClientManager.java
@@ -9,6 +9,9 @@
  */
 package org.eclipse.scout.rt.shared.http.async;
 
+import java.util.function.BiConsumer;
+
+import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
@@ -36,6 +39,11 @@ public class H2AsyncHttpClientManager extends AbstractAsyncHttpClientManager<H2A
   @Override
   protected void interceptCreateClient(H2AsyncClientBuilder builder) {
     builder.useSystemProperties();
+  }
+
+  @Override
+  protected BiConsumer<H2AsyncClientBuilder, CookieStore> getInstallCookieStoreBiConsumer() {
+    return (builder, cookieStore) -> builder.setDefaultCookieStore(cookieStore);
   }
 
   @Override


### PR DESCRIPTION
Restore previous behavior: Cookies must use session cookie store if proxy method is called from within a session; default cookie store must only be used if no session available.