### PR TITLE
Bump derby to latest version

### DIFF
--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -24,7 +24,7 @@
     <jdk.source.version>${javaVersion}</jdk.source.version>
     <org.eclipse.scout.rt.version>24.1-SNAPSHOT</org.eclipse.scout.rt.version>
     <org.jooq.version>3.16.16</org.jooq.version>
-    <derby.version>10.16.1.1</derby.version>
+    <derby.version>10.16.1.2</derby.version>
     <master_npm_release_dependency_mapping>--mapping.0.regex=@eclipse-scout --mapping.0.version=${org.eclipse.scout.rt.version}</master_npm_release_dependency_mapping>
 
     <!-- docker image build settings -->


### PR DESCRIPTION
This PR bumps the version of derby used in a sample app as the version currently used is flagged as having a vulnerability.