### PR TITLE
HttpProxy: Fix cookie support

### DIFF
--- a/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxyTest.java
+++ b/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxyTest.java
@@ -29,9 +29,11 @@ import java.util.stream.Stream;
 
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpResponse;
@@ -51,26 +53,33 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.util.EnumerationUtility;
 import org.eclipse.scout.rt.platform.util.ImmutablePair;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.SleepUtil;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.server.commons.BufferedServletOutputStream;
+import org.eclipse.scout.rt.shared.ISession;
+import org.eclipse.scout.rt.shared.http.ApacheMultiSessionCookieStore;
 import org.eclipse.scout.rt.shared.http.async.AbstractAsyncHttpClientManager;
 import org.eclipse.scout.rt.shared.http.async.DefaultAsyncHttpClientManager;
 import org.eclipse.scout.rt.shared.http.async.ForceHttp2DefaultAsyncHttpClientManager;
 import org.eclipse.scout.rt.shared.http.async.H2AsyncHttpClientManager;
+import org.eclipse.scout.rt.testing.platform.mock.RegisterBeanTestRule;
 import org.eclipse.scout.rt.testing.platform.runner.JUnitExceptionHandler;
 import org.eclipse.scout.rt.testing.platform.runner.parameterized.IScoutTestParameter;
 import org.eclipse.scout.rt.testing.platform.runner.parameterized.NonParameterized;
 import org.eclipse.scout.rt.testing.platform.runner.parameterized.ParameterizedPlatformTestRunner;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
+import org.mockito.ArgumentCaptor;
 
 @RunWith(ParameterizedPlatformTestRunner.class)
 public class HttpProxyTest {
@@ -81,12 +90,17 @@ public class HttpProxyTest {
 
   private HttpProxyTestParameter m_httpProxyTestParameter;
 
+  private static final TestApacheMultiSessionCookieStore COOKIE_STORE = spy(new TestApacheMultiSessionCookieStore());
+
+  @ClassRule // use a fixed cookie store for all tests (with accessible default cookie store)
+  public static final RegisterBeanTestRule<ApacheMultiSessionCookieStore> COOKIE_STORE_REGISTER_BEAN_TEST_RULE = new RegisterBeanTestRule<>(ApacheMultiSessionCookieStore.class, COOKIE_STORE);
+
   @Parameters
   public static List<IScoutTestParameter> getParameters() {
     return List.of(
-        new HttpProxyTestParameter(BEANS.get(DefaultAsyncHttpClientManager.class), server -> new ServerConnector(server, new HttpConnectionFactory())),
-        new HttpProxyTestParameter(BEANS.get(H2AsyncHttpClientManager.class), server -> new ServerConnector(server, new HTTP2CServerConnectionFactory(new HttpConfiguration()))),
-        new HttpProxyTestParameter(BEANS.get(ForceHttp2DefaultAsyncHttpClientManager.class), server -> new ServerConnector(server, new HTTP2CServerConnectionFactory(new HttpConfiguration()))));
+        new HttpProxyTestParameter(new DefaultAsyncHttpClientManager(), server -> new ServerConnector(server, new HttpConnectionFactory())),
+        new HttpProxyTestParameter(new H2AsyncHttpClientManager(), server -> new ServerConnector(server, new HTTP2CServerConnectionFactory(new HttpConfiguration()))),
+        new HttpProxyTestParameter(new ForceHttp2DefaultAsyncHttpClientManager(), server -> new ServerConnector(server, new HTTP2CServerConnectionFactory(new HttpConfiguration()))));
   }
 
   public HttpProxyTest(HttpProxyTestParameter testParameter) {
@@ -100,6 +114,10 @@ public class HttpProxyTest {
     if (m_httpProxyTestParameter != null) {
       m_proxy.withHttpClientManager(m_httpProxyTestParameter.getClientManager());
     }
+
+    // we use a static spy mocked bean, therefore reset it for each test
+    reset(COOKIE_STORE);
+    COOKIE_STORE.m_defaultCookieStore.clear();
   }
 
   @Before
@@ -440,6 +458,45 @@ public class HttpProxyTest {
     assertArrayEquals(expectedContent, ((BufferedServletOutputStream) resp.getOutputStream()).getContent());
   }
 
+  @Test
+  public void testProxyRequest_cookiesSessionBasedCookieStore() {
+    RunContexts.copyCurrent(true)
+        .withThreadLocal(ISession.CURRENT, mock(ISession.class))
+        .run(() -> testProxyRequest_cookiesInternal(false));
+  }
+
+  @Test
+  public void testProxyRequest_cookiesDefaultCookieStore() {
+    testProxyRequest_cookiesInternal(true);
+  }
+
+  protected void testProxyRequest_cookiesInternal(boolean expectDefaultCookieStore) {
+    CookieStore defaultCookieStore = COOKIE_STORE.m_defaultCookieStore;
+    int previousDefaultCount = defaultCookieStore.getCookies().size();
+
+    AbstractHandler handler = new AbstractHandler() {
+      @Override
+      public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // yummy: there is a cookie
+        response.addCookie(new Cookie("snickers", "bar"));
+        baseRequest.setHandled(true);
+        response.flushBuffer();
+      }
+    };
+
+    // call the request
+    testProxyRequestInternal(handler, 1, "/");
+
+    // one cookie should have been added, check expectations
+    ArgumentCaptor<org.apache.hc.client5.http.cookie.Cookie> cookieCaptor = ArgumentCaptor.forClass(org.apache.hc.client5.http.cookie.Cookie.class);
+    verify(COOKIE_STORE, times(1)).addCookie(cookieCaptor.capture());
+    assertEquals("snickers", cookieCaptor.getValue().getName());
+    assertEquals("bar", cookieCaptor.getValue().getValue());
+
+    // never-ever add a cookie to the default store (session specific should have been used)
+    assertEquals(previousDefaultCount + (expectDefaultCookieStore ? 1 : 0), defaultCookieStore.getCookies().size());
+  }
+
   @Ignore // do not run this (long) test on CI (at least as long as we do not run tests in parallel), however can be used for testing locally
   @Test
   public void testProxyRequest_longDuration() throws IOException {
@@ -540,6 +597,22 @@ public class HttpProxyTest {
     @Override
     public String getName() {
       return m_clientManager.getClass().getSimpleName();
+    }
+  }
+
+  @IgnoreBean
+  public static class TestApacheMultiSessionCookieStore extends ApacheMultiSessionCookieStore {
+
+    private CookieStore m_defaultCookieStore;
+
+    @Override
+    protected CookieStore createDefaultCookieStore() {
+      m_defaultCookieStore = super.createDefaultCookieStore();
+      return m_defaultCookieStore;
+    }
+
+    public CookieStore getDefaultCookieStore() {
+      return m_defaultCookieStore;
     }
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,8 +10,10 @@
 package org.eclipse.scout.rt.shared.http.async;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.DefaultClientConnectionReuseStrategy;
 import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
@@ -59,7 +61,6 @@ public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManage
   protected void interceptCreateClient(HttpAsyncClientBuilder builder) {
     // see very similar code in org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory.newHttpTransport(IHttpTransportManager), unfortunately there is no common interface
     installConfigurableProxySelector(builder);
-    installMultiSessionCookieStore(builder);
 
     setConnectionKeepAliveAndRetrySettings(builder);
 
@@ -71,9 +72,9 @@ public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManage
     builder.setRoutePlanner(new SystemDefaultRoutePlanner(BEANS.get(ConfigurableProxySelector.class)));
   }
 
-  protected void installMultiSessionCookieStore(HttpAsyncClientBuilder builder) {
-    // see very similar code in org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory.installMultiSessionCookieStore(HttpClientBuilder), unfortunately there is no common interface
-    builder.setDefaultCookieStore(BEANS.get(ApacheMultiSessionCookieStore.class));
+  @Override
+  protected BiConsumer<HttpAsyncClientBuilder, CookieStore> getInstallCookieStoreBiConsumer() {
+    return (builder, cookieStore) -> builder.setDefaultCookieStore(cookieStore);
   }
 
   protected void setConnectionKeepAliveAndRetrySettings(HttpAsyncClientBuilder builder) {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/H2AsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/H2AsyncHttpClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,9 @@
  */
 package org.eclipse.scout.rt.shared.http.async;
 
+import java.util.function.BiConsumer;
+
+import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
@@ -36,6 +39,11 @@ public class H2AsyncHttpClientManager extends AbstractAsyncHttpClientManager<H2A
   @Override
   protected void interceptCreateClient(H2AsyncClientBuilder builder) {
     builder.useSystemProperties();
+  }
+
+  @Override
+  protected BiConsumer<H2AsyncClientBuilder, CookieStore> getInstallCookieStoreBiConsumer() {
+    return (builder, cookieStore) -> builder.setDefaultCookieStore(cookieStore);
   }
 
   @Override


### PR DESCRIPTION
Restore previous behavior: Cookies must use session cookie store if proxy method is called from within a session; default cookie store must only be used if no session available.

383346