### PR TITLE
JsonCalendar: fix resourcesToJson()

### DIFF
--- a/org.eclipse.scout.rt.ui.html.test/pom.xml
+++ b/org.eclipse.scout.rt.ui.html.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+  ~ Copyright (c) 2010, 2024 BSI Business Systems Integration AG
   ~
   ~ This program and the accompanying materials are made
   ~ available under the terms of the Eclipse Public License 2.0
@@ -9,7 +9,7 @@
   ~ SPDX-License-Identifier: EPL-2.0
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -39,6 +39,12 @@
     <dependency>
       <groupId>org.eclipse.scout.rt</groupId>
       <artifactId>org.eclipse.scout.rt.client.test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.scout.rt</groupId>
+      <artifactId>org.eclipse.scout.rt.rest.jackson</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/calendar/JsonCalendarTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/calendar/JsonCalendarTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html.json.calendar;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.ui.basic.calendar.AbstractCalendar;
+import org.eclipse.scout.rt.client.ui.basic.calendar.ICalendar;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.shared.services.common.calendar.CalendarResourceDo;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.eclipse.scout.rt.ui.html.UiSessionTestUtility;
+import org.eclipse.scout.rt.ui.html.json.fixtures.UiSessionMock;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(TestEnvironmentClientSession.class)
+public class JsonCalendarTest {
+
+  private UiSessionMock m_uiSession;
+
+  @Before
+  public void setUp() {
+    m_uiSession = new UiSessionMock();
+  }
+
+  @Test
+  public void testResourcesToJson() {
+    P_Calendar calendar = createCalendar();
+
+    JsonCalendar<ICalendar> jsonCalendar;
+    JSONObject json;
+
+    // ------------------
+
+    jsonCalendar = UiSessionTestUtility.newJsonAdapter(m_uiSession, calendar);
+    json = jsonCalendar.toJson();
+    assertNotNull(json);
+    assertFalse(json.has("resources"));
+    jsonCalendar.dispose();
+
+    // ------------------
+
+    calendar.setResources(new ArrayList<>());
+    jsonCalendar = UiSessionTestUtility.newJsonAdapter(m_uiSession, calendar);
+    json = jsonCalendar.toJson();
+    assertNotNull(json);
+    assertEquals(new JSONArray(), json.getJSONArray("resources"));
+    jsonCalendar.dispose();
+
+    // ------------------
+
+    calendar.setResources(List.of(BEANS.get(CalendarResourceDo.class).withName("test")));
+    jsonCalendar = UiSessionTestUtility.newJsonAdapter(m_uiSession, calendar);
+    json = jsonCalendar.toJson();
+    assertNotNull(json);
+    JSONArray array = json.getJSONArray("resources");
+    assertEquals(1, array.length());
+    assertEquals("scout.CalendarResource", ((JSONObject) array.get(0)).getString("_type"));
+    assertEquals("test", ((JSONObject) array.get(0)).getString("name"));
+    jsonCalendar.dispose();
+  }
+
+  /**
+   * Creates an empty calendar.
+   */
+  private P_Calendar createCalendar() {
+    P_Calendar calendar = new P_Calendar();
+    calendar.init();
+    return calendar;
+  }
+
+  public static class P_Calendar extends AbstractCalendar {
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/calendar/JsonCalendar.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/calendar/JsonCalendar.java
@@ -21,8 +21,6 @@ import org.eclipse.scout.rt.client.ui.basic.calendar.CalendarEvent;
 import org.eclipse.scout.rt.client.ui.basic.calendar.CalendarListener;
 import org.eclipse.scout.rt.client.ui.basic.calendar.ICalendar;
 import org.eclipse.scout.rt.client.ui.basic.calendar.ICalendarUIFacade;
-import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
-import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.ImmutablePair;
 import org.eclipse.scout.rt.platform.util.Pair;
@@ -32,6 +30,7 @@ import org.eclipse.scout.rt.ui.html.IUiSession;
 import org.eclipse.scout.rt.ui.html.json.AbstractJsonWidget;
 import org.eclipse.scout.rt.ui.html.json.FilteredJsonAdapterIds;
 import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
+import org.eclipse.scout.rt.ui.html.json.JsonDataObjectHelper;
 import org.eclipse.scout.rt.ui.html.json.JsonDate;
 import org.eclipse.scout.rt.ui.html.json.JsonDateRange;
 import org.eclipse.scout.rt.ui.html.json.JsonEvent;
@@ -65,6 +64,8 @@ public class JsonCalendar<CALENDAR extends ICalendar> extends AbstractJsonWidget
   private static final String EVENT_RESOURCE_VISIBILITY_CHANGE = "resourceVisibilityChange";
   private static final String EVENT_SELECTED_RESOURCE_CHANGE = "selectedResourceChange";
 
+  private final JsonDataObjectHelper m_jsonDoHelper = BEANS.get(JsonDataObjectHelper.class); // cached instance
+
   private CalendarListener m_calendarListener;
   private JsonContextMenu<IContextMenu> m_jsonContextMenu;
 
@@ -75,6 +76,10 @@ public class JsonCalendar<CALENDAR extends ICalendar> extends AbstractJsonWidget
   @Override
   public String getObjectType() {
     return "Calendar";
+  }
+
+  protected JsonDataObjectHelper jsonDoHelper() {
+    return m_jsonDoHelper;
   }
 
   @Override
@@ -158,7 +163,7 @@ public class JsonCalendar<CALENDAR extends ICalendar> extends AbstractJsonWidget
       @SuppressWarnings("unchecked")
       @Override
       public Object prepareValueForToJson(Object value) {
-        return resourcesToJsonArray(((List<IDoEntity>) value));
+        return resourcesToJson(((List<CalendarResourceDo>) value));
       }
     });
     putJsonProperty(new JsonProperty<>(ICalendar.PROP_VIEW_RANGE, model) {
@@ -269,9 +274,8 @@ public class JsonCalendar<CALENDAR extends ICalendar> extends AbstractJsonWidget
     return (JsonCalendarComponent<C>) getUiSession().getJsonAdapter(adapterId);
   }
 
-  protected JSONArray resourcesToJsonArray(List<IDoEntity> resources) {
-    String str = BEANS.get(IDataObjectMapper.class).writeValue(resources);
-    return new JSONArray(str);
+  protected JSONArray resourcesToJson(List<CalendarResourceDo> resources) {
+    return jsonDoHelper().dataObjectsToJson(resources);
   }
 
   @Override


### PR DESCRIPTION
When no resources are available in the calendar, the conversion to JSON failed with a NullPointerException. JSONArray does not support null as argument. To properly convert data objects from the model in the JSON layer, the JsonDataObjectHelper should be used, which handles edge cases like this correctly.

389988