### PR TITLE
Fix height of html and body element

### DIFF
--- a/eclipse-scout-core/src/main.less
+++ b/eclipse-scout-core/src/main.less
@@ -7,6 +7,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
+html {
+  height: 100%;
+  width: 100%;
+}
+
 body {
   background-color: @body-background-color;
   #scout.font-text-normal();


### PR DESCRIPTION
The height of a DOM element depends on the height of the inner elements. Because Scout places all elements with an absolute position, the automatically calculated height of the body is 0.

Setting the height of the html and body element to 100% corrects this issue.

372440