### PR TITLE
LocalLookupCall: fix order of getDataByText result

### DIFF
--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCallTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -131,6 +131,17 @@ public class LocalLookupCallTest {
   }
 
   @Test
+  public void testGetDataByTexOrder() {
+    P_LocalLookupCall lc = new P_LocalLookupCall();
+    lc.setWildcard("*");
+    lc.setText("*");
+    List<? extends ILookupRow<Integer>> rows = lc.getDataByText();
+    assertEquals("lorem", rows.get(0).getText());
+    assertEquals("ipsum", rows.get(1).getText());
+    assertEquals("dolor", rows.get(2).getText());
+  }
+
+  @Test
   public void testGetDataByKey() {
     runGetDataByKey(0, null);
     runGetDataByKey(1, ROW10_KEY);
@@ -155,7 +166,6 @@ public class LocalLookupCallTest {
     runGetDataByRec(1, ROW30_KEY);
     runGetDataByRec(0, ROW11_KEY);
     runGetDataByRec(0, 799999);
-
   }
 
   @Test

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCall.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.shared.services.lookup;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,7 +136,7 @@ public class LocalLookupCall<T> extends LookupCall<T> {
    */
   @Override
   public List<? extends ILookupRow<T>> getDataByText() {
-    Map<T, ILookupRow<T>> list = new HashMap<>();
+    Map<T, ILookupRow<T>> list = new LinkedHashMap<>();
     Pattern p = createSearchPattern(getText());
     List<? extends ILookupRow<T>> lookupRows = createLookupRowsFiltered();
     for (ILookupRow<T> row : lookupRows) {


### PR DESCRIPTION
getDataByText does not return the results by insertion order anymore. Compared to getDataByAll, which still does it correctly.

The bug was introduced with 251c05954edee6e1a6fc992320b56a3f964a2af8