### PR TITLE
Charts: add option legendPointsVisible

### DIFF
--- a/eclipse-scout-chart/src/chart/Chart.ts
+++ b/eclipse-scout-chart/src/chart/Chart.ts
@@ -170,7 +170,8 @@ export class Chart extends Widget implements ChartModel {
           legend: {
             display: true,
             clickable: false,
-            position: Chart.Position.RIGHT
+            position: Chart.Position.RIGHT,
+            pointsVisible: true
           }
         }
       }
@@ -463,6 +464,7 @@ export type ChartConfigOptions = Omit<ChartOptions, 'scales'> & {
   plugins?: {
     legend?: {
       clickable?: boolean;
+      pointsVisible?: boolean;
     };
   };
 };

--- a/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
+++ b/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
@@ -540,6 +540,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
       this._computeDatasets(this.chart.data, config);
     }
     this._adjustData(config);
+    this._adjustLegend(config);
     this._adjustTooltip(config);
     this._adjustGrid(config);
     this._adjustPlugins(config);
@@ -758,6 +759,26 @@ export class ChartJsRenderer extends AbstractChartRenderer {
       this.onlyIntegers = config.data.datasets.every(dataset => dataset.data.every((data: ScatterDataPoint | BubbleDataPoint) => numbers.isInteger(data.x) && numbers.isInteger(data.y)));
     } else {
       this.onlyIntegers = config.data.datasets.every(dataset => dataset.data.every(data => numbers.isInteger(data)));
+    }
+  }
+
+  protected _adjustLegend(config: ChartConfig) {
+    if (!config || !config.type || !config.options) {
+      return;
+    }
+
+    config.options = $.extend(true, {}, config.options, {
+      plugins: {
+        legend: {
+          labels: {
+            generateLabels: this._legendLabelGenerator
+          }
+        }
+      }
+    });
+
+    if (!config.options.plugins.legend.pointsVisible) {
+      config.options.plugins.legend.labels.boxWidth = 0;
     }
   }
 
@@ -2039,8 +2060,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
       plugins: {
         legend: {
           labels: {
-            color: this._computeLabelColor(config.type),
-            generateLabels: this._legendLabelGenerator
+            color: this._computeLabelColor(config.type)
           }
         }
       }
@@ -2085,7 +2105,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
         legendColor, borderColor, backgroundColor;
       if (dataset && scout.isOneOf((dataset.type || config.type), Chart.Type.LINE, Chart.Type.BAR, Chart.Type.RADAR, Chart.Type.BUBBLE, Chart.Type.SCATTER)) {
         legendColor = arrays.ensure(dataset.legendColor)[0];
-        borderColor = this._adjustColorOpacity(dataset.borderColor as string, 1);
+        borderColor = this._adjustColorOpacity(arrays.ensure(dataset.borderColor as string | string[])[0], 1);
       } else if (data.datasets.length && scout.isOneOf(config.type, Chart.Type.PIE, Chart.Type.DOUGHNUT, Chart.Type.POLAR_AREA)) {
         dataset = data.datasets[0];
         legendColor = Array.isArray(dataset.legendColor) ? dataset.legendColor[idx] : dataset.legendColor;

--- a/org.eclipse.scout.rt.chart.client/src/main/java/org/eclipse/scout/rt/chart/client/ui/basic/chart/AbstractChart.java
+++ b/org.eclipse.scout.rt.chart.client/src/main/java/org/eclipse/scout/rt/chart/client/ui/basic/chart/AbstractChart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -145,6 +145,7 @@ public abstract class AbstractChart extends AbstractWidget implements IChart, IE
         .withLegendDisplay(true)
         .withLegendClickable(false)
         .withLegendPositionRight()
+        .withLegendPointsVisible(true)
         .withDatalabelsDisplay(false);
   }
 

--- a/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/ChartConfig.java
+++ b/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/ChartConfig.java
@@ -61,6 +61,7 @@ public class ChartConfig implements IChartConfig {
   protected static final String LEGEND_DISPLAY = combine(LEGEND, "display");
   protected static final String LEGEND_CLICKABLE = combine(LEGEND, "clickable");
   protected static final String LEGEND_POSITION = combine(LEGEND, "position");
+  protected static final String LEGEND_POINTS_VISIBLE = combine(LEGEND, "pointsVisible");
   protected static final String ELEMENTS = combine(OPTIONS, "elements");
   protected static final String LINE = combine(ELEMENTS, "line");
   protected static final String LINE_TENSION = combine(LINE, "tension");
@@ -640,6 +641,21 @@ public class ChartConfig implements IChartConfig {
   @Override
   public IChartConfig withLegendPositionRight() {
     return withLegendPosition(RIGHT);
+  }
+
+  @Override
+  public IChartConfig withLegendPointsVisible(boolean legendPointsVisible) {
+    return withProperty(LEGEND_POINTS_VISIBLE, legendPointsVisible);
+  }
+
+  @Override
+  public IChartConfig removeLegendPointsVisible() {
+    return removeProperty(LEGEND_POINTS_VISIBLE);
+  }
+
+  @Override
+  public boolean isLegendPointsVisible() {
+    return BooleanUtility.nvl((Boolean) getProperty(LEGEND_POINTS_VISIBLE));
   }
 
   @Override

--- a/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/IChartConfig.java
+++ b/org.eclipse.scout.rt.chart.shared/src/main/java/org/eclipse/scout/rt/chart/shared/data/basic/chart/IChartConfig.java
@@ -215,6 +215,12 @@ public interface IChartConfig extends Serializable {
 
   IChartConfig withLegendPositionRight();
 
+  IChartConfig withLegendPointsVisible(boolean legendPointsVisible);
+
+  IChartConfig removeLegendPointsVisible();
+
+  boolean isLegendPointsVisible();
+
   IChartConfig withLineTension(BigDecimal tension);
 
   IChartConfig removeLineTension();


### PR DESCRIPTION
Sometimes it is necessary to hide the colored points in the legend. The new option legendPointsVisible will hide those elements iff set to false. The default value of this option is true.

390246