### PR TITLE
390626 BeanManager: Concurrency Issue when unregistering

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/services/common/notifications/NotificationDispatcherTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/services/common/notifications/NotificationDispatcherTest.java
@@ -23,7 +23,6 @@ import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
-import org.eclipse.scout.rt.platform.IBeanManager;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.job.IBlockingCondition;
 import org.eclipse.scout.rt.platform.job.IFuture;
@@ -47,32 +46,22 @@ import org.mockito.Mockito;
 public class NotificationDispatcherTest {
 
   private List<IBean<?>> m_serviceReg;
-  private volatile GlobalNotificationHandler m_globalNotificationHanlder;
-  private volatile GroupNotificationHandler m_groupNotificationHanlder;
+  private volatile GlobalNotificationHandler m_globalNotificationHandler;
+  private volatile GroupNotificationHandler m_groupNotificationHandler;
 
   @Before
   public void before() {
-    m_globalNotificationHanlder = mock(GlobalNotificationHandler.class);
-    m_groupNotificationHanlder = mock(GroupNotificationHandler.class);
+    m_globalNotificationHandler = mock(GlobalNotificationHandler.class);
+    m_groupNotificationHandler = mock(GroupNotificationHandler.class);
     m_serviceReg = BeanTestingHelper.get().registerBeans(
-        new BeanMetaData(GlobalNotificationHandler.class).withInitialInstance(m_globalNotificationHanlder).withApplicationScoped(true),
-        new BeanMetaData(GroupNotificationHandler.class).withInitialInstance(m_groupNotificationHanlder).withApplicationScoped(true));
-
-    // ensure bean hander cache of notification dispatcher gets refreshed
-    IBeanManager beanManager = BEANS.getBeanManager();
-    IBean<NotificationHandlerRegistry> bean = beanManager.getBean(NotificationHandlerRegistry.class);
-    beanManager.unregisterBean(bean);
-    beanManager.registerClass(NotificationHandlerRegistry.class);
+        new BeanMetaData(GlobalNotificationHandler.class).withInitialInstance(m_globalNotificationHandler).withApplicationScoped(true),
+        new BeanMetaData(GroupNotificationHandler.class).withInitialInstance(m_groupNotificationHandler).withApplicationScoped(true),
+        new BeanMetaData(NotificationHandlerRegistry.class));
   }
 
   @After
   public void after() {
     BeanTestingHelper.get().unregisterBeans(m_serviceReg);
-    // ensure bean hander cache of notification dispatcher gets refreshed
-    IBeanManager beanManager = BEANS.getBeanManager();
-    IBean<NotificationHandlerRegistry> bean = beanManager.getBean(NotificationHandlerRegistry.class);
-    beanManager.unregisterBean(bean);
-    beanManager.registerClass(NotificationHandlerRegistry.class);
   }
 
   @Test
@@ -88,8 +77,8 @@ public class NotificationDispatcherTest {
         .withRunContext(ClientRunContexts.copyCurrent()))
         .whenDone(event -> cond.setBlocking(false), null);
     cond.waitFor();
-    Mockito.verify(m_globalNotificationHanlder, Mockito.times(1)).handleNotification(Mockito.any(Serializable.class));
-    Mockito.verify(m_groupNotificationHanlder, Mockito.times(0)).handleNotification(Mockito.any(INotificationGroup.class));
+    Mockito.verify(m_globalNotificationHandler, Mockito.times(1)).handleNotification(Mockito.any(Serializable.class));
+    Mockito.verify(m_groupNotificationHandler, Mockito.times(0)).handleNotification(Mockito.any(INotificationGroup.class));
   }
 
   @Test
@@ -106,8 +95,8 @@ public class NotificationDispatcherTest {
         .withRunContext(ClientRunContexts.copyCurrent()))
         .whenDone(event -> cond.setBlocking(false), null);
     cond.waitFor();
-    Mockito.verify(m_globalNotificationHanlder, Mockito.times(3)).handleNotification(Mockito.any(Serializable.class));
-    Mockito.verify(m_groupNotificationHanlder, Mockito.times(2)).handleNotification(Mockito.any(INotificationGroup.class));
+    Mockito.verify(m_globalNotificationHandler, Mockito.times(3)).handleNotification(Mockito.any(Serializable.class));
+    Mockito.verify(m_groupNotificationHandler, Mockito.times(2)).handleNotification(Mockito.any(INotificationGroup.class));
   }
 
   /**
@@ -141,7 +130,7 @@ public class NotificationDispatcherTest {
     private static final long serialVersionUID = 1L;
   }
 
-  public static interface INotificationGroup extends Serializable {
+  public interface INotificationGroup extends Serializable {
 
   }
 

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/services/common/notifications/NotificationDispatcherTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/services/common/notifications/NotificationDispatcherTest.java
@@ -62,7 +62,7 @@ public class NotificationDispatcherTest {
     IBeanManager beanManager = BEANS.getBeanManager();
     IBean<NotificationHandlerRegistry> bean = beanManager.getBean(NotificationHandlerRegistry.class);
     beanManager.unregisterBean(bean);
-    beanManager.registerBean(new BeanMetaData(bean));
+    beanManager.registerClass(NotificationHandlerRegistry.class);
   }
 
   @After
@@ -72,7 +72,7 @@ public class NotificationDispatcherTest {
     IBeanManager beanManager = BEANS.getBeanManager();
     IBean<NotificationHandlerRegistry> bean = beanManager.getBean(NotificationHandlerRegistry.class);
     beanManager.unregisterBean(bean);
-    beanManager.registerBean(new BeanMetaData(bean));
+    beanManager.registerClass(NotificationHandlerRegistry.class);
   }
 
   @Test

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/BeanManagerIsBeanTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/BeanManagerIsBeanTest.java
@@ -9,11 +9,14 @@
  */
 package org.eclipse.scout.rt.platform;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.scout.rt.platform.internal.BeanManagerImplementor;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,5 +42,42 @@ public class BeanManagerIsBeanTest {
 
     // JRE classes are no beans
     assertFalse(context.isBean(String.class));
+  }
+
+
+  @Test
+  public void testUnregisterBean() throws InterruptedException {
+    long startTime = System.nanoTime();
+    long delta = 2_000_000_000L;
+    BeanTestingHelper helper = BEANS.get(BeanTestingHelper.class);
+    AtomicReference<Exception> occurredException = new AtomicReference<>();
+    Thread t1 = new Thread(() -> {
+      while (System.nanoTime() - startTime < delta) {
+        try {
+          BEANS.get(TestA.class);
+        }
+        catch (Exception e) {
+          occurredException.set(e);
+        }
+      }
+    });
+    Thread t2 = new Thread(() -> {
+      while (System.nanoTime() - startTime < delta) {
+        IBean<Object> bean = helper.registerBean(new BeanMetaData(TestB.class).withReplace(true));
+        helper.unregisterBean(bean);
+      }
+    });
+    t1.start();
+    t2.start();
+    Thread.sleep(2_000);
+    Assert.assertNull("Exception occurred: " + occurredException, occurredException.get());
+  }
+
+  @Bean
+  public static class TestA {
+  }
+
+  @IgnoreBean
+  public static class TestB extends TestA {
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/internal/BeanImplementor.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/internal/BeanImplementor.java
@@ -23,8 +23,8 @@ public class BeanImplementor<T> implements IBean<T> {
   private final Class<? extends T> m_beanClazz;
   private final Map<Class<? extends Annotation>, Annotation> m_beanAnnotations;
   private final T m_initialInstance;
+  private final IBeanInstanceProducer<T> m_producer;
   private boolean m_instanceAvailable;
-  private IBeanInstanceProducer<T> m_producer;
 
   /**
    * Creates a {@link BeanImplementor} with the default producer.
@@ -54,6 +54,9 @@ public class BeanImplementor<T> implements IBean<T> {
     }
     else if (!m_beanClazz.isInterface()) {
       m_producer = beanInstanceProducer;
+    }
+    else {
+      m_producer = null;
     }
   }
 
@@ -104,10 +107,6 @@ public class BeanImplementor<T> implements IBean<T> {
   @Override
   public IBeanInstanceProducer<T> getBeanInstanceProducer() {
     return m_producer;
-  }
-
-  protected void dispose() {
-    m_producer = null;
   }
 
   @Override

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/internal/BeanManagerImplementor.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/internal/BeanManagerImplementor.java
@@ -183,9 +183,6 @@ public class BeanManagerImplementor implements IBeanManager {
           h.removeBean(bean);
         }
       }
-      if (bean instanceof BeanImplementor) {
-        ((BeanImplementor) bean).dispose();
-      }
     }
     finally {
       m_lock.writeLock().unlock();

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/notification/NotificationHandlerRegistryTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/notification/NotificationHandlerRegistryTest.java
@@ -12,7 +12,6 @@ package org.eclipse.scout.rt.shared.notification;
 import java.io.Serializable;
 
 import org.eclipse.scout.rt.platform.BEANS;
-import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.IBeanManager;
 import org.eclipse.scout.rt.testing.platform.mock.BeanMock;
@@ -51,7 +50,7 @@ public class NotificationHandlerRegistryTest {
     IBeanManager beanManager = BEANS.getBeanManager();
     IBean<NotificationHandlerRegistry> bean = beanManager.getBean(NotificationHandlerRegistry.class);
     beanManager.unregisterBean(bean);
-    beanManager.registerBean(new BeanMetaData(bean));
+    beanManager.registerClass(NotificationHandlerRegistry.class);
   }
 
   /**

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/notification/NotificationHandlerRegistryTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/notification/NotificationHandlerRegistryTest.java
@@ -12,8 +12,9 @@ package org.eclipse.scout.rt.shared.notification;
 import java.io.Serializable;
 
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
-import org.eclipse.scout.rt.platform.IBeanManager;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.mock.BeanMock;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.After;
@@ -34,23 +35,17 @@ public class NotificationHandlerRegistryTest {
   //notification handler for all INotificationGroup
   @BeanMock
   private GroupNotificationHandler m_groupNotificationHanlder;
+  private IBean<Object> m_registryBean;
 
   @Before
   public void before() {
     // ensure bean hander cache of notification dispatcher gets refreshed
-    ensureHandlerRegistryRefreshed();
+    m_registryBean = BeanTestingHelper.get().registerBean(new BeanMetaData(NotificationHandlerRegistry.class));
   }
 
   @After
   public void after() {
-    ensureHandlerRegistryRefreshed();
-  }
-
-  private void ensureHandlerRegistryRefreshed() {
-    IBeanManager beanManager = BEANS.getBeanManager();
-    IBean<NotificationHandlerRegistry> bean = beanManager.getBean(NotificationHandlerRegistry.class);
-    beanManager.unregisterBean(bean);
-    beanManager.registerClass(NotificationHandlerRegistry.class);
+    BeanTestingHelper.get().unregisterBean(m_registryBean);
   }
 
   /**
@@ -90,7 +85,7 @@ public class NotificationHandlerRegistryTest {
     }
   }
 
-  public static interface INotificationGroup extends Serializable {
+  public interface INotificationGroup extends Serializable {
 
   }
 


### PR DESCRIPTION
Fix concurrency issue that happens only because m_producer is set to null when unregistering an IBean.
Preferable, the m_producer is final.