### PR TITLE
SimpleTab: Remove disabled style

### DIFF
--- a/eclipse-scout-core/src/tabbox/SimpleTab.less
+++ b/eclipse-scout-core/src/tabbox/SimpleTab.less
@@ -119,14 +119,6 @@
     color: @active-color;
   }
 
-  &.disabled {
-    cursor: default;
-
-    & > .title-line > .title {
-      color: @disabled-color;
-    }
-  }
-
   &.selected {
     cursor: default;
     background-color: @simple-tab-selected-background-color;


### PR DESCRIPTION
Remove disabled style for SimpleTabs, as no functionality changes when these are disabled. They are still clickable in the tab box, but do not look like this