### PR TITLE
Improve resolution of textKeys and iconIds

### DIFF
--- a/eclipse-scout-core/src/text/TextMap.ts
+++ b/eclipse-scout-core/src/text/TextMap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,6 @@ export class TextMap {
   constructor(textMap?: Record<string, string>) {
     this.map = textMap || {};
   }
-
-  static TEXT_KEY_REGEX = /\${textKey:([a-zA-Z0-9.]*)}/;
 
   /**
    * Returns the text for the given key.

--- a/eclipse-scout-core/test/text/textsSpec.ts
+++ b/eclipse-scout-core/test/text/textsSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -82,7 +82,6 @@ describe('texts', () => {
       // Texts which were registered but are part of the new model too are replaced
       expect(texts.get('de').get('theKey')).toBe('de');
     });
-
   });
 
   describe('get', () => {
@@ -121,7 +120,80 @@ describe('texts', () => {
       expect(Object.keys(textMap.map).length).toBe(0);
       expect(textMap.parent).toEqual(texts._get('de'));
     });
-
   });
 
+  describe('resolve', () => {
+
+    it('resolves text', () => {
+      texts.init(model);
+      expect(texts.resolveText('${textKey:theKey}', 'de')).toBe('de');
+      expect(texts.resolveText('${textKey:_DoesNotExist}', 'de')).toBe('[undefined text: _DoesNotExist]');
+      expect(texts.resolveText('foo ${textKey:theKey}', 'de')).toBe('foo ${textKey:theKey}');
+      expect(texts.resolveText('bar', 'de')).toBe('bar');
+    });
+
+    it('resolves text property', () => {
+      texts.init(model);
+
+      setFixtures(sandbox());
+      let session = sandboxSession();
+
+      // With session on object
+
+      let obj = {
+        session: session,
+        text: '${textKey:theKey}',
+        xyz: '${textKey:theKey}',
+        foo: 'bar'
+      };
+
+      texts.resolveTextProperty(obj);
+      expect(obj.text).toBe('deCH');
+      expect(obj.xyz).toBe('${textKey:theKey}');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj, 'xyz');
+      expect(obj.text).toBe('deCH');
+      expect(obj.xyz).toBe('deCH');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj, 'foo');
+      expect(obj.text).toBe('deCH');
+      expect(obj.xyz).toBe('deCH');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj, 'doesNotExist');
+      expect(obj.text).toBe('deCH');
+      expect(obj.xyz).toBe('deCH');
+      expect(obj.foo).toBe('bar');
+
+      // Without session on object
+
+      let obj2 = {
+        text: '${textKey:theKey}',
+        xyz: '${textKey:theKey}',
+        foo: 'bar'
+      };
+
+      texts.resolveTextProperty(obj2, null, session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.xyz).toBe('${textKey:theKey}');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj2, 'xyz', session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.xyz).toBe('deCH');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj2, 'foo', session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.xyz).toBe('deCH');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj2, 'doesNotExist', session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.xyz).toBe('deCH');
+      expect(obj2.foo).toBe('bar');
+    });
+  });
 });

--- a/eclipse-scout-core/test/util/iconsSpec.ts
+++ b/eclipse-scout-core/test/util/iconsSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -51,4 +51,54 @@ describe('icons', () => {
     expect(icon.appendCssClass('font-icon')).toBe('font-icon font-widgetIcons');
   });
 
+  it('resolves iconId', () => {
+    expect(icons.resolveIconId('${iconId:ANGLE_UP}')).toBe(icons.ANGLE_UP);
+    expect(icons.resolveIconId('${iconId:_DOES_NOT_EXIST_}')).toBe(undefined);
+    expect(icons.resolveIconId('foo ${iconId:ANGLE_UP}')).toBe('foo ${iconId:ANGLE_UP}');
+    expect(icons.resolveIconId('bar')).toBe('bar');
+    expect(icons.resolveIconId(icons.INFO)).toBe(icons.INFO);
+
+    window['testIconsSpec'] = {icons: {FOO: 'bar'}}; // dummy namespace
+    expect(icons.resolveIconId('${iconId:testIconsSpec.FOO}')).toBe('bar');
+    delete window['testIconsSpec'];
+  });
+
+  it('resolves iconId property', () => {
+    let obj = {
+      iconId: '${iconId:ANGLE_UP}',
+      name: 'xyz',
+      foo: '${iconId:ANGLE_UP}',
+      bar: icons.ANGLE_UP
+    };
+
+    icons.resolveIconProperty(obj);
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe('${iconId:ANGLE_UP}');
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperty(obj, 'name');
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe('${iconId:ANGLE_UP}');
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperty(obj, 'foo');
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe(icons.ANGLE_UP);
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperty(obj, 'bar');
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe(icons.ANGLE_UP);
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperty(obj, 'doesNotExist');
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe(icons.ANGLE_UP);
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+  });
 });


### PR DESCRIPTION
- Match entire string instead of substrings (that was most likely not intentional)
- The default namespace for iconIds is 'scout'. This now also works if the icons object is replaced.
- Cleanup code
- Cleanup JsDoc
- Add specs