### PR TITLE
FormFieldTile: hide loaded content while insert animation

### DIFF
--- a/eclipse-scout-core/src/tile/fields/FormFieldTile.less
+++ b/eclipse-scout-core/src/tile/fields/FormFieldTile.less
@@ -95,16 +95,6 @@
       display: none;
     }
 
-    /* Define a short transition for opacity changes on all field elements (used in .loading state) */
-
-    & > label,
-    & > .mandatory-indicator,
-    & > .field,
-    & > .status {
-      transition: opacity 0.15s; /* Same time is used in animation() of .loading-indicator */
-      opacity: 1;
-    }
-
     & > .status {
       display: flex;
       align-items: center;
@@ -174,13 +164,17 @@
     }
   }
 
+  // Define a short transition for opacity changes (used in .loading state)
+  & > :not(.loading-indicator) {
+    transition: opacity 0.15s; // Same time is used in animation() of .loading-indicator
+    opacity: 1;
+  }
+
   &.loading {
-    & > .form-field > label,
-    & > .form-field > .mandatory-indicator,
-    & > .form-field > .field,
-    & > .form-field > .status {
-      /* Same as 'visibility: hidden', except it can be animated with CSS transitions */
-      opacity: 0;
+    pointer-events: none;
+
+    & > :not(.loading-indicator) {
+      opacity: 0; // animated with CSS transition
     }
 
     & > .loading-indicator {

--- a/eclipse-scout-core/src/tile/fields/FormFieldTile.ts
+++ b/eclipse-scout-core/src/tile/fields/FormFieldTile.ts
@@ -34,6 +34,18 @@ export class FormFieldTile extends WidgetTile {
     this._renderCompact();
   }
 
+  protected override _renderLoading() {
+    // Setting the loading flag to false will show content of the tile immediately and the layout will be validated.
+    // However, if the tile is currently being animated, the layout validation will wait until the animation has
+    // finished (see HtmlComponent#_checkValidationPossible). To prevent showing non-layouted elements, we therefore
+    // also have to postpone the removal of the 'loading' class.
+    if (!this.loading && this.$container.hasAnimationClass()) {
+      this.$container.oneAnimationEnd(() => this.rendered && this._renderLoading());
+    } else {
+      super._renderLoading();
+    }
+  }
+
   protected override _setTileWidget(tileWidget: Widget) {
     super._setTileWidget(tileWidget);
     this._setDisplayStyle(this.displayStyle);


### PR DESCRIPTION
When a form field tile is loading the content is hidden via CSS and a loading indicator is shown instead. Setting the loading flag to false will show content of the tile immediately and the layout will be validated. However, if the tile is currently being animated, the layout validation will wait until the animation has finished (see HtmlComponent#_checkValidationPossible).

To prevent showing non-layouted elements, we therefore also have to postpone the removal of the 'loading' class.

Additionally, the 'loading' CSS class was simplified to hide everything except the loading indicator (instead of only parts of the inner form field). This allows for custom tiles with additional elements.

389516