### PR TITLE
TableTileGridMediator: fix removal of table user filters

### DIFF
--- a/eclipse-scout-core/test/table/TableTileModeSpec.ts
+++ b/eclipse-scout-core/test/table/TableTileModeSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {SpecTable, TableModelWithCells, TableSpecHelper} from '../../src/testing/index';
-import {HtmlTile, scout} from '../../src';
+import {HtmlTile, KeyTableFilter, scout, TableTextUserFilter} from '../../src';
 
 describe('TableTileModeSpec', () => {
   let session: SandboxSession;
@@ -68,6 +68,74 @@ describe('TableTileModeSpec', () => {
       table.sort(table.columns[0], 'desc');
       table.setTileMode(true);
       expect(table.tableTileGridMediator.tileAccordion.groups.length).toBe(5);
+    });
+
+    it('filters data (key filter)', () => {
+      table.setCellValue(table.columns[0], table.rows[0], 'u001');
+      table.setCellValue(table.columns[0], table.rows[1], 'u002');
+      table.setCellValue(table.columns[0], table.rows[2], 'u003');
+      table.setCellValue(table.columns[0], table.rows[3], 'u004');
+      table.setCellValue(table.columns[0], table.rows[4], 'u005');
+      table.setCellText(table.columns[0], table.rows[0], 'Alice Smith');
+      table.setCellText(table.columns[0], table.rows[1], 'Bob Jones');
+      table.setCellText(table.columns[0], table.rows[2], 'Charlie Black');
+      table.setCellText(table.columns[0], table.rows[3], 'Doris Smith');
+      table.setCellText(table.columns[0], table.rows[4], 'Elias Crawford');
+
+      table.setTileMode(true);
+      expect(table.filteredRows().length).toBe(5);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(5);
+
+      let filter1 = new KeyTableFilter(row => row.cells[0].value);
+      filter1.setAcceptedKeys('u001', 'u002', 'u003');
+      table.addFilter(filter1);
+      expect(table.filteredRows().length).toBe(3);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(3);
+
+      table.addFilter(filter1);
+      expect(table.filteredRows().length).toBe(3);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(3);
+
+      table.removeFilter(filter1);
+      expect(table.filteredRows().length).toBe(5);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(5);
+
+      let filter2 = new KeyTableFilter(row => row.cells[0].value);
+      filter2.setAcceptedKeys('u001', 'u003', 'u004', 'u005');
+      table.addFilter(filter2);
+      expect(table.filteredRows().length).toBe(4);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(4);
+
+      let filter3 = scout.create(TableTextUserFilter, {
+        session: session,
+        table: table,
+        text: 'jones'
+      });
+      table.addFilter(filter3);
+      expect(table.filteredRows().length).toBe(0);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(0);
+
+      let filter4 = scout.create(TableTextUserFilter, {
+        session: session,
+        table: table,
+        text: 'black'
+      });
+      table.addFilter(filter4);
+      expect(table.filteredRows().length).toBe(1);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(1);
+
+      let filter5 = scout.create(TableTextUserFilter, {
+        session: session,
+        table: table,
+        text: 'smith'
+      });
+      table.addFilter(filter5);
+      expect(table.filteredRows().length).toBe(2);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(2);
+
+      table.removeFilter(filter5);
+      expect(table.filteredRows().length).toBe(4);
+      expect(table.tableTileGridMediator.tileAccordion.getFilteredTileCount()).toBe(4);
     });
   });
 });


### PR DESCRIPTION
Table user filters are identified by a key. If such a filter is added to a table, any existing filter with the same key is automatically removed first (but without triggering an event). For each filter added to the table, the TableTileGridMediator creates a corresponding tile filter. If multiple table filters with the same key (e.g. TableTextUserFilter) are added, the previous tile filter was not correctly removed.

This is apparent in the following situation:
- Switch a table to the tile mode
- Enter a value in the filter field in the table footer -> filter is correctly applied (both table rows and tiles are filtered)
- Enter a different value in the filter field -> filter is also applied
- Remove the filter text -> filter is correctly removed from the table (all rows are visible again), but not from the tile. The first added text filter seems to remain forever.

To fix the problem, the tile filters created by the mediator have to be stored in a list. This allows the mediator to identify and remove table user filters later, similar to Table#addFilter.

387837