### PR TITLE
TileGridLayout: mark tiles as 'animating' while changing bounds

### DIFF
--- a/eclipse-scout-core/src/jquery/jquery-scout-types.ts
+++ b/eclipse-scout-core/src/jquery/jquery-scout-types.ts
@@ -685,32 +685,32 @@ declare global {
     /**
      * Animates from old to new width. The default duration is set to 300ms.
      */
-    cssWidthAnimated(oldWidth: number, newWidth: number, options: JQuery.EffectsOptions<TElement>);
+    cssWidthAnimated(oldWidth: number, newWidth: number, options?: JQuery.EffectsOptions<TElement>);
 
     /**
      * Animates from old to new height. The default duration is set to 300ms.
      */
-    cssHeightAnimated(oldHeight: number, newHeight: number, options: JQuery.EffectsOptions<TElement>);
+    cssHeightAnimated(oldHeight: number, newHeight: number, options?: JQuery.EffectsOptions<TElement>);
 
     /**
      * Animates the left property from old to new left. The default duration is set to 300ms.
      */
-    cssLeftAnimated(from: number, to: number, options: JQuery.EffectsOptions<TElement>): this;
+    cssLeftAnimated(from: number, to: number, options?: JQuery.EffectsOptions<TElement>): this;
 
     /**
      * Animates the top property from old to new top. The default duration is set to 300ms.
      */
-    cssTopAnimated(from: number, to: number, options: JQuery.EffectsOptions<TElement>): this;
+    cssTopAnimated(from: number, to: number, options?: JQuery.EffectsOptions<TElement>): this;
 
     /**
      * Animates the given properties from old to new. The default duration is set to 300ms.
      */
-    cssAnimated<T extends JQuery.PlainObject<string | number>>(fromValues: T, toValues: T, options: JQuery.EffectsOptions<TElement>): this;
+    cssAnimated<T extends JQuery.PlainObject<string | number>>(fromValues: T, toValues: T, options?: JQuery.EffectsOptions<TElement>): this;
 
     /**
      * Animates the width of the current element to its preferred width.
      */
-    cssWidthToContentAnimated(options: JQuery.EffectsOptions<TElement>);
+    cssWidthToContentAnimated(options?: JQuery.EffectsOptions<TElement>);
 
     /**
      * Offset to a specific ancestor and not to the document as offset() would do.

--- a/eclipse-scout-core/test/layout/HtmlComponentSpec.ts
+++ b/eclipse-scout-core/test/layout/HtmlComponentSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -202,7 +202,7 @@ describe('HtmlComponent', () => {
       expect(htmlChild.$comp.parents).not.toHaveBeenCalled();
     });
 
-    it('does not layout components with an animating parent', () => {
+    it('does not layout components with an animating parent (CSS)', () => {
       $comp.addClass('animate-test');
       spyOn(htmlChild.layout, 'layout').and.callThrough();
       htmlChild.validateLayout();
@@ -214,7 +214,7 @@ describe('HtmlComponent', () => {
       expect(htmlChild.layout.layout).toHaveBeenCalled();
     });
 
-    it('does not layout animated components', () => {
+    it('does not layout animated components (CSS)', () => {
       $comp.addClass('animate-test');
       spyOn(htmlComp.layout, 'layout').and.callThrough();
       htmlComp.validateLayout();
@@ -226,6 +226,37 @@ describe('HtmlComponent', () => {
       expect(htmlComp.layout.layout).toHaveBeenCalled();
     });
 
+    it('does not layout components with an animating parent (JS)', () => {
+      let deferred = $.Deferred();
+      let promise = deferred.promise();
+      $comp.data('animate-promise', promise);
+      // use always(), so it will be executed immediately when the promise is resolved (otherwise, we might get an endless loop)
+      promise.always(() => $comp.removeData('animate-promise'));
+
+      spyOn(htmlChild.layout, 'layout').and.callThrough();
+      htmlChild.validateLayout();
+      expect(htmlChild.layout.layout).not.toHaveBeenCalled();
+
+      // Simulate end of animation
+      deferred.resolve();
+      expect(htmlChild.layout.layout).toHaveBeenCalled();
+    });
+
+    it('does not layout animated components (JS)', () => {
+      let deferred = $.Deferred();
+      let promise = deferred.promise();
+      $comp.data('animate-promise', promise);
+      // use always(), so it will be executed immediately when the promise is resolved (otherwise, we might get an endless loop)
+      promise.always(() => $comp.removeData('animate-promise'));
+
+      spyOn(htmlComp.layout, 'layout').and.callThrough();
+      htmlComp.validateLayout();
+      expect(htmlComp.layout.layout).not.toHaveBeenCalled();
+
+      // Simulate end of animation
+      deferred.resolve();
+      expect(htmlComp.layout.layout).toHaveBeenCalled();
+    });
   });
 
   describe('prefSize', () => {


### PR DESCRIPTION
Add a class 'animate-tile-bounds' while tile bounds are changed with a jQuery animation. This prevents inner layouts from being validated and measuring wrong dimensions.

390356