### PR TITLE
TreeProposalChooser: Fix hierarchy when duplicated lookupRows provided

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/TreeProposalChooser.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/TreeProposalChooser.ts
@@ -83,7 +83,7 @@ export class TreeProposalChooser<TValue> extends ProposalChooser<TValue, Tree, P
       appendResult = scout.nvl(result.appendResult, false);
 
     if (appendResult) {
-      treeNodesFlat = lookupRows.map(this._createTreeNode.bind(this));
+      treeNodesFlat = this._lookupRowsToFlatList(lookupRows);
       treeNodes = this._flatListToSubTree(treeNodesFlat);
       if (treeNodes.length) {
         let parentNode = null;
@@ -103,7 +103,7 @@ export class TreeProposalChooser<TValue> extends ProposalChooser<TValue, Tree, P
       }
     } else {
       this.content.deleteAllChildNodes();
-      treeNodesFlat = lookupRows.map(this._createTreeNode.bind(this));
+      treeNodesFlat = this._lookupRowsToFlatList(lookupRows);
       treeNodes = this._flatListToSubTree(treeNodesFlat);
       if (result.byText) {
         this._expandAllParentNodes(treeNodesFlat);
@@ -213,6 +213,18 @@ export class TreeProposalChooser<TValue> extends ProposalChooser<TValue, Tree, P
       }
     }, this.content.nodes);
     return leafs;
+  }
+
+  /**
+   * This function creates a list of flat tree nodes from a list of lookup rows.
+   * Nodes with duplicate ids are filtered, only the first node with the same id is kept.
+   */
+  protected _lookupRowsToFlatList(lookupRows: LookupRow<TValue>[]): ProposalTreeNode<TValue>[] {
+    let nodeIds = new Set();
+    return lookupRows.map(this._createTreeNode.bind(this))
+      .filter(node => {
+        return nodeIds.has(node.id) ? false : nodeIds.add(node.id);
+      });
   }
 
   /**

--- a/eclipse-scout-core/test/form/fields/smartfield/TreeProposalChooserSpec.ts
+++ b/eclipse-scout-core/test/form/fields/smartfield/TreeProposalChooserSpec.ts
@@ -77,10 +77,6 @@ describe('TreeProposalChooser', () => {
       });
 
       let lookupRows: LookupRow<number>[] = [
-        // @ts-expect-error
-        scout.create((LookupRow<number>), {
-          text: 'No Key, No Parent'
-        }),
         scout.create((LookupRow<number>), {
           key: null,
           text: 'Explicit null Key, No Parent'
@@ -107,13 +103,43 @@ describe('TreeProposalChooser', () => {
       });
       // Lookup rows with parentKey = null are top level nodes. They must never be linked to another lookup row, even if there is a lookup row with key = null.
       // Key = null has a special behavior: when such a row is clicked the text is cleared since the new value is null.
-      expect(chooser.content.nodes.length).toBe(4);
+      expect(chooser.content.nodes.length).toBe(3);
       expect(chooser.content.nodes[0].parentNode).toBe(null);
       expect(chooser.content.nodes[1].parentNode).toBe(null);
       expect(chooser.content.nodes[2].parentNode).toBe(null);
-      expect(chooser.content.nodes[3].parentNode).toBe(null);
-      expect(chooser.content.nodes[3].expanded).toBe(true);
-      expect(chooser.content.nodes[3].childNodes[0].parentNode).toBe(chooser.content.nodes[3]);
+      expect(chooser.content.nodes[2].expanded).toBe(true);
+      expect(chooser.content.nodes[2].childNodes[0].parentNode).toBe(chooser.content.nodes[2]);
+    });
+
+    it('does not get messed up with undefined keys', () => {
+      // dummy smart field
+      let smartField = scout.create((SmartField<number>), {
+        parent: session.desktop
+      });
+
+      let chooser = scout.create((TreeProposalChooser<number>), {
+        parent: session.desktop,
+        smartField: smartField
+      });
+
+      let lookupRows: LookupRow<number>[] = [
+        // @ts-expect-error
+        scout.create((LookupRow<number>), {
+          text: 'No Key, No Parent'
+        }),
+        scout.create((LookupRow<number>), {
+          key: 1,
+          text: 'No Parent'
+        })
+      ];
+
+      chooser.setLookupResult({
+        queryBy: QueryBy.ALL,
+        lookupRows: lookupRows
+      });
+      expect(chooser.content.nodes.length).toBe(2);
+      expect(chooser.content.nodes[0].parentNode).toBe(null);
+      expect(chooser.content.nodes[1].parentNode).toBe(null);
     });
 
     it('clears the field if a lookup row with key null is selected', () => {
@@ -177,6 +203,39 @@ describe('TreeProposalChooser', () => {
       popup.selectLookupRow();
       expect(smartField.value).toBe(null);
       expect(smartField.displayText).toBe('');
+    });
+
+    it('filters lookup rows with same key', () => {
+      let smartField = scout.create(SmartField, {
+        parent: session.desktop
+      });
+
+      let chooser = scout.create(TreeProposalChooser, {
+        parent: session.desktop,
+        smartField: smartField
+      });
+
+      let lookupRows = [
+        createLookupRow(0, null, 'Value 1'),
+        createLookupRow(1, null, 'Value 2'),
+        createLookupRow(1, null, 'Duplicate Value 2'),
+        createLookupRow(2, 1, 'Child Value 2'),
+        createLookupRow(2, 0, 'Duplicate Child Value 2')
+      ];
+      lookupRows[2].active = false;
+
+      chooser.setLookupResult({
+        queryBy: QueryBy.ALL,
+        lookupRows: lookupRows
+      });
+
+      expect(chooser.content.nodes.length).toBe(2);
+      expect(chooser.content.nodes[0].parentNode).toBe(null);
+      expect(chooser.content.nodes[1].parentNode).toBe(null);
+      expect(chooser.content.nodes[1].text).toBe('Value 2');
+      expect(chooser.content.nodes[1].childNodes.length).toBe(1);
+      expect(chooser.content.nodes[1].childNodes[0].text).toBe('Child Value 2');
+      expect(chooser.content.nodes[1].childNodes[0].parentNode).toBe(chooser.content.nodes[1]);
     });
   });
 });

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCall.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCall.java
@@ -12,11 +12,9 @@ package org.eclipse.scout.rt.shared.services.lookup;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -136,23 +134,23 @@ public class LocalLookupCall<T> extends LookupCall<T> {
    */
   @Override
   public List<? extends ILookupRow<T>> getDataByText() {
-    Map<T, ILookupRow<T>> list = new LinkedHashMap<>();
+    List<ILookupRow<T>> list = new ArrayList<>();
     Pattern p = createSearchPattern(getText());
     List<? extends ILookupRow<T>> lookupRows = createLookupRowsFiltered();
     for (ILookupRow<T> row : lookupRows) {
       if (row.getText() != null && p.matcher(row.getText().toLowerCase()).matches()) {
-        list.put(row.getKey(), row);
+        list.add(row);
       }
     }
     if (isHierarchicalLookup()) {
       Map<T, Set<ILookupRow<T>>> nodeMap = createNodeMap(lookupRows);
       List<ILookupRow<T>> children = new ArrayList<>();
-      for (ILookupRow<T> res : list.values()) {
+      for (ILookupRow<T> res : list) {
         collectChildrenRec(nodeMap, res.getKey(), children);
       }
-      list.putAll(children.stream().collect(Collectors.toMap(ILookupRow::getKey, Function.identity())));
+      list.addAll(children);
     }
-    return new ArrayList<>(list.values());
+    return list;
   }
 
   /**


### PR DESCRIPTION
For hierarchical smart fields where a child node is provided multiple times in the lookup result, the parent may wasn't resolved correctly such that the child node was displayed at top level. In Java, duplicated lookup rows are already filtered for hierarchical SmartFields, see
HierarchicalLookupResultBuilder.getRowsWithParents(List>, VALUE). Analogous logic is now added in TypeScript.

Revert 251c05954edee6e1a6fc992320b56a3f964a2af8 since now solved generally, independent of the LookupCall.