### PR TITLE
ChartFieldTile: fix colorScheme if tileWidget changes

### DIFF
--- a/eclipse-scout-chart/src/tile/ChartFieldTile.ts
+++ b/eclipse-scout-chart/src/tile/ChartFieldTile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {FormFieldTile, PropertyChangeEvent} from '@eclipse-scout/core';
+import {ColorScheme, FormFieldTile, PropertyChangeEvent} from '@eclipse-scout/core';
 import {Chart, ChartField, ChartFieldTileModel} from '../index';
 import {ChartConfig} from '../chart/Chart';
 
@@ -22,8 +22,8 @@ export class ChartFieldTile extends FormFieldTile implements ChartFieldTileModel
     this._chartConfigChangeHandler = this._onChartConfigChange.bind(this);
   }
 
-  protected override _renderColorScheme() {
-    super._renderColorScheme();
+  protected override _setColorScheme(colorScheme: ColorScheme | string) {
+    super._setColorScheme(colorScheme);
     this._updateChartColorScheme();
   }
 
@@ -46,6 +46,7 @@ export class ChartFieldTile extends FormFieldTile implements ChartFieldTileModel
       this.tileWidget.chart.off('propertyChange:config', this._chartConfigChangeHandler);
     }
     super._setTileWidget(tileWidget);
+    this._updateChartColorScheme();
     this.tileWidget.chart.on('propertyChange:config', this._chartConfigChangeHandler);
   }
 }

--- a/eclipse-scout-chart/test/chart/ChartJsRendererSpec.ts
+++ b/eclipse-scout-chart/test/chart/ChartJsRendererSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/eclipse-scout-chart/test/chart/ChartJsRendererSpec.ts
+++ b/eclipse-scout-chart/test/chart/ChartJsRendererSpec.ts
@@ -8,18 +8,44 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Chart, ChartJsRenderer} from '../../src/index';
+import {Chart, ChartConfig, ChartJsRenderer} from '../../src/index';
+import {scout} from '@eclipse-scout/core';
+import {ChartArea} from 'chart.js';
 
 describe('ChartJsRendererSpec', () => {
+  let session: SandboxSession;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+  });
+
+  class SpecChartJsRenderer extends ChartJsRenderer {
+
+    override _adjustGridMaxMin(config: ChartConfig, chartArea: ChartArea) {
+      super._adjustGridMaxMin(config, chartArea);
+    }
+
+    override _adjustBubbleSizes(config: ChartConfig, chartArea: ChartArea) {
+      super._adjustBubbleSizes(config, chartArea);
+    }
+  }
 
   describe('_adjustGridMaxMin', () => {
-    let renderer = new ChartJsRenderer({}),
+    let renderer: SpecChartJsRenderer,
+      chartArea: ChartArea,
+      defaultConfig: Partial<ChartConfig>,
+      defaultScalesConfig: Partial<ChartConfig>,
+      defaultScaleConfig: Partial<ChartConfig>;
+
+    beforeEach(() => {
+      renderer = new SpecChartJsRenderer(scout.create(Chart, {parent: session.desktop}));
       chartArea = {
         top: 0,
         bottom: 300,
         left: 0,
         right: 750
-      },
+      } as ChartArea;
       defaultConfig = {
         data: {
           datasets: [{
@@ -30,7 +56,7 @@ describe('ChartJsRendererSpec', () => {
         options: {
           adjustGridMaxMin: true
         }
-      },
+      };
       defaultScalesConfig = $.extend(true, {}, defaultConfig, {
         options: {
           scales: {
@@ -42,7 +68,7 @@ describe('ChartJsRendererSpec', () => {
             }
           }
         }
-      }),
+      });
       defaultScaleConfig = $.extend(true, {}, defaultConfig, {
         options: {
           scales: {
@@ -52,6 +78,7 @@ describe('ChartJsRendererSpec', () => {
           }
         }
       });
+    });
 
     it('bar chart, min/max is set on y axis', () => {
       let config = $.extend(true, {}, defaultScalesConfig, {type: Chart.Type.BAR});
@@ -223,23 +250,28 @@ describe('ChartJsRendererSpec', () => {
   });
 
   describe('_adjustBubbleSizes', () => {
-    let renderer = new ChartJsRenderer({}),
+    let renderer: SpecChartJsRenderer,
+      chartArea: ChartArea,
+      defaultConfig: ChartConfig;
+
+    beforeEach(() => {
+      renderer = new SpecChartJsRenderer(scout.create(Chart, {parent: session.desktop}));
       chartArea = {
         top: 0,
         bottom: 300,
         left: 0,
         right: 750
-      },
+      } as ChartArea;
       defaultConfig = {
         type: Chart.Type.BUBBLE,
         data: {
           datasets: [{
             data: [
-              {z: 100},
-              {z: 81},
-              {z: 49},
-              {z: 25},
-              {z: 16}
+              {x: 0, y: 0, z: 100},
+              {x: 0, y: 0, z: 81},
+              {x: 0, y: 0, z: 49},
+              {x: 0, y: 0, z: 25},
+              {x: 0, y: 0, z: 16}
             ],
             label: 'Dataset 1'
           }]
@@ -248,6 +280,7 @@ describe('ChartJsRendererSpec', () => {
           bubble: {}
         }
       };
+    });
 
     it('neither sizeOfLargestBubble nor minBubbleSize is set', () => {
       let config = $.extend(true, {}, defaultConfig);
@@ -255,11 +288,11 @@ describe('ChartJsRendererSpec', () => {
       renderer._adjustBubbleSizes(config, chartArea);
 
       expect(config.data.datasets[0].data).toEqual([
-        {r: 10, z: 100},
-        {r: 9, z: 81},
-        {r: 7, z: 49},
-        {r: 5, z: 25},
-        {r: 4, z: 16}
+        {x: 0, y: 0, r: 10, z: 100},
+        {x: 0, y: 0, r: 9, z: 81},
+        {x: 0, y: 0, r: 7, z: 49},
+        {x: 0, y: 0, r: 5, z: 25},
+        {x: 0, y: 0, r: 4, z: 16}
       ]);
     });
 
@@ -270,11 +303,11 @@ describe('ChartJsRendererSpec', () => {
       renderer._adjustBubbleSizes(config, chartArea);
 
       expect(config.data.datasets[0].data).toEqual([
-        {r: 20, z: 100},
-        {r: 18, z: 81},
-        {r: 14, z: 49},
-        {r: 10, z: 25},
-        {r: 8, z: 16}
+        {x: 0, y: 0, r: 20, z: 100},
+        {x: 0, y: 0, r: 18, z: 81},
+        {x: 0, y: 0, r: 14, z: 49},
+        {x: 0, y: 0, r: 10, z: 25},
+        {x: 0, y: 0, r: 8, z: 16}
       ]);
     });
 
@@ -283,17 +316,17 @@ describe('ChartJsRendererSpec', () => {
       config.options.bubble.sizeOfLargestBubble = 20;
 
       config.data.datasets[0].data = [
-        {z: 0},
-        {z: 0},
-        {z: 0}
+        {x: 0, y: 0, z: 0},
+        {x: 0, y: 0, z: 0},
+        {x: 0, y: 0, z: 0}
       ];
 
       renderer._adjustBubbleSizes(config, chartArea);
 
       expect(config.data.datasets[0].data).toEqual([
-        {r: 20, z: 0},
-        {r: 20, z: 0},
-        {r: 20, z: 0}
+        {x: 0, y: 0, r: 20, z: 0},
+        {x: 0, y: 0, r: 20, z: 0},
+        {x: 0, y: 0, r: 20, z: 0}
       ]);
     });
 
@@ -304,11 +337,11 @@ describe('ChartJsRendererSpec', () => {
       renderer._adjustBubbleSizes(config, chartArea);
 
       expect(config.data.datasets[0].data).toEqual([
-        {r: 12.5, z: 100},
-        {r: 11.25, z: 81},
-        {r: 8.75, z: 49},
-        {r: 6.25, z: 25},
-        {r: 5, z: 16}
+        {x: 0, y: 0, r: 12.5, z: 100},
+        {x: 0, y: 0, r: 11.25, z: 81},
+        {x: 0, y: 0, r: 8.75, z: 49},
+        {x: 0, y: 0, r: 6.25, z: 25},
+        {x: 0, y: 0, r: 5, z: 16}
       ]);
     });
 
@@ -316,17 +349,17 @@ describe('ChartJsRendererSpec', () => {
       let config = $.extend(true, {}, defaultConfig);
       config.options.bubble.minBubbleSize = 5;
 
-      config.data.datasets[0].data.push({z: 0});
+      config.data.datasets[0].data.push({x: 0, y: 0, z: 0});
 
       renderer._adjustBubbleSizes(config, chartArea);
 
       expect(config.data.datasets[0].data).toEqual([
-        {r: 15, z: 100},
-        {r: 14, z: 81},
-        {r: 12, z: 49},
-        {r: 10, z: 25},
-        {r: 9, z: 16},
-        {r: 5, z: 0}
+        {x: 0, y: 0, r: 15, z: 100},
+        {x: 0, y: 0, r: 14, z: 81},
+        {x: 0, y: 0, r: 12, z: 49},
+        {x: 0, y: 0, r: 10, z: 25},
+        {x: 0, y: 0, r: 9, z: 16},
+        {x: 0, y: 0, r: 5, z: 0}
       ]);
     });
 
@@ -338,11 +371,11 @@ describe('ChartJsRendererSpec', () => {
       renderer._adjustBubbleSizes(config, chartArea);
 
       expect(config.data.datasets[0].data).toEqual([
-        {r: 20, z: 100},
-        {r: 18, z: 81},
-        {r: 14, z: 49},
-        {r: 10, z: 25},
-        {r: 8, z: 16}
+        {x: 0, y: 0, r: 20, z: 100},
+        {x: 0, y: 0, r: 18, z: 81},
+        {x: 0, y: 0, r: 14, z: 49},
+        {x: 0, y: 0, r: 10, z: 25},
+        {x: 0, y: 0, r: 8, z: 16}
       ]);
     });
 
@@ -351,17 +384,17 @@ describe('ChartJsRendererSpec', () => {
       config.options.bubble.sizeOfLargestBubble = 20;
       config.options.bubble.minBubbleSize = 5;
 
-      config.data.datasets[0].data.push({z: 1});
+      config.data.datasets[0].data.push({x: 0, y: 0, z: 1});
 
       renderer._adjustBubbleSizes(config, chartArea);
 
       expect(config.data.datasets[0].data).toEqual([
-        {r: 20, z: 100},
-        {r: 9 * (5 / 3) + (10 / 3), z: 81},
-        {r: 15, z: 49},
-        {r: 5 * (5 / 3) + (10 / 3), z: 25},
-        {r: 10, z: 16},
-        {r: 5, z: 1}
+        {x: 0, y: 0, r: 20, z: 100},
+        {x: 0, y: 0, r: 9 * (5 / 3) + (10 / 3), z: 81},
+        {x: 0, y: 0, r: 15, z: 49},
+        {x: 0, y: 0, r: 5 * (5 / 3) + (10 / 3), z: 25},
+        {x: 0, y: 0, r: 10, z: 16},
+        {x: 0, y: 0, r: 5, z: 1}
       ]);
     });
   });

--- a/eclipse-scout-chart/test/chart/ChartSpec.ts
+++ b/eclipse-scout-chart/test/chart/ChartSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/eclipse-scout-chart/test/chart/FulfillmentChartRendererSpec.ts
+++ b/eclipse-scout-chart/test/chart/FulfillmentChartRendererSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/eclipse-scout-chart/test/chart/FulfillmentChartRendererSpec.ts
+++ b/eclipse-scout-chart/test/chart/FulfillmentChartRendererSpec.ts
@@ -7,11 +7,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Chart, FulfillmentChartRenderer} from '../../src/index';
+import {AbstractSvgChartRenderer, Chart, FulfillmentChartRenderer} from '../../src/index';
 import {scout} from '@eclipse-scout/core';
 
 describe('FulfillmentChartRendererSpec', () => {
-  let session;
+  let session: SandboxSession;
 
   beforeEach(() => {
     setFixtures(sandbox());
@@ -25,19 +25,26 @@ describe('FulfillmentChartRendererSpec', () => {
     };
 
     it('without start value property', () => {
-      let fulfillment = new FulfillmentChartRenderer({});
+      let fulfillment = new FulfillmentChartRenderer(scout.create(Chart, {parent: session.desktop}));
       expect(fulfillment.shouldAnimateRemoveOnUpdate(opts)).toBe(true);
 
-      fulfillment = new FulfillmentChartRenderer({
-        config: 'notEmpty'
-      });
-      expect(fulfillment.shouldAnimateRemoveOnUpdate(opts)).toBe(true);
-
-      fulfillment = new FulfillmentChartRenderer({
+      fulfillment = new FulfillmentChartRenderer(scout.create(Chart, {
+        parent: session.desktop,
         config: {
-          fulfillment: 'notEmpty'
+          type: Chart.Type.FULFILLMENT
         }
-      });
+      }));
+      expect(fulfillment.shouldAnimateRemoveOnUpdate(opts)).toBe(true);
+
+      fulfillment = new FulfillmentChartRenderer(scout.create(Chart, {
+        parent: session.desktop,
+        config: {
+          type: Chart.Type.FULFILLMENT,
+          options: {
+            fulfillment: {}
+          }
+        }
+      }));
       expect(fulfillment.shouldAnimateRemoveOnUpdate(opts)).toBe(true);
 
       opts.requestAnimation = false;
@@ -57,16 +64,18 @@ describe('FulfillmentChartRendererSpec', () => {
         chartValueGroups: [actualChartValue, totalChartValue]
       };
       let config = {
+        type: Chart.Type.FULFILLMENT,
         options: {
           fulfillment: {
             startValue: 2
           }
         }
       };
-      let chart = {
-        data: data,
-        config: config
-      };
+      let chart = scout.create(Chart, {
+        parent: session.desktop,
+        data,
+        config
+      });
 
       let fulfillment = new FulfillmentChartRenderer(chart);
       expect(fulfillment.shouldAnimateRemoveOnUpdate(opts)).toBe(false);
@@ -100,7 +109,7 @@ describe('FulfillmentChartRendererSpec', () => {
       });
       chart.render();
       chart.chartRenderer.refresh();
-      expect(chart.chartRenderer.$svg.attr('aria-description')).toBeTruthy();
+      expect((chart.chartRenderer as AbstractSvgChartRenderer).$svg.attr('aria-description')).toBeTruthy();
     });
   });
 });

--- a/eclipse-scout-chart/test/chart/SpeedoChartRendererSpec.ts
+++ b/eclipse-scout-chart/test/chart/SpeedoChartRendererSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/eclipse-scout-chart/test/chart/SpeedoChartRendererSpec.ts
+++ b/eclipse-scout-chart/test/chart/SpeedoChartRendererSpec.ts
@@ -7,28 +7,29 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-/* global sandboxSession, createSimpleModel*/
-
-import {Chart, SpeedoChartRenderer} from '../../src/index';
+import {AbstractSvgChartRenderer, Chart, SpeedoChartRenderer} from '../../src/index';
 import {scout} from '@eclipse-scout/core';
 import {LocaleSpecHelper} from '@eclipse-scout/core/testing';
 
 describe('SpeedoChartRenderer', () => {
-  let locale, helper, session;
+  let session: SandboxSession;
 
   beforeEach(() => {
     setFixtures(sandbox());
     session = sandboxSession();
-    helper = new LocaleSpecHelper();
-    locale = helper.createLocale(LocaleSpecHelper.DEFAULT_LOCALE);
+    session.locale = new LocaleSpecHelper().createLocale(LocaleSpecHelper.DEFAULT_LOCALE);
   });
+
+  class SpecSpeedoChartRenderer extends SpeedoChartRenderer {
+
+    override _formatValue(value: number): string {
+      return super._formatValue(value);
+    }
+  }
 
   describe('_formatValue', () => {
     it('should display compact labels for large values', () => {
-      let speedo = new SpeedoChartRenderer({});
-      speedo.session = {
-        locale: locale
-      };
+      let speedo = new SpecSpeedoChartRenderer(scout.create(Chart, {parent: session.desktop}));
       expect(speedo._formatValue(1)).toBe('1');
       expect(speedo._formatValue(999)).toBe('999');
       expect(speedo._formatValue(1000)).toBe('1\'000');
@@ -48,7 +49,6 @@ describe('SpeedoChartRenderer', () => {
         data: {
           axes: [],
           chartValueGroups: [{
-            clickable: true,
             colorHexValue: '#ffee00',
             groupName: 'Group0',
             values: [
@@ -58,7 +58,6 @@ describe('SpeedoChartRenderer', () => {
         },
         config: {
           type: Chart.Type.SPEEDO,
-          clickable: true,
           options: {
             autoColor: true,
             clickable: true,
@@ -96,7 +95,7 @@ describe('SpeedoChartRenderer', () => {
 
   describe('calculations', () => {
     it('rounded segments are always in the correct part', () => {
-      let speedo = new SpeedoChartRenderer({});
+      let speedo = new SpeedoChartRenderer(scout.create(Chart, {parent: session.desktop}));
 
       speedo.parts = SpeedoChartRenderer.NUM_PARTS_GREEN_EDGE;
       speedo.numSegmentsPerPart = 8;
@@ -149,7 +148,6 @@ describe('SpeedoChartRenderer', () => {
         data: {
           axes: [],
           chartValueGroups: [{
-            clickable: true,
             colorHexValue: '#ffee00',
             groupName: 'Group0',
             values: [
@@ -159,7 +157,6 @@ describe('SpeedoChartRenderer', () => {
         },
         config: {
           type: Chart.Type.SPEEDO,
-          clickable: true,
           options: {
             autoColor: true,
             clickable: true,
@@ -180,7 +177,7 @@ describe('SpeedoChartRenderer', () => {
       });
       chart.render();
       chart.chartRenderer.refresh();
-      expect(chart.chartRenderer.$svg.attr('aria-description')).toBeTruthy();
+      expect((chart.chartRenderer as AbstractSvgChartRenderer).$svg.attr('aria-description')).toBeTruthy();
     });
   });
 });

--- a/eclipse-scout-chart/test/table/controls/ChartTableControlSpec.ts
+++ b/eclipse-scout-chart/test/table/controls/ChartTableControlSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/eclipse-scout-chart/test/test-index.ts
+++ b/eclipse-scout-chart/test/test-index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/eclipse-scout-chart/test/test-index.ts
+++ b/eclipse-scout-chart/test/test-index.ts
@@ -9,5 +9,6 @@
  */
 import {JasmineScout} from '@eclipse-scout/core/testing';
 
-let context = require.context('./', true, /[sS]pec\.js$/);
+// @ts-expect-error
+let context = require.context('./', true, /[sS]pec\.[t|j]s$/);
 JasmineScout.runTestSuite(context);

--- a/eclipse-scout-chart/test/tile/ChartFieldTileSpec.ts
+++ b/eclipse-scout-chart/test/tile/ChartFieldTileSpec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {ColorScheme, colorSchemes, scout} from '@eclipse-scout/core';
+import {Chart, ChartField, ChartFieldModel, ChartFieldTile, ChartFieldTileModel} from '../../src/index';
+import $ from 'jquery';
+
+describe('ChartFieldTile', () => {
+  let session: SandboxSession;
+  let tile: ChartFieldTile;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    tile = createChartFieldTile();
+  });
+
+  function createChartFieldTile(model?: ChartFieldTileModel): ChartFieldTile {
+    return scout.create(ChartFieldTile, $.extend({}, {
+      parent: session.desktop,
+      tileWidget: {
+        objectType: ChartField,
+        chart: {
+          objectType: Chart
+        }
+      }
+    }, model));
+  }
+
+  function createChartField(model?: ChartFieldModel): ChartField {
+    return scout.create(ChartField, $.extend({}, {
+      parent: session.desktop,
+      chart: {
+        objectType: Chart
+      }
+    }, model));
+  }
+
+  function getChartColorScheme(): ColorScheme {
+    return tile.tileWidget.chart.config.options.colorScheme as ColorScheme;
+  }
+
+  describe('colorScheme', () => {
+
+    it('is updated on the chart if changed on the tile', () => {
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.DEFAULT, true));
+
+      tile.setColorScheme(colorSchemes.ColorSchemeId.RAINBOW);
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.RAINBOW, true));
+
+      tile.setColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted');
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted', true));
+    });
+
+    it('is prevented from being updated on the chart', () => {
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.DEFAULT, true));
+
+      const chart = tile.tileWidget.chart;
+      const setChartColorScheme = (colorScheme: string) => {
+        chart.setConfig($.extend(true, {}, chart.config, {
+          options: {colorScheme}
+        }));
+      };
+
+      setChartColorScheme(colorSchemes.ColorSchemeId.RAINBOW);
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.DEFAULT, true));
+
+      setChartColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted');
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.DEFAULT, true));
+
+      tile.setColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted');
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted', true));
+
+      setChartColorScheme(colorSchemes.ColorSchemeId.RAINBOW);
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted', true));
+
+      setChartColorScheme(colorSchemes.ColorSchemeId.DEFAULT);
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted', true));
+    });
+
+    it('is set on the chart if the tile widget changes', () => {
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.DEFAULT, true));
+
+      const createChartFieldWithColorScheme = (colorScheme: string) => createChartField({
+        chart: {
+          objectType: Chart,
+          config: {
+            type: Chart.Type.PIE,
+            options: {colorScheme}
+          }
+        }
+      });
+
+      tile.setTileWidget(createChartFieldWithColorScheme(colorSchemes.ColorSchemeId.RAINBOW));
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.DEFAULT, true));
+
+      tile.setTileWidget(createChartFieldWithColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted'));
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.DEFAULT, true));
+
+      tile.setColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted');
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted', true));
+
+      tile.setTileWidget(createChartFieldWithColorScheme(colorSchemes.ColorSchemeId.RAINBOW));
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted', true));
+
+      tile.setTileWidget(createChartFieldWithColorScheme(colorSchemes.ColorSchemeId.DEFAULT));
+      expect(getChartColorScheme()).toEqual(colorSchemes.ensureColorScheme(colorSchemes.ColorSchemeId.ALTERNATIVE + '-inverted', true));
+    });
+  });
+});

--- a/eclipse-scout-chart/tsconfig.json
+++ b/eclipse-scout-chart/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist/d.ts"
   },
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "./test/**/*"
   ]
 }


### PR DESCRIPTION
The colorScheme of the ChartFieldTile is always transferred to the
chart. The tile listens to all changes of the charts config and adjusts
the colorScheme accordingly. In addition, the tile needs to update the
colorScheme if the tileWidget changes.

390174