### PR TITLE
eclipse-scout/chart: add exports in package.json

### DIFF
--- a/eclipse-scout-chart/package.json
+++ b/eclipse-scout-chart/package.json
@@ -20,14 +20,26 @@
     "chart"
   ],
   "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/d.ts/src/index.d.ts",
+        "import": "./dist/eclipse-scout-chart.esm.js"
+      },
+      "./src/*": "./src/*"
+    },
     "main": "./dist/eclipse-scout-chart.esm.js",
     "module": "./dist/eclipse-scout-chart.esm.js",
     "types": "./dist/d.ts/index.d.ts"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./src/*": "./src/*"
   },
   "main": "./src/index.ts",
   "module": "./src/index.ts",
   "files": [
     "dist",
+    "!dist/d.ts/test",
     "src"
   ],
   "scripts": {


### PR DESCRIPTION
The test code contains a "require" which is interpreted as commonjs
feature. When a module depends on eclipse-scout/chart it interprets
the files in this dependency as ES module if explicitly stated in the
package.json or if there are no commonjs features in the source code. As
we can not eliminate the "require" from the test code the exports are
added to the package.json to ensure only the correct run time files are
checked.
Exclude test d.ts files from packaging.