### PR TITLE
Extensions: use extension chain in AbstractSmartColumnExtension

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/extension/ui/basic/table/columns/AbstractSmartColumnExtension.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/extension/ui/basic/table/columns/AbstractSmartColumnExtension.java
@@ -23,6 +23,6 @@ public abstract class AbstractSmartColumnExtension<VALUE, OWNER extends Abstract
 
   @Override
   public void execPrepareLookup(SmartColumnPrepareLookupChain<VALUE> chain, ILookupCall<VALUE> call, ITableRow row) {
+    chain.execPrepareLookup(call, row);
   }
-
 }


### PR DESCRIPTION
The method execPrepareLookup in the AbstractSmartColumnExtension must use the SmartColumnPrepareLookupChain to call execPrepareLookup of the chain. Otherwise, it is not possible to call the original execPrepareLookup method of the extended SmartColum.

391224