### PR TITLE
FormFieldTile: support loading indicator for custom tiles

### DIFF
--- a/eclipse-scout-core/src/tile/fields/FormFieldTile.less
+++ b/eclipse-scout-core/src/tile/fields/FormFieldTile.less
@@ -95,16 +95,6 @@
       display: none;
     }
 
-    /* Define a short transition for opacity changes on all field elements (used in .loading state) */
-
-    & > label,
-    & > .mandatory-indicator,
-    & > .field,
-    & > .status {
-      transition: opacity 0.15s; /* Same time is used in animation() of .loading-indicator */
-      opacity: 1;
-    }
-
     & > .status {
       display: flex;
       align-items: center;
@@ -174,13 +164,16 @@
     }
   }
 
+  // Define a short transition for opacity changes (used in .loading state)
+  & > .form-field {
+    transition: opacity 0.15s; // Same time is used in animation() of .loading-indicator
+    opacity: 1;
+  }
+
   &.loading {
-    & > .form-field > label,
-    & > .form-field > .mandatory-indicator,
-    & > .form-field > .field,
-    & > .form-field > .status {
-      /* Same as 'visibility: hidden', except it can be animated with CSS transitions */
-      opacity: 0;
+    & > .form-field {
+      pointer-events: none;
+      opacity: 0; // animated with CSS transition
     }
 
     & > .loading-indicator {


### PR DESCRIPTION
The 'loading' CSS class was simplified to hide everything except the loading indicator (instead of only parts of the inner form field). This allows for custom tiles with additional elements.

Also disabled pointer events while loading because only reducing the opacity does not prevent clicks.

389516