### PR TITLE
RemoteFileService: fix locale filename calculation

### DIFF
--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/file/RemoteFileServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/file/RemoteFileServiceTest.java
@@ -9,10 +9,12 @@
  */
 package org.eclipse.scout.rt.server.services.common.file;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.junit.Test;
 
 public class RemoteFileServiceTest {
@@ -84,6 +86,20 @@ public class RemoteFileServiceTest {
   protected void checkAddLocaleToFileName(String initialName, String expectedFileNameAfterTest, Locale locale, Integer fileExistsAtLevel) {
     AtomicInteger fileLocaleLevel = new AtomicInteger(0);
     String fileNameAfterExtend = service.tryAddLocaleToFileName(initialName, locale, "test/", file -> fileLocaleLevel.getAndIncrement() == fileExistsAtLevel);
+    Assertions.assertEquals(fileNameAfterExtend, expectedFileNameAfterTest);
+  }
+
+  @Test
+  public void testFallbackFilenameWhenTemplateMissing() {
+    checkAddLocaleToFileName("Example.txt", "Example.txt", new Locale("de", "CH"), CollectionUtility.arrayList("Example.txt"));
+    checkAddLocaleToFileName("Example.txt", "Example_de.txt", new Locale("de", "CH"), CollectionUtility.arrayList("Example.txt", "Example_de.txt"));
+    checkAddLocaleToFileName("Example.txt", "Example_de.txt", new Locale("de", "CH"), CollectionUtility.arrayList("Example_de.txt"));
+    checkAddLocaleToFileName("Example.txt", "Example_de_CH.txt", new Locale("de", "CH"), CollectionUtility.arrayList("Example.txt", "Example_de_CH.txt"));
+    checkAddLocaleToFileName("Example.txt", "Example_de_CH.txt", new Locale("de", "CH"), CollectionUtility.arrayList("Example_de_CH.txt"));
+  }
+
+  protected void checkAddLocaleToFileName(String initialName, String expectedFileNameAfterTest, Locale locale, List<String> existingFilenames) {
+    String fileNameAfterExtend = service.tryAddLocaleToFileName(initialName, locale, "test/", file -> existingFilenames.contains(file.getName()));
     Assertions.assertEquals(fileNameAfterExtend, expectedFileNameAfterTest);
   }
 

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/file/RemoteFileService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/file/RemoteFileService.java
@@ -308,7 +308,7 @@ public class RemoteFileService implements IRemoteFileService {
       }
       localeText = localeText.substring(0, localeText.lastIndexOf(LOCALE_DELIMITER));
       extendedFilename = prefix + localeText + suffix;
-      test = new File(canonicalFolder, filename);
+      test = new File(canonicalFolder, extendedFilename);
     }
     return extendedFilename;
   }


### PR DESCRIPTION
The existence of the file was checked with the wrong filename

390987