### PR TITLE
FormFieldTile: remove disabled style

### DIFF
--- a/eclipse-scout-core/src/style/sizes-dark.less
+++ b/eclipse-scout-core/src/style/sizes-dark.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 @desktop-tab-border-width: 1px;
+@dashboard-tile-inverted-selected-border-width: 2px;
 @popup-border-width: 1px;
 @tooltip-border-width: 1px;
 @scroll-shadow-size-large: 14px;

--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -144,6 +144,8 @@
 @dashboard-tile-drop-shadow-light-alpha: 0.05;
 @dashboard-tile-drop-shadow-dark-alpha: 0.1;
 @dashboard-tile-border-radius: @border-radius-large;
+@dashboard-tile-selected-border-width: 2px;
+@dashboard-tile-inverted-selected-border-width: 3px;
 @date-picker-header-height: 36px;
 @date-picker-month-padding: 13px;
 @date-picker-day-margin: 2px;

--- a/eclipse-scout-core/src/tile/fields/FormFieldTile.less
+++ b/eclipse-scout-core/src/tile/fields/FormFieldTile.less
@@ -37,7 +37,6 @@
     --box-shadow-2-blur: @drop-shadow-blur;
     --box-shadow-2-alpha: @dashboard-tile-drop-shadow-light-alpha;
 
-    &.disabled,
     &.inverted {
       --box-shadow-2-alpha: @dashboard-tile-drop-shadow-dark-alpha;
     }
@@ -178,17 +177,11 @@
     }
   }
 
-  &.disabled:not(.read-only) {
-    --tile-background-color: @tile-default-border-color;
-  }
-
   &.inverted {
     --tile-background-color: @tile-default-inverted-background-color;
     color: @tile-default-inverted-color;
 
     &.disabled:not(.read-only) {
-      --tile-background-color: @tile-default-border-color;
-
       & ::-moz-selection {
         #scout.text-selection();
       }
@@ -282,10 +275,6 @@
     --tile-background-color: @tile-alternative-background-color;
     color: @tile-alternative-color;
 
-    &.disabled:not(.read-only) {
-      --tile-background-color: @tile-default-border-color;
-    }
-
     & > .form-field {
       & > label {
         color: @tile-alternative-label-color;
@@ -309,10 +298,6 @@
   &.inverted.color-alternative {
     --tile-background-color: @tile-alternative-inverted-background-color;
     color: @tile-alternative-inverted-color;
-
-    &.disabled:not(.read-only) {
-      --tile-background-color: @tile-default-border-color;
-    }
 
     & ::-moz-selection {
       #scout.text-selection();
@@ -354,11 +339,11 @@
   }
 
   &.selected:not(.dragged):not(.resizing) {
-    --box-shadow-1-spread: 2px;
+    --box-shadow-1-spread: @dashboard-tile-selected-border-width;
     --box-shadow-1-color: @dashboard-tile-default-selected-border-color;
 
     &.inverted {
-      --box-shadow-1-spread: 3px;
+      --box-shadow-1-spread: @dashboard-tile-inverted-selected-border-width;
       --box-shadow-1-color: @dashboard-tile-default-inverted-selected-border-color;
     }
 

--- a/eclipse-scout-core/src/tile/fields/button/TileButton.less
+++ b/eclipse-scout-core/src/tile/fields/button/TileButton.less
@@ -94,7 +94,7 @@
     }
   }
 
-  &:hover {
+  &:hover:not(.disabled) {
     --tile-background-color: @tile-button-default-hover-background-color;
 
     .dimmed-background & {
@@ -102,8 +102,8 @@
     }
   }
 
-  &:active,
-  &.active {
+  &:active:not(.disabled),
+  &.active:not(.disabled) {
     --tile-background-color: @tile-button-default-active-background-color;
   }
 
@@ -122,7 +122,7 @@
       }
     }
 
-    &:hover {
+    &:hover:not(.disabled) {
       --tile-background-color: @tile-button-default-inverted-hover-background-color;
 
       & > .tile-button {
@@ -130,8 +130,8 @@
       }
     }
 
-    &:active,
-    &.active {
+    &:active:not(.disabled),
+    &.active:not(.disabled) {
       --tile-background-color: @tile-button-default-inverted-active-background-color;
 
       & > .tile-button {
@@ -155,7 +155,7 @@
       }
     }
 
-    &:hover {
+    &:hover:not(.disabled) {
       --tile-background-color: @tile-button-alternative-inverted-hover-background-color;
 
       & > .tile-button {
@@ -163,8 +163,8 @@
       }
     }
 
-    &:active,
-    &.active {
+    &:active:not(.disabled),
+    &.active:not(.disabled) {
       --tile-background-color: @tile-button-alternative-inverted-active-background-color;
 
       & > .tile-button {
@@ -174,15 +174,11 @@
   }
 
   &.disabled {
+    &,
+    &.inverted {
+      --tile-background-color: @tile-default-background-color;
 
-    .dimmed-background & {
-      --box-shadow-2-alpha: @dashboard-tile-drop-shadow-light-alpha;
-    }
-
-    & > .tile-button {
-      &, .inverted&, .color-alternative.inverted& {
-        background-color: transparent;
-        border-color: transparent;
+      & > .tile-button {
         cursor: default;
 
         & > .field {


### PR DESCRIPTION
The current disabled style looks bad, especially the inverted one. Since most of the tiles (except button like tiles) can be used when disabled anyway, they should not look disabled.

-> Removed disabled style of regular form field tiles and adjusted
   disabled style of tile buttons.

Also set tile selection border width of inverted tiles in dark mode to 2px because inverted and regular tiles look the same.

389352