### PR TITLE
Improve error text for cyclic dependencies

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/namespace/NamespaceVersionedModelTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/namespace/NamespaceVersionedModelTest.java
@@ -203,6 +203,7 @@ public class NamespaceVersionedModelTest {
         item("bravo-6", dep("alfa-4")))); // dependency cycle
     assertThrows(AssertionException.class, () -> createInventory(
         item("alfa-4", dep("charlie-8")),
+        item("foxtrot-1"),
         item("charlie-8", dep("bravo-6")),
         item("bravo-6", dep("alfa-4")))); // dependency cycle
     assertThrows(AssertionException.class, () -> createInventory(

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/namespace/NamespaceVersionedModel.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/namespace/NamespaceVersionedModel.java
@@ -616,7 +616,7 @@ public class NamespaceVersionedModel<T extends INamespaceVersioned> {
         }
       }
       if (!m_dependencyMap.isEmpty()) {
-        fail("Unable to resolve all dependencies - cycle in dependencies? {}", dependencyModelToString(m_dependencyMap));
+        fail("Unable to resolve all dependencies - cycle in the already reduced dependencies? {}", dependencyModelToString(m_dependencyMap));
       }
       return null;
     }


### PR DESCRIPTION
The dependencies displayed in the exception are only a subset of all dependencies. Error text improved to avoid confusion.

383291