### PR TITLE
FocusManager: ignore elements covered by a glasspane while tabbing

### DIFF
--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -2199,6 +2199,9 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
     if (!$elem.is(':focusable')) {
       return false;
     }
+    if (this.session.focusManager.isElementCovertByGlassPane($elem)) {
+      return false;
+    }
     if (scout.nvl(checkTabbable, true)) {
       return $elem.is(':tabbable');
     }

--- a/eclipse-scout-core/test/focus/FocusManagerSpec.ts
+++ b/eclipse-scout-core/test/focus/FocusManagerSpec.ts
@@ -322,5 +322,49 @@ describe('FocusManager', () => {
       expect(input1.selectionStart).toBe(0);
       expect(input1.selectionEnd).toBe(5);
     });
+
+    it('does not focus elements covered by a glasspane', () => {
+      let $container = session.$entryPoint.appendDiv();
+      let input1 = $container.appendElement('<input type="text">')[0];
+      let input2 = $container.appendElement('<input type="text">')[0];
+      let input3 = $container.appendElement('<input type="text">')[0];
+      focusManager.installFocusContext($container);
+
+      // Cover middle element
+      let glassPane = scout.create(GlassPane, {parent: session.desktop});
+      glassPane.render($(input2));
+      focusManager.requestFocus(input1);
+      expect(document.activeElement).toBe(input1);
+      focusManager.focusNextTabbable($container.activeElement());
+      expect(document.activeElement).toBe(input3);
+      focusManager.focusNextTabbable($container.activeElement(), false);
+      expect(document.activeElement).toBe(input1);
+
+      // Cover last element
+      glassPane.remove();
+      glassPane.render($(input3));
+      focusManager.focusNextTabbable($container.activeElement());
+      expect(document.activeElement).toBe(input2);
+      focusManager.focusNextTabbable($container.activeElement());
+      expect(document.activeElement).toBe(input1);
+      focusManager.focusNextTabbable($container.activeElement(), false);
+      expect(document.activeElement).toBe(input2);
+
+      // Cover first element
+      glassPane.remove();
+      glassPane.render($(input1));
+      focusManager.focusNextTabbable($container.activeElement(), false);
+      expect(document.activeElement).toBe(input3);
+      focusManager.focusNextTabbable($container.activeElement());
+      expect(document.activeElement).toBe(input2);
+
+      // Cover every element
+      let glassPane2 = scout.create(GlassPane, {parent: session.desktop});
+      glassPane2.render($(input2));
+      let glassPane3 = scout.create(GlassPane, {parent: session.desktop});
+      glassPane3.render($(input3));
+      focusManager.focusNextTabbable(input1);
+      expect(document.activeElement).toBe(session.$entryPoint[0]);
+    });
   });
 });

--- a/eclipse-scout-core/test/widget/WidgetSpec.ts
+++ b/eclipse-scout-core/test/widget/WidgetSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {EventListener, EventSupport, Form, GroupBox, HtmlComponent, Menu, NullWidget, ObjectFactory, scout, StringField, TableRow, TreeVisitResult, Widget} from '../../src/index';
+import {EventListener, EventSupport, Form, GlassPane, GroupBox, HtmlComponent, Menu, NullWidget, ObjectFactory, scout, StringField, TableRow, TreeVisitResult, Widget} from '../../src/index';
 import {InitModelOf} from '../../src/scout';
 
 describe('Widget', () => {
@@ -1933,6 +1933,39 @@ describe('Widget', () => {
       widget.render(session.$entryPoint);
       widget.validateLayoutTree(); // <-- this triggers the focus to be set
       expect(document.activeElement).toBe(widget.$container[0]);
+    });
+  });
+
+  describe('isFocusable', () => {
+
+    it('returns true if the element is focusable', () => {
+      let widget = createWidget({
+        parent: parent
+      });
+      widget.render(session.$entryPoint);
+      widget.$container.setTabbable(true);
+      expect(widget.isFocusable()).toBe(true);
+      expect(widget.isFocusable(false)).toBe(true);
+
+      widget.$container.setTabbableOrFocusable(false);
+      expect(widget.isFocusable()).toBe(false); // Not tabbable, only focusable
+      expect(widget.isFocusable(false)).toBe(true);
+
+      widget.$container.setTabbable(false);
+      expect(widget.isFocusable()).toBe(false);
+      expect(widget.isFocusable(false)).toBe(false);
+    });
+
+    it('returns false if the element is covered by a glasspane', () => {
+      let widget = createWidget({
+        parent: parent
+      });
+      widget.render(session.$entryPoint);
+      widget.$container.setTabbable(true);
+      let glassPane = scout.create(GlassPane, {parent: session.desktop});
+      glassPane.render(widget.$container);
+      expect(widget.isFocusable()).toBe(false);
+      expect(widget.isFocusable(false)).toBe(false);
     });
   });
 


### PR DESCRIPTION
If an element is covered by a glasspane, it must not be tabbable. Currently, the focus manager correctly prohibits focus changes to such elements, but it will focus the entry point instead. This means, if the user is tabbing, the entry point will be focused instead of the next tabbable element in a focus context.

The change in Widget.isFocusable was not necessary to fix this issue but it makes it consistent.