### PR TITLE
IdCodec: use IdCodecException

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/id/AbstractIdCodecTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/id/AbstractIdCodecTest.java
@@ -29,7 +29,6 @@ import org.eclipse.scout.rt.dataobject.id.IdCodec.IdCodecFlag;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
-import org.eclipse.scout.rt.platform.exception.PlatformException;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.date.IDateProvider;
@@ -106,7 +105,7 @@ public abstract class AbstractIdCodecTest {
     FixtureCustomComparableRawDataId id = IIds.create(FixtureCustomComparableRawDataId.class, new CustomComparableRawDataType(100));
 
     // no type mapper registered
-    assertThrows(PlatformException.class, () -> getCodec().toQualified(id));
+    assertThrows(IdCodecException.class, () -> getCodec().toQualified(id));
 
     try {
       getCodec().registerRawTypeMapper(CustomComparableRawDataType.class, CustomComparableRawDataType::of, CustomComparableRawDataType::toString);
@@ -168,7 +167,7 @@ public abstract class AbstractIdCodecTest {
   @Test
   public void testToQualifiedIdUnsupportedType() {
     // no IdTypeName annotation
-    assertThrows(PlatformException.class, () -> getCodec().toQualified((IId) () -> null));
+    assertThrows(IdCodecException.class, () -> getCodec().toQualified((IId) () -> null));
   }
 
   @Test
@@ -231,7 +230,7 @@ public abstract class AbstractIdCodecTest {
     FixtureCustomComparableRawDataId id = IIds.create(FixtureCustomComparableRawDataId.class, new CustomComparableRawDataType(100));
 
     // no type mapper registered
-    assertThrows(PlatformException.class, () -> getCodec().toUnqualified(id));
+    assertThrows(IdCodecException.class, () -> getCodec().toUnqualified(id));
 
     try {
       getCodec().registerRawTypeMapper(CustomComparableRawDataType.class, CustomComparableRawDataType::of, CustomComparableRawDataType::toString);
@@ -299,7 +298,7 @@ public abstract class AbstractIdCodecTest {
   @Test
   public void testToUnqualifiedIdUnsupportedType() {
     // unsupported type to unwrap
-    assertThrows(PlatformException.class, () -> getCodec().toUnqualified((IId) () -> null));
+    assertThrows(IdCodecException.class, () -> getCodec().toUnqualified((IId) () -> null));
   }
 
   @Test
@@ -354,7 +353,7 @@ public abstract class AbstractIdCodecTest {
     FixtureCustomComparableRawDataId id1 = IIds.create(FixtureCustomComparableRawDataId.class, new CustomComparableRawDataType(100));
 
     // no type mapper registered
-    assertThrows(PlatformException.class, () -> getCodec().fromQualified("scout.FixtureCustomComparableRawDataId:100"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromQualified("scout.FixtureCustomComparableRawDataId:100"));
 
     try {
       getCodec().registerRawTypeMapper(CustomComparableRawDataType.class, CustomComparableRawDataType::of, CustomComparableRawDataType::toString);
@@ -444,10 +443,10 @@ public abstract class AbstractIdCodecTest {
 
   @Test
   public void testFromQualifiedCompositeIdWrongNumberOfComponents() {
-    assertThrows(PlatformException.class, () -> getCodec().fromQualified("scout.FixtureCompositeId:foo"));
-    assertThrows(PlatformException.class, () -> getCodec().fromQualified("scout.FixtureCompositeId:foo;" + TEST_UUID + ";foo"));
-    assertThrows(PlatformException.class, () -> getCodec().fromQualified("scout.FixtureCompositeWithAllTypesId:;"));
-    assertThrows(PlatformException.class, () -> getCodec().fromQualified("scout.FixtureCompositeWithAllTypesId:;;;"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromQualified("scout.FixtureCompositeId:foo"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromQualified("scout.FixtureCompositeId:foo;" + TEST_UUID + ";foo"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromQualified("scout.FixtureCompositeWithAllTypesId:;"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromQualified("scout.FixtureCompositeWithAllTypesId:;;;"));
   }
 
   @Test
@@ -478,7 +477,7 @@ public abstract class AbstractIdCodecTest {
     FixtureCustomComparableRawDataId id1 = IIds.create(FixtureCustomComparableRawDataId.class, new CustomComparableRawDataType(100));
 
     // no type mapper registered
-    assertThrows(PlatformException.class, () -> getCodec().fromUnqualified(FixtureCustomComparableRawDataId.class, "100"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(FixtureCustomComparableRawDataId.class, "100"));
 
     try {
       getCodec().registerRawTypeMapper(CustomComparableRawDataType.class, CustomComparableRawDataType::of, CustomComparableRawDataType::toString);
@@ -506,8 +505,8 @@ public abstract class AbstractIdCodecTest {
 
   @Test
   public void testFromUnqualifiedNullIdClass() {
-    assertThrows(PlatformException.class, () -> getCodec().fromUnqualified(null, null));
-    assertThrows(PlatformException.class, () -> getCodec().fromUnqualified(null, "foo"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(null, null));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(null, "foo"));
   }
 
   @Test
@@ -562,33 +561,33 @@ public abstract class AbstractIdCodecTest {
 
   @Test
   public void testFromUnqualifiedCompositeIdWrongNumberOfComponents() {
-    assertThrows(PlatformException.class, () -> getCodec().fromUnqualified(FixtureCompositeId.class, "foo"));
-    assertThrows(PlatformException.class, () -> getCodec().fromUnqualified(FixtureCompositeId.class, "foo;" + TEST_UUID + ";foo"));
-    assertThrows(PlatformException.class, () -> getCodec().fromUnqualified(FixtureCompositeWithAllTypesId.class, ";"));
-    assertThrows(PlatformException.class, () -> getCodec().fromUnqualified(FixtureCompositeWithAllTypesId.class, ";;;"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(FixtureCompositeId.class, "foo"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(FixtureCompositeId.class, "foo;" + TEST_UUID + ";foo"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(FixtureCompositeWithAllTypesId.class, ";"));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(FixtureCompositeWithAllTypesId.class, ";;;"));
   }
 
-  @Test(expected = PlatformException.class)
+  @Test(expected = IdCodecException.class)
   public void testFromQualified_InvalidType() {
     getCodec().fromQualified("scout.FixtureUuId:Other:" + TEST_UUID);
   }
 
-  @Test(expected = PlatformException.class)
+  @Test(expected = IdCodecException.class)
   public void testFromQualified_UnknownType() {
     getCodec().fromQualified("DoesNotExist:" + TEST_UUID);
   }
 
-  @Test(expected = PlatformException.class)
+  @Test(expected = IdCodecException.class)
   public void testFromQualified_InvalidFormat_noColon() {
     getCodec().fromQualified("DoesNotExist");
   }
 
-  @Test(expected = PlatformException.class)
+  @Test(expected = IdCodecException.class)
   public void testFromQualified_InvalidFormat_duplicateColon() {
     getCodec().fromQualified("DoesNotExist:d:d");
   }
 
-  @Test(expected = PlatformException.class)
+  @Test(expected = IdCodecException.class)
   public void testFromQualified_UnsupportedWrappedType() {
     getCodec().fromQualified("DoesNotExist:" + TEST_UUID);
   }
@@ -741,8 +740,8 @@ public abstract class AbstractIdCodecTest {
 
   @Test
   public void testEmptyIdWithSignature() {
-    assertThrows(AssertionException.class, () -> getCodec().fromQualified("scout.FixtureIntegerId:###CNCgkNhEN4PEpNkWvRPY/jEIwn49f1xGLgmXyi6SdlI=", IdCodecFlag.SIGNATURE));
-    assertThrows(AssertionException.class, () -> getCodec().fromUnqualified(FixtureIntegerId.class, "###CNCgkNhEN4PEpNkWvRPY/jEIwn49f1xGLgmXyi6SdlI=", IdCodecFlag.SIGNATURE));
+    assertThrows(IdCodecException.class, () -> getCodec().fromQualified("scout.FixtureIntegerId:###CNCgkNhEN4PEpNkWvRPY/jEIwn49f1xGLgmXyi6SdlI=", IdCodecFlag.SIGNATURE));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(FixtureIntegerId.class, "###CNCgkNhEN4PEpNkWvRPY/jEIwn49f1xGLgmXyi6SdlI=", IdCodecFlag.SIGNATURE));
   }
 
   @Test
@@ -756,10 +755,10 @@ public abstract class AbstractIdCodecTest {
     assertEquals(stringId, getCodec().fromUnqualified(FixtureStringId.class, "some", IdCodecFlag.SIGNATURE));
 
     var integerId = FixtureIntegerId.of(42);
-    assertThrows(AssertionException.class, () -> getCodec().toQualified(integerId, IdCodecFlag.SIGNATURE));
-    assertThrows(AssertionException.class, () -> getCodec().toUnqualified(integerId, IdCodecFlag.SIGNATURE));
-    assertThrows(AssertionException.class, () -> getCodec().fromQualified("scout.FixtureIntegerId:42###CNCgkNhEN4PEpNkWvRPY/jEIwn49f1xGLgmXyi6SdlI=", IdCodecFlag.SIGNATURE));
-    assertThrows(AssertionException.class, () -> getCodec().fromUnqualified(FixtureIntegerId.class, "42###CNCgkNhEN4PEpNkWvRPY/jEIwn49f1xGLgmXyi6SdlI=", IdCodecFlag.SIGNATURE));
+    assertThrows(IdCodecException.class, () -> getCodec().toQualified(integerId, IdCodecFlag.SIGNATURE));
+    assertThrows(IdCodecException.class, () -> getCodec().toUnqualified(integerId, IdCodecFlag.SIGNATURE));
+    assertThrows(IdCodecException.class, () -> getCodec().fromQualified("scout.FixtureIntegerId:42###CNCgkNhEN4PEpNkWvRPY/jEIwn49f1xGLgmXyi6SdlI=", IdCodecFlag.SIGNATURE));
+    assertThrows(IdCodecException.class, () -> getCodec().fromUnqualified(FixtureIntegerId.class, "42###CNCgkNhEN4PEpNkWvRPY/jEIwn49f1xGLgmXyi6SdlI=", IdCodecFlag.SIGNATURE));
   }
 
   @IdTypeName("scout.FixtureDateId")

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/id/IdCodecException.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/id/IdCodecException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.id;
+
+import org.eclipse.scout.rt.platform.exception.PlatformException;
+
+/**
+ * Represents errors that occur during serialization/deserialization in the {@link IdCodec}.
+ *
+ * @since 24.2
+ */
+public class IdCodecException extends PlatformException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * see {@link PlatformException#PlatformException(String, Object...)}
+   */
+  public IdCodecException(final String message, final Object... args) {
+    super(message, args);
+  }
+}

--- a/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/exception/DefaultExceptionMapperTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/exception/DefaultExceptionMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
 
 import org.eclipse.scout.rt.dataobject.exception.AccessForbiddenException;
 import org.eclipse.scout.rt.dataobject.exception.ResourceNotFoundException;
+import org.eclipse.scout.rt.dataobject.id.IdCodecException;
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.exception.RemoteSystemUnavailableException;
@@ -165,6 +166,17 @@ public class DefaultExceptionMapperTest {
       assertEquals(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), response.getStatus());
       ErrorDo error = response.readEntity(ErrorResponse.class).getError();
       assertEquals(exception.getMessage(), error.getMessage());
+    }
+  }
+
+  @Test
+  public void testToResponseIdCodecException() {
+    var mapper = new IdCodecExceptionMapper();
+    var exception = new IdCodecException("foo {}", "bar", new Exception());
+    try (Response response = mapper.toResponse(exception)) {
+      assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+      ErrorDo error = response.readEntity(ErrorResponse.class).getError();
+      assertEquals(Response.Status.BAD_REQUEST.getReasonPhrase(), error.getMessage());
     }
   }
 

--- a/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/param/IIdParamConverterProviderTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/param/IIdParamConverterProviderTest.java
@@ -24,7 +24,7 @@ import org.eclipse.scout.rt.dataobject.fixture.FixtureUuId;
 import org.eclipse.scout.rt.dataobject.id.IId;
 import org.eclipse.scout.rt.dataobject.id.IUuId;
 import org.eclipse.scout.rt.dataobject.id.IdCodec.IdCodecFlag;
-import org.eclipse.scout.rt.platform.exception.PlatformException;
+import org.eclipse.scout.rt.dataobject.id.IdCodecException;
 import org.eclipse.scout.rt.rest.param.IIdParamConverterProvider.IdCodecFlags;
 import org.eclipse.scout.rt.rest.param.IIdParamConverterProvider.QualifiedIIdParamConverter;
 import org.eclipse.scout.rt.rest.param.IIdParamConverterProvider.UnqualifiedIIdParamConverter;
@@ -92,7 +92,7 @@ public class IIdParamConverterProviderTest {
     ParamConverter<FixtureUuId> conv = m_provider.getConverter(FixtureUuId.class, null, null);
 
     assertNull(conv.fromString(null));
-    assertThrows(PlatformException.class, () -> conv.fromString("invalid UUID"));
+    assertThrows(IdCodecException.class, () -> conv.fromString("invalid UUID"));
 
     assertNotNull(conv);
     FixtureUuId id = conv.fromString(TEST_UUID.unwrapAsString());
@@ -105,7 +105,7 @@ public class IIdParamConverterProviderTest {
     ParamConverter<IUuId> conv = m_provider.getConverter(IUuId.class, null, null);
 
     assertNull(conv.fromString(null));
-    assertThrows(PlatformException.class, () -> conv.fromString("invalid_type:invalid UUID"));
+    assertThrows(IdCodecException.class, () -> conv.fromString("invalid_type:invalid UUID"));
 
     assertNotNull(conv);
     IUuId id = conv.fromString("scout.FixtureUuId:" + TEST_UUID.unwrapAsString());
@@ -118,7 +118,7 @@ public class IIdParamConverterProviderTest {
     ParamConverter<FixtureCompositeId> conv = m_provider.getConverter(FixtureCompositeId.class, null, null);
 
     assertNull(conv.fromString(null));
-    assertThrows(PlatformException.class, () -> conv.fromString("invalid"));
+    assertThrows(IdCodecException.class, () -> conv.fromString("invalid"));
 
     assertNotNull(conv);
     FixtureCompositeId id = conv.fromString("abc;" + TEST_UUID.unwrapAsString());

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/IdCodecExceptionMapper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/IdCodecExceptionMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.exception;
+
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.scout.rt.dataobject.id.IdCodecException;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.rest.error.ErrorResponseBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IdCodecExceptionMapper extends AbstractExceptionMapper<IdCodecException> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IdCodecExceptionMapper.class);
+
+  @Override
+  protected Response toResponseImpl(IdCodecException exception) {
+    //noinspection LoggingPlaceholderCountMatchesArgumentCount
+    LOG.info("{}: {}", exception.getClass().getSimpleName(), exception.getMessage(), LOG.isDebugEnabled() ? exception : null);
+    return BEANS.get(ErrorResponseBuilder.class)
+        .withHttpStatus(Response.Status.BAD_REQUEST)
+        .withMessage(Response.Status.BAD_REQUEST.getReasonPhrase()) // do not return internal exception message
+        .build();
+  }
+}


### PR DESCRIPTION
Introduce new IdCodecException and use it in IdCodec whenever an exception is thrown during serialization/deserialization of an IId. Also add an IdCodecExceptionMapper, that returns a "400 - Bad Request" when an IdCodecException is thrown and only logs the stacktrace if debug is enabled.

391961