### PR TITLE
SimpleTab: fix rendering the title/subTitle if it is set to null

### DIFF
--- a/eclipse-scout-core/src/tabbox/SimpleTab.ts
+++ b/eclipse-scout-core/src/tabbox/SimpleTab.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -137,9 +137,7 @@ export class SimpleTab<TView extends SimpleTabView = SimpleTabView> extends Widg
   }
 
   protected _renderTitle() {
-    if (this.title || this.subTitle) { // $title is always needed if subtitle is not empty
-      this.$title.textOrNbsp(this.title);
-    }
+    this.$title.textOrNbsp(this.title);
   }
 
   setSubTitle(subTitle: string) {
@@ -147,16 +145,7 @@ export class SimpleTab<TView extends SimpleTabView = SimpleTabView> extends Widg
   }
 
   protected _renderSubTitle() {
-    if (this.subTitle) {
-      if (!this.title) {
-        this._renderTitle();
-      }
-      this.$subTitle.textOrNbsp(this.subTitle);
-    } else {
-      if (!this.title) {
-        this._renderTitle();
-      }
-    }
+    this.$subTitle.text(this.subTitle);
   }
 
   setIconId(iconId: string) {


### PR DESCRIPTION
The title and the subTitle can be set to null, undefined or empty string. An earlier implementation has handled this case by removing the DOM elements $title or $subTitle. When this was refactored the removal of the DOM elements was removed and since then the content of the DOM element is only updated if the value is not empty. Because of this the content could not have been removed.