### PR TITLE
Testing: improve check of async jobs started in test cases

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
@@ -95,6 +95,7 @@ import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.exception.VetoException;
 import org.eclipse.scout.rt.platform.holders.Holder;
 import org.eclipse.scout.rt.platform.holders.IHolder;
+import org.eclipse.scout.rt.platform.job.JobInput;
 import org.eclipse.scout.rt.platform.job.JobState;
 import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.reflect.ConfigurationUtility;
@@ -1621,6 +1622,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
       fireNotification(DesktopEvent.TYPE_NOTIFICATION_ADDED, notification);
       if (notification.getDuration() > 0) {
         ModelJobs.schedule(() -> removeNotification(notification), ModelJobs.newInput(ClientRunContexts.copyCurrent())
+            .withExecutionHint(JobInput.EXECUTION_HINT_TESTING_DO_NOT_WAIT_FOR_THIS_JOB)
             .withExecutionTrigger(Jobs.newExecutionTrigger()
                 .withStartIn(notification.getDuration(), TimeUnit.MILLISECONDS)));
       }

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/testing/platform/runner/statement/AssertNoRunningJobStatementTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/testing/platform/runner/statement/AssertNoRunningJobStatementTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.testing.platform.runner.statement;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.scout.rt.platform.context.RunContexts;
+import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.job.Jobs;
+import org.eclipse.scout.rt.platform.util.SleepUtil;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@Ignore // only used for development
+@RunWith(PlatformTestRunner.class)
+public class AssertNoRunningJobStatementTest {
+
+  @Test
+  public void testJobCompletesWithinTest() {
+    assertTrue(Jobs.schedule(() -> true,
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty()))
+        .awaitDoneAndGet(500, TimeUnit.MILLISECONDS));
+    // not expecting 'job did not complete' warning in log
+  }
+
+  @Test
+  public void testJobStartedWithinTestTakesLongerThan500Millis() {
+    Jobs.schedule(() -> SleepUtil.sleepSafe(750, TimeUnit.MILLISECONDS),
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty()));
+    // expecting 'job did not complete' warning in log
+  }
+
+  @Test
+  public void testDelayedCancelledJob() {
+    IFuture<Boolean> f = Jobs.schedule(() -> true,
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty())
+            .withExecutionTrigger(Jobs.newExecutionTrigger().withStartIn(750, TimeUnit.MILLISECONDS)));
+    SleepUtil.sleepSafe(50, TimeUnit.MILLISECONDS);
+    f.cancel(true);
+    // not expecting 'job did not complete' warning in log
+  }
+
+  @Test
+  public void testDelayedJob() {
+    Jobs.schedule(() -> true,
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty())
+            .withExecutionTrigger(Jobs.newExecutionTrigger().withStartIn(750, TimeUnit.MILLISECONDS)));
+    // expecting 'job did not complete' warning in log
+  }
+
+  @Test
+  public void testUnfinishedCancelledJob() {
+    IFuture<Void> f = Jobs.schedule(() -> SleepUtil.sleepSafe(70, TimeUnit.SECONDS),
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty()));
+    SleepUtil.sleepSafe(50, TimeUnit.MILLISECONDS);
+    f.cancel(false); // do not interrupt, otherwise sleepSafe is pointless
+    // not expecting 'job did not complete' warning in log
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/job/JobInput.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/job/JobInput.java
@@ -34,6 +34,13 @@ import org.slf4j.helpers.MessageFormatter;
 @Bean
 public class JobInput {
 
+  /**
+   * Execution hint used to advise Scout testing not to wait for marked jobs to complete before continuing with the test
+   * execution. Use this hint very moderately ond only if it is not possible to either suppress or wait for the async
+   * operation. See AssertNoRunningJobsStatement.
+   */
+  public static final String EXECUTION_HINT_TESTING_DO_NOT_WAIT_FOR_THIS_JOB = "scout.testing.doNotWaitForThisJob";
+
   public static final long EXPIRE_NEVER = 0;
 
   protected String m_name;


### PR DESCRIPTION
Add execution hint for background jobs executing deferred operations that are not directly attached to a particular test case.

391676