### PR TITLE
Table/Tree: fix scrollToSelection() while opening form

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -611,7 +611,7 @@ export class Calendar extends Widget implements CalendarModel {
   }
 
   updateScrollPosition(animate: boolean) {
-    if (!this.rendered) {
+    if (!this.rendered || !this.htmlComp?.layouted) {
       // Execute delayed because table may be not layouted yet
       this.session.layoutValidator.schedulePostValidateFunction(this._updateScrollPosition.bind(this, true, animate));
     } else {
@@ -1134,7 +1134,8 @@ export class Calendar extends Widget implements CalendarModel {
           $e.removeClass('hidden');
         }
         if (animate) {
-          $e.animateAVCSD('height', h, () => {
+          $e.animateAVCSD('height', h,
+            () => {
               if (h === 0) {
                 $e.addClass('hidden');
               }

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -3448,7 +3448,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   }
 
   revealSelection() {
-    if (!this._isDataRendered()) {
+    if (!this._isDataRendered() || !this.htmlComp?.layouted) {
       // Execute delayed because table may be not layouted yet
       this.session.layoutValidator.schedulePostValidateFunction(this.revealSelection.bind(this));
       return;

--- a/eclipse-scout-core/src/tile/TileGrid.ts
+++ b/eclipse-scout-core/src/tile/TileGrid.ts
@@ -1129,7 +1129,7 @@ export class TileGrid<TTile extends Tile = Tile> extends Widget implements TileG
    * Brings the first selected tile into view by scrolling the first scrollable parent.
    */
   revealSelection() {
-    if (!this.rendered) {
+    if (!this.rendered || !this.htmlComp?.layouted) {
       // Execute delayed because tileGrid may be not layouted yet
       this.session.layoutValidator.schedulePostValidateFunction(this.revealSelection.bind(this));
       return;

--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -2001,7 +2001,7 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
   }
 
   revealSelection() {
-    if (!this.rendered) {
+    if (!this.rendered || !this.htmlComp?.layouted) {
       // Execute delayed because tree may be not layouted yet
       this.session.layoutValidator.schedulePostValidateFunction(this.revealSelection.bind(this));
       return;

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/TableTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/TableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,10 +13,12 @@ import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.ui.IEventHistory;
 import org.eclipse.scout.rt.client.ui.basic.table.TableTest.P_Table.FirstColumn;
 import org.eclipse.scout.rt.client.ui.basic.table.columns.AbstractIntegerColumn;
 import org.eclipse.scout.rt.client.ui.basic.table.columns.AbstractStringColumn;
@@ -84,9 +86,9 @@ public class TableTest {
 
     final ITableRow insertedRow = table.addRow(row, true);
 
-    assertEquals(false, insertedRow.isChecked());
-    assertEquals(null, insertedRow.getCssClass());
-    assertEquals(null, insertedRow.getIconId());
+    assertFalse(insertedRow.isChecked());
+    assertNull(insertedRow.getCssClass());
+    assertNull(insertedRow.getIconId());
 
     row = new TableRow(cols);
 
@@ -100,7 +102,7 @@ public class TableTest {
 
     final ITableRow insertedRow2 = table.addRow(row, true);
 
-    assertEquals(true, insertedRow2.isChecked());
+    assertTrue(insertedRow2.isChecked());
     assertEquals("abc", insertedRow2.getCssClass());
     assertEquals(fontSpec, insertedRow2.getCell(0).getFont());
     assertEquals("iconId", insertedRow2.getIconId());
@@ -145,7 +147,7 @@ public class TableTest {
 
     table.discardDeletedRow(deletedRows.get(0));
     assertRowCount(0, 1, table);
-    asssertNoTable(deletedRows.get(0));
+    assertNoTable(deletedRows.get(0));
     assertStatusAndTable(table, ITableRow.STATUS_DELETED, deletedRows.get(1));
     assertEquals(1, ta.getEvents().size());
     assertEquals(TableEvent.TYPE_ALL_ROWS_DELETED, ta.getEvents().get(0).getType());
@@ -172,7 +174,7 @@ public class TableTest {
 
     table.discardDeletedRow(row1);
     assertRowCount(1, 0, table);
-    asssertNoTable(row1);
+    assertNoTable(row1);
     assertStatusAndTable(table, ITableRow.STATUS_NON_CHANGED, row2);
 
   }
@@ -196,8 +198,8 @@ public class TableTest {
 
     table.discardAllDeletedRows();
     assertRowCount(0, 0, table);
-    asssertNoTable(deletedRows.get(0));
-    asssertNoTable(deletedRows.get(1));
+    assertNoTable(deletedRows.get(0));
+    assertNoTable(deletedRows.get(1));
   }
 
   /**
@@ -261,12 +263,12 @@ public class TableTest {
     table.setSortEnabled(false);
 
     //ensure table state:
-    assertEquals("SortEnabled", false, table.isSortEnabled());
+    assertFalse("SortEnabled", table.isSortEnabled());
     assertEquals("FirstColumn - sort index", -1, table.getFirstColumn().getSortIndex());
     assertEquals("SecondColumn - sort index", -1, table.getSecondColumn().getSortIndex());
     assertEquals("ThirdColumn - sort index", 0, table.getThirdColumn().getSortIndex());
     assertEquals("ThirdColumn - initial sort index", 20, table.getThirdColumn().getInitialSortIndex());
-    assertEquals("ThirdColumn - initial alwaysIncludeSortAtBegin", true, table.getThirdColumn().isInitialAlwaysIncludeSortAtBegin());
+    assertTrue("ThirdColumn - initial alwaysIncludeSortAtBegin", table.getThirdColumn().isInitialAlwaysIncludeSortAtBegin());
 
     //fill the table and sort:
     fillTable(table);
@@ -286,7 +288,7 @@ public class TableTest {
   /**
    * Test of {@link AbstractTable#sort()}. Sorted by:
    * <ol>
-   * <li>ThridColumn (defined with AlwaysIncludeSortAtBegin in the column)
+   * <li>ThirdColumn (defined with AlwaysIncludeSortAtBegin in the column)
    * <li>FirstColumn descending.
    * </ol>
    */
@@ -299,13 +301,13 @@ public class TableTest {
     table.getColumnSet().setSortColumn(table.getFirstColumn(), false);
 
     //ensure table state:
-    assertEquals("SortEnabled", true, table.isSortEnabled());
+    assertTrue("SortEnabled", table.isSortEnabled());
     assertEquals("FirstColumn - sort index", 1, table.getFirstColumn().getSortIndex());
-    assertEquals("FirstColumn - sort ascending", false, table.getFirstColumn().isSortAscending());
+    assertFalse("FirstColumn - sort ascending", table.getFirstColumn().isSortAscending());
     assertEquals("SecondColumn - sort index", -1, table.getSecondColumn().getSortIndex());
     assertEquals("ThirdColumn - sort index", 0, table.getThirdColumn().getSortIndex());
     assertEquals("ThirdColumn - initial sort index", 20, table.getThirdColumn().getInitialSortIndex());
-    assertEquals("ThirdColumn - initial alwaysIncludeSortAtBegin", true, table.getThirdColumn().isInitialAlwaysIncludeSortAtBegin());
+    assertTrue("ThirdColumn - initial alwaysIncludeSortAtBegin", table.getThirdColumn().isInitialAlwaysIncludeSortAtBegin());
     assertEquals("ColumnSet PermanentHeadSortColumns size", 1, table.getColumnSet().getPermanentHeadSortColumns().size());
     assertEquals("ColumnSet SortColumns size", 2, table.getColumnSet().getSortColumns().size());
 
@@ -325,7 +327,7 @@ public class TableTest {
   }
 
   /**
-   * Test of {@link AbstractTable#sort()}. Sorted by: - 1. ThridColumn (defined with AlwaysIncludeSortAtBegin in the
+   * Test of {@link AbstractTable#sort()}. Sorted by: - 1. ThirdColumn (defined with AlwaysIncludeSortAtBegin in the
    * column) - 2. SecondColumn descending - 3. FirstColumn ascending.
    */
   @Test
@@ -338,14 +340,14 @@ public class TableTest {
     table.getColumnSet().addSortColumn(table.getFirstColumn(), true);
 
     //ensure table state:
-    assertEquals("SortEnabled", true, table.isSortEnabled());
+    assertTrue("SortEnabled", table.isSortEnabled());
     assertEquals("FirstColumn - sort index", 2, table.getFirstColumn().getSortIndex());
-    assertEquals("FirstColumn - sort ascending", true, table.getFirstColumn().isSortAscending());
+    assertTrue("FirstColumn - sort ascending", table.getFirstColumn().isSortAscending());
     assertEquals("SecondColumn - sort index", 1, table.getSecondColumn().getSortIndex());
-    assertEquals("SecondColumn - sort ascending", false, table.getSecondColumn().isSortAscending());
+    assertFalse("SecondColumn - sort ascending", table.getSecondColumn().isSortAscending());
     assertEquals("ThirdColumn - sort index", 0, table.getThirdColumn().getSortIndex());
     assertEquals("ThirdColumn - initial sort index", 20, table.getThirdColumn().getInitialSortIndex());
-    assertEquals("ThirdColumn - initial alwaysIncludeSortAtBegin", true, table.getThirdColumn().isInitialAlwaysIncludeSortAtBegin());
+    assertTrue("ThirdColumn - initial alwaysIncludeSortAtBegin", table.getThirdColumn().isInitialAlwaysIncludeSortAtBegin());
     assertEquals("ColumnSet PermanentHeadSortColumns size", 1, table.getColumnSet().getPermanentHeadSortColumns().size());
     assertEquals("ColumnSet SortColumns size", 3, table.getColumnSet().getSortColumns().size());
 
@@ -365,7 +367,7 @@ public class TableTest {
   }
 
   @Test
-  public void testgetRowByKey() {
+  public void testGetRowByKey() {
     P_Table table = createTestTable(ITableRow.STATUS_NON_CHANGED);
 
     Assert.assertNull(table.getRowByKey(null));
@@ -378,7 +380,7 @@ public class TableTest {
   }
 
   /**
-   * Test of {@link AbstractTable#sort()}. Only sorted by ThridColumn (defined with AlwaysIncludeSortAtBegin in the
+   * Test of {@link AbstractTable#sort()}. Only sorted by ThirdColumn (defined with AlwaysIncludeSortAtBegin in the
    * column).
    */
   @Test
@@ -387,12 +389,12 @@ public class TableTest {
     table.init();
 
     //ensure table state:
-    assertEquals("SortEnabled", true, table.isSortEnabled());
+    assertTrue("SortEnabled", table.isSortEnabled());
     assertEquals("FirstColumn - sort index", -1, table.getFirstColumn().getSortIndex());
     assertEquals("SecondColumn - sort index", -1, table.getSecondColumn().getSortIndex());
     assertEquals("ThirdColumn - sort index", 0, table.getThirdColumn().getSortIndex());
     assertEquals("ThirdColumn - initial sort index", 20, table.getThirdColumn().getInitialSortIndex());
-    assertEquals("ThirdColumn - initial alwaysIncludeSortAtBegin", true, table.getThirdColumn().isInitialAlwaysIncludeSortAtBegin());
+    assertTrue("ThirdColumn - initial alwaysIncludeSortAtBegin", table.getThirdColumn().isInitialAlwaysIncludeSortAtBegin());
     assertEquals("ColumnSet PermanentHeadSortColumns size", 1, table.getColumnSet().getPermanentHeadSortColumns().size());
     assertEquals("ColumnSet SortColumns size", 1, table.getColumnSet().getSortColumns().size());
 
@@ -451,7 +453,7 @@ public class TableTest {
 
   /**
    * ResetColumnConfiguration disposes the column set and creates a new one. If there was a context column, it has to be
-   * set to null. Otherwise the UI would throw an error because the column is not known (anymore).
+   * set to null. Otherwise, the UI would throw an error because the column is not known (anymore).
    */
   @Test
   public void testResetContextColumn() {
@@ -682,10 +684,6 @@ public class TableTest {
     assertEquals("table", expectedTable, row.getTable());
   }
 
-  /**
-   * @param expectedStatus
-   * @return
-   */
   private static String decodeStatus(int status) {
     switch (status) {
       case ITableRow.STATUS_DELETED:
@@ -701,7 +699,7 @@ public class TableTest {
     }
   }
 
-  private static void asssertNoTable(ITableRow row) {
+  private static void assertNoTable(ITableRow row) {
     assertNull(row.getTable());
   }
 
@@ -903,5 +901,37 @@ public class TableTest {
     assertEquals("a  bc 12 3", table.unwrapText(" \t\n\ra\t bc\n\r \n\r \n\r  12\t3"));
     assertEquals("a  bc 12 3", table.unwrapText("a\t bc\n\r \n\r \n\r  12\t3\n\r\t "));
     assertEquals("a  bc 12 3", table.unwrapText(" \t\n\ra\t bc\n\r \n\r \n\r  12\t3\n\r\t "));
+  }
+
+  @Test
+  public void testEventHistory() {
+    P_Table table = new P_Table() {
+      @Override
+      protected IEventHistory<TableEvent> createEventHistory() {
+        return new DefaultTableEventHistory(5000L) {
+          @Override
+          public void notifyEvent(TableEvent event) {
+            if (event.getType() == -42) {
+              addToCache(event.getType(), event);
+            }
+            super.notifyEvent(event);
+          }
+        };
+      }
+    };
+    assertTrue(table.getEventHistory().getRecentEvents().isEmpty());
+
+    TableEvent customEvent = new TableEvent(table, -42);
+    TableEvent anotherCustomEvent = new TableEvent(table, -43); // will be ignored
+    TableEvent scrollToSelectionEvent = new TableEvent(table, TableEvent.TYPE_SCROLL_TO_SELECTION);
+
+    table.fireTableEventInternal(customEvent);
+    table.fireTableEventInternal(anotherCustomEvent);
+    table.fireTableEventInternal(scrollToSelectionEvent);
+
+    Collection<TableEvent> recentEvents = table.getEventHistory().getRecentEvents();
+    assertEquals(2, recentEvents.size());
+    assertTrue(recentEvents.contains(customEvent));
+    assertTrue(recentEvents.contains(scrollToSelectionEvent));
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1075,16 +1075,14 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
     setCompactHandler(createCompactHandler());
     setCompact(getConfiguredCompact());
 
-    // add Convenience observer for drag & drop callbacks, event history and ui sort possible check
-    addTableListener(new TableAdapter() {
-
-      @Override
-      public void tableChanged(TableEvent e) {
+    // add convenience observer for drag & drop callbacks, event history and ui sort possible check
+    addTableListener(e -> {
         //event history
         IEventHistory<TableEvent> h = getEventHistory();
         if (h != null) {
           h.notifyEvent(e);
         }
+
         //dnd
         switch (e.getType()) {
           case TableEvent.TYPE_ROWS_DRAG_REQUEST: {
@@ -1147,10 +1145,7 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
             checkIfColumnPreventsUiSortForTable();
             break;
         }
-      }
-
-    }, TableEvent.TYPE_ROWS_DRAG_REQUEST, TableEvent.TYPE_ROW_DROP_ACTION, TableEvent.TYPE_ROWS_COPY_REQUEST, TableEvent.TYPE_ALL_ROWS_DELETED, TableEvent.TYPE_ROWS_DELETED, TableEvent.TYPE_ROWS_INSERTED, TableEvent.TYPE_ROWS_UPDATED,
-        TableEvent.TYPE_ROWS_CHECKED, TableEvent.TYPE_COLUMN_HEADERS_UPDATED, TableEvent.TYPE_COLUMN_STRUCTURE_CHANGED);
+    });
   }
 
   protected void initMenus() {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
@@ -101,8 +101,8 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
 
   /**
    * Provides 4 boolean flags.<br>
-   * Currently used: {@link #AUTO_DISCARD_ON_DELETE}, {@link #AUTO_TITLE},
-   * {@link #ACTION_RUNNING}, {@link #SAVE_AND_RESTORE_SCROLLBARS}
+   * Currently used: {@link #AUTO_DISCARD_ON_DELETE}, {@link #AUTO_TITLE}, {@link #ACTION_RUNNING},
+   * {@link #SAVE_AND_RESTORE_SCROLLBARS}
    */
   private byte m_flags;
 
@@ -321,9 +321,9 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
 
   /**
    * Configures whether this tree should save and restore its coordinates of the vertical and horizontal scrollbars. If
-   * this property is set to {@code true}, the tree saves its scrollbars coordinates to the {@link AbstractClientSession} upon
-   * detaching the UI component from Scout. The coordinates are restored (if the coordinates are available), when the UI
-   * component is attached to Scout.
+   * this property is set to {@code true}, the tree saves its scrollbars coordinates to the
+   * {@link AbstractClientSession} upon detaching the UI component from Scout. The coordinates are restored (if the
+   * coordinates are available), when the UI component is attached to Scout.
    * <p>
    * Subclasses can override this method. Default is {@code false}.
    *
@@ -339,11 +339,11 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
    * When set to {@code true}, all children of a node will be checked/unchecked together with their parents.
    * <p>
    * The state of a node is a representation of its children.
-   *  <ul>
-   *  <li>When none of the children are checked, the node is unchecked</li>
-   *  <li>When some of the children are checked, the node is partly checked</li>
-   *  <li>When all of the children are checked, the node is also checked</li>
-   *  </ul>
+   * <ul>
+   * <li>When none of the children are checked, the node is unchecked</li>
+   * <li>When some of the children are checked, the node is partly checked</li>
+   * <li>When all of the children are checked, the node is also checked</li>
+   * </ul>
    * <p>
    * Only has an effect if the tree is checkable.
    * <p>
@@ -492,8 +492,8 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
   }
 
   /**
-   * this method should not be implemented if you support {@link #interceptDrag(Collection)} (drag of
-   * multiple nodes), as it takes precedence
+   * this method should not be implemented if you support {@link #interceptDrag(Collection)} (drag of multiple nodes),
+   * as it takes precedence
    *
    * @return a transferable object representing the given row
    */
@@ -613,80 +613,76 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
     setToggleBreadcrumbStyleEnabled(getConfiguredToggleBreadcrumbStyleEnabled());
     setRootNode(new AbstractTreeNode() {
     });
-    // add Convenience observer for drag & drop callbacks and event history
-    addTreeListener(
-        e -> {
-          //event history
-          IEventHistory<TreeEvent> h = getEventHistory();
-          if (h != null) {
-            h.notifyEvent(e);
-          }
-          //dnd
-          switch (e.getType()) {
-            case TreeEvent.TYPE_NODES_DRAG_REQUEST: {
-              m_lastSeenDropNode = null;
-              if (e.getDragObject() == null) {
-                try {
-                  TransferObject transferObject = interceptDrag(e.getNode());
-                  if (transferObject == null) {
-                    transferObject = interceptDrag(e.getNodes());
-                  }
-                  e.setDragObject(transferObject);
-                }
-                catch (Exception t) {
-                  LOG.error("Drag", t);
-                }
+
+    // add convenience observer for drag & drop callbacks and event history
+    addTreeListener(e -> {
+      //event history
+      IEventHistory<TreeEvent> h = getEventHistory();
+      if (h != null) {
+        h.notifyEvent(e);
+      }
+
+      //dnd
+      switch (e.getType()) {
+        case TreeEvent.TYPE_NODES_DRAG_REQUEST: {
+          m_lastSeenDropNode = null;
+          if (e.getDragObject() == null) {
+            try {
+              TransferObject transferObject = interceptDrag(e.getNode());
+              if (transferObject == null) {
+                transferObject = interceptDrag(e.getNodes());
               }
-              break;
+              e.setDragObject(transferObject);
             }
-            case TreeEvent.TYPE_NODE_DROP_ACTION: {
-              m_lastSeenDropNode = null;
-              if (e.getDropObject() != null) {
-                try {
-                  interceptDrop(e.getNode(), e.getDropObject());
-                }
-                catch (Exception t) {
-                  LOG.error("Drop", t);
-                }
-              }
-              break;
-            }
-            case TreeEvent.TYPE_NODES_SELECTED: {
-              rebuildKeyStrokesInternal();
-              break;
-            }
-            case TreeEvent.TYPE_NODES_CHECKED: {
-              try {
-                interceptNodesChecked(CollectionUtility.arrayList(e.getNodes()));
-              }
-              catch (RuntimeException ex) {
-                BEANS.get(ExceptionHandler.class).handle(ex);
-              }
-              break;
-            }
-            case TreeEvent.TYPE_NODE_DROP_TARGET_CHANGED: {
-              try {
-                if (m_lastSeenDropNode == null || m_lastSeenDropNode != e.getNode()) {
-                  m_lastSeenDropNode = e.getNode();
-                  interceptDropTargetChanged(e.getNode());
-                }
-              }
-              catch (RuntimeException ex) {
-                LOG.error("DropTargetChanged", ex);
-              }
-              break;
-            }
-            case TreeEvent.TYPE_DRAG_FINISHED: {
-              m_lastSeenDropNode = null;
+            catch (Exception t) {
+              LOG.error("Drag", t);
             }
           }
-        },
-        TreeEvent.TYPE_NODES_DRAG_REQUEST,
-        TreeEvent.TYPE_NODE_DROP_ACTION,
-        TreeEvent.TYPE_NODES_SELECTED,
-        TreeEvent.TYPE_NODES_CHECKED,
-        TreeEvent.TYPE_NODE_DROP_TARGET_CHANGED,
-        TreeEvent.TYPE_DRAG_FINISHED);
+          break;
+        }
+        case TreeEvent.TYPE_NODE_DROP_ACTION: {
+          m_lastSeenDropNode = null;
+          if (e.getDropObject() != null) {
+            try {
+              interceptDrop(e.getNode(), e.getDropObject());
+            }
+            catch (Exception t) {
+              LOG.error("Drop", t);
+            }
+          }
+          break;
+        }
+        case TreeEvent.TYPE_NODES_SELECTED: {
+          rebuildKeyStrokesInternal();
+          break;
+        }
+        case TreeEvent.TYPE_NODES_CHECKED: {
+          try {
+            interceptNodesChecked(CollectionUtility.arrayList(e.getNodes()));
+          }
+          catch (RuntimeException ex) {
+            BEANS.get(ExceptionHandler.class).handle(ex);
+          }
+          break;
+        }
+        case TreeEvent.TYPE_NODE_DROP_TARGET_CHANGED: {
+          try {
+            if (m_lastSeenDropNode == null || m_lastSeenDropNode != e.getNode()) {
+              m_lastSeenDropNode = e.getNode();
+              interceptDropTargetChanged(e.getNode());
+            }
+          }
+          catch (RuntimeException ex) {
+            LOG.error("DropTargetChanged", ex);
+          }
+          break;
+        }
+        case TreeEvent.TYPE_DRAG_FINISHED: {
+          m_lastSeenDropNode = null;
+        }
+      }
+    });
+
     // key shortcuts
     List<Class<? extends IKeyStroke>> configuredKeyStrokes = getConfiguredKeyStrokes();
     List<IKeyStroke> ksList = new ArrayList<>(configuredKeyStrokes.size());


### PR DESCRIPTION
- Remove filter for listener (event history is expected to receive all events)
- When revealing the selection, not only check if the widget is rendered but also check if the layout is valid. Otherwise, the measured scroll position will be wrong.

393011