### PR TITLE
Testing: improve check of async jobs started in test cases

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
@@ -95,6 +95,7 @@ import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.exception.VetoException;
 import org.eclipse.scout.rt.platform.holders.Holder;
 import org.eclipse.scout.rt.platform.holders.IHolder;
+import org.eclipse.scout.rt.platform.job.JobInput;
 import org.eclipse.scout.rt.platform.job.JobState;
 import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.reflect.ConfigurationUtility;
@@ -1621,6 +1622,7 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
       fireNotification(DesktopEvent.TYPE_NOTIFICATION_ADDED, notification);
       if (notification.getDuration() > 0) {
         ModelJobs.schedule(() -> removeNotification(notification), ModelJobs.newInput(ClientRunContexts.copyCurrent())
+            .withExecutionHint(JobInput.EXECUTION_HINT_TESTING_DO_NOT_WAIT_FOR_THIS_JOB)
             .withExecutionTrigger(Jobs.newExecutionTrigger()
                 .withStartIn(notification.getDuration(), TimeUnit.MILLISECONDS)));
       }

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/statement/AssertNoRunningJobsStatement.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/statement/AssertNoRunningJobsStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,15 +10,16 @@
 package org.eclipse.scout.rt.testing.platform.runner.statement;
 
 import static org.junit.Assert.fail;
-import java.util.ArrayList;
+
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.job.JobInput;
 import org.eclipse.scout.rt.platform.job.JobState;
 import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.job.listener.IJobListener;
@@ -28,16 +29,19 @@ import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.IRegistrationHandle;
 import org.eclipse.scout.rt.platform.util.concurrent.TimedOutError;
 import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Statement to assert no running jobs after test execution to prevent job interferences among test classes using a
- * shared platform.
+ * shared platform. Jobs marked with {@link JobInput#EXECUTION_HINT_TESTING_DO_NOT_WAIT_FOR_THIS_JOB} are ignored.
  *
  * @since 5.2
  */
 public class AssertNoRunningJobsStatement extends Statement {
-
-  private static final long AWAIT_DONE_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(1);
+  private static final Logger LOG = LoggerFactory.getLogger(AssertNoRunningJobsStatement.class);
+  private static final long AWAIT_DONE_TIMEOUT_NANOS = TimeUnit.MINUTES.toNanos(1);
+  private static final long REPORT_THRESHOLD_NANOS = TimeUnit.MILLISECONDS.toNanos(500);
 
   private final Statement m_next;
   private final String m_context;
@@ -65,22 +69,24 @@ public class AssertNoRunningJobsStatement extends Statement {
 
     final Set<IFuture<?>> scheduledFutures = jobListener.getScheduledFutures();
     if (!scheduledFutures.isEmpty()) {
-      assertNoRunningJobs(Jobs.newFutureFilterBuilder()
-          .andMatchFuture(scheduledFutures)
-          .toFilter());
+      assertNoRunningJobs(scheduledFutures);
     }
   }
 
   /**
    * Asserts that all jobs accepted by the given filter are in 'done' state.
    */
-  private void assertNoRunningJobs(final Predicate<IFuture<?>> jobFilter) {
+  private void assertNoRunningJobs(final Set<IFuture<?>> futures) {
     try {
+      //noinspection ResultOfMethodCallIgnored
       Thread.interrupted(); // clear the thread's interrupted status, in case the JUnit test interrupted the executing thread.
-      Jobs.getJobManager().awaitDone(jobFilter, AWAIT_DONE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+      removeAndAwaitDone(futures);
     }
     catch (final TimedOutError e) { // NOSONAR
-      final List<String> runningJobs = findJobNames(jobFilter);
+      final List<String> runningJobs = futures.stream()
+          .filter(f -> !f.isDone()) // because of the TimedOutError there could still be done jobs in the list
+          .map(f -> f.getJobInput().getName())
+          .collect(Collectors.toList());
       if (!runningJobs.isEmpty()) {
         fail(String.format("Test failed because some jobs did not complete yet. [context=%s, jobs=%s]", m_context, runningJobs));
       }
@@ -88,14 +94,31 @@ public class AssertNoRunningJobsStatement extends Statement {
   }
 
   /**
-   * Finds running job names which comply with the given filter.
+   * Waits until the given futures are done and removes them.
    */
-  private List<String> findJobNames(final Predicate<IFuture<?>> filter) {
-    final List<String> jobs = new ArrayList<>();
-    for (final IFuture<?> future : Jobs.getJobManager().getFutures(filter)) {
-      jobs.add(future.getJobInput().getName());
+  private void removeAndAwaitDone(Set<IFuture<?>> futures) {
+    // implementation note: we do not use IJobManager.awaitDone because we want to report jobs running longer than REPORT_THRESHOLD_NANOS.
+    long nanosWaited = 0;
+    boolean reported = false;
+    while (nanosWaited < AWAIT_DONE_TIMEOUT_NANOS) {
+      // remove all done jobs
+      futures.removeIf(IFuture::isDone);
+      if (futures.isEmpty()) {
+        return;
+      }
+
+      final IFuture<?> next = futures.iterator().next();
+      final long startNanos = System.nanoTime();
+      next.awaitDone(AWAIT_DONE_TIMEOUT_NANOS - nanosWaited, TimeUnit.NANOSECONDS);
+      nanosWaited += System.nanoTime() - startNanos;
+
+      if (!reported && nanosWaited > REPORT_THRESHOLD_NANOS) {
+        LOG.warn("The job '{}' did not complete within {}ms [took {}ms].\n"
+            + "Hint: in case of deferred background operations that do not impact the test execution, consider using JobInput.EXECUTION_HINT_TESTING_DO_NOT_WAIT_FOR_THIS_JOB",
+            next.getJobInput().getName(), TimeUnit.NANOSECONDS.toMillis(REPORT_THRESHOLD_NANOS), TimeUnit.NANOSECONDS.toMillis(nanosWaited));
+        reported = true;
+      }
     }
-    return jobs;
   }
 
   /**
@@ -123,13 +146,18 @@ public class AssertNoRunningJobsStatement extends Statement {
     @Override
     public void changed(final JobEvent event) {
       if (isScheduledByInitialThread() || isScheduledByInitialJob() || isScheduledByDescendantJob()) {
+        final IFuture<?> future = event.getData().getFuture();
+        // ignore specifically marked jobs
+        if (future.containsExecutionHint(JobInput.EXECUTION_HINT_TESTING_DO_NOT_WAIT_FOR_THIS_JOB)) {
+          return;
+        }
         m_scheduledFutures.put(event.getData().getFuture(), PRESENT);
       }
     }
 
     /**
-     * @return Returns <code>true</code> if the the initial statement was not executed by a job and the current thread
-     *         is the initial thread.
+     * @return Returns <code>true</code> if the initial statement was not executed by a job and the current thread is
+     *         the initial thread.
      */
     private boolean isScheduledByInitialThread() {
       return m_initialThread != null && m_initialThread == Thread.currentThread();

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/testing/platform/runner/statement/AssertNoRunningJobStatementTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/testing/platform/runner/statement/AssertNoRunningJobStatementTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.testing.platform.runner.statement;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.scout.rt.platform.context.RunContexts;
+import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.job.Jobs;
+import org.eclipse.scout.rt.platform.util.SleepUtil;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@Ignore // only used for development
+@RunWith(PlatformTestRunner.class)
+public class AssertNoRunningJobStatementTest {
+
+  @Test
+  public void testJobCompletesWithinTest() {
+    assertTrue(Jobs.schedule(() -> true,
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty()))
+        .awaitDoneAndGet(500, TimeUnit.MILLISECONDS));
+    // not expecting 'job did not complete' warning in log
+  }
+
+  @Test
+  public void testJobStartedWithinTestTakesLongerThan500Millis() {
+    Jobs.schedule(() -> SleepUtil.sleepSafe(750, TimeUnit.MILLISECONDS),
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty()));
+    // expecting 'job did not complete' warning in log
+  }
+
+  @Test
+  public void testDelayedCancelledJob() {
+    IFuture<Boolean> f = Jobs.schedule(() -> true,
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty())
+            .withExecutionTrigger(Jobs.newExecutionTrigger().withStartIn(750, TimeUnit.MILLISECONDS)));
+    SleepUtil.sleepSafe(50, TimeUnit.MILLISECONDS);
+    f.cancel(true);
+    // not expecting 'job did not complete' warning in log
+  }
+
+  @Test
+  public void testDelayedJob() {
+    Jobs.schedule(() -> true,
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty())
+            .withExecutionTrigger(Jobs.newExecutionTrigger().withStartIn(750, TimeUnit.MILLISECONDS)));
+    // expecting 'job did not complete' warning in log
+  }
+
+  @Test
+  public void testUnfinishedCancelledJob() {
+    IFuture<Void> f = Jobs.schedule(() -> SleepUtil.sleepSafe(70, TimeUnit.SECONDS),
+        Jobs.newInput()
+            .withRunContext(RunContexts.empty()));
+    SleepUtil.sleepSafe(50, TimeUnit.MILLISECONDS);
+    f.cancel(false); // do not interrupt, otherwise sleepSafe is pointless
+    // not expecting 'job did not complete' warning in log
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/job/JobInput.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/job/JobInput.java
@@ -34,6 +34,13 @@ import org.slf4j.helpers.MessageFormatter;
 @Bean
 public class JobInput {
 
+  /**
+   * Execution hint used to advise Scout testing not to wait for marked jobs to complete before continuing with the test
+   * execution. Use this hint very moderately ond only if it is not possible to either suppress or wait for the async
+   * operation. See AssertNoRunningJobsStatement.
+   */
+  public static final String EXECUTION_HINT_TESTING_DO_NOT_WAIT_FOR_THIS_JOB = "scout.testing.doNotWaitForThisJob";
+
   public static final long EXPIRE_NEVER = 0;
 
   protected String m_name;


### PR DESCRIPTION
Add execution hint for background jobs executing deferred operations that are not directly attached to a particular test case.

391676

(cherry picked from commit 7849976083da572f55d9d3840f17dd92ace24715)