### PR TITLE
ComboMenu: fix prefSize when child actions have a custom layout

### DIFF
--- a/eclipse-scout-core/src/menu/ComboMenu.ts
+++ b/eclipse-scout-core/src/menu/ComboMenu.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {EventHandler, HtmlComponent, Menu, PropertyChangeEvent, widgets} from '../index';
+import {ColumnLayout, EventHandler, HtmlComponent, Menu, PropertyChangeEvent, widgets} from '../index';
 
 export class ComboMenu extends Menu {
   protected _childVisibleChangeHandler: EventHandler<PropertyChangeEvent<boolean>>;
@@ -24,6 +24,7 @@ export class ComboMenu extends Menu {
     }
     this.$container.unfocusable();
     this.htmlComp = HtmlComponent.install(this.$container, this.session);
+    this.htmlComp.setLayout(new ColumnLayout());
   }
 
   protected override _renderProperties() {

--- a/eclipse-scout-core/test/menu/ComboMenuSpec.ts
+++ b/eclipse-scout-core/test/menu/ComboMenuSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,11 +7,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ComboMenu, EllipsisMenu, Menu, MenuBar, scout, Session} from '../../src/index';
+import {Button, ComboMenu, EllipsisMenu, FormFieldMenu, Menu, MenuBar, scout, Session} from '../../src/index';
 
 describe('ComboMenu', () => {
 
-  let session:Session, $sandbox: JQuery;
+  let session: Session, $sandbox: JQuery;
 
   beforeEach(() => {
     setFixtures(sandbox());
@@ -154,6 +154,93 @@ describe('ComboMenu', () => {
       ellipsis.setSelected(false);
       expect(ellipsis.popup).toBe(null);
       expect(session.desktop.getPopups().length).toBe(0);
+    });
+  });
+
+  describe('preferred size', () => {
+
+    it('considers pref sizes of child layouts', () => {
+      let comboMenu = scout.create(ComboMenu, {
+        parent: session.desktop,
+        childActions: [
+          {
+            id: 'childMenu1',
+            objectType: Menu,
+            text: 'Foo'
+          },
+          {
+            id: 'childMenu2',
+            objectType: FormFieldMenu,
+            field: {
+              id: 'childMenu2Button',
+              objectType: Button,
+              label: 'Button Menu'
+            }
+          },
+          {
+            id: 'childMenu3',
+            objectType: Menu,
+            text: 'Bar',
+            childActions: [{
+              id: 'childMenu31',
+              objectType: Menu,
+              text: 'Bar Foo'
+            }, {
+              id: 'childMenu32',
+              objectType: Menu,
+              text: 'Bar Bar'
+            }]
+          }
+        ]
+      });
+      expect(comboMenu.childActions.length).toBe(3);
+      expect(comboMenu.childActions[0].childActions.length).toBe(0);
+      expect(comboMenu.childActions[1].childActions.length).toBe(0);
+      expect(comboMenu.childActions[1]).toBeInstanceOf(FormFieldMenu);
+      expect((comboMenu.childActions[1] as FormFieldMenu).field).toBeInstanceOf(Button);
+      expect(comboMenu.childActions[2].childActions.length).toBe(2);
+      let childMenu1 = comboMenu.widget('childMenu1');
+      let childMenu2 = comboMenu.widget('childMenu2');
+      let childMenu2Button = comboMenu.widget('childMenu2Button');
+      let childMenu3 = comboMenu.widget('childMenu3');
+      let childMenu31 = comboMenu.widget('childMenu31');
+      let childMenu32 = comboMenu.widget('childMenu32');
+
+      // ----------------------------
+
+      comboMenu.render($sandbox);
+      expect(comboMenu.rendered).toBe(true);
+      expect(comboMenu.htmlComp.valid).toBe(false);
+      expect(childMenu1.rendered).toBe(true);
+      expect(childMenu1.htmlComp.valid).toBe(false);
+      expect(childMenu2.rendered).toBe(true);
+      expect(childMenu2.htmlComp.valid).toBe(false);
+      expect(childMenu2Button.rendered).toBe(true);
+      expect(childMenu2Button.htmlComp.valid).toBe(false);
+      expect(childMenu3.rendered).toBe(true);
+      expect(childMenu3.htmlComp.valid).toBe(false);
+      expect(childMenu31.rendered).toBe(false);
+      expect(childMenu32.rendered).toBe(false);
+
+      let comboMenuPrefSizeSpy = spyOn(comboMenu.htmlComp.layout, 'preferredLayoutSize').and.callThrough();
+      let childMenu1PrefSizeSpy = spyOn(childMenu1.htmlComp.layout, 'preferredLayoutSize').and.callThrough();
+      let childMenu2PrefSizeSpy = spyOn(childMenu2.htmlComp.layout, 'preferredLayoutSize').and.callThrough();
+      let childMenu2ButtonPrefSizeSpy = spyOn(childMenu2Button.htmlComp.layout, 'preferredLayoutSize').and.callThrough();
+      let childMenu3PrefSizeSpy = spyOn(childMenu3.htmlComp.layout, 'preferredLayoutSize').and.callThrough();
+
+      comboMenu.htmlComp.prefSize();
+      // Computing the prefSize does not validate the layout...
+      expect(comboMenu.htmlComp.valid).toBe(false);
+      expect(childMenu1.htmlComp.valid).toBe(false);
+      expect(childMenu2.htmlComp.valid).toBe(false);
+      expect(childMenu2Button.htmlComp.valid).toBe(false);
+      expect(childMenu3.htmlComp.valid).toBe(false);
+      // ...but each layout should have been asked for its pref size
+      expect(comboMenuPrefSizeSpy).toHaveBeenCalled();
+      expect(childMenu1PrefSizeSpy).toHaveBeenCalled();
+      expect(childMenu2PrefSizeSpy).toHaveBeenCalled();
+      expect(childMenu2ButtonPrefSizeSpy).toHaveBeenCalled();
+      expect(childMenu3PrefSizeSpy).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
A ComboMenu may contain a FormFieldMenu which in turn contains a FormField, e.g. a Button. When the MenuBar is layouted initially, it reads the preferred size of each menu item before they are actually layouted. The NullLayout just ready the current CSS size from the DOM. This is not necessarily correct if the inner layout (e.g. a Button) relies on its layout to report the correct preferred size. To fix this, we explicitly set a ColumnLayout to the ComboMenu that has a different implementation of the preferredLayoutSize() method.

389822