### PR TITLE
Menubar: don't wrap right menu box

### DIFF
--- a/eclipse-scout-core/src/form/fields/groupbox/GroupBox.less
+++ b/eclipse-scout-core/src/form/fields/groupbox/GroupBox.less
@@ -83,7 +83,7 @@
   &.has-menubar {
 
     & > .menubar {
-      display: inline-block;
+      display: inline-flex;
       border: none;
       background-color: transparent;
       vertical-align: middle;

--- a/eclipse-scout-core/src/menu/menubar/MenuBar.less
+++ b/eclipse-scout-core/src/menu/menubar/MenuBar.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,10 +36,10 @@
 
 .menubar {
   position: relative;
+  display: flex;
   width: 100%;
   background-color: @menubar-background-color;
   border-bottom: 1px solid @border-color;
-  white-space: nowrap;
 
   &.bottom {
     border-bottom: 0;
@@ -53,7 +53,7 @@
   align-items: center;
 
   &.right {
-    float: right;
+    margin-left: auto;
   }
 
   & > .menu-separator {


### PR DESCRIPTION
It can happen that the right menu box wraps if it is slightly too large and does not fully fit into the menubar.

The bug was introduced with 24.1 with the change of the DOM order of the menu boxes due to accessibility reasons.
It looks like wrapping cannot be controlled easily when using float: right, so it now uses display: flex and margin-left: auto which seems to work reliably.

388293