### PR TITLE
Permission UiNotification: only notify affected users

### DIFF
--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/IAccessControlService.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/IAccessControlService.java
@@ -14,6 +14,8 @@ import java.util.function.Consumer;
 
 import javax.security.auth.Subject;
 
+import org.eclipse.scout.rt.platform.cache.ICache;
+import org.eclipse.scout.rt.platform.cache.ICacheEntryFilter;
 import org.eclipse.scout.rt.platform.service.IService;
 
 /**
@@ -57,18 +59,25 @@ public interface IAccessControlService extends IService {
    * the entries have already been removed.
    *
    * @param listener
-   *     The listener to add. The {@link IAccessControlService} given to the listener is the service in which
-   *     entries have been invalidated.
+   *          The listener to add. The {@link ICacheEntryFilter} given to the listener is the filter passed to
+   *          {@link ICache#invalidate(ICacheEntryFilter, boolean)}.
    */
-  void addInvalidationListener(Consumer<IAccessControlService> listener);
+  void addInvalidationListener(Consumer<ICacheEntryFilter<Object, IPermissionCollection>> listener);
 
   /**
    * Removes the given listener.
    */
-  void removeInvalidationListener(Consumer<IAccessControlService> listener);
+  void removeInvalidationListener(Consumer<ICacheEntryFilter<Object, IPermissionCollection>> listener);
 
   /**
    * @return All registered invalidation listeners.
    */
-  List<Consumer<IAccessControlService>> getInvalidationListeners();
+  List<Consumer<ICacheEntryFilter<Object, IPermissionCollection>>> getInvalidationListeners();
+
+  /**
+   * @param cacheKey
+   *     A cacheKey used by the internal cache of this service.
+   * @return The userId (username) of the given cacheKey.
+   */
+  String getUserIdForCacheKey(Object cacheKey);
 }


### PR DESCRIPTION
If the server-side permissions cache is invalidated using the KeyCacheEntryFilter (which only invalidates specific entries), only users that belong to these invalidated entries are notified.

This is important as the cache entry for a user is invalidated on logout which would refresh all users browser caches when a user closes the application.

393577