### PR TITLE
TileButton: support labelVisible

### DIFF
--- a/eclipse-scout-core/src/tile/fields/button/TileButton.less
+++ b/eclipse-scout-core/src/tile/fields/button/TileButton.less
@@ -12,6 +12,10 @@
   padding-bottom: 0;
   cursor: pointer;
 
+  &.label-hidden {
+    padding-top: 0; // Override FormFieldTile.less
+  }
+
   & > .field {
     position: relative;
     display: flex;
@@ -57,6 +61,10 @@
 
 .tile.dashboard.compact > .tile-button {
   padding-bottom: 0; // Override FormFieldTile.less
+
+  &.label-hidden {
+    padding-top: 0; // Override FormFieldTile.less
+  }
 
   & > .field {
     padding-top: 12px;

--- a/eclipse-scout-core/src/tile/fields/button/TileButton.ts
+++ b/eclipse-scout-core/src/tile/fields/button/TileButton.ts
@@ -85,4 +85,9 @@ export class TileButton extends Button {
       tooltips.uninstall(this.$container);
     }
   }
+
+  protected override _renderLabelVisible() {
+    super._renderLabelVisible();
+    this._renderChildVisible(this.$buttonLabel, this.labelVisible);
+  }
 }


### PR DESCRIPTION
Tile buttons did not respect the label visible property. The same applies to regular buttons, but since they are used frequently changing their behaviour would likely break existing code (see also TODO in Button.ts).

393740