### PR TITLE
HTTP client connection manager pools metrics

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
@@ -85,6 +85,7 @@ import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.eclipse.scout.rt.platform.util.concurrent.ICancellable;
 import org.eclipse.scout.rt.rest.IRestHttpRequestUriEncoder;
 import org.eclipse.scout.rt.rest.client.RestClientProperties;
+import org.eclipse.scout.rt.shared.http.HttpClientMetricsHelper;
 import org.eclipse.scout.rt.shared.http.proxy.ConfigurableProxySelector;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientRequest;
@@ -97,6 +98,9 @@ import org.glassfish.jersey.message.internal.ReaderWriter;
 import org.glassfish.jersey.message.internal.Statuses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
 
 /**
  * A {@link Connector} that utilizes the Apache HTTP Client to send and receive HTTP request and responses.
@@ -190,7 +194,23 @@ public class ScoutApacheConnector implements Connector {
       connectionManager.setDefaultMaxPerRoute(defaultMaxPerRoute);
     }
 
+    initMetrics(config, connectionManager);
     return connectionManager;
+  }
+
+  /**
+   * Initializes metrics for this HTTP connection manager (if configured by setting a value for
+   * {@link RestClientProperties#OTEL_HTTP_CLIENT_NAME}).
+   */
+  protected void initMetrics(Configuration config, PoolingHttpClientConnectionManager connectionManager) {
+    Object httpClientName = config.getProperty(RestClientProperties.OTEL_HTTP_CLIENT_NAME);
+    if (httpClientName instanceof String) {
+      Meter meter = GlobalOpenTelemetry.get().getMeter(getClass().getName());
+      BEANS.get(HttpClientMetricsHelper.class).initMetrics(meter, (String) httpClientName,
+          connectionManager.getTotalStats()::getAvailable,
+          connectionManager.getTotalStats()::getLeased,
+          connectionManager.getTotalStats()::getMax);
+    }
   }
 
   /**

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/AbstractRestClientHelper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/AbstractRestClientHelper.java
@@ -124,6 +124,13 @@ public abstract class AbstractRestClientHelper implements IRestClientHelper {
     configureClientBuilder(clientBuilder);
   }
 
+  /**
+   * Enables OpenTelemetry metrics for this HTTP client using given {@code httpClientName}.
+   */
+  protected void enableMetrics(ClientBuilder clientBuilder, String httpClientName) {
+    clientBuilder.property(RestClientProperties.OTEL_HTTP_CLIENT_NAME, httpClientName);
+  }
+
   protected void registerContextResolvers(ClientBuilder clientBuilder) {
     // Context resolver, e.g. resolver for ObjectMapper
     for (ContextResolver resolver : validateContextResolvers(getContextResolversToRegister())) {

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
@@ -267,6 +267,17 @@ public final class RestClientProperties {
   public static final String VALIDATE_CONNECTION_AFTER_INACTIVITY = "scout.rest.client.http.validateAfterInactivity";
 
   /**
+   * Activates OpenTelemetry metrics for HTTP client connection pool using property value as HTTP client name.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.String}.
+   * </p>
+   * <p>
+   * The default value is {@code null} (deactivated).
+   * </p>
+   */
+  public static final String OTEL_HTTP_CLIENT_NAME = "scout.rest.client.http.otel.name";
+
+  /**
    * Activates the new Scout apache connector implementation.
    * <p>
    * <b>Note:</b> The scout apache connector will become the default implementation with release 23.1 and this property

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/commons/http/TestingHttpClient.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/commons/http/TestingHttpClient.java
@@ -29,6 +29,7 @@ import org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory;
 import org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory.ApacheHttpTransportBuilder;
 import org.eclipse.scout.rt.shared.http.DefaultHttpTransportManager;
 import org.eclipse.scout.rt.shared.http.IHttpTransportBuilder;
+import org.eclipse.scout.rt.shared.http.IHttpTransportManager;
 
 import com.google.api.client.http.HttpTransport;
 
@@ -79,8 +80,8 @@ public class TestingHttpClient extends DefaultHttpTransportManager {
     }
 
     @Override
-    protected HttpClientConnectionManager createHttpClientConnectionManager() {
-      PoolingHttpClientConnectionManager connManager = (PoolingHttpClientConnectionManager) super.createHttpClientConnectionManager();
+    protected HttpClientConnectionManager createHttpClientConnectionManager(IHttpTransportManager manager) {
+      PoolingHttpClientConnectionManager connManager = (PoolingHttpClientConnectionManager) super.createHttpClientConnectionManager(manager);
       connManager.setDefaultConnectionConfig(
           ConnectionConfig
               .custom()

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTest.java
@@ -20,7 +20,6 @@ import java.io.OutputStream;
 import org.eclipse.scout.rt.platform.serialization.SerializationUtility;
 import org.eclipse.scout.rt.shared.SharedConfigProperties.ServiceTunnelTargetUrlProperty;
 import org.eclipse.scout.rt.shared.http.AbstractHttpTransportManager;
-import org.eclipse.scout.rt.shared.http.IHttpTransportBuilder;
 import org.eclipse.scout.rt.shared.http.IHttpTransportManager;
 import org.eclipse.scout.rt.shared.servicetunnel.IServiceTunnelContentHandler;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
@@ -87,6 +86,11 @@ public class HttpServiceTunnelTest {
               .build();
 
           @Override
+          public String getName() {
+            return "scout.transport.test-service-tunnel";
+          }
+
+          @Override
           public HttpTransport getHttpTransport() {
             return m_transport;
           }
@@ -95,12 +99,6 @@ public class HttpServiceTunnelTest {
           public HttpRequestFactory getHttpRequestFactory() {
             return m_transport.createRequestFactory(createHttpRequestInitializer());
           }
-
-          @Override
-          public void interceptNewHttpTransport(IHttpTransportBuilder builder) {
-            // nop
-          }
-
         };
       }
     };

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/BasicAuthHttpTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/BasicAuthHttpTransportManager.java
@@ -17,8 +17,14 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
 
 public class BasicAuthHttpTransportManager extends AbstractHttpTransportManager {
+
   private String m_user;
   private String m_password;
+
+  @Override
+  public String getName() {
+    return "scout.transport.basic-auth";
+  }
 
   public BasicAuthHttpTransportManager withUser(String user) {
     m_user = user;

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/DefaultHttpTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/DefaultHttpTransportManager.java
@@ -11,4 +11,9 @@
 package org.eclipse.scout.rt.shared.http;
 
 public class DefaultHttpTransportManager extends AbstractHttpTransportManager {
+
+  @Override
+  public String getName() {
+    return "scout.transport.default";
+  }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/HttpClientMetricsHelper.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/HttpClientMetricsHelper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) BSI Business Systems Integration AG. All rights reserved.
+ * http://www.bsiag.com/
+ */
+package org.eclipse.scout.rt.shared.http;
+
+import java.util.function.Supplier;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+
+/**
+ * Helper to provide metrics for Scout's HTTP clients.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md#metric-httpclientopen_connections">
+ * OpenTelemetry: Semantic Conventions for HTTP Metrics</a>
+ */
+@ApplicationScoped
+public class HttpClientMetricsHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpClientMetricsHelper.class);
+
+  protected static final AttributeKey<String> HTTP_CLIENT_NAME = AttributeKey.stringKey("http.client.name");
+  protected static final AttributeKey<String> HTTP_CONNECTION_STATE = AttributeKey.stringKey("state");
+
+  public void initMetrics(Meter meter, String httpClientName, Supplier<Integer> idleConnectionCount, Supplier<Integer> activeConnectionCount, Supplier<Integer> maxConnectionCount) {
+    Assertions.assertNotNullOrEmpty(httpClientName, "HTTP client name not specified. A Java process can use multiple HTTP connection providers (pools). To distinguish them in such situations, a unique HTTP client name is required.");
+    LOG.info("Init HTTP client connection pool '{}'", httpClientName);
+
+    ObservableLongMeasurement connectionsUsage = meter.upDownCounterBuilder("http.client.open_connections")
+        .setDescription("Number of outbound HTTP connections that are currently active or idle on the client.")
+        .setUnit("{connection}")
+        .buildObserver();
+    ObservableLongMeasurement maxConnections = meter.upDownCounterBuilder("http.client.connections.max")
+        .setDescription("The maximum number of allowed outbound HTTP connections.")
+        .setUnit("{connection}")
+        .buildObserver();
+
+    Attributes defaultAttributes = Attributes.of(HTTP_CLIENT_NAME, httpClientName);
+    Attributes activeConnectionsAttributes = defaultAttributes.toBuilder().put(HTTP_CONNECTION_STATE, "active").build();
+    Attributes idleConnectionsAttributes = defaultAttributes.toBuilder().put(HTTP_CONNECTION_STATE, "idle").build();
+
+    //noinspection resource
+    meter.batchCallback(() -> {
+          connectionsUsage.record(activeConnectionCount.get(), activeConnectionsAttributes);
+          connectionsUsage.record(idleConnectionCount.get(), idleConnectionsAttributes);
+          maxConnections.record(maxConnectionCount.get(), defaultAttributes);
+        },
+        connectionsUsage,
+        maxConnections);
+  }
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/IHttpTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/IHttpTransportManager.java
@@ -22,6 +22,15 @@ import com.google.api.client.http.HttpTransport;
 public interface IHttpTransportManager {
 
   /**
+   * TODO 25.1 pbz Change this method to non-default
+   *
+   * @return Technical transport manager name used for metrics.
+   */
+  default String getName() {
+    return "scout.transport.default";
+  }
+
+  /**
    * Get the {@link HttpTransport} instance. This method may create new instances or return a previously created one.
    */
   HttpTransport getHttpTransport();

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTransportManager.java
@@ -25,6 +25,11 @@ import org.eclipse.scout.rt.shared.servicetunnel.http.HttpServiceTunnelConfigura
 public class HttpServiceTunnelTransportManager extends AbstractHttpTransportManager {
 
   @Override
+  public String getName() {
+    return "scout.transport.service-tunnel";
+  }
+
+  @Override
   public void interceptNewHttpTransport(IHttpTransportBuilder builder0) {
     super.interceptNewHttpTransport(builder0);
 


### PR DESCRIPTION
Add OpenTelemetry metrics for HTTP client connection pool:
- active/idle connections
- max connections

393561