### PR TITLE
Connection properties for REST HTTP client

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
@@ -71,11 +71,14 @@ import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.apache.http.impl.io.DefaultHttpRequestWriterFactory;
 import org.apache.http.protocol.HTTP;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.config.AbstractIntegerConfigProperty;
+import org.eclipse.scout.rt.platform.config.AbstractLongConfigProperty;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.context.RunMonitor;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.platform.util.BooleanUtility;
 import org.eclipse.scout.rt.platform.util.IRegistrationHandle;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.eclipse.scout.rt.platform.util.concurrent.ICancellable;
@@ -169,19 +172,19 @@ public class ScoutApacheConnector implements Connector {
             .register("http", PlainConnectionSocketFactory.getSocketFactory())
             .register("https", sslConnectionSocketFactory)
             .build(),
-        connFactory, null, null, getKeepAliveTimeoutMillis(), TimeUnit.MILLISECONDS);
+        connFactory, null, null, getKeepAliveTimeoutMillis(config), TimeUnit.MILLISECONDS);
 
-    final int validateAfterInactivityMillis = getValidateAfterInactivityMillis();
+    final int validateAfterInactivityMillis = getValidateAfterInactivityMillis(config);
     if (validateAfterInactivityMillis > 0) {
       connectionManager.setValidateAfterInactivity(validateAfterInactivityMillis);
     }
 
-    final int maxTotal = getMaxConnectionsTotal();
+    final int maxTotal = getMaxConnectionsTotal(config);
     if (maxTotal > 0) {
       connectionManager.setMaxTotal(maxTotal);
     }
 
-    final int defaultMaxPerRoute = getMaxConnectionsPerRoute();
+    final int defaultMaxPerRoute = getMaxConnectionsPerRoute(config);
     if (defaultMaxPerRoute > 0) {
       connectionManager.setDefaultMaxPerRoute(defaultMaxPerRoute);
     }
@@ -205,26 +208,72 @@ public class ScoutApacheConnector implements Connector {
   }
 
   /**
-   * Max timeout in ms connections are kept open when idle (requires keep-alive support). Default is 30 minutes.
+   * @deprecated This method will be removed with Scout release 25.1. Use the configuration property to change this
+   * configuration or override method {@link #getKeepAliveTimeoutMillis(Configuration)}.
    */
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
   protected long getKeepAliveTimeoutMillis() {
-    return TimeUnit.MINUTES.toMillis(30);
+    return CONFIG.getPropertyValue(RestHttpTransportConnectionKeepAliveProperty.class);
+  }
+
+  /**
+   * Max timeout in ms connections are kept open when idle (requires keep-alive support).
+   */
+  protected long getKeepAliveTimeoutMillis(Configuration config) {
+    return ObjectUtility.nvl(
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.CONNECTION_KEEP_ALIVE), Long.class),
+        getKeepAliveTimeoutMillis());
+  }
+
+  /**
+   * @deprecated This method will be removed with Scout release 25.1. Use the configuration property to change this
+   *             configuration or override method {@link #getMaxConnectionsTotal(Configuration)}.
+   */
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  protected int getMaxConnectionsTotal() {
+    return CONFIG.getPropertyValue(RestHttpTransportMaxConnectionsTotalProperty.class);
   }
 
   /**
    * Max number of total concurrent connections managed by the {@link HttpClientConnectionManager} returned by
-   * {@link #createConnectionManager(Client, Configuration, SSLContext)}. Default is 128.
+   * {@link #createConnectionManager(Client, Configuration, SSLContext)}.
    */
-  protected int getMaxConnectionsTotal() {
-    return 128;
+  protected int getMaxConnectionsTotal(Configuration config) {
+    return ObjectUtility.nvl(
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.MAX_CONNECTIONS_TOTAL), Integer.class),
+        getMaxConnectionsTotal());
+  }
+
+  /**
+   * @deprecated This method will be removed with Scout release 25.1. Use the configuration property to change this
+   *             configuration or override method {@link #getMaxConnectionsPerRoute(Configuration)}.
+   */
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  protected int getMaxConnectionsPerRoute() {
+    return CONFIG.getPropertyValue(RestHttpTransportMaxConnectionsPerRouteProperty.class);
   }
 
   /**
    * Max number of concurrent connections per route managed by the {@link HttpClientConnectionManager} returned by
-   * {@link #createConnectionManager(Client, Configuration, SSLContext)}. Default is 32.
+   * {@link #createConnectionManager(Client, Configuration, SSLContext)}.
    */
-  protected int getMaxConnectionsPerRoute() {
-    return 32;
+  protected int getMaxConnectionsPerRoute(Configuration config) {
+    return ObjectUtility.nvl(
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.MAX_CONNECTIONS_PER_ROUTE), Integer.class),
+        getMaxConnectionsPerRoute());
+  }
+
+  /**
+   * @deprecated This method will be removed with Scout release 25.1. Use the configuration property to change this
+   * configuration or override method {@link #getValidateAfterInactivityMillis(Configuration)}.
+   */
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  protected int getValidateAfterInactivityMillis() {
+    return CONFIG.getPropertyValue(RestHttpTransportValidateAfterInactivityProperty.class);
   }
 
   /**
@@ -232,8 +281,10 @@ public class ScoutApacheConnector implements Connector {
    * leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps
    * detect connections that have become stale (half-closed) while kept inactive in the pool.
    */
-  protected int getValidateAfterInactivityMillis() {
-    return 1;
+  protected int getValidateAfterInactivityMillis(Configuration config) {
+    return ObjectUtility.nvl(
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.VALIDATE_CONNECTION_AFTER_INACTIVITY), Integer.class),
+        getValidateAfterInactivityMillis());
   }
 
   /**
@@ -647,6 +698,80 @@ public class ScoutApacheConnector implements Connector {
         // (3) close response
         m_response.close();
       }
+    }
+  }
+
+  public static class RestHttpTransportConnectionKeepAliveProperty extends AbstractLongConfigProperty {
+
+    @Override
+    public Long getDefaultValue() {
+      return TimeUnit.MINUTES.toMillis(30);
+    }
+
+    @Override
+    public String description() {
+      return "Specifies the maximum life time in milliseconds for kept alive connections of the REST HTTP client. The default value is 30 minutes.";
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.connectionKeepAlive";
+    }
+  }
+
+  public static class RestHttpTransportMaxConnectionsPerRouteProperty extends AbstractIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 32;
+    }
+
+    @Override
+    public String description() {
+      return "Configuration property to define the default maximum connections per route of the Apache HTTP client. The default value is " + getDefaultValue();
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.maxConnectionsPerRoute";
+    }
+  }
+
+  public static class RestHttpTransportMaxConnectionsTotalProperty extends AbstractIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 128;
+    }
+
+    @Override
+    public String description() {
+      return "Specifies the total maximum connections of the Apache HTTP client. The default value is " + getDefaultValue();
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.maxConnectionsTotal";
+    }
+  }
+
+  public static class RestHttpTransportValidateAfterInactivityProperty extends AbstractIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 1;
+    }
+
+    @Override
+    public String description() {
+      return "Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being"
+          + " leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps"
+          + " detect connections that have become stale (half-closed) while kept inactive in the pool. The default value is " + getDefaultValue();
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.validateAfterInactivity";
     }
   }
 }

--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnectorTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnectorTest.java
@@ -15,6 +15,8 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiConsumer;
@@ -24,6 +26,7 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.net.ssl.SSLContext;
 import javax.ws.rs.RedirectionException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -38,10 +41,13 @@ import javax.ws.rs.core.Response.Status;
 
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
 import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.context.CorrelationId;
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
@@ -53,6 +59,11 @@ import org.eclipse.scout.rt.rest.jersey.ProxyServletParameters;
 import org.eclipse.scout.rt.rest.jersey.RestClientHttpProxyServlet;
 import org.eclipse.scout.rt.rest.jersey.RestClientTestEchoResponse;
 import org.eclipse.scout.rt.rest.jersey.RestClientTestEchoServlet;
+import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportConnectionKeepAliveProperty;
+import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportMaxConnectionsPerRouteProperty;
+import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportMaxConnectionsTotalProperty;
+import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportValidateAfterInactivityProperty;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientRequest;
@@ -410,6 +421,85 @@ public class ScoutApacheConnectorTest {
     assertEquals(expectedUserAgent, entity.getReceivedHeaders().get(HttpHeaders.USER_AGENT));
 
     response.close();
+  }
+
+  @Test
+  public void testHttpTransportProperties_defaultValues() {
+    Client client = Mockito.mock(Client.class);
+    Configuration config = Mockito.mock(Configuration.class);
+    assertConnectionManager(client, config, 32, 128, 1);
+  }
+
+  @Test
+  public void testHttpTransportProperties_byConfigProperties() {
+    List<IBean<?>> beans = new ArrayList<>();
+    try {
+      beans.add(BEANS.get(BeanTestingHelper.class).mockConfigProperty(RestHttpTransportMaxConnectionsPerRouteProperty.class, 100));
+      beans.add(BEANS.get(BeanTestingHelper.class).mockConfigProperty(RestHttpTransportMaxConnectionsTotalProperty.class, 200));
+      beans.add(BEANS.get(BeanTestingHelper.class).mockConfigProperty(RestHttpTransportValidateAfterInactivityProperty.class, 300));
+      Client client = Mockito.mock(Client.class);
+      Configuration config = Mockito.mock(Configuration.class);
+      assertConnectionManager(client, config, 100, 200, 300);
+    }
+    finally {
+      beans.forEach(BeanTestingHelper.get()::unregisterBean);
+    }
+  }
+
+  @Test
+  public void testHttpTransportProperties_byClientProperties() {
+    Client client = Mockito.mock(Client.class);
+    Configuration config = Mockito.mock(Configuration.class);
+    when(config.getProperty(RestClientProperties.MAX_CONNECTIONS_PER_ROUTE)).thenReturn(100);
+    when(config.getProperty(RestClientProperties.MAX_CONNECTIONS_TOTAL)).thenReturn(200);
+    when(config.getProperty(RestClientProperties.VALIDATE_CONNECTION_AFTER_INACTIVITY)).thenReturn(300);
+    assertConnectionManager(client, config, 100, 200, 300);
+  }
+
+  protected void assertConnectionManager(Client client, Configuration config, int maxPerRoute, int maxTotal, int validateAfterInactivity) {
+    PoolingHttpClientConnectionManager[] httpClientConnectionManager = new PoolingHttpClientConnectionManager[1];
+    new ScoutApacheConnector(client, config) {
+      @Override
+      protected HttpClientConnectionManager createConnectionManager(Client client, Configuration config, SSLContext sslContext) {
+        httpClientConnectionManager[0] = (PoolingHttpClientConnectionManager) super.createConnectionManager(client, config, sslContext);
+        return httpClientConnectionManager[0];
+      }
+    };
+    assertEquals(maxTotal, httpClientConnectionManager[0].getMaxTotal());
+    assertEquals(maxPerRoute, httpClientConnectionManager[0].getDefaultMaxPerRoute());
+    assertEquals(validateAfterInactivity, httpClientConnectionManager[0].getValidateAfterInactivity());
+  }
+
+  @Test
+  public void testHttpConnectionKeepAlive_defaultValue() {
+    Client client = Mockito.mock(Client.class);
+    Configuration config = Mockito.mock(Configuration.class);
+    ScoutApacheConnector connector = new ScoutApacheConnector(client, config);
+    assertEquals(30 * 60 * 1000, connector.getKeepAliveTimeoutMillis(config));
+  }
+
+  @Test
+  public void testHttpConnectionKeepAlive_byConfigProperty() {
+    List<IBean<?>> beans = new ArrayList<>();
+    try {
+      beans.add(BEANS.get(BeanTestingHelper.class).mockConfigProperty(RestHttpTransportConnectionKeepAliveProperty.class, 100L));
+      Client client = Mockito.mock(Client.class);
+      Configuration config = Mockito.mock(Configuration.class);
+      ScoutApacheConnector connector = new ScoutApacheConnector(client, config);
+      assertEquals(100L, connector.getKeepAliveTimeoutMillis(config));
+    }
+    finally {
+      beans.forEach(BeanTestingHelper.get()::unregisterBean);
+    }
+  }
+
+  @Test
+  public void testHttpConnectionKeepAlive_byClientProperty() {
+    Client client = Mockito.mock(Client.class);
+    Configuration config = Mockito.mock(Configuration.class);
+    when(config.getProperty(RestClientProperties.CONNECTION_KEEP_ALIVE)).thenReturn(200L);
+    ScoutApacheConnector connector = new ScoutApacheConnector(client, config);
+    assertEquals(200L, connector.getKeepAliveTimeoutMillis(config));
   }
 
   protected JerseyTestRestClientHelper newHelper(BiConsumer<JerseyTestRestClientHelper, ClientBuilder> clientBuilderCustomizer) {

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
@@ -220,6 +220,52 @@ public final class RestClientProperties {
   public static final String SUPPRESS_DEFAULT_USER_AGENT = "scout.rest.client.suppressDefaultUserAgent";
 
   /**
+   * Specifies the maximum lifetime in milliseconds for kept alive connections of the REST HTTP client.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Long}.
+   * </p>
+   * <p>
+   * The default value is 30 * 60 * 1000 (e.g. 30 minutes).
+   * </p>
+   */
+  public static final String CONNECTION_KEEP_ALIVE = "scout.rest.client.http.connectionKeepAlive";
+
+  /**
+   * Specifies the default maximum connections per route of the REST HTTP client.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Integer}.
+   * </p>
+   * <p>
+   * The default value is 32.
+   * </p>
+   */
+  public static final String MAX_CONNECTIONS_PER_ROUTE = "scout.rest.client.http.maxConnectionsPerRoute";
+
+  /**
+   * Specifies the total maximum connections of the REST HTTP client
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Integer}.
+   * </p>
+   * <p>
+   * The default value is 128.
+   * </p>
+   */
+  public static final String MAX_CONNECTIONS_TOTAL = "scout.rest.client.http.maxConnectionsTotal";
+
+  /**
+   * Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being
+   * leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps
+   * detect connections that have become stale (half-closed) while kept inactive in the pool.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Integer}.
+   * </p>
+   * <p>
+   * The default value is 1 ms.
+   * </p>
+   */
+  public static final String VALIDATE_CONNECTION_AFTER_INACTIVITY = "scout.rest.client.http.validateAfterInactivity";
+
+  /**
    * Connect timeout interval, in milliseconds. This property is supported either on rest client level (e.g. for all
    * calls) or on a request level (e.g. for a single call).
    * <p>


### PR DESCRIPTION
Added config properties and REST client properties for:
- max connections in total
- max connections per route
- connection keep alive time
- connection validate after inactivity time

393566