### PR TITLE
Fix toValidFilename for malformed filenames

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/FileUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/FileUtilityTest.java
@@ -185,6 +185,13 @@ public class FileUtilityTest {
         FileUtility
             .toValidFilename(
                 "someReallyLongName01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123.doc"));
+
+    assertEquals("_.txt", FileUtility.toValidFilename("...txt"));
+    assertEquals("_.txt", FileUtility.toValidFilename("..txt"));
+    assertEquals("_.txt", FileUtility.toValidFilename(" .txt"));
+    assertEquals("_.txt", FileUtility.toValidFilename("  .txt"));
+    assertEquals("_.txt", FileUtility.toValidFilename(" _.txt"));
+
   }
 
   @Test

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/FileUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/FileUtility.java
@@ -502,15 +502,31 @@ public final class FileUtility {
       }
       s = buf.toString();
     }
+    final String[] filenameParts = getFilenameParts(s);
+    String name = filenameParts[0];
+    //remove leading dots, whitespace from name part
+    name = PAT_FILENAME_REMOVE_LEADING_CHARACTERS.matcher(name).replaceAll("$1");
+    name = PAT_FILENAME_TRIM.matcher(name).replaceAll("");
 
-    //remove leading and trailing dots, whitespace
-    s = PAT_FILENAME_REMOVE_LEADING_CHARACTERS.matcher(s).replaceAll("$1");
-    s = PAT_FILENAME_REMOVE_TRAILING_CHARACTERS.matcher(s).replaceAll("$1");
-    s = PAT_FILENAME_TRIM.matcher(s).replaceAll("");
-
-    if (s.isEmpty()) {
-      return DEFAULT_FILENAME;
+    if (name.isEmpty()) {
+      name = DEFAULT_FILENAME;
     }
+
+    String ext = filenameParts[1];
+    if (StringUtility.isNullOrEmpty(ext)) {
+      //no extension found, remove trailing dots, whitespace from name part
+      name = PAT_FILENAME_REMOVE_TRAILING_CHARACTERS.matcher(name).replaceAll("$1");
+    }
+    else {
+      //remove trailing dots, whitespace from extension
+      ext = PAT_FILENAME_REMOVE_TRAILING_CHARACTERS.matcher(ext).replaceAll("$1");
+      ext = PAT_FILENAME_TRIM.matcher(ext).replaceAll("");
+    }
+
+    filenameParts[0] = name;
+    filenameParts[1] = ext;
+    s = StringUtility.join(".", filenameParts);
+    s = PAT_FILENAME_TRIM.matcher(s).replaceAll("");
 
     // on some operating systems, the name may not be longer than 250 characters
     if (s.length() > 250) {


### PR DESCRIPTION
Filenames in the form of "...ext" were transformed to "ext", leading problems when the extension was relevant for the further use.

Solution is to keep the extension intact and only replace all but the dot right before the extension with '_'.

357297