### PR TITLE
Connection properties for REST HTTP client

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
+
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.core.Configuration;
@@ -72,11 +73,14 @@ import org.apache.hc.core5.http.io.entity.AbstractHttpEntity;
 import org.apache.hc.core5.http.io.entity.BufferedHttpEntity;
 import org.apache.hc.core5.util.TimeValue;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.config.AbstractIntegerConfigProperty;
+import org.eclipse.scout.rt.platform.config.AbstractLongConfigProperty;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.context.RunMonitor;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.platform.util.BooleanUtility;
 import org.eclipse.scout.rt.platform.util.IRegistrationHandle;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.eclipse.scout.rt.platform.util.concurrent.ICancellable;
@@ -169,22 +173,22 @@ public class ScoutApacheConnector implements Connector {
             .register("http", PlainConnectionSocketFactory.getSocketFactory())
             .register("https", sslConnectionSocketFactory)
             .build(),
-        null, null, TimeValue.ofMilliseconds(getKeepAliveTimeoutMillis()), connFactory);
+        null, null, TimeValue.ofMilliseconds(getKeepAliveTimeoutMillis(config)), connFactory);
 
     Builder connectionConfigBuilder = ConnectionConfig.custom()
-        .setTimeToLive(TimeValue.ofMilliseconds(getKeepAliveTimeoutMillis()));
+        .setTimeToLive(TimeValue.ofMilliseconds(getKeepAliveTimeoutMillis(config)));
 
-    final int validateAfterInactivityMillis = getValidateAfterInactivityMillis();
+    final int validateAfterInactivityMillis = getValidateAfterInactivityMillis(config);
     if (validateAfterInactivityMillis > 0) {
       connectionConfigBuilder.setValidateAfterInactivity(validateAfterInactivityMillis, TimeUnit.MILLISECONDS);
     }
 
-    final int maxTotal = getMaxConnectionsTotal();
+    final int maxTotal = getMaxConnectionsTotal(config);
     if (maxTotal > 0) {
       connectionManager.setMaxTotal(maxTotal);
     }
 
-    final int defaultMaxPerRoute = getMaxConnectionsPerRoute();
+    final int defaultMaxPerRoute = getMaxConnectionsPerRoute(config);
     if (defaultMaxPerRoute > 0) {
       connectionManager.setDefaultMaxPerRoute(defaultMaxPerRoute);
     }
@@ -209,26 +213,32 @@ public class ScoutApacheConnector implements Connector {
   }
 
   /**
-   * Max timeout in ms connections are kept open when idle (requires keep-alive support). Default is 30 minutes.
+   * Max timeout in ms connections are kept open when idle (requires keep-alive support).
    */
-  protected long getKeepAliveTimeoutMillis() {
-    return TimeUnit.MINUTES.toMillis(30);
+  protected long getKeepAliveTimeoutMillis(Configuration config) {
+    return ObjectUtility.nvl(
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.CONNECTION_KEEP_ALIVE), Long.class),
+        CONFIG.getPropertyValue(RestHttpTransportConnectionKeepAliveProperty.class));
   }
 
   /**
    * Max number of total concurrent connections managed by the {@link HttpClientConnectionManager} returned by
-   * {@link #createConnectionManager(Client, Configuration, SSLContext)}. Default is 128.
+   * {@link #createConnectionManager(Client, Configuration, SSLContext)}.
    */
-  protected int getMaxConnectionsTotal() {
-    return 128;
+  protected int getMaxConnectionsTotal(Configuration config) {
+    return ObjectUtility.nvl(
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.MAX_CONNECTIONS_TOTAL), Integer.class),
+        CONFIG.getPropertyValue(RestHttpTransportMaxConnectionsTotalProperty.class));
   }
 
   /**
    * Max number of concurrent connections per route managed by the {@link HttpClientConnectionManager} returned by
-   * {@link #createConnectionManager(Client, Configuration, SSLContext)}. Default is 32.
+   * {@link #createConnectionManager(Client, Configuration, SSLContext)}.
    */
-  protected int getMaxConnectionsPerRoute() {
-    return 32;
+  protected int getMaxConnectionsPerRoute(Configuration config) {
+    return ObjectUtility.nvl(
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.MAX_CONNECTIONS_PER_ROUTE), Integer.class),
+        CONFIG.getPropertyValue(RestHttpTransportMaxConnectionsPerRouteProperty.class));
   }
 
   /**
@@ -236,8 +246,10 @@ public class ScoutApacheConnector implements Connector {
    * leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps
    * detect connections that have become stale (half-closed) while kept inactive in the pool.
    */
-  protected int getValidateAfterInactivityMillis() {
-    return 1;
+  protected int getValidateAfterInactivityMillis(Configuration config) {
+    return ObjectUtility.nvl(
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.VALIDATE_CONNECTION_AFTER_INACTIVITY), Integer.class),
+        CONFIG.getPropertyValue(RestHttpTransportValidateAfterInactivityProperty.class));
   }
 
   /**
@@ -655,6 +667,80 @@ public class ScoutApacheConnector implements Connector {
         // (3) close response
         m_response.close();
       }
+    }
+  }
+
+  public static class RestHttpTransportConnectionKeepAliveProperty extends AbstractLongConfigProperty {
+
+    @Override
+    public Long getDefaultValue() {
+      return TimeUnit.MINUTES.toMillis(30);
+    }
+
+    @Override
+    public String description() {
+      return "Specifies the maximum life time in milliseconds for kept alive connections of the REST HTTP client. The default value is 30 minutes.";
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.connectionKeepAlive";
+    }
+  }
+
+  public static class RestHttpTransportMaxConnectionsPerRouteProperty extends AbstractIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 32;
+    }
+
+    @Override
+    public String description() {
+      return "Configuration property to define the default maximum connections per route of the Apache HTTP client. The default value is " + getDefaultValue();
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.maxConnectionsPerRoute";
+    }
+  }
+
+  public static class RestHttpTransportMaxConnectionsTotalProperty extends AbstractIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 128;
+    }
+
+    @Override
+    public String description() {
+      return "Specifies the total maximum connections of the Apache HTTP client. The default value is " + getDefaultValue();
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.maxConnectionsTotal";
+    }
+  }
+
+  public static class RestHttpTransportValidateAfterInactivityProperty extends AbstractIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 1;
+    }
+
+    @Override
+    public String description() {
+      return "Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being"
+          + " leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps"
+          + " detect connections that have become stale (half-closed) while kept inactive in the pool. The default value is " + getDefaultValue();
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.validateAfterInactivity";
     }
   }
 }

--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/TestingRestClientConfigFactory.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/TestingRestClientConfigFactory.java
@@ -49,12 +49,12 @@ public class TestingRestClientConfigFactory extends JerseyClientConfigFactory {
       }
 
       @Override
-      protected int getMaxConnectionsTotal() {
+      protected int getMaxConnectionsTotal(Configuration config) {
         return 1;
       }
 
       @Override
-      protected int getMaxConnectionsPerRoute() {
+      protected int getMaxConnectionsPerRoute(Configuration config) {
         return 1;
       }
     });

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
@@ -220,6 +220,52 @@ public final class RestClientProperties {
   public static final String SUPPRESS_DEFAULT_USER_AGENT = "scout.rest.client.suppressDefaultUserAgent";
 
   /**
+   * Specifies the maximum lifetime in milliseconds for kept alive connections of the REST HTTP client.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Long}.
+   * </p>
+   * <p>
+   * The default value is 30 * 60 * 1000 (e.g. 30 minutes).
+   * </p>
+   */
+  public static final String CONNECTION_KEEP_ALIVE = "scout.rest.client.http.connectionKeepAlive";
+
+  /**
+   * Specifies the default maximum connections per route of the REST HTTP client.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Integer}.
+   * </p>
+   * <p>
+   * The default value is 32.
+   * </p>
+   */
+  public static final String MAX_CONNECTIONS_PER_ROUTE = "scout.rest.client.http.maxConnectionsPerRoute";
+
+  /**
+   * Specifies the total maximum connections of the REST HTTP client
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Integer}.
+   * </p>
+   * <p>
+   * The default value is 128.
+   * </p>
+   */
+  public static final String MAX_CONNECTIONS_TOTAL = "scout.rest.client.http.maxConnectionsTotal";
+
+  /**
+   * Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being
+   * leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps
+   * detect connections that have become stale (half-closed) while kept inactive in the pool.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Integer}.
+   * </p>
+   * <p>
+   * The default value is 1 ms.
+   * </p>
+   */
+  public static final String VALIDATE_CONNECTION_AFTER_INACTIVITY = "scout.rest.client.http.validateAfterInactivity";
+
+  /**
    * Connect timeout interval, in milliseconds. This property is supported either on rest client level (e.g. for all
    * calls) or on a request level (e.g. for a single call).
    * <p>


### PR DESCRIPTION
Added config properties and REST client properties for:
- max connections in total
- max connections per route
- connection keep alive time
- connection validate after inactivity time

393566