### PR TITLE
HTTP client connection manager pools metrics

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnectorTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnectorTest.java
@@ -11,8 +11,7 @@ package org.eclipse.scout.rt.rest.jersey.client;
 
 import static org.eclipse.scout.rt.rest.jersey.EchoServletParameters.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -22,6 +21,7 @@ import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -47,6 +47,7 @@ import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
 import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.context.CorrelationId;
 import org.eclipse.scout.rt.platform.context.RunContexts;
@@ -63,6 +64,7 @@ import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTran
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportMaxConnectionsPerRouteProperty;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportMaxConnectionsTotalProperty;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportValidateAfterInactivityProperty;
+import org.eclipse.scout.rt.shared.http.HttpClientMetricsHelper;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.glassfish.jersey.client.ClientProperties;
@@ -70,7 +72,10 @@ import org.glassfish.jersey.client.ClientRequest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+
+import io.opentelemetry.api.metrics.Meter;
 
 @RunWith(PlatformTestRunner.class)
 public class ScoutApacheConnectorTest {
@@ -500,6 +505,49 @@ public class ScoutApacheConnectorTest {
     when(config.getProperty(RestClientProperties.CONNECTION_KEEP_ALIVE)).thenReturn(200L);
     ScoutApacheConnector connector = new ScoutApacheConnector(client, config);
     assertEquals(200L, connector.getKeepAliveTimeoutMillis(config));
+  }
+
+  @Test
+  public void testMetricsDisabled() {
+    Client client = Mockito.mock(Client.class);
+    Configuration config = Mockito.mock(Configuration.class);
+    when(config.getProperty(RestClientProperties.OTEL_HTTP_CLIENT_NAME)).thenReturn(null);
+    List<IBean<?>> beans = new ArrayList<>();
+    try {
+      HttpClientMetricsHelper mock = Mockito.mock(HttpClientMetricsHelper.class);
+      beans.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(HttpClientMetricsHelper.class, mock)));
+      new ScoutApacheConnector(client, config);
+      verify(mock, never()).initMetrics(any(Meter.class), any(), any(), any(), any());
+    }
+    finally {
+      beans.forEach(BeanTestingHelper.get()::unregisterBean);
+    }
+  }
+
+  @Test
+  public void testMetricsEnabled() {
+    Client client = Mockito.mock(Client.class);
+    Configuration config = Mockito.mock(Configuration.class);
+    when(config.getProperty(RestClientProperties.OTEL_HTTP_CLIENT_NAME)).thenReturn("mock-http-client-name");
+    when(config.getProperty(RestClientProperties.MAX_CONNECTIONS_TOTAL)).thenReturn(123);
+
+    List<IBean<?>> beans = new ArrayList<>();
+    try {
+      HttpClientMetricsHelper mock = Mockito.mock(HttpClientMetricsHelper.class);
+      @SuppressWarnings("unchecked") ArgumentCaptor<Supplier<Integer>> idleCaptor = ArgumentCaptor.forClass(Supplier.class);
+      @SuppressWarnings("unchecked") ArgumentCaptor<Supplier<Integer>> activeCaptor = ArgumentCaptor.forClass(Supplier.class);
+      @SuppressWarnings("unchecked") ArgumentCaptor<Supplier<Integer>> maxCaptor = ArgumentCaptor.forClass(Supplier.class);
+      beans.add(BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(HttpClientMetricsHelper.class, mock)));
+      new ScoutApacheConnector(client, config);
+
+      verify(mock, only()).initMetrics(any(Meter.class), eq("mock-http-client-name"), idleCaptor.capture(), activeCaptor.capture(), maxCaptor.capture());
+      assertEquals(Integer.valueOf(0), idleCaptor.getValue().get());
+      assertEquals(Integer.valueOf(0), activeCaptor.getValue().get());
+      assertEquals(Integer.valueOf(123), maxCaptor.getValue().get());
+    }
+    finally {
+      beans.forEach(BeanTestingHelper.get()::unregisterBean);
+    }
   }
 
   protected JerseyTestRestClientHelper newHelper(BiConsumer<JerseyTestRestClientHelper, ClientBuilder> clientBuilderCustomizer) {

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/AbstractRestClientHelper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/AbstractRestClientHelper.java
@@ -123,6 +123,13 @@ public abstract class AbstractRestClientHelper implements IRestClientHelper {
     configureClientBuilder(clientBuilder);
   }
 
+  /**
+   * Enables OpenTelemetry metrics for this HTTP client using given {@code httpClientName}.
+   */
+  protected void enableMetrics(ClientBuilder clientBuilder, String httpClientName) {
+    clientBuilder.property(RestClientProperties.OTEL_HTTP_CLIENT_NAME, httpClientName);
+  }
+
   protected void registerContextResolvers(ClientBuilder clientBuilder) {
     // Context resolver, e.g. resolver for ObjectMapper
     for (ContextResolver resolver : validateContextResolvers(getContextResolversToRegister())) {

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
@@ -266,6 +266,17 @@ public final class RestClientProperties {
   public static final String VALIDATE_CONNECTION_AFTER_INACTIVITY = "scout.rest.client.http.validateAfterInactivity";
 
   /**
+   * Activates OpenTelemetry metrics for HTTP client connection pool using property value as HTTP client name.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.String}.
+   * </p>
+   * <p>
+   * The default value is {@code null} (deactivated).
+   * </p>
+   */
+  public static final String OTEL_HTTP_CLIENT_NAME = "scout.rest.client.http.otel.name";
+
+  /**
    * Connect timeout interval, in milliseconds. This property is supported either on rest client level (e.g. for all
    * calls) or on a request level (e.g. for a single call).
    * <p>

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/commons/http/TestingHttpClient.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/commons/http/TestingHttpClient.java
@@ -28,6 +28,7 @@ import org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory;
 import org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory.ApacheHttpTransportBuilder;
 import org.eclipse.scout.rt.shared.http.DefaultHttpTransportManager;
 import org.eclipse.scout.rt.shared.http.IHttpTransportBuilder;
+import org.eclipse.scout.rt.shared.http.IHttpTransportManager;
 
 import com.google.api.client.http.HttpTransport;
 
@@ -78,8 +79,8 @@ public class TestingHttpClient extends DefaultHttpTransportManager {
     }
 
     @Override
-    protected HttpClientConnectionManager createHttpClientConnectionManager() {
-      PoolingHttpClientConnectionManager connManager = (PoolingHttpClientConnectionManager) super.createHttpClientConnectionManager();
+    protected HttpClientConnectionManager createHttpClientConnectionManager(IHttpTransportManager manager) {
+      PoolingHttpClientConnectionManager connManager = (PoolingHttpClientConnectionManager) super.createHttpClientConnectionManager(manager);
       connManager.setDefaultConnectionConfig(
           ConnectionConfig
               .custom()

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTest.java
@@ -19,7 +19,6 @@ import java.io.OutputStream;
 import org.eclipse.scout.rt.platform.serialization.SerializationUtility;
 import org.eclipse.scout.rt.shared.SharedConfigProperties.ServiceTunnelTargetUrlProperty;
 import org.eclipse.scout.rt.shared.http.AbstractHttpTransportManager;
-import org.eclipse.scout.rt.shared.http.IHttpTransportBuilder;
 import org.eclipse.scout.rt.shared.http.IHttpTransportManager;
 import org.eclipse.scout.rt.shared.servicetunnel.IServiceTunnelContentHandler;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
@@ -86,6 +85,11 @@ public class HttpServiceTunnelTest {
               .build();
 
           @Override
+          public String getName() {
+            return "scout.transport.test-service-tunnel";
+          }
+
+          @Override
           public HttpTransport getHttpTransport() {
             return m_transport;
           }
@@ -94,12 +98,6 @@ public class HttpServiceTunnelTest {
           public HttpRequestFactory getHttpRequestFactory() {
             return m_transport.createRequestFactory(createHttpRequestInitializer());
           }
-
-          @Override
-          public void interceptNewHttpTransport(IHttpTransportBuilder builder) {
-            // nop
-          }
-
         };
       }
     };

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/ApacheHttpTransportFactory.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/ApacheHttpTransportFactory.java
@@ -45,6 +45,9 @@ import org.eclipse.scout.rt.shared.servicetunnel.http.MultiSessionCookieStore;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+
 /**
  * Factory to create the {@link ApacheHttpTransport} instances.
  */
@@ -59,7 +62,7 @@ public class ApacheHttpTransportFactory implements IHttpTransportFactory {
 
     setConnectionKeepAliveAndRetrySettings(builder);
 
-    HttpClientConnectionManager cm = createHttpClientConnectionManager();
+    HttpClientConnectionManager cm = createHttpClientConnectionManager(manager);
     if (cm != null) {
       builder.setConnectionManager(cm);
     }
@@ -112,7 +115,7 @@ public class ApacheHttpTransportFactory implements IHttpTransportFactory {
    * {@link HttpClientBuilder}. Caution: Returning a custom connection manager overrides several properties of the
    * {@link HttpClientBuilder}.
    */
-  protected HttpClientConnectionManager createHttpClientConnectionManager() {
+  protected HttpClientConnectionManager createHttpClientConnectionManager(IHttpTransportManager manager) {
     final PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(
         RegistryBuilder.<ConnectionSocketFactory> create()
             .register("http", createPlainSocketFactory())
@@ -129,7 +132,19 @@ public class ApacheHttpTransportFactory implements IHttpTransportFactory {
     if (defaultMaxPerRoute > 0) {
       connectionManager.setDefaultMaxPerRoute(defaultMaxPerRoute);
     }
+    initMetrics(manager, connectionManager);
     return connectionManager;
+  }
+
+  /**
+   * Initializes metrics for this connection manager.
+   */
+  protected void initMetrics(IHttpTransportManager manager, PoolingHttpClientConnectionManager connectionManager) {
+    Meter meter = GlobalOpenTelemetry.get().getMeter(getClass().getName());
+    BEANS.get(HttpClientMetricsHelper.class).initMetrics(meter, manager.getName(),
+        connectionManager.getTotalStats()::getAvailable,
+        connectionManager.getTotalStats()::getLeased,
+        connectionManager.getTotalStats()::getMax);
   }
 
   protected SSLConnectionSocketFactory createSSLConnectionSocketFactory() {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/BasicAuthHttpTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/BasicAuthHttpTransportManager.java
@@ -16,8 +16,14 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
 
 public class BasicAuthHttpTransportManager extends AbstractHttpTransportManager {
+
   private String m_user;
   private String m_password;
+
+  @Override
+  public String getName() {
+    return "scout.transport.basic-auth";
+  }
 
   public BasicAuthHttpTransportManager withUser(String user) {
     m_user = user;

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/DefaultHttpTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/DefaultHttpTransportManager.java
@@ -10,4 +10,9 @@
 package org.eclipse.scout.rt.shared.http;
 
 public class DefaultHttpTransportManager extends AbstractHttpTransportManager {
+
+  @Override
+  public String getName() {
+    return "scout.transport.default";
+  }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/HttpClientMetricsHelper.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/HttpClientMetricsHelper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) BSI Business Systems Integration AG. All rights reserved.
+ * http://www.bsiag.com/
+ */
+package org.eclipse.scout.rt.shared.http;
+
+import java.util.function.Supplier;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+
+/**
+ * Helper to provide metrics for Scout's HTTP clients.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md#metric-httpclientopen_connections">
+ * OpenTelemetry: Semantic Conventions for HTTP Metrics</a>
+ */
+@ApplicationScoped
+public class HttpClientMetricsHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpClientMetricsHelper.class);
+
+  protected static final AttributeKey<String> HTTP_CLIENT_NAME = AttributeKey.stringKey("http.client.name");
+  protected static final AttributeKey<String> HTTP_CONNECTION_STATE = AttributeKey.stringKey("state");
+
+  public void initMetrics(Meter meter, String httpClientName, Supplier<Integer> idleConnectionCount, Supplier<Integer> activeConnectionCount, Supplier<Integer> maxConnectionCount) {
+    Assertions.assertNotNullOrEmpty(httpClientName, "HTTP client name not specified. A Java process can use multiple HTTP connection providers (pools). To distinguish them in such situations, a unique HTTP client name is required.");
+    LOG.info("Init HTTP client connection pool '{}'", httpClientName);
+
+    ObservableLongMeasurement connectionsUsage = meter.upDownCounterBuilder("http.client.open_connections")
+        .setDescription("Number of outbound HTTP connections that are currently active or idle on the client.")
+        .setUnit("{connection}")
+        .buildObserver();
+    ObservableLongMeasurement maxConnections = meter.upDownCounterBuilder("http.client.connections.max")
+        .setDescription("The maximum number of allowed outbound HTTP connections.")
+        .setUnit("{connection}")
+        .buildObserver();
+
+    Attributes defaultAttributes = Attributes.of(HTTP_CLIENT_NAME, httpClientName);
+    Attributes activeConnectionsAttributes = defaultAttributes.toBuilder().put(HTTP_CONNECTION_STATE, "active").build();
+    Attributes idleConnectionsAttributes = defaultAttributes.toBuilder().put(HTTP_CONNECTION_STATE, "idle").build();
+
+    //noinspection resource
+    meter.batchCallback(() -> {
+          connectionsUsage.record(activeConnectionCount.get(), activeConnectionsAttributes);
+          connectionsUsage.record(idleConnectionCount.get(), idleConnectionsAttributes);
+          maxConnections.record(maxConnectionCount.get(), defaultAttributes);
+        },
+        connectionsUsage,
+        maxConnections);
+  }
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/IHttpTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/IHttpTransportManager.java
@@ -21,6 +21,15 @@ import com.google.api.client.http.HttpTransport;
 public interface IHttpTransportManager {
 
   /**
+   * TODO 25.1 pbz Change this method to non-default
+   *
+   * @return Technical transport manager name used for metrics.
+   */
+  default String getName() {
+    return "scout.transport.default";
+  }
+
+  /**
    * Get the {@link HttpTransport} instance. This method may create new instances or return a previously created one.
    */
   HttpTransport getHttpTransport();

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTransportManager.java
@@ -24,6 +24,11 @@ import org.eclipse.scout.rt.shared.servicetunnel.http.HttpServiceTunnelConfigura
 public class HttpServiceTunnelTransportManager extends AbstractHttpTransportManager {
 
   @Override
+  public String getName() {
+    return "scout.transport.service-tunnel";
+  }
+
+  @Override
   public void interceptNewHttpTransport(IHttpTransportBuilder builder0) {
     super.interceptNewHttpTransport(builder0);
 


### PR DESCRIPTION
Add OpenTelemetry metrics for HTTP client connection pool:
- active/idle connections
- max connections

Co-authored-by: Bruno Koeferli <bruno.koeferli@bsiag.com>

393561