### PR TITLE
Calendar: don't apply selection twice when clicking on component

### DIFF
--- a/eclipse-scout-core/src/calendar/CalendarComponent.ts
+++ b/eclipse-scout-core/src/calendar/CalendarComponent.ts
@@ -149,7 +149,7 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
         .data('partDay', partDay)
         .on('mouseenter', this._onMouseEnter.bind(this))
         .on('mouseleave', this._onMouseLeave.bind(this))
-        .on('mouseup', this._onMouseUp.bind(this))
+        .on('mousedown', this._onMouseDown.bind(this))
         .on('contextmenu', this._onContextMenu.bind(this));
       $part.appendDiv('calendar-component-leftcolorborder');
       let $partContent = $part.appendDiv('content');
@@ -321,7 +321,7 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
     this._$parts.forEach($part => $part.removeClass('hover'));
   }
 
-  protected _onMouseUp(event: JQuery.MouseUpEvent) {
+  protected _onMouseDown(event: JQuery.MouseDownEvent) {
     // don't show popup if dragging is in process
     if (this.parent._moveData && this.parent._moveData.moving) {
       return;


### PR DESCRIPTION
When a click happened on a calendar component, two event listeners have changed the calendar selection. Only one selection change is necessary. Both listeners handle now the MouseDown Event and the calendar is ignoring the click when it happens on a component, only the component is changing the selection.

394064