### PR TITLE
Calendar: don't apply selection twice when clicking on component

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -702,6 +702,12 @@ export class Calendar extends Widget implements CalendarModel {
   protected _onDayMouseDown(withTime: boolean, event: JQuery.MouseDownEvent) {
     let selectedDate = new Date($(event.delegateTarget).data('date')),
       timeChanged = false;
+
+    // Do not apply selection when clicked on calendar component
+    if ($(event.target).closest('.calendar-component').length > 0) {
+      return;
+    }
+
     if (withTime && (this.isDay() || this.isWeek() || this.isWorkWeek())) {
       let seconds = this._getSelectedSeconds(event);
       if (seconds < 60 * 60 * 24) {

--- a/eclipse-scout-core/src/calendar/CalendarComponent.ts
+++ b/eclipse-scout-core/src/calendar/CalendarComponent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -130,7 +130,7 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
         .addClass(this.item.cssClass)
         .data('component', this)
         .data('partDay', partDay)
-        .on('mouseup', this._onMouseUp.bind(this))
+        .on('mousedown', this._onMouseDown.bind(this))
         .on('contextmenu', this._onContextMenu.bind(this));
       $part.appendDiv('calendar-component-leftcolorborder');
       let $partContent = $part.appendDiv('content');
@@ -275,7 +275,7 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
     this.parent._selectedComponentChanged(this, $part.data('partDay') as Date, updateScrollPosition);
   }
 
-  protected _onMouseUp(event: JQuery.MouseUpEvent) {
+  protected _onMouseDown(event: JQuery.MouseDownEvent) {
     // don't show popup if dragging is in process
     if (this.parent._moveData && this.parent._moveData.moving) {
       return;


### PR DESCRIPTION
When a click happened on a calendar component, two event listeners have changed the calendar selection. Only one selection change is necessary. Both listeners handle now the MouseDown Event and the calendar is ignoring the click when it happens on a component, only the component is changing the selection.

394064