### PR TITLE
Permission cache: invalidate on logout only if triggered by HTTP request

### DIFF
--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/security/LogoutService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/security/LogoutService.java
@@ -24,10 +24,12 @@ public class LogoutService implements ILogoutService {
 
   @Override
   public void logout() {
-    BEANS.get(IAccessControlService.class).clearCacheOfCurrentUser();
-
     HttpServletRequest httpRequest = IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST.get();
     if (httpRequest != null) {
+      // clear permission cache only if logout is triggered by an external HTTP request (explicitly not when triggered
+      // by HTTP session invalidation)
+      BEANS.get(IAccessControlService.class).clearCacheOfCurrentUser();
+
       try {
         HttpSession session = httpRequest.getSession(false);
         if (session != null) {


### PR DESCRIPTION
The HTTP session timeout of the backend server is small compared to
the lifetime of the HTTP session on the UI server (default 5 minutes).
Whenever a backend session is invalidated due to inactivity, the
permissions of the affected user are also removed from the
AccessControlCache. This leads to a client notification and now also to
a UI notification. The UI server removes the user from its cache and the
web browser reloads the permissions. Both although the user is still
logged in and his permissions did not change.

It is correct that the AccessControlCache is invalidated in the event of
a dedicated logout by the user.

It is also desirable that a session timeout on the UI server leads to a
complete logout on the backend server, including invalidation of the
AccessControlCache.

394781