### PR TITLE
Calendar: incorrect scroll shadow

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.less
+++ b/eclipse-scout-core/src/calendar/Calendar.less
@@ -520,6 +520,7 @@
 
 .calendar-day {
   padding: 0;
+  height: 100%;
 
   &:not(.calendar-no-label)::before {
     position: absolute;

--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -466,7 +466,6 @@ export class Calendar extends Widget implements CalendarModel {
     let dayContextMenuCallback = this._onDayContextMenu.bind(this);
     for (let dayBottom = 0; dayBottom < 7; dayBottom++) {
       $weekTopGridDays.appendDiv('calendar-day')
-        .addClass('calendar-scrollable-components')
         .data('day', dayBottom)
         .on('contextmenu', dayContextMenuCallback);
     }
@@ -527,7 +526,8 @@ export class Calendar extends Widget implements CalendarModel {
     $dayName.appendDiv('resource-column')
       .data('resourceId', this.defaultResource.resourceId);
     $fullDay.appendDiv('resource-column')
-      .data('resourceId', this.defaultResource.resourceId);
+      .data('resourceId', this.defaultResource.resourceId)
+      .addClass('calendar-scrollable-components');
     $day.appendDiv('resource-column')
       .data('resourceId', this.defaultResource.resourceId);
 
@@ -537,7 +537,8 @@ export class Calendar extends Widget implements CalendarModel {
         .data('resourceId', resources.resourceId)
         .attr('data-resource-name', resources.name);
       $fullDay.appendDiv('resource-column')
-        .data('resourceId', resources.resourceId);
+        .data('resourceId', resources.resourceId)
+        .addClass('calendar-scrollable-components');
       $day.appendDiv('resource-column')
         .data('resourceId', resources.resourceId);
     });
@@ -1234,7 +1235,7 @@ export class Calendar extends Widget implements CalendarModel {
   }
 
   protected _updateScrollbars($parent: JQuery, animate: boolean) {
-    let $scrollables = $('.calendar-scrollable-components > .resource-column', $parent);
+    let $scrollables = $('.calendar-scrollable-components', $parent);
     $scrollables.each((i, elem) => {
       scrollbars.update($(elem), true);
     });
@@ -1243,7 +1244,7 @@ export class Calendar extends Widget implements CalendarModel {
   }
 
   protected _uninstallComponentScrollbars($parent: JQuery) {
-    $parent.find('.calendar-scrollable-components > .resource-column').each((i, elem) => {
+    $parent.find('.calendar-scrollable-components').each((i, elem) => {
       scrollbars.uninstall($(elem), this.session);
     });
   }
@@ -1316,13 +1317,11 @@ export class Calendar extends Widget implements CalendarModel {
   }
 
   protected _calculateFullDayIndexKey(component: CalendarComponent, date: Date): string {
-    let resourceId = this.defaultResource.resourceId;
-
-    if (component) {
-      resourceId = component.getResourceId();
+    let prefix = '';
+    if (this.isDay()) {
+      prefix = component.getResourceId();
     }
-
-    return resourceId + strings.asString(date.valueOf());
+    return prefix + date.valueOf();
   }
 
   layoutYearPanel() {
@@ -1492,6 +1491,7 @@ export class Calendar extends Widget implements CalendarModel {
   protected override _remove() {
     this._uninstallComponentScrollbars(this.$grid);
     this._uninstallComponentScrollbars(this.$topGrid);
+    scrollbars.uninstall(this.$list, this.session);
 
     this.$window
       .off('mousemove touchmove', this._mouseMoveHandler)
@@ -1698,7 +1698,7 @@ export class Calendar extends Widget implements CalendarModel {
         session: this.session,
         axis: 'y'
       });
-      this.$topGrid.find('.calendar-scrollable-components > .resource-column')
+      this.$topGrid.find('.calendar-scrollable-components')
         .each((i, elem) => {
           let $topDay = $(elem);
           if ($topDay.data('scrollable')) {

--- a/eclipse-scout-core/test/calendar/CalendarSpec.ts
+++ b/eclipse-scout-core/test/calendar/CalendarSpec.ts
@@ -761,9 +761,10 @@ describe('Calendar', () => {
       let businessResources = createCalendarResource('Business calendar');
       let externalResources = createCalendarResource('External calendar', true, false);
       let calendar = initCalendar(businessResources, externalResources);
+      calendar.setDisplayMode(Calendar.DisplayMode.DAY);
 
       let businessComp = createCalendarComponent(calendar, stringDay, stringDay, businessResources.resourceId, true);
-      let secondBusniessComp = createCalendarComponent(calendar, stringDay, stringDay, businessResources.resourceId, true);
+      let secondBusinessComp = createCalendarComponent(calendar, stringDay, stringDay, businessResources.resourceId, true);
       let externalComp = createCalendarComponent(calendar, stringDay, stringDay, externalResources.resourceId, true);
 
       // Act
@@ -771,8 +772,28 @@ describe('Calendar', () => {
 
       // Assert
       expect(businessComp.fullDayIndex).toBe(0);
-      expect(secondBusniessComp.fullDayIndex).toBe(1);
+      expect(secondBusinessComp.fullDayIndex).toBe(1);
       expect(externalComp.fullDayIndex).toBe(0);
+    });
+
+    it('should correctly update full day indices on week', () => {
+      // Arrange
+      let businessResources = createCalendarResource('Business calendar');
+      let externalResources = createCalendarResource('External calendar', true, false);
+      let calendar = initCalendar(businessResources, externalResources);
+      calendar.setDisplayMode(Calendar.DisplayMode.WEEK);
+
+      let businessComp = createCalendarComponent(calendar, stringDay, stringDay, businessResources.resourceId, true);
+      let secondBusinessComp = createCalendarComponent(calendar, stringDay, stringDay, businessResources.resourceId, true);
+      let externalComp = createCalendarComponent(calendar, stringDay, stringDay, externalResources.resourceId, true);
+
+      // Act
+      calendar._updateFullDayIndices(calendar.components);
+
+      // Assert
+      expect(businessComp.fullDayIndex).toBe(0);
+      expect(secondBusinessComp.fullDayIndex).toBe(1);
+      expect(externalComp.fullDayIndex).toBe(2);
     });
 
     describe('resource panel visible', () => {
@@ -845,10 +866,10 @@ describe('Calendar', () => {
       calendar.setDisplayMode(Calendar.DisplayMode.DAY);
 
       // Act
-      let currentComponenteResourceId = getCurrentResourceIdFor(component);
+      let currentComponentResourceId = getCurrentResourceIdFor(component);
 
       // Assert
-      expect(currentComponenteResourceId).toBe(unnamedResource.resourceId);
+      expect(currentComponentResourceId).toBe(unnamedResource.resourceId);
     });
 
     describe('range selection on resources', () => {


### PR DESCRIPTION
The css query selecting the divs to update was too explicit. Therefore, the scroll shadows were not updated when in month view.

394666