### PR TITLE
UI notification should only be sent once in a cluster

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/ICacheInvalidationListener.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/ICacheInvalidationListener.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.cache;
+
+/**
+ * Listener interface to be notified when {@link ICache#invalidate(ICacheEntryFilter, boolean)} has been called.
+ */
+public interface ICacheInvalidationListener<K, V> {
+
+  /**
+   * Called when {@link ICache#invalidate(ICacheEntryFilter, boolean)} has been called.
+   *
+   * @param filter
+   *          The {@link ICacheEntryFilter} which was used in the invalidation. May be {@code null} (which means nothing
+   *          was invalidated).
+   * @param propagate
+   *          {@code true} indicates that the event occurred on this node and will be forwarded to other cluster nodes,
+   *          {@code false} indicates that the event occurred on another node and was propagated to the current node
+   *          through the cluster.
+   */
+  void invalidated(ICacheEntryFilter<K, V> filter, boolean propagate);
+}

--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/AbstractAccessControlService.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/AbstractAccessControlService.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,6 +30,7 @@ import org.eclipse.scout.rt.platform.cache.AllCacheEntryFilter;
 import org.eclipse.scout.rt.platform.cache.ICache;
 import org.eclipse.scout.rt.platform.cache.ICacheBuilder;
 import org.eclipse.scout.rt.platform.cache.ICacheEntryFilter;
+import org.eclipse.scout.rt.platform.cache.ICacheInvalidationListener;
 import org.eclipse.scout.rt.platform.cache.ICacheValueResolver;
 import org.eclipse.scout.rt.platform.cache.KeyCacheEntryFilter;
 import org.eclipse.scout.rt.platform.context.RunContext;
@@ -61,7 +61,7 @@ public abstract class AbstractAccessControlService<K> implements IAccessControlS
 
   private volatile Pattern[] m_userIdSearchPatterns;
   private volatile ICache<K, IPermissionCollection> m_cache;
-  private volatile IFastListenerList<Consumer<ICacheEntryFilter<Object, IPermissionCollection>>> m_invalidationListeners;
+  private volatile IFastListenerList<ICacheInvalidationListener<Object, IPermissionCollection>> m_invalidationListeners;
 
   public AbstractAccessControlService() {
     m_userIdSearchPatterns = new Pattern[]{
@@ -136,26 +136,26 @@ public abstract class AbstractAccessControlService<K> implements IAccessControlS
     @Override
     public void invalidate(ICacheEntryFilter<Object, IPermissionCollection> filter, boolean propagate) {
       super.invalidate(filter, propagate);
-      BEANS.get(IAccessControlService.class).getInvalidationListeners().forEach(l -> l.accept(filter));
+      BEANS.get(IAccessControlService.class).getInvalidationListeners().forEach(l -> l.invalidated(filter, propagate));
     }
   }
 
   @Override
-  public void addInvalidationListener(Consumer<ICacheEntryFilter<Object, IPermissionCollection>> listener) {
+  public void addInvalidationListener(ICacheInvalidationListener<Object, IPermissionCollection> listener) {
     if (listener != null) {
       m_invalidationListeners.add(listener);
     }
   }
 
   @Override
-  public void removeInvalidationListener(Consumer<ICacheEntryFilter<Object, IPermissionCollection>> listener) {
+  public void removeInvalidationListener(ICacheInvalidationListener<Object, IPermissionCollection> listener) {
     if (listener != null) {
       m_invalidationListeners.remove(listener);
     }
   }
 
   @Override
-  public List<Consumer<ICacheEntryFilter<Object, IPermissionCollection>>> getInvalidationListeners() {
+  public List<ICacheInvalidationListener<Object, IPermissionCollection>> getInvalidationListeners() {
     return m_invalidationListeners.list();
   }
 

--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/IAccessControlService.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/IAccessControlService.java
@@ -10,12 +10,12 @@
 package org.eclipse.scout.rt.security;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 import javax.security.auth.Subject;
 
 import org.eclipse.scout.rt.platform.cache.ICache;
 import org.eclipse.scout.rt.platform.cache.ICacheEntryFilter;
+import org.eclipse.scout.rt.platform.cache.ICacheInvalidationListener;
 import org.eclipse.scout.rt.platform.service.IService;
 
 /**
@@ -62,21 +62,21 @@ public interface IAccessControlService extends IService {
    *          The listener to add. The {@link ICacheEntryFilter} given to the listener is the filter passed to
    *          {@link ICache#invalidate(ICacheEntryFilter, boolean)}.
    */
-  void addInvalidationListener(Consumer<ICacheEntryFilter<Object, IPermissionCollection>> listener);
+  void addInvalidationListener(ICacheInvalidationListener<Object, IPermissionCollection> listener);
 
   /**
    * Removes the given listener.
    */
-  void removeInvalidationListener(Consumer<ICacheEntryFilter<Object, IPermissionCollection>> listener);
+  void removeInvalidationListener(ICacheInvalidationListener<Object, IPermissionCollection> listener);
 
   /**
    * @return All registered invalidation listeners.
    */
-  List<Consumer<ICacheEntryFilter<Object, IPermissionCollection>>> getInvalidationListeners();
+  List<ICacheInvalidationListener<Object, IPermissionCollection>> getInvalidationListeners();
 
   /**
    * @param cacheKey
-   *     A cacheKey used by the internal cache of this service.
+   *          A cacheKey used by the internal cache of this service.
    * @return The userId (username) of the given cacheKey.
    */
   String getUserIdForCacheKey(Object cacheKey);

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/notification/INotificationHandler.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/notification/INotificationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,19 +12,19 @@ package org.eclipse.scout.rt.shared.notification;
 import java.io.Serializable;
 
 import org.eclipse.scout.rt.platform.ApplicationScoped;
-import org.eclipse.scout.rt.platform.BEANS;
 
 /**
- * Notification handler for notifications of a given type. A registration of an {@link INotificationHandler} is not
- * needed. All handlers will be picked up using the {@link BEANS#all(INotificationHandler)}.
+ * Notification handler for notifications of a given type. A registration of an
+ * {@link org.eclipse.scout.rt.shared.notification.INotificationHandler} is not needed. All handlers will be picked up
+ * using the {@link org.eclipse.scout.rt.platform.BEANS#all(Class)}.
  * <h3>Client notifications</h3> A client notification addressed to users, sessions (also all sessions and all users)
  * will be executed in a client run context having the corresponding client session on the thread context. A
  * notification addressed to one or many nodes (nodeId) will be executed in a empty run context with no access to a
  * certain session.
  *
- * @param T
+ * @param <T>
  *          the type of the notification
- * @see NotificationHandlerRegistry
+ * @see org.eclipse.scout.rt.shared.notification.NotificationHandlerRegistry
  */
 @FunctionalInterface
 @ApplicationScoped
@@ -32,8 +32,6 @@ public interface INotificationHandler<T extends Serializable> {
 
   /**
    * Handle notifications of type T
-   *
-   * @param notification
    */
   void handleNotification(T notification);
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/ICodeService.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/ICodeService.java
@@ -13,9 +13,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import org.eclipse.scout.rt.platform.cache.ICacheEntryFilter;
+import org.eclipse.scout.rt.platform.cache.ICacheInvalidationListener;
 import org.eclipse.scout.rt.platform.service.IService;
 
 public interface ICodeService extends IService {
@@ -72,17 +72,17 @@ public interface ICodeService extends IService {
    *          The listener to add. All entries in the cache which accept the given {@link ICacheEntryFilter} have been
    *          invalidated.
    */
-  void addInvalidationListener(Consumer<ICacheEntryFilter<CodeTypeCacheKey, ICodeType<?, ?>>> listener);
+  void addInvalidationListener(ICacheInvalidationListener<CodeTypeCacheKey, ICodeType<?, ?>> listener);
 
   /**
    * Removes the given listener.
    */
-  void removeInvalidationListener(Consumer<ICacheEntryFilter<CodeTypeCacheKey, ICodeType<?, ?>>> listener);
+  void removeInvalidationListener(ICacheInvalidationListener<CodeTypeCacheKey, ICodeType<?, ?>> listener);
 
   /**
    * @return All registered invalidation listeners.
    */
-  List<Consumer<ICacheEntryFilter<CodeTypeCacheKey, ICodeType<?, ?>>>> getInvalidationListeners();
+  List<ICacheInvalidationListener<CodeTypeCacheKey, ICodeType<?, ?>>> getInvalidationListeners();
 
   /**
    * @return all code type classes


### PR DESCRIPTION
In a cluster environment the UI notification for an event should only be sent to the browser once. This is done on the primary cluster node (the one the invalidation starts) for all clients in all cluster nodes. Therefore, invalidation events coming from a cluster sync can be ignored on secondary nodes.

394718