### PR TITLE
HTTP client connection manager pools metrics

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
@@ -86,6 +86,7 @@ import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.eclipse.scout.rt.platform.util.concurrent.ICancellable;
 import org.eclipse.scout.rt.rest.IRestHttpRequestUriEncoder;
 import org.eclipse.scout.rt.rest.client.RestClientProperties;
+import org.eclipse.scout.rt.shared.http.HttpClientMetricsHelper;
 import org.eclipse.scout.rt.shared.http.proxy.ConfigurableProxySelector;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientRequest;
@@ -98,6 +99,9 @@ import org.glassfish.jersey.message.internal.ReaderWriter;
 import org.glassfish.jersey.message.internal.Statuses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
 
 /**
  * A {@link Connector} that utilizes the Apache HTTP Client to send and receive HTTP request and responses.
@@ -194,7 +198,20 @@ public class ScoutApacheConnector implements Connector {
     }
 
     connectionManager.setDefaultConnectionConfig(connectionConfigBuilder.build());
+    initMetrics(config, connectionManager);
     return connectionManager;
+  }
+
+  /**
+   * Initializes metrics for this HTTP connection manager (if configured by setting a value for
+   * {@link RestClientProperties#OTEL_HTTP_CLIENT_NAME}).
+   */
+  protected void initMetrics(Configuration config, PoolingHttpClientConnectionManager connectionManager) {
+    Object httpClientName = config.getProperty(RestClientProperties.OTEL_HTTP_CLIENT_NAME);
+    if (httpClientName instanceof String) {
+      Meter meter = GlobalOpenTelemetry.get().getMeter(getClass().getName());
+      BEANS.get(HttpClientMetricsHelper.class).initMetrics(meter, (String) httpClientName, connectionManager::getTotalStats);
+    }
   }
 
   /**

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/AbstractRestClientHelper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/AbstractRestClientHelper.java
@@ -125,6 +125,13 @@ public abstract class AbstractRestClientHelper implements IRestClientHelper {
     configureClientBuilder(clientBuilder);
   }
 
+  /**
+   * Enables OpenTelemetry metrics for this HTTP client using given {@code httpClientName}.
+   */
+  protected void enableMetrics(ClientBuilder clientBuilder, String httpClientName) {
+    clientBuilder.property(RestClientProperties.OTEL_HTTP_CLIENT_NAME, httpClientName);
+  }
+
   protected void registerContextResolvers(ClientBuilder clientBuilder) {
     // Context resolver, e.g. resolver for ObjectMapper
     for (ContextResolver resolver : validateContextResolvers(getContextResolversToRegister())) {

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
@@ -266,6 +266,17 @@ public final class RestClientProperties {
   public static final String VALIDATE_CONNECTION_AFTER_INACTIVITY = "scout.rest.client.http.validateAfterInactivity";
 
   /**
+   * Activates OpenTelemetry metrics for HTTP client connection pool using property value as HTTP client name.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.String}.
+   * </p>
+   * <p>
+   * The default value is {@code null} (deactivated).
+   * </p>
+   */
+  public static final String OTEL_HTTP_CLIENT_NAME = "scout.rest.client.http.otel.name";
+
+  /**
    * Connect timeout interval, in milliseconds. This property is supported either on rest client level (e.g. for all
    * calls) or on a request level (e.g. for a single call).
    * <p>

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/http/AbstractHttpClientMetricsTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/http/AbstractHttpClientMetricsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.function.Supplier;
+
+import org.apache.hc.core5.pool.ConnPoolStats;
+import org.apache.hc.core5.pool.PoolStats;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import io.opentelemetry.api.metrics.Meter;
+
+/**
+ * Abstract test case for correct metrics initialization of HTTP connection pool.
+ */
+public abstract class AbstractHttpClientMetricsTest {
+
+  protected void runTestInitMetrics(Runnable metricsInitializer, ConnPoolStats<?> connPoolStatsMock, String httpClientName) {
+    IBean<?> bean = null;
+    try {
+      HttpClientMetricsHelper mock = Mockito.mock(HttpClientMetricsHelper.class);
+      bean = BEANS.get(BeanTestingHelper.class).registerBean(new BeanMetaData(HttpClientMetricsHelper.class, mock));
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Supplier<PoolStats>> poolStatsCaptor = ArgumentCaptor.forClass(Supplier.class);
+
+      when(connPoolStatsMock.getTotalStats()).thenReturn(new PoolStats(10, 0, 20, 40));
+      metricsInitializer.run();
+
+      // verify init once and pool stats values
+      verify(mock, only()).initMetrics(any(Meter.class), eq(httpClientName), poolStatsCaptor.capture());
+      assertEquals(20, poolStatsCaptor.getValue().get().getAvailable());
+      assertEquals(10, poolStatsCaptor.getValue().get().getLeased());
+      assertEquals(40, poolStatsCaptor.getValue().get().getMax());
+
+      // verify changed pool stats values
+      when(connPoolStatsMock.getTotalStats()).thenReturn(new PoolStats(20, 0, 10, 50));
+      assertEquals(10, poolStatsCaptor.getValue().get().getAvailable());
+      assertEquals(20, poolStatsCaptor.getValue().get().getLeased());
+      assertEquals(50, poolStatsCaptor.getValue().get().getMax());
+    }
+    finally {
+      BeanTestingHelper.get().unregisterBean(bean);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/http/ApacheHttpTransportFactoryTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/http/ApacheHttpTransportFactoryTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.http;
+
+import static org.mockito.Mockito.when;
+
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test for {@link ApacheHttpTransportFactory}
+ */
+public class ApacheHttpTransportFactoryTest extends AbstractHttpClientMetricsTest {
+
+  @Test
+  public void testInitMetrics() {
+    IHttpTransportManager manager = Mockito.mock(IHttpTransportManager.class);
+    when(manager.getName()).thenReturn("mock-transport-name");
+    PoolingHttpClientConnectionManager connectionManagerMock = Mockito.mock(PoolingHttpClientConnectionManager.class);
+    ApacheHttpTransportFactory transportFactory = new ApacheHttpTransportFactory();
+    runTestInitMetrics(() -> transportFactory.initMetrics(manager, connectionManagerMock), connectionManagerMock, manager.getName());
+  }
+}
+

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManagerTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManagerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.http.async;
+
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.eclipse.scout.rt.shared.http.AbstractHttpClientMetricsTest;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test for {@link DefaultAsyncHttpClientManager}
+ */
+public class DefaultAsyncHttpClientManagerTest extends AbstractHttpClientMetricsTest {
+
+  @Test
+  public void testInitMetrics() {
+    PoolingAsyncClientConnectionManager poolingConnectionManagerMock = Mockito.mock(PoolingAsyncClientConnectionManager.class);
+    DefaultAsyncHttpClientManager asyncHttpClientManager = new DefaultAsyncHttpClientManager();
+    runTestInitMetrics(() -> asyncHttpClientManager.initMetrics(poolingConnectionManagerMock), poolingConnectionManagerMock, asyncHttpClientManager.getName());
+  }
+}

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTest.java
@@ -19,7 +19,6 @@ import java.io.OutputStream;
 import org.eclipse.scout.rt.platform.serialization.SerializationUtility;
 import org.eclipse.scout.rt.shared.SharedConfigProperties.ServiceTunnelTargetUrlProperty;
 import org.eclipse.scout.rt.shared.http.AbstractHttpTransportManager;
-import org.eclipse.scout.rt.shared.http.IHttpTransportBuilder;
 import org.eclipse.scout.rt.shared.http.IHttpTransportManager;
 import org.eclipse.scout.rt.shared.servicetunnel.IServiceTunnelContentHandler;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
@@ -86,6 +85,11 @@ public class HttpServiceTunnelTest {
               .build();
 
           @Override
+          public String getName() {
+            return "scout.transport.test-service-tunnel";
+          }
+
+          @Override
           public HttpTransport getHttpTransport() {
             return m_transport;
           }
@@ -94,12 +98,6 @@ public class HttpServiceTunnelTest {
           public HttpRequestFactory getHttpRequestFactory() {
             return m_transport.createRequestFactory(createHttpRequestInitializer());
           }
-
-          @Override
-          public void interceptNewHttpTransport(IHttpTransportBuilder builder) {
-            // nop
-          }
-
         };
       }
     };

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/ApacheHttpTransportFactory.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/ApacheHttpTransportFactory.java
@@ -19,6 +19,7 @@ import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
@@ -44,6 +45,9 @@ import org.eclipse.scout.rt.shared.http.retry.CustomHttpRequestRetryStrategy;
 import org.eclipse.scout.rt.shared.http.transport.ApacheHttpTransport;
 
 import com.google.api.client.http.HttpTransport;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
 
 /**
  * Factory to create the {@link ApacheHttpTransport} instances.
@@ -148,7 +152,17 @@ public class ApacheHttpTransportFactory implements IHttpTransportFactory {
     }
     interceptNewHttpClientConnectionManager(builder, manager);
 
-    return builder.build();
+    PoolingHttpClientConnectionManager connectionManager = builder.build();
+    initMetrics(manager, connectionManager);
+    return connectionManager;
+  }
+
+  /**
+   * Initializes metrics for this connection manager.
+   */
+  protected void initMetrics(IHttpTransportManager manager, PoolingHttpClientConnectionManager connectionManager) {
+    Meter meter = GlobalOpenTelemetry.get().getMeter(getClass().getName());
+    BEANS.get(HttpClientMetricsHelper.class).initMetrics(meter, manager.getName(), connectionManager::getTotalStats);
   }
 
   protected SSLConnectionSocketFactory createSSLConnectionSocketFactory() {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/DefaultHttpTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/DefaultHttpTransportManager.java
@@ -10,4 +10,9 @@
 package org.eclipse.scout.rt.shared.http;
 
 public class DefaultHttpTransportManager extends AbstractHttpTransportManager {
+
+  @Override
+  public String getName() {
+    return "scout.transport.default";
+  }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/HttpClientMetricsHelper.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/HttpClientMetricsHelper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) BSI Business Systems Integration AG. All rights reserved.
+ * http://www.bsiag.com/
+ */
+package org.eclipse.scout.rt.shared.http;
+
+import java.util.function.Supplier;
+
+import org.apache.hc.core5.pool.PoolStats;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+
+/**
+ * Helper to provide metrics for Scout's HTTP clients.
+ *
+ * @see <a href=
+ *      "https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md#metric-httpclientopen_connections">
+ *      OpenTelemetry: Semantic Conventions for HTTP Metrics</a>
+ */
+@ApplicationScoped
+public class HttpClientMetricsHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpClientMetricsHelper.class);
+
+  protected static final AttributeKey<String> HTTP_CLIENT_NAME = AttributeKey.stringKey("http.client.name");
+  protected static final AttributeKey<String> HTTP_CONNECTION_STATE = AttributeKey.stringKey("state");
+
+  public void initMetrics(Meter meter, String httpClientName, Supplier<PoolStats> poolStatsSupplier) {
+    Assertions.assertNotNullOrEmpty(httpClientName, "HTTP client name not specified. A Java process can use multiple HTTP connection providers (pools). To distinguish them in such situations, a unique HTTP client name is required.");
+    LOG.info("Init HTTP client connection pool '{}'", httpClientName);
+
+    ObservableLongMeasurement connectionsUsage = meter.upDownCounterBuilder("http.client.open_connections")
+        .setDescription("Number of outbound HTTP connections that are currently active or idle on the client.")
+        .setUnit("{connection}")
+        .buildObserver();
+    ObservableLongMeasurement maxConnections = meter.upDownCounterBuilder("http.client.connections.max")
+        .setDescription("The maximum number of allowed outbound HTTP connections.")
+        .setUnit("{connection}")
+        .buildObserver();
+
+    Attributes defaultAttributes = Attributes.of(HTTP_CLIENT_NAME, httpClientName);
+    Attributes activeConnectionsAttributes = defaultAttributes.toBuilder().put(HTTP_CONNECTION_STATE, "active").build();
+    Attributes idleConnectionsAttributes = defaultAttributes.toBuilder().put(HTTP_CONNECTION_STATE, "idle").build();
+
+    //noinspection resource
+    meter.batchCallback(() -> {
+      PoolStats stats = poolStatsSupplier.get();
+      connectionsUsage.record(stats.getLeased(), activeConnectionsAttributes);
+      connectionsUsage.record(stats.getAvailable(), idleConnectionsAttributes);
+      maxConnections.record(stats.getMax(), defaultAttributes);
+    },
+        connectionsUsage,
+        maxConnections);
+  }
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/IHttpTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/IHttpTransportManager.java
@@ -21,6 +21,11 @@ import com.google.api.client.http.HttpTransport;
 public interface IHttpTransportManager {
 
   /**
+   * @return Technical transport manager name used for metrics.
+   */
+  String getName();
+
+  /**
    * Get the {@link HttpTransport} instance. This method may create new instances or return a previously created one.
    */
   HttpTransport getHttpTransport();

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
@@ -29,6 +29,7 @@ import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.util.BooleanUtility;
 import org.eclipse.scout.rt.platform.util.NumberUtility;
 import org.eclipse.scout.rt.shared.http.ApacheMultiSessionCookieStore;
+import org.eclipse.scout.rt.shared.http.HttpClientMetricsHelper;
 import org.eclipse.scout.rt.shared.http.HttpConfigurationProperties.ApacheHttpTransportConnectionTimeToLiveProperty;
 import org.eclipse.scout.rt.shared.http.HttpConfigurationProperties.ApacheHttpTransportEvictExpiredConnectionsProperty;
 import org.eclipse.scout.rt.shared.http.HttpConfigurationProperties.ApacheHttpTransportEvictIdleConnectionsTimeoutProperty;
@@ -39,6 +40,9 @@ import org.eclipse.scout.rt.shared.http.HttpConfigurationProperties.ApacheHttpTr
 import org.eclipse.scout.rt.shared.http.HttpConfigurationProperties.ApacheHttpTransportRetryOnSocketExceptionByConnectionResetProperty;
 import org.eclipse.scout.rt.shared.http.proxy.ConfigurableProxySelector;
 import org.eclipse.scout.rt.shared.http.retry.CustomHttpRequestRetryStrategy;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
 
 /**
  * <p>
@@ -56,6 +60,13 @@ import org.eclipse.scout.rt.shared.http.retry.CustomHttpRequestRetryStrategy;
  * @see ConfigurableProxySelector
  */
 public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManager<HttpAsyncClientBuilder> {
+
+  /**
+   * @return Technical transport manager name used for metrics.
+   */
+  protected String getName() {
+    return "scout.transport.async.default";
+  }
 
   @Override
   protected HttpAsyncClientBuilder createBuilder() {
@@ -156,7 +167,17 @@ public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManage
     }
 
     interceptCreateConnectionManager(builder);
-    return builder.build();
+    PoolingAsyncClientConnectionManager connectionManager = builder.build();
+    initMetrics(connectionManager);
+    return connectionManager;
+  }
+
+  /**
+   * Initializes metrics for this connection manager.
+   */
+  protected void initMetrics(PoolingAsyncClientConnectionManager connectionManager) {
+    Meter meter = GlobalOpenTelemetry.get().getMeter(getClass().getName());
+    BEANS.get(HttpClientMetricsHelper.class).initMetrics(meter, getName(), connectionManager::getTotalStats);
   }
 
   protected void interceptCreateConnectionManager(PoolingAsyncClientConnectionManagerBuilder builder) {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/ForceHttp2DefaultAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/ForceHttp2DefaultAsyncHttpClientManager.java
@@ -21,6 +21,11 @@ import org.apache.hc.core5.http2.HttpVersionPolicy;
 public class ForceHttp2DefaultAsyncHttpClientManager extends DefaultAsyncHttpClientManager {
 
   @Override
+  public String getName() {
+    return "scout.transport.async.forceHttp2";
+  }
+
+  @Override
   protected void interceptCreateConnectionManager(PoolingAsyncClientConnectionManagerBuilder builder) {
     // this setting seems to be used also for non-encrypted connections
     builder.setDefaultTlsConfig(TlsConfig.custom().setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_2).build());

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/H2AsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/H2AsyncHttpClientManager.java
@@ -17,9 +17,15 @@ import org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 
+import io.opentelemetry.api.OpenTelemetry;
+
 /**
  * <p>
  * Use {@link HttpAsyncClients#customHttp2()} to initialize this client.
+ * </p>
+ * <p>
+ * Note: This {@link AbstractAsyncHttpClientManager} implementation does not provide any {@link OpenTelemetry} metrics
+ * since is uses only one HTTP connection per route.
  * </p>
  * <p>
  * <b>Use with care:</b> According to {@link H2AsyncClientBuilder} which is effectively used, all requests are

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTransportManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnelTransportManager.java
@@ -24,6 +24,11 @@ import org.eclipse.scout.rt.shared.servicetunnel.http.HttpServiceTunnelConfigura
 public class HttpServiceTunnelTransportManager extends AbstractHttpTransportManager {
 
   @Override
+  public String getName() {
+    return "scout.transport.service-tunnel";
+  }
+
+  @Override
   public void interceptNewHttpTransport(IHttpTransportBuilder builder0) {
     super.interceptNewHttpTransport(builder0);
 


### PR DESCRIPTION
Add OpenTelemetry metrics for HTTP client connection pool:
- active/idle connections
- max connections

393561

(cherry picked from commit ab97e46f21e4f3f4900f0318ae0d0182ddba213f)

ab97e46f 393561 HTTP client connection manager pools metrics