### PR TITLE
Add Transaction Handling REST response filter

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.server/src/main/java/org/eclipse/scout/rt/rest/jersey/server/TransactionHandlingRestContainerResponseFilter.java
+++ b/org.eclipse.scout.rt.rest.jersey.server/src/main/java/org/eclipse/scout/rt/rest/jersey/server/TransactionHandlingRestContainerResponseFilter.java
@@ -1,0 +1,23 @@
+package org.eclipse.scout.rt.rest.jersey.server;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.platform.transaction.ITransaction;
+import org.eclipse.scout.rt.platform.transaction.ITransactionCommitProtocol;
+import org.eclipse.scout.rt.rest.container.IRestContainerResponseFilter;
+
+import java.util.Optional;
+
+/**
+ * Ensures any ongoing transaction is either committed or rolled back BEFORE the response is sent to the client.
+ */
+@Order(1e30)
+public class TransactionHandlingRestContainerResponseFilter implements IRestContainerResponseFilter {
+
+  @Override
+  public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+    Optional.ofNullable(ITransaction.CURRENT.get()).ifPresent(BEANS.get(ITransactionCommitProtocol.class)::commitOrRollback);
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.test/pom.xml
+++ b/org.eclipse.scout.rt.rest.jersey.test/pom.xml
@@ -67,5 +67,14 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.eclipse.scout.rt</groupId>
+        <artifactId>org.eclipse.scout.rt.server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.scout.rt</groupId>
+      <artifactId>org.eclipse.scout.rt.server.test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/JerseyTestApplication.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/JerseyTestApplication.java
@@ -26,6 +26,7 @@ import org.eclipse.scout.rt.platform.exception.PlatformException;
 import org.eclipse.scout.rt.platform.util.LocalHostAddressHelper;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.rest.RestApplication;
+import org.eclipse.scout.rt.server.context.ServerRunContextFilter;
 import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.servlet.ServletProperties;
@@ -157,6 +158,7 @@ public class JerseyTestApplication {
 
       // register RestApplication
       ServletHolder servlet = handler.addServlet(ServletContainer.class, "/api/*");
+      handler.addFilter(ServerRunContextFilter.class, "/api/*", null);
       servlet.setInitParameter(ServerProperties.WADL_FEATURE_DISABLE, Boolean.TRUE.toString());
       servlet.setInitParameter(ServletProperties.JAXRS_APPLICATION_CLASS, RestApplication.class.getName());
       servlet.setInitOrder(1); // load-on-startup

--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/JerseyTestServerSession.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/JerseyTestServerSession.java
@@ -1,0 +1,14 @@
+package org.eclipse.scout.rt.rest.jersey;
+
+import org.eclipse.scout.rt.server.AbstractServerSession;
+
+public class JerseyTestServerSession extends AbstractServerSession {
+  public JerseyTestServerSession() {
+    super(true);
+  }
+
+  @Override
+  public String getId() {
+    return "default";
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/TransactionHandlingTestResource.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/TransactionHandlingTestResource.java
@@ -1,0 +1,33 @@
+package org.eclipse.scout.rt.rest.jersey.fixture;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.scout.rt.platform.transaction.AbstractTransactionMember;
+import org.eclipse.scout.rt.platform.transaction.ITransaction;
+import org.eclipse.scout.rt.rest.IRestResource;
+
+@Path("transactionHandling")
+public class TransactionHandlingTestResource implements IRestResource {
+
+  @POST
+  @Path("throwExceptionInTransaction")
+  @Consumes(MediaType.APPLICATION_JSON)
+  public String throwExceptionInTransaction() {
+    ITransaction.CURRENT.get().registerMember(new AbstractTransactionMember(TransactionHandlingTestResource.class.getName()) {
+
+      @Override
+      public boolean needsCommit() {
+        return true;
+      }
+
+      @Override
+      public boolean commitPhase1() {
+        throw new ProcessingException("intentionally failing transaction");
+      }
+    });
+    return "done";
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/server/TransactionHandlingRestContainerResponseFilterTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/server/TransactionHandlingRestContainerResponseFilterTest.java
@@ -1,0 +1,40 @@
+package org.eclipse.scout.rt.rest.jersey.server;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.rest.client.AntiCsrfClientFilter;
+import org.eclipse.scout.rt.rest.jersey.JerseyTestApplication;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PlatformTestRunner.class)
+public class TransactionHandlingRestContainerResponseFilterTest {
+
+  @BeforeClass
+  public static void beforeClass() {
+    BEANS.get(JerseyTestApplication.class).ensureStarted();
+  }
+
+  protected Invocation.Builder request() {
+    return ClientBuilder.newClient()
+        .register(AntiCsrfClientFilter.class)
+        .target("http://localhost:" + BEANS.get(JerseyTestApplication.class).getPort() + "/api/transactionHandling/throwExceptionInTransaction")
+        .request()
+        .accept(MediaType.APPLICATION_JSON);
+  }
+
+  @Test
+  public void testFailingTransaction() {
+    try (Response response = request().post(Entity.json("null"))) {
+      assertEquals("When an exception is thrown during a commit, the response should signal an error.", 500, response.getStatus());
+    }
+  }
+}

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/JUnitServerSessionProviderWithCache.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/JUnitServerSessionProviderWithCache.java
@@ -30,6 +30,9 @@ public class JUnitServerSessionProviderWithCache extends ServerSessionProviderWi
 
   @Override
   protected CompositeObject newSessionCacheKey(final String sessionId, final Subject subject) {
+    if (sessionId == null && subject == null) {
+      return null;
+    }
     final Object[] superComponents = super.newSessionCacheKey(sessionId, subject).getComponents();
     if (superComponents == null) {
       return null;


### PR DESCRIPTION
Ensuring Transaction has been rolled back or committed before the rest response is sent to the client. Excpetions during commit/rollback should result in an error (HTTP status 500).