### PR TITLE
Make scroll containers unfocusable

### DIFF
--- a/eclipse-scout-core/src/desktop/OpenUriHandler.ts
+++ b/eclipse-scout-core/src/desktop/OpenUriHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -104,7 +104,7 @@ export class OpenUriHandler implements OpenUriHandlerModel, ObjectWithType {
   openUriInIFrame(uri: string) {
     // Create a hidden iframe and set the URI as src attribute value
     let $iframe = this.session.$entryPoint.appendElement('<iframe>', 'download-frame')
-      .attr('tabindex', -1)
+      .attr('tabindex', -2)
       .attr('src', uri);
 
     // Remove the iframe again after 10s (should be enough to get the download started)

--- a/eclipse-scout-core/src/focus/FocusContext.ts
+++ b/eclipse-scout-core/src/focus/FocusContext.ts
@@ -94,16 +94,16 @@ export class FocusContext {
    * behavior).
    */
   focusNextTabbable(forward = true, event?: KeyDownEvent) {
-    let $allFocusableElements = this.$container.find(':tabbable:visible');
+    let $allFocusableElements = this.$container.find(':tabbable');
     let $focusableElements = $allFocusableElements.filter((index, elem) => !this.focusManager.isElementCovertByGlassPane(elem));
     if ($focusableElements.length === 0) {
       return; // no focusable elements -> nothing to do
     }
 
     let activeElement = this.$container.activeElement(true);
+    let activeElementIndex = $focusableElements.index(activeElement);
     let firstFocusableElement = $focusableElements.first()[0];
     let lastFocusableElement = $focusableElements.last()[0];
-    let activeElementIndex = $focusableElements.index(activeElement);
 
     let elementToFocus = null;
     let explicitFocus = false;
@@ -164,18 +164,28 @@ export class FocusContext {
    */
   protected _onFocusIn(event: FocusInEvent) {
     let $target = $(event.target);
+
+    // Sometimes, the browser focuses an element that we don't consider focusable (e.g. scrollable divs, https://developer.chrome.com/blog/keyboard-focusable-scrollers).
+    // Redirect the focus to the first focusable parent element.
+    if (!$target.is(':focusable')) {
+      // noinspection CssInvalidPseudoSelector (inspection seems to confuse $.fn.closest with the native Element.closest method)
+      $target = $target.parent().closest(':focusable');
+    }
+
     $target.on('remove', this._removeListener);
-    this.focusedElement = event.target;
+
+    let target = $target[0];
+    this.focusedElement = target;
 
     // Do not update current focus context nor validate focus if target is $entryPoint.
     // That is because focusing the $entryPoint is done whenever no control is currently focusable, e.g. due to glass panes.
-    if (event.target === this.$container.entryPoint(true)) {
+    if (target === this.$container.entryPoint(true)) {
       return;
     }
 
     // Make this context the active context (nothing done if already active) and validate the focus event.
     this.focusManager._pushIfAbsentElseMoveTop(this);
-    this.validateAndSetFocus(event.target);
+    this.validateAndSetFocus(target);
     event.stopPropagation(); // Prevent a possible 'parent' focus context to consume this event. Otherwise, that 'parent context' would be activated as well.
   }
 

--- a/eclipse-scout-core/src/form/fields/datefield/DateField.ts
+++ b/eclipse-scout-core/src/form/fields/datefield/DateField.ts
@@ -1219,7 +1219,7 @@ export class DateField extends ValueField<Date, Date | string> implements DateFi
     this.setSuppressStatus(FormField.SuppressStatus.ALL);
     let $predictionField = $inputField.clone()
       .addClass('predict')
-      .attr('tabindex', '-1')
+      .attr('tabindex', '-2')
       .insertBefore($inputField);
     if ($inputField.hasClass('has-error')) {
       $predictionField.addClass('has-error');

--- a/eclipse-scout-core/src/scrollbar/scrollbars.ts
+++ b/eclipse-scout-core/src/scrollbar/scrollbars.ts
@@ -209,6 +209,12 @@ export const scrollbars = {
       $container.css('overflow', 'auto');
     }
     $container.css('-webkit-overflow-scrolling', 'touch');
+    // Under certain circumstances, browsers automatically make scroll containers focusable, e.g. https://developer.chrome.com/blog/keyboard-focusable-scrollers.
+    // Because this interferes with Scout's focus management, we explicitly add a negative tabindex to disable this behavior.
+    // The value '-2' (instead of '-1') means that the element is ignored by  the ':focusable' selector, see jquery-scout-selectors.js.
+    if ($container.attr('tabindex') === undefined) {
+      $container.attr('tabindex', '-2');
+    }
   },
 
   installScrollShadow($container: JQuery, options: ScrollbarInstallOptions) {

--- a/eclipse-scout-core/test/scrollbar/scrollbarsSpec.ts
+++ b/eclipse-scout-core/test/scrollbar/scrollbarsSpec.ts
@@ -342,4 +342,83 @@ describe('scrollbars', () => {
       scrollbars.uninstall($container, session);
     });
   });
+
+  describe('install', () => {
+
+    it('js-only: does not add tabindex', () => {
+      let $container = createScrollable();
+      scrollbars.install($container, {
+        parent: new NullWidget(),
+        session: session,
+        nativeScrollbars: false,
+        hybridScrollbars: false
+      });
+      expect($container.attr('tabindex')).toBe(undefined);
+      scrollbars.uninstall($container, session);
+      expect($container.attr('tabindex')).toBe(undefined);
+    });
+
+    it('hybrid: adds tabindex', () => {
+      let $container = createScrollable();
+      scrollbars.install($container, {
+        parent: new NullWidget(),
+        session: session,
+        nativeScrollbars: false,
+        hybridScrollbars: true
+      });
+      expect($container.attr('tabindex')).toBe('-2');
+      scrollbars.uninstall($container, session);
+      expect($container.attr('tabindex')).toBe('-2'); // not removed on uninstall
+    });
+
+    it('native-only: adds tabindex', () => {
+      let $container = createScrollable();
+      scrollbars.install($container, {
+        parent: new NullWidget(),
+        session: session,
+        nativeScrollbars: true,
+        hybridScrollbars: false
+      });
+      expect($container.attr('tabindex')).toBe('-2');
+      scrollbars.uninstall($container, session);
+      expect($container.attr('tabindex')).toBe('-2'); // not removed on uninstall
+    });
+
+    it('never adds tabindex if already present', () => {
+      let $container = createScrollable();
+
+      $container.attr('tabindex', '1');
+      scrollbars.install($container, {
+        parent: new NullWidget(),
+        session: session,
+        nativeScrollbars: false,
+        hybridScrollbars: false
+      });
+      expect($container.attr('tabindex')).toBe('1');
+      scrollbars.uninstall($container, session);
+      expect($container.attr('tabindex')).toBe('1');
+
+      $container.attr('tabindex', '2');
+      scrollbars.install($container, {
+        parent: new NullWidget(),
+        session: session,
+        nativeScrollbars: false,
+        hybridScrollbars: true
+      });
+      expect($container.attr('tabindex')).toBe('2');
+      scrollbars.uninstall($container, session);
+      expect($container.attr('tabindex')).toBe('2');
+
+      $container.attr('tabindex', '3');
+      scrollbars.install($container, {
+        parent: new NullWidget(),
+        session: session,
+        nativeScrollbars: true,
+        hybridScrollbars: false
+      });
+      expect($container.attr('tabindex')).toBe('3');
+      scrollbars.uninstall($container, session);
+      expect($container.attr('tabindex')).toBe('3');
+    });
+  });
 });


### PR DESCRIPTION
Browser manufacturers recently changed the default behavior of scrollable elements (which they call "scrollers"). To improve accessibility, these elements are now automatically keyboard focusable (but not click focusable) when the content is larger than the viewport and does not contain any focusable elements.
See: https://developer.chrome.com/blog/keyboard-focusable-scrollers

This introduces additional tab stops that are currently not properly visualized by Scout and may therefore be confusing. It also interferes with existing logic in some of the more complex widgets, e.g. Table, Tree, TileGrid. For example, the '.table' element has an explicit tabindex="0" attribute, but the inner '.table-data' element does not. However, because the '.table-data' is scrollable, the browser now makes the element focusable automatically. But using the arrow keys to scroll the '.table-data' will not work, because the Table widget uses those keystrokes to move the select row and automatically refocuses the '.table' element.

To restore the previous behavior, we automatically add a negative tabindex to all scroll containers. This skips the element during key navigation, but it may still receive the focus programmatically or via a mouse click. Therefore, we use "-2" instead of "-1" (same native behavior) and explicitly exclude it in the custom ':focusable' selector. The FocusContext can therefore detect when such an element receives the focus and can re-position the focus to the nearest focusable parent element.

In future versions, we plan to make scrollable containers focusable again, but it requires additional changes (e.g. proper handling of keystrokes).

381281