### PR TITLE
DynamicResourceInfo: Allow internal loading of BinaryResource from URL

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/DynamicResourceInfo.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/DynamicResourceInfo.java
@@ -65,7 +65,7 @@ public class DynamicResourceInfo {
   }
 
   /**
-   * @param jsonAdapter
+   * @param jsonAdapter adapter matching the path
    * @param path
    *          decoded path (non url-encoded)
    */
@@ -80,6 +80,27 @@ public class DynamicResourceInfo {
       return null;
     }
     if (!jsonAdapter.getId().equals(parts.getAdapterId())) {
+      return null;
+    }
+    return new DynamicResourceInfo(jsonAdapter, parts.getFilename());
+  }
+
+  /**
+   * @param uiSession session matching the path
+   * @param path
+   *          decoded path (non url-encoded)
+   */
+  public static DynamicResourceInfo fromPath(IUiSession uiSession, String path) {
+    DynamicResourcePathComponents parts = DynamicResourcePathComponents.fromPath(path);
+    if (parts == null) {
+      return null;
+    }
+    // compare the session id to the passed in session to ensure that the resource path matches
+    if (!uiSession.getUiSessionId().equals(parts.getUiSessionId())) {
+      return null;
+    }
+    IJsonAdapter<?> jsonAdapter = uiSession.getJsonAdapter(parts.getAdapterId());
+    if (jsonAdapter == null) {
       return null;
     }
     return new DynamicResourceInfo(jsonAdapter, parts.getFilename());


### PR DESCRIPTION
Add method to DynamicResourceInfo to support the loading of a BinaryResource only by IUiSession, without knowing the IJsonAdapter directly.

329612

(cherry picked from commit 89ec87843c6364c76cb473fd45ddfcd63631258f)