### PR TITLE
AccessControl.ts: let app handle bootstrap errors

### DIFF
--- a/eclipse-scout-core/src/config/ConfigPropertyCache.ts
+++ b/eclipse-scout-core/src/config/ConfigPropertyCache.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, ConfigProperties, DoEntity, ObjectModel, objects, System, systems} from '../index';
+import {App, arrays, ConfigProperties, DoEntity, ObjectModel, objects, System, systems} from '../index';
 import $ from 'jquery';
 
 /**
@@ -39,6 +39,7 @@ export class ConfigPropertyCache implements ObjectModel<ConfigPropertyCache> {
   bootstrap(urls: string | string[], system?: string): JQuery.Promise<void> {
     let promises = arrays.ensure(urls)
       .map(url => $.ajaxJson(url)
+        .then(response => App.handleJsonError(url, response))
         .then(properties => this._handleBootstrapResponse(properties, system)));
     return $.promiseAll(promises);
   }

--- a/eclipse-scout-core/src/security/access.ts
+++ b/eclipse-scout-core/src/security/access.ts
@@ -25,7 +25,7 @@ export const access = {
     if (!accessControl) {
       accessControl = scout.create(AccessControl, {permissionsUrl});
     }
-    return accessControl.whenSync();
+    return accessControl.bootstrap();
   },
 
   /**
@@ -40,7 +40,7 @@ export const access = {
     if (!accessControl) {
       return;
     }
-    accessControl.stopSync();
+    accessControl.destroy();
     accessControl = null;
   },
 

--- a/eclipse-scout-core/src/testing/security/accessSpecHelper.ts
+++ b/eclipse-scout-core/src/testing/security/accessSpecHelper.ts
@@ -55,8 +55,8 @@ class StaticAccessControl extends AccessControl {
     this._permissionCollection = PermissionCollection.ensure(permissionCollectionModel);
   }
 
-  protected override _sync() {
-    // nop
+  protected override _load(): JQuery.Promise<void> {
+    return $.resolvedPromise();
   }
 
   protected override _subscribeForNotifications() {
@@ -65,9 +65,5 @@ class StaticAccessControl extends AccessControl {
 
   protected override _unsubscribeFromNotifications() {
     // nop
-  }
-
-  override whenSync(): JQuery.Promise<void> {
-    return $.resolvedPromise();
   }
 }

--- a/eclipse-scout-core/src/text/texts.ts
+++ b/eclipse-scout-core/src/text/texts.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, Session, TextMap} from '../index';
+import {App, arrays, Session, TextMap} from '../index';
 import $ from 'jquery';
 
 export type TextMapType = Record<string, TextMap>;
@@ -41,14 +41,8 @@ export const texts = {
   },
 
   /** @internal */
-  _handleBootstrapResponse(url: string | string[], data: any) {
-    if (data && data.error) {
-      // The result may contain a json error (e.g. session timeout) -> abort processing
-      throw {
-        error: data.error,
-        url: url
-      };
-    }
+  _handleBootstrapResponse(url: string, data: any) {
+    App.handleJsonError(url, data);
     texts.init(data);
   },
 

--- a/eclipse-scout-core/src/util/defaultValues.ts
+++ b/eclipse-scout-core/src/util/defaultValues.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {objects, strings, TypeDescriptor} from '../index';
+import {App, objects, strings, TypeDescriptor} from '../index';
 import $ from 'jquery';
 
 export interface DefaultValuesBootstrapOptions {
@@ -35,7 +35,8 @@ export const defaultValues = {
     options = $.extend({}, defaultOptions, options);
     // Load default value configuration from server (and cache it)
     return $.ajaxJson(options.url)
-      .done(defaultValues.init.bind(this));
+      .then(response => App.handleJsonError(options.url, response))
+      .then(defaultValues.init.bind(this));
   },
 
   init(data: any) {

--- a/eclipse-scout-core/src/util/locales.ts
+++ b/eclipse-scout-core/src/util/locales.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, Locale, LocaleModel, objects, scout, texts} from '../index';
+import {App, arrays, Locale, LocaleModel, objects, scout, texts} from '../index';
 import $ from 'jquery';
 
 export const locales = {
@@ -20,13 +20,7 @@ export const locales = {
 
   /** @internal */
   _handleBootstrapResponse(url: string, data: any) {
-    if (data && data.error) {
-      // The result may contain a json error (e.g. session timeout) -> abort processing
-      throw {
-        error: data.error,
-        url: url
-      };
-    }
+    App.handleJsonError(url, data);
     locales.init(data);
   },
 


### PR DESCRIPTION
With Microsoft Edge, if a tab is closed and reopened after the http session has expired, the index.html is loaded from cache without revalidating which starts the bootstrap requests. These requests will fail and may return 401 (Unauthorized). In that case, the app would trigger a page reload because the login site needs to be displayed. Unfortunately, the status code gets lost for the permission call, so the message "Permissions were not synchronized successfully." is shown and the user has to manually reload the page.

395126