### PR TITLE
Add shake animation when unchecking last visible calendar

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -1599,6 +1599,9 @@ export class Calendar extends Widget implements CalendarModel {
     updatedResources.forEach(tuple => {
       this._updateResourcesVisibleProperty(tuple[0], tuple[1]);
     });
+    if (!this.rendered) {
+      return;
+    }
     if (!this.isDay()) {
       // No re-rendering required when on day -> component is hidden by layout
       this._renderComponents();

--- a/eclipse-scout-core/src/calendar/ResourcePanel.less
+++ b/eclipse-scout-core/src/calendar/ResourcePanel.less
@@ -13,3 +13,10 @@
   position: relative;
   padding-right: 25px;
 }
+
+.resource-panel-tree {
+
+  & > .tree-data > .tree-node > .tree-node-checkbox.animate-unable-uncheck {
+    #scout.animation-shake()
+  }
+}

--- a/eclipse-scout-core/src/calendar/ResourcePanel.ts
+++ b/eclipse-scout-core/src/calendar/ResourcePanel.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, CalendarResourceLookupCall, HtmlComponent, InitModelOf, LookupRow, ObjectOrModel, ResourcePanelTreeNode, scout, SingleLayout, Tree, TreeBox, TreeBoxTreeNode, TreeNodesCheckedEvent, Widget} from '../index';
+import {arrays, CalendarResourceLookupCall, HtmlComponent, InitModelOf, LookupRow, ObjectOrModel, ResourcePanelTreeNode, scout, SingleLayout, Tree, TreeBox, TreeBoxTreeNode, TreeNode, TreeNodesCheckedEvent, Widget} from '../index';
 
 export class ResourcePanel extends Widget {
   treeBox: ResourcePanelTreeBox;
@@ -22,6 +22,7 @@ export class ResourcePanel extends Widget {
       statusVisible: false,
       tree: {
         objectType: ResourcePanelTree,
+        cssClass: 'resource-panel-tree',
         checkable: true,
         textFilterEnabled: false,
         _scrollDirections: 'y',
@@ -64,7 +65,12 @@ class ResourcePanelTreeBox extends TreeBox<string> {
     } else if (!this._populating) {
       // Reapply the value to the tree
       this._syncValueToTree(this.value);
+      this._triggerShakeAnimation(event.nodes[0]);
     }
+  }
+
+  protected _triggerShakeAnimation(node: TreeNode) {
+    node.$node.children('.tree-node-checkbox').addClassForAnimation('animate-unable-uncheck');
   }
 }
 


### PR DESCRIPTION
When the user tries to hide the last visible calendar, the tree node shakes and is not uncheckable. This commit includes also a bugfix to correctly update the visibility of a calendar when the calendar is initialized but not rendered.

387614