### PR TITLE
objects: add isPojo()

### DIFF
--- a/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
+++ b/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
@@ -907,11 +907,11 @@ export class ChartJsRenderer extends AbstractChartRenderer {
     }
     if (objects.isFunction(tooltipLabelValue)) {
       labelValue = tooltipLabelValue(tooltipItem);
-      labelValue = objects.isString(labelValue) || objects.isPlainObject(labelValue) ? labelValue : '';
+      labelValue = objects.isString(labelValue) || objects.isObject(labelValue) ? labelValue : '';
     }
     if (objects.isFunction(tooltipColor)) {
       labelColor = tooltipColor(tooltipItem);
-      labelColor = objects.isPlainObject(labelColor) ? (labelColor.backgroundColor || '') : '';
+      labelColor = objects.isObject(labelColor) ? (labelColor.backgroundColor || '') : '';
     }
     return {label, labelValue, labelColor};
   }
@@ -1110,7 +1110,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
       value = dataset.data[dataIndex];
 
     if (this._isHorizontalBar(config)) {
-      if (objects.isPlainObject(value) && objects.isArray(value.x) && value.x.length === 2) {
+      if (objects.isObject(value) && objects.isArray(value.x) && value.x.length === 2) {
         let avg = (value.x[0] + value.x[1]) / 2;
         tooltipDirection = avg < 0 ? 'left' : 'right';
       } else {

--- a/eclipse-scout-core/src/App.ts
+++ b/eclipse-scout-core/src/App.ts
@@ -246,7 +246,7 @@ export class App extends EventEmitter {
         this._handleBootstrapTimeoutError(vararg, url);
         return;
       }
-    } else if (objects.isPlainObject(vararg) && vararg.error) {
+    } else if (objects.isObject(vararg) && vararg.error) {
       // Json based error
       // Json errors (normally processed by Session.js) are returned with http status 200
       if (vararg.error.code === Session.JsonResponseError.SESSION_TIMEOUT) {

--- a/eclipse-scout-core/src/ObjectFactory.ts
+++ b/eclipse-scout-core/src/ObjectFactory.ts
@@ -151,7 +151,7 @@ export class ObjectFactory {
       options = options || {};
       model = modelOrOptions;
       objectType = objectTypeOrModel;
-    } else if (objects.isPlainObject(objectTypeOrModel)) {
+    } else if (objects.isObject(objectTypeOrModel)) {
       options = modelOrOptions || {};
       model = objectTypeOrModel;
       if (!model.objectType) {

--- a/eclipse-scout-core/src/dataobject/dataObjects.ts
+++ b/eclipse-scout-core/src/dataobject/dataObjects.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {arrays, DoEntity, scout} from '..';
+import {arrays, DoEntity, objects, scout} from '..';
 
 export const dataObjects = {
   /**
@@ -31,7 +31,7 @@ export const dataObjects = {
       return;
     }
     scout.assertParameter('contribution', contribution);
-    if ($.isPlainObject(contribution)) {
+    if (objects.isPojo(contribution)) {
       scout.assertProperty(contribution, '_type');
       dataObjects.removeContribution(contribution._type, doEntity);
     } else {

--- a/eclipse-scout-core/src/form/fields/FormField.ts
+++ b/eclipse-scout-core/src/form/fields/FormField.ts
@@ -253,7 +253,7 @@ export class FormField extends Widget implements FormFieldModel {
   private _initGridDataHints(gridDataHints: GridData) {
     if (gridDataHints instanceof GridData) {
       this.gridDataHints = gridDataHints;
-    } else if (objects.isPlainObject(gridDataHints)) {
+    } else if (objects.isObject(gridDataHints)) {
       $.extend(this.gridDataHints, gridDataHints);
     } else {
       this.gridDataHints = gridDataHints;

--- a/eclipse-scout-core/src/security/PermissionCollection.ts
+++ b/eclipse-scout-core/src/security/PermissionCollection.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {DoEntity, FullModelOf, InitModelOf, ObjectModel, ObjectOrModel, Permission, PermissionLevel, PropertyChangeEvent, PropertyEventEmitter, PropertyEventMap, scout} from '../index';
+import {DoEntity, FullModelOf, InitModelOf, ObjectModel, ObjectOrModel, objects, Permission, PermissionLevel, PropertyChangeEvent, PropertyEventEmitter, PropertyEventMap, scout} from '../index';
 
 export class PermissionCollection extends PropertyEventEmitter implements PermissionCollectionModel {
   declare self: PermissionCollection;
@@ -172,7 +172,7 @@ export class PermissionCollection extends PropertyEventEmitter implements Permis
    */
   protected static _ensurePermissionMap(permissionModelMapModel: PermissionModelMapModel): PermissionMap {
     // permissionModelMapModel is a map or an object
-    if ($.isPlainObject(permissionModelMapModel)) {
+    if (objects.isPojo(permissionModelMapModel)) {
       // permissionModelMapModel is an object, create a map containing the entries of the object
       permissionModelMapModel = new Map(Object.entries(permissionModelMapModel));
     }

--- a/eclipse-scout-core/src/session/BusySupport.ts
+++ b/eclipse-scout-core/src/session/BusySupport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -66,7 +66,7 @@ export class BusySupport implements ObjectWithType {
    */
   setBusy(options: boolean | BusyIndicatorOptions) {
     let optionsObj: BusyIndicatorOptions;
-    if (objects.isPlainObject(options)) {
+    if (objects.isObject(options)) {
       optionsObj = options;
     } else {
       optionsObj = {

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -4079,7 +4079,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
       return;
     }
     let returnValue = column.calculateOptimalWidth();
-    if (objects.isPlainObject(returnValue)) {
+    if (objects.isObject(returnValue)) {
       // Function returned a promise -> delay resizing
       returnValue.always(this._resizeToFit.bind(this, column, maxWidth));
     } else {

--- a/eclipse-scout-core/src/table/TableAdapter.ts
+++ b/eclipse-scout-core/src/table/TableAdapter.ts
@@ -748,7 +748,7 @@ export class TableAdapter extends ModelAdapter {
         // cell properties, which is required because the Column checks, whether it should apply
         // defaults from the Column instance to a cell, or use the values from the cell.
         let model;
-        if (objects.isPlainObject(vararg)) {
+        if (objects.isObject(vararg)) {
           model = vararg;
           model.value = this._ensureValue(model.value);
           // Parse the value if a text but no value is provided. The server does only set the text if value and text are equal.

--- a/eclipse-scout-core/src/tile/TileGrid.ts
+++ b/eclipse-scout-core/src/tile/TileGrid.ts
@@ -811,7 +811,7 @@ export class TileGrid<TTile extends Tile = Tile> extends Widget implements TileG
     if (placeholder instanceof PlaceholderTile) {
       return placeholder;
     }
-    if (objects.isPlainObject(placeholder)) {
+    if (objects.isObject(placeholder)) {
       return scout.create($.extend(true, {}, {
         objectType: PlaceholderTile,
         parent: this

--- a/eclipse-scout-core/src/util/defaultValues.ts
+++ b/eclipse-scout-core/src/util/defaultValues.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -141,16 +141,16 @@ export const defaultValues = {
       // If property does not exist, set the default value and return.
       if (object[realProp] === undefined) {
         object[realProp] = objects.valueCopy(defaults[realProp]);
-      } else if (objects.isPlainObject(object[realProp]) && objects.isPlainObject(defaults[prop])) {
+      } else if (objects.isObject(object[realProp]) && objects.isObject(defaults[prop])) {
         // Special case: "default objects". If the property value is an object and default
         // value is also an object, extend the property value instead of replacing it.
         defaultValues._extendWithDefaults(object[realProp], defaults[prop]);
-      } else if (Array.isArray(object[realProp]) && objects.isPlainObject(defaults[prop])) {
+      } else if (Array.isArray(object[realProp]) && objects.isObject(defaults[prop])) {
         // Special case: "array of default objects": If the property value is an array of objects and
         // the default value is an object, extend each object in the array with the default value.
         let objectArray = object[realProp];
         for (let i = 0; i < objectArray.length; i++) {
-          if (objects.isPlainObject(objectArray[i])) {
+          if (objects.isObject(objectArray[i])) {
             defaultValues._extendWithDefaults(objectArray[i], defaults[prop]);
           }
         }

--- a/eclipse-scout-core/src/util/objects.ts
+++ b/eclipse-scout-core/src/util/objects.ts
@@ -187,7 +187,7 @@ export const objects = {
         }, copy);
       }
 
-      if (objects.isPlainObject(obj)) {
+      if (objects.isObject(obj)) {
         let copy = {};
         seen.set(obj, copy);
         return Object.keys(obj)
@@ -368,12 +368,30 @@ export const objects = {
   },
 
   /**
-   * @returns true if the given object is an object: no primitive type (number, string, boolean, bigint, symbol), no array, not null and not undefined.
+   * @deprecated The method was renamed to {@link isObject}. Use the new name or consider using {@link isPojo} instead.
    */
   isPlainObject<T>(obj: T): obj is Exclude<typeof obj, Primitive | undefined | null | T[]> {
+    return objects.isObject(obj);
+  },
+
+  /**
+   * @returns true if the given object is an object: no primitive type (number, string, boolean, bigint, symbol), no array, not null and not undefined.
+   */
+  isObject<T>(obj: T): obj is Exclude<typeof obj, Primitive | undefined | null | T[]> {
     return typeof obj === 'object' &&
       !objects.isNullOrUndefined(obj) &&
       !Array.isArray(obj);
+  },
+
+  /**
+   * @returns true if the given object is a plain old JavaScript object, which is an object created by the object literal notation ({}) or using `new Object()`.
+   */
+  isPojo<T>(obj: T): obj is Exclude<typeof obj, Primitive | undefined | null | T[]> {
+    if (!objects.isObject(obj)) {
+      return false;
+    }
+    let prototype = Object.getPrototypeOf(obj);
+    return prototype === Object.prototype || prototype === null;
   },
 
   /**
@@ -526,7 +544,7 @@ export const objects = {
     if (objA === objB) {
       return true;
     }
-    if (objects.isPlainObject(objA) && objects.isPlainObject(objB)) {
+    if (objects.isObject(objA) && objects.isObject(objB)) {
       if (objects.isFunction(objA.equals) && objects.isFunction(objB.equals)) {
         return objA.equals(objB);
       }
@@ -670,7 +688,7 @@ export const objects = {
     if (objects.isNullOrUndefined(object)) {
       return object;
     }
-    if (!objects.isPlainObject(object)) {
+    if (!objects.isObject(object)) {
       throw new Error('Not an object: ' + object);
     }
     Object.keys(object).forEach(key => {
@@ -691,7 +709,7 @@ export const objects = {
     if (objects.isNullOrUndefined(obj)) {
       return true;
     }
-    if (!objects.isPlainObject(obj)) {
+    if (!objects.isObject(obj)) {
       return;
     }
     return Object.keys(obj).length === 0;

--- a/eclipse-scout-core/test/util/objectsSpec.ts
+++ b/eclipse-scout-core/test/util/objectsSpec.ts
@@ -573,18 +573,48 @@ describe('objects', () => {
     });
   });
 
-  describe('isPlainObject', () => {
+  describe('isObject', () => {
 
-    it('works as expected', () => {
-      expect(objects.isPlainObject({})).toBe(true);
-      expect(objects.isPlainObject({foo: 'bar'})).toBe(true);
-      expect(objects.isPlainObject([])).toBe(false);
-      expect(objects.isPlainObject(null)).toBe(false);
-      expect(objects.isPlainObject(undefined)).toBe(false);
-      expect(objects.isPlainObject(1)).toBe(false);
-      expect(objects.isPlainObject('foo')).toBe(false);
+    it('returns true for objects', () => {
+      expect(objects.isObject({})).toBe(true);
+      expect(objects.isObject({foo: 'bar'})).toBe(true);
+      expect(objects.isObject(Object.create(null))).toBe(true);
+      expect(objects.isObject(new Widget())).toBe(true);
+      // noinspection JSPrimitiveTypeWrapperUsage
+      expect(objects.isObject(new Object())).toBe(true);
     });
 
+    it('returns false for non-objects', () => {
+      expect(objects.isObject(Widget)).toBe(false);
+      expect(objects.isObject([])).toBe(false);
+      expect(objects.isObject(null)).toBe(false);
+      expect(objects.isObject(undefined)).toBe(false);
+      expect(objects.isObject(1)).toBe(false);
+      expect(objects.isObject('foo')).toBe(false);
+      expect(objects.isObject(true)).toBe(false);
+    });
+  });
+
+  describe('isPojo', () => {
+
+    it('returns true for plain objects', () => {
+      expect(objects.isPojo({})).toBe(true);
+      expect(objects.isPojo({foo: 'bar'})).toBe(true);
+      expect(objects.isPojo(Object.create(null))).toBe(true);
+      // noinspection JSPrimitiveTypeWrapperUsage
+      expect(objects.isPojo(new Object())).toBe(true);
+    });
+
+    it('returns false for non-plain objects', () => {
+      expect(objects.isPojo(new Widget())).toBe(false);
+      expect(objects.isPojo(Widget)).toBe(false);
+      expect(objects.isPojo([])).toBe(false);
+      expect(objects.isPojo(null)).toBe(false);
+      expect(objects.isPojo(undefined)).toBe(false);
+      expect(objects.isPojo(1)).toBe(false);
+      expect(objects.isPojo('foo')).toBe(false);
+      expect(objects.isPojo(true)).toBe(false);
+    });
   });
 
   describe('argumentsToArray', () => {


### PR DESCRIPTION
The existing isPlainObject actually has the wrong name, it does not check for *plain* objects, just for objects.
Adjusting the behavior would likely break existing code, so there is now a new method called isPojo (short for plain old JavaScript object) with the correct implementation.
The old function is deprecated and renamed to isObject.