### PR TITLE
TableField: wrong 'empty' state if user changes column settings

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsForm.java
@@ -176,6 +176,13 @@ public class OrganizeColumnsForm extends AbstractForm implements IOrganizeColumn
       return 350;
     }
 
+    @Override
+    protected boolean execIsEmpty() {
+      // Changes on this form must not be propagated to the parent which eventually is a table.
+      // Otherwise, the table would be marked as non-empty as soon as the tables on this form are changed.
+      return true;
+    }
+
     @Order(10)
     @ClassId("abaf2e0c-1c14-4b99-81dc-8b83453f5766")
     public class GroupBox extends AbstractGroupBox {


### PR DESCRIPTION
If a table field is mandatory and has no rows, the  property 'empty' must return true. This works correctly until the user opens the OrganizeColumnsForm and removes or adds a column. The MainBox of the OrganizeColumnsForm is a child field of the table field because of the OrganizeColumnsMenu. ExecIsEmpty also considers the child fields to compute the empty state, so as soon as the fields on the form change its state, the parent table field changes its state as well which has the effect that the form can be saved even though the table still has no rows.

396456