### PR TITLE
Do not use filterMenuRec for Calendar menus

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/MenuUtility.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/action/menu/MenuUtility.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.scout.rt.client.ui.IWidget;
 import org.eclipse.scout.rt.client.ui.action.ActionFinder;
@@ -116,6 +117,17 @@ public final class MenuUtility {
    * {@link MenuWrapper#wrapMenu(IMenu, IMenuTypeMapper, Predicate)}) and its child menus are filtered as well.
    */
   public static List<IMenu> filterMenusRec(List<IMenu> menus, final Predicate<IMenu> filter) {
+    return filterMenus(menus, filter, m -> m.hasChildActions() ? MenuWrapper.wrapMenu(m, OutlineMenuWrapper.AUTO_MENU_TYPE_MAPPER, filter) : m);
+  }
+
+  /**
+   * Filters the given list of menus.
+   */
+  public static List<IMenu> filterMenus(List<IMenu> menus, final Predicate<IMenu> filter) {
+    return filterMenus(menus, filter, UnaryOperator.identity());
+  }
+
+  private static List<IMenu> filterMenus(List<IMenu> menus, final Predicate<IMenu> filter, final UnaryOperator<IMenu> menuMapper) {
     if (menus != null) {
       List<IMenu> result = new ArrayList<>(menus.size());
       for (IMenu m : menus) {
@@ -123,9 +135,7 @@ public final class MenuUtility {
           result.add(m);
         }
         else if (filter.test(m)) {
-          if (m.hasChildActions()) {
-            m = MenuWrapper.wrapMenu(m, OutlineMenuWrapper.AUTO_MENU_TYPE_MAPPER, filter);
-          }
+          m = menuMapper.apply(m);
           result.add(m);
         }
       }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/AbstractCalendar.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/calendar/AbstractCalendar.java
@@ -276,7 +276,7 @@ public abstract class AbstractCalendar extends AbstractWidget implements ICalend
         ICalendarItemProvider provider = ConfigurationUtility.newInnerInstance(this, itemProviderClazz);
         producerList.add(provider);
         // add empty space menus to the context menu
-        menus.addAllOrdered(MenuUtility.filterMenusRec(provider.getMenus(), MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(CalendarMenuType.EmptySpace), false)));
+        menus.addAllOrdered(MenuUtility.filterMenus(provider.getMenus(), MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(CalendarMenuType.EmptySpace), false)));
       }
       catch (Exception e) {
         BEANS.get(ExceptionHandler.class).handle(new ProcessingException("error creating instance of class '" + itemProviderClazz.getName() + "'.", e));
@@ -699,7 +699,7 @@ public abstract class AbstractCalendar extends AbstractWidget implements ICalend
     }
     // add menus of provider
     if (provider != null) {
-      m_inheritedMenusOfSelectedProvider = MenuUtility.filterMenusRec(provider.getMenus(), MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(CalendarMenuType.CalendarComponent), false));
+      m_inheritedMenusOfSelectedProvider = MenuUtility.filterMenus(provider.getMenus(), MenuUtility.createMenuFilterMenuTypes(CollectionUtility.hashSet(CalendarMenuType.CalendarComponent), false));
       getContextMenu().addChildActions(m_inheritedMenusOfSelectedProvider);
     }
   }


### PR DESCRIPTION
MenuUtility.filterMenusRec(List<IMenu>, Predicate<IMenu>) wrappes menus with child actions. In the case of the calendar, no wrapper menus should be used, since wrapper menus won't propagate the owner value change event.
Added new method MenuUtility.filterMenus(List<IMenu>, Predicate<IMenu>) which is used by the calendar instead

332126