### PR TITLE
SmartField: add method to update lookupRow without changing value

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
@@ -1505,6 +1505,17 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
     this.resetDisplayText();
   }
 
+  /**
+   * Rebuilds the cached {@link lookupRow} and updates the display text. The {@link lookupCall} is used to
+   * retrieve a fresh lookup row for the current {@link value}. This can be useful if the underlying data
+   * has been changed since first resolving the lookup row. This method does _not_ trigger a property change
+   * event for the `value` property.
+   */
+  updateLookupRow() {
+    this._setLookupRow(null); // reset cached lookup row
+    this.setValue(this.value); // rebuild lookup row and update display text
+  }
+
   override setDisplayText(displayText: string) {
     super.setDisplayText(displayText);
     this._userWasTyping = false;


### PR DESCRIPTION
If the lookup call changes dynamically (e.g. language switch, or singular/plural) the currently displayed lookup row in a SmartField might need to be updated. This can be achieved by setting the value to null and the back to the previous value. However, this triggers property change events for the 'value' property, which might have unwanted effects. To only update the cached 'lookupRow' from the current value without changing the value itself, a new method updateLookupRow() is provided. It re-resolves the lookup row and updates the display text accordingly.

369273