### PR TITLE
tileUtil: moveOtherTilesDown can lead to overlaps

### DIFF
--- a/eclipse-scout-core/src/tile/tileUtil.ts
+++ b/eclipse-scout-core/src/tile/tileUtil.ts
@@ -113,7 +113,7 @@ export const tileUtil = {
             // Ignore tiles without explicit positions, they will be arranged automatically by the logical grid
             continue;
           }
-          let bottomGridData = bottomGridDataPerColumn[x];
+          let bottomGridData = lowestGridData(bottomGridDataPerColumn.slice(x, x + gridData.w));
           if (!bottomGridData) {
             // If tile is not inside the affected columns, skip it
             continue;
@@ -145,6 +145,18 @@ export const tileUtil = {
           bottomGridDataPerColumn[x] = gridData;
         }
       }
+    }
+
+    /**
+     * @returns the grid data with the largest y-value of the given gridDatas
+     */
+    function lowestGridData(gridDatas: GridData[]): GridData {
+      return gridDatas.reduce((prev, curr) => {
+        if (curr?.y > prev?.y) {
+          return curr;
+        }
+        return prev;
+      }, gridDatas[0]);
     }
   }
 };

--- a/eclipse-scout-core/test/tile/tileUtilSpec.ts
+++ b/eclipse-scout-core/test/tile/tileUtilSpec.ts
@@ -305,6 +305,30 @@ describe('tileUtil', () => {
       verify(gridDatas, 0, {x: 2, y: 1, w: 1, h: 2}, expGridDatas);
     });
 
+    it('moves wide tile on the bottom and tile on the right down ', () => {
+      /**
+       * |_||_|
+       * |__|
+       */
+      let gridDatas = [
+        {x: 1, y: 1, w: 1, h: 1},
+        {x: 2, y: 1, w: 1, h: 1},
+        {x: 1, y: 2, w: 2, h: 1}
+      ];
+      /**
+       * |  |
+       * |__|
+       *  |_|
+       * |__|
+       */
+      let expGridDatas = [
+        null,
+        {x: 2, y: 3, w: 1, h: 1},
+        {x: 1, y: 4, w: 2, h: 1}
+      ];
+      verify(gridDatas, 0, {x: 1, y: 1, w: 2, h: 2}, expGridDatas);
+    });
+
     it('moves tile on the bottom right of a tile below a tile down ', () => {
       /**
        *  |_|


### PR DESCRIPTION
A tile that spans columns must consider the bottom grid data of every spanned column, not just the first one.

395112