### PR TITLE
FocusContext: prevent scroll when validating focus on 'focusin' event

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.ts
+++ b/eclipse-scout-core/src/focus/FocusContext.ts
@@ -169,7 +169,8 @@ export class FocusContext {
     // Redirect the focus to the first focusable parent element.
     if (!$target.is(':focusable')) {
       // noinspection CssInvalidPseudoSelector (inspection seems to confuse $.fn.closest with the native Element.closest method)
-      $target = $target.parent().closest(':focusable');
+      let $newTarget = $target.parent().closest(':focusable');
+      focusUtils.focusLater($newTarget, {preventScroll: true});
     }
 
     $target.on('remove', this._removeListener);

--- a/eclipse-scout-core/src/focus/focusUtils.ts
+++ b/eclipse-scout-core/src/focus/focusUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -117,6 +117,29 @@ export const focusUtils = {
       let focusedElement = doc.activeElement;
       if (focusedElement === $entryPoint[0]) {
         prevFocusedElement.focus();
+      }
+    });
+  },
+
+  /**
+   * Sets the focus to the given target element just before the next repaint (using requestAnimationFrame).
+   * This allows other event handlers to be fired before the focus is actually changed.
+   *
+   * @param target the element to be focused
+   * @param options options to be passed to the {@link HTMLElement#focus} call
+   */
+  focusLater(target: HTMLElement | JQuery, options?: FocusOptions) {
+    let $target = $.ensure(target);
+    if (!$target.length) {
+      return; // nothing to do
+    }
+    let doc = $target.document(true);
+    let prevFocusedElement = doc.activeElement;
+    requestAnimationFrame(() => {
+      // Check if the active element is the same as before. If not, someone has changed the focus
+      // in the meantime and the scheduled "focusLater" request is probably obsolete.
+      if (doc.activeElement === prevFocusedElement) {
+        $target[0].focus(options);
       }
     });
   }


### PR DESCRIPTION
When a DOM element receives the focus, the current FocusContext updates its internal state and validates the focus (e.g. checks that the element is not covered by a glass pane). When doing so, it must not change the scroll position. This is especially relevant when the focus is changed to a different element, e.g. when clicking on a scroll container that we don't consider scrollable (tabindex=-2) but is natively focused by the browser.

381281