### PR TITLE
Tile: do not trigger onLoadDataCancel() when tile is reloaded

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/tile/AbstractTile.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/tile/AbstractTile.java
@@ -396,6 +396,7 @@ public abstract class AbstractTile extends AbstractWidget implements ITile {
   @Override
   public void cancelLoading() {
     if (getLoadJobFuture() != null) {
+      getLoadJobFuture().addExecutionHint(TileDataLoadManager.MANUAL_CANCELLATION_MARKER);
       getLoadJobFuture().cancel(true);
     }
   }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/tile/TileDataLoadManager.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/tile/TileDataLoadManager.java
@@ -39,7 +39,13 @@ import org.eclipse.scout.rt.shared.job.filter.future.SessionFutureFilter;
 @ApplicationScoped
 public class TileDataLoadManager {
 
-  private static final String MANUAL_CANCELLATION_MARKER = "cancelledByTileDataLoadManager";
+  /**
+   * Execution hint for an async tile load job that should not call {@link ITile#onLoadDataCancel()} when cancelled.
+   * Intended to be added to {@link IFuture}s that are cancelled explicitly. A typical use case is a reload operation,
+   * where the current load job is cancelled and a new job is scheduled right away.
+   */
+  public static final String MANUAL_CANCELLATION_MARKER = "manualCancellationMarker";
+
   private final IExecutionSemaphore m_tileExecutionSemaphore = Jobs.newExecutionSemaphore(CONFIG.getPropertyValue(TileMaxConcurrentDataLoadThreadsProperty.class)).seal();
 
   public TileDataLoadManager() {


### PR DESCRIPTION
When a tile is reloaded while the previous load call is still running, the previous future is cancelled explicitly. However, because we immediately schedule a new load future, it is not necessary to call the onLoadDataCancel() callback. If that callback is used to show an error message, it would even be wrong! To achieve this behavior, we set a special execution hint on the previous future to indicate that the cancellation happend explicitly and does not need to be handled by the tile.

392970