### PR TITLE
getGrantedPermissionLevel: Ignore null attribute

### DIFF
--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/DefaultPermissionCollection.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/DefaultPermissionCollection.java
@@ -103,7 +103,6 @@ public class DefaultPermissionCollection extends AbstractPermissionCollection {
   @Override
   public PermissionLevel getGrantedPermissionLevel(IPermission permission) {
     if (permission == null) {
-      LOG.warn("getGrantedPermissionLevel was called w/o a permission, returning undefined level");
       return PermissionLevel.UNDEFINED;
     }
 


### PR DESCRIPTION
In 66924c59a7a8f899ee8ba51acf6f239300c19a1d a warning was introduced if getGrantedPermissionLevel was called with a null input; however this null input is valid after all, see javadoc on IPermissionCollection; remove incorrect warning.

397579