### PR TITLE
FocusContext: only change focus for elements with tabindex="-2"

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.ts
+++ b/eclipse-scout-core/src/focus/FocusContext.ts
@@ -165,9 +165,9 @@ export class FocusContext {
   protected _onFocusIn(event: FocusInEvent) {
     let $target = $(event.target);
 
-    // Sometimes, the browser focuses an element that we don't consider focusable (e.g. scrollable divs, https://developer.chrome.com/blog/keyboard-focusable-scrollers).
+    // SPECIAL CASE: We consider elements with tabindex="-2" to be _never_ focusable, not even programmatically!
     // Redirect the focus to the first focusable parent element.
-    if (!$target.is(':focusable')) {
+    if (Number($target.attr('tabindex')) === -2) {
       // noinspection CssInvalidPseudoSelector (inspection seems to confuse $.fn.closest with the native Element.closest method)
       let $newTarget = $target.parent().closest(':focusable');
       focusUtils.focusLater($newTarget, {preventScroll: true});


### PR DESCRIPTION
Certains elements are sometimes focusable, sometimes not. For example, an <iframe> is only (keyboard) focusable if it does not contain a focusable elements, e.g. only text. In that case we want to accept the focus, because the text could not be selected by mouse otherwise.

The special "focus later" case is only explicitly needed for elements that are focusable, but we never want the focus to be on. We use the special tabindex "-2" to mark them.

381281