### PR TITLE
Table: startCellEdit must not fail if row is not rendered or hiding

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -3250,6 +3250,9 @@ export class Table extends Widget implements TableModel {
     let popup = column.startCellEdit(row, field);
     this.cellEditorPopup = popup;
     this.$container.toggleClass('has-cell-editor-popup', !!popup);
+    if (!popup.rendered) {
+      this.cancelCellEdit();
+    }
     return popup;
   }
 
@@ -3282,7 +3285,17 @@ export class Table extends Widget implements TableModel {
     field.destroy();
   }
 
+  /**
+   * Completes the cell editing with the following steps:
+   * - Triggers the `completeCellEdit` event. If `preventDefault()` is called on the event, the following steps are not executed.
+   * - Updates the cell value with the value from the cell editor.
+   * - Closes the cell editor.
+   */
   completeCellEdit() {
+    if (!this.cellEditorPopup) {
+      // No editing in progress
+      return;
+    }
     let field = this.cellEditorPopup.cell.field;
     let event = this.trigger('completeCellEdit', {
       field: field,
@@ -3292,11 +3305,20 @@ export class Table extends Widget implements TableModel {
     });
 
     if (!event.defaultPrevented) {
-      return this.endCellEdit(field, true);
+      this.endCellEdit(field, true);
     }
   }
 
+  /**
+   * Cancels the cell editing with the following steps:
+   * - Triggers the `cancelCellEdit` event. If `preventDefault()` is called on the event, the following step is not executed.
+   * - Closes the cell editor without updating the cell's value.
+   */
   cancelCellEdit() {
+    if (!this.cellEditorPopup) {
+      // No editing in progress
+      return;
+    }
     let field = this.cellEditorPopup.cell.field;
     let event = this.trigger('cancelCellEdit', {
       field: field,

--- a/eclipse-scout-core/src/table/columns/Column.ts
+++ b/eclipse-scout-core/src/table/columns/Column.ts
@@ -449,14 +449,19 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
   }
 
   startCellEdit(row: TableRow, field: ValueField<TValue>): CellEditorPopup<TValue> {
-    let $row = row.$row,
-      cell = this.cell(row),
-      $cell = this.table.$cell(this, $row);
-
+    let cell = this.cell(row);
     cell.field = field;
     // Override field alignment with the cell's alignment
     cell.field.gridData.horizontalAlignment = cell.horizontalAlignment;
     let popup = this._createEditorPopup(row, cell);
+    if (!row.$row || row.$row.hasClass('hiding')) {
+      // Don't open popup if row has been removed or is being removed
+      return popup;
+    }
+    let $cell = this.table.$cell(this, row.$row);
+    if (!$cell) {
+      return popup;
+    }
     popup.$anchor = $cell;
     popup.open(this.table.$data);
     return popup;

--- a/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
+++ b/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
@@ -167,15 +167,18 @@ export class CellEditorPopup<TValue> extends Popup implements CellEditorPopupMod
   }
 
   override position(switchIfNecessary?: boolean) {
-    let $tableData = this.table.$data,
-      $row = this.row.$row,
-      $cell = this.$anchor,
-      insetsLeft = $tableData.cssPaddingLeft() + $row.cssMarginLeft() + $row.cssBorderLeftWidth();
+    if (!this.rendered) {
+      return;
+    }
 
     this._alignWithSelection();
 
+    let $cell = this.$anchor;
     let cellBounds = graphics.bounds($cell);
+    let $row = this.row.$row;
     let rowBounds = graphics.bounds($row);
+    let $tableData = this.table.$data;
+    let insetsLeft = $tableData.cssPaddingLeft() + $row.cssMarginLeft() + $row.cssBorderLeftWidth();
     this.setLocation(new Point(insetsLeft + cellBounds.x, $tableData.scrollTop() + rowBounds.y));
   }
 

--- a/eclipse-scout-core/test/table/editor/CellEditorSpec.ts
+++ b/eclipse-scout-core/test/table/editor/CellEditorSpec.ts
@@ -281,7 +281,7 @@ describe('CellEditor', () => {
   });
 
   describe('startCellEdit', () => {
-    let table;
+    let table: Table;
 
     beforeEach(() => {
       let model = helper.createModelFixture(2, 2);
@@ -333,6 +333,55 @@ describe('CellEditor', () => {
       table.attach();
       assertCellEditorIsOpen(table, table.columns[0], table.rows[0]);
       expect(table.cellEditorPopup.cell.field).toBe(field);
+    });
+
+    it('does nothing if cell is not rendered', () => {
+      table.columns[0].setEditable(true);
+      table.remove(); // Remove, so that filtering won't be animated and cells won't be rendered when editing starts
+      table.addFilter(() => false); // Don't accept any row
+      table.render();
+      helper.applyDisplayStyle(table);
+      let cancelEvent;
+      table.on('cancelCellEdit', event => {
+        cancelEvent = event;
+      });
+
+      let field = createStringField();
+      let popup = table.startCellEdit(table.columns[0], table.rows[0], field);
+      expect(popup.cell.field).toBe(field);
+      // Popup is not rendered because cell is not rendered
+      expect($findPopup().length).toBe(0);
+      // Expect cancel event so field will be disposed correctly
+      expect(cancelEvent.column).toBe(table.columns[0]);
+      expect(cancelEvent.row).toBe(table.rows[0]);
+      expect(cancelEvent.field).toBe(table.rows[0].cells[0].field);
+      expect(cancelEvent.field.destroyed).toBe(true);
+    });
+
+    it('does nothing if row is hiding', () => {
+      table.columns[0].setEditable(true);
+      table.addFilter(() => false); // Don't accept any row
+      expect(table.rows[0].$row).toHaveClass('hiding');
+
+      let cancelEvent;
+      table.on('cancelCellEdit', event => {
+        cancelEvent = event;
+      });
+
+      let field = createStringField();
+      let popup = table.startCellEdit(table.columns[0], table.rows[0], field);
+      expect(popup.cell.field).toBe(field);
+      // Popup is not rendered because row is hiding
+      // -> Popup would be positioned on the wrong row
+      // -> Repositioning initiated by table layout or scrolling could cause errors because there is no anchor
+      expect($findPopup().length).toBe(0);
+      // Expect cancel event so field will be disposed correctly
+      expect(cancelEvent.column).toBe(table.columns[0]);
+      expect(cancelEvent.row).toBe(table.rows[0]);
+      expect(cancelEvent.field).toBe(table.rows[0].cells[0].field);
+      expect(cancelEvent.field.destroyed).toBe(true);
+
+      popup.position(); // Must not fail if popup is not rendered
     });
   });
 


### PR DESCRIPTION
Use case:
- Filter is active which hides all rows
- table.focusCell() is called

Currently, an exception occurs because startCellEdit calls table.$cell() which fails because $row is null.

397551

If startCell is called while the row is still hiding because of the filtering, the exception does not occur immediately. Instead, the popup is positioned incorrectly and an exception occurs as soon as the popup is being repositioned (e.g. when the table is layouted or scrolled).

The rendered check at CellEditorPopup.position is not required to solve this error. It has been added to make it consistent with the super class. And to make it more failsafe because startCellEdit may return a popup that is not rendered.

350207