### PR TITLE
Add Java representation for Switch widget (ToggleSwitch)

### DIFF
--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -910,6 +910,7 @@ export * from './form/fields/wrappedform/WrappedFormFieldEventMap';
 export * from './form/fields/wrappedform/WrappedFormFieldAdapter';
 export * from './calendar/ResourcePanel';
 export * from './switch/Switch';
+export * from './switch/SwitchAdapter';
 export * from './switch/SwitchModel';
 export * from './switch/SwitchEventMap';
 export * from './switch/SwitchNavigationKeyStroke';

--- a/eclipse-scout-core/src/switch/Switch.ts
+++ b/eclipse-scout-core/src/switch/Switch.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -188,7 +188,7 @@ export class Switch extends Widget implements SwitchModel {
 
   /**
    * @param originalEvent original event that caused the toggle
-   * @param newValue if set, the `activated` property is set to this value.
+   * @param activated if set, the `activated` property is set to this value.
    *           Otherwise, it is set to opposite of the current value.
    */
   toggleSwitch(originalEvent?: JQuery.Event, activated?: boolean) {

--- a/eclipse-scout-core/src/switch/SwitchAdapter.ts
+++ b/eclipse-scout-core/src/switch/SwitchAdapter.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {ModelAdapter} from '../session/ModelAdapter';
+
+export class SwitchAdapter extends ModelAdapter {
+
+  constructor() {
+    super();
+    this._addRemoteProperties(['activated']);
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/toggleswitch/AbstractToggleSwitch.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/toggleswitch/AbstractToggleSwitch.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.toggleswitch;
+
+import org.eclipse.scout.rt.client.ModelContextProxy;
+import org.eclipse.scout.rt.client.ModelContextProxy.ModelContext;
+import org.eclipse.scout.rt.client.ui.AbstractWidget;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.platform.annotations.ConfigProperty;
+import org.eclipse.scout.rt.platform.classid.ClassId;
+
+@ClassId("8f5e0016-cd17-47ce-bdac-034888f6915f")
+public class AbstractToggleSwitch extends AbstractWidget implements IToggleSwitch {
+
+  private IToggleSwitchUIFacade m_uiFacade;
+
+  public AbstractToggleSwitch() {
+    this(true);
+  }
+
+  public AbstractToggleSwitch(boolean callInitializer) {
+    super(callInitializer);
+  }
+
+  @Override
+  protected void initConfig() {
+    m_uiFacade = BEANS.get(ModelContextProxy.class).newProxy(createUIFacade(), ModelContext.copyCurrent());
+    super.initConfig();
+    setActivated(getConfiguredActivated());
+    setLabel(getConfiguredLabel());
+    setLabelHtmlEnabled(getConfiguredLabelHtmlEnabled());
+    setLabelVisible(getConfiguredLabelVisible());
+    setTooltipText(getConfiguredTooltipText());
+    setIconVisible(getConfiguredIconVisible());
+    setDisplayStyle(getConfiguredDisplayStyle());
+    setTabbable(getConfiguredTabbable());
+  }
+
+  @Override
+  public IToggleSwitchUIFacade getUIFacade() {
+    return m_uiFacade;
+  }
+
+  protected IToggleSwitchUIFacade createUIFacade() {
+    return new P_UIFacade();
+  }
+
+  @ConfigProperty(ConfigProperty.BOOLEAN)
+  @Order(10)
+  protected boolean getConfiguredActivated() {
+    return false;
+  }
+
+  @ConfigProperty(ConfigProperty.TEXT)
+  @Order(20)
+  protected String getConfiguredLabel() {
+    return null;
+  }
+
+  /**
+   * Configures, if HTML rendering is enabled.
+   * <p>
+   * Subclasses can override this method. Default is {@code false}. Make sure that any user input (or other insecure
+   * input) is encoded (security), if this property is enabled.
+   *
+   * @return {@code true}, if HTML rendering is enabled, {@code false} otherwise.
+   */
+  @ConfigProperty(ConfigProperty.BOOLEAN)
+  @Order(21)
+  protected boolean getConfiguredLabelHtmlEnabled() {
+    return false;
+  }
+
+  /**
+   * <ul>
+   * <li>{@code true}: label is visible
+   * <li>{@code false}: label is invisible
+   * <li>{@code null}: label is visible depending on whether {@link #getLabel()} contains text
+   * </ul>
+   */
+  @ConfigProperty(ConfigProperty.BOOLEAN)
+  @Order(22)
+  protected Boolean getConfiguredLabelVisible() {
+    return null;
+  }
+
+  @ConfigProperty(ConfigProperty.TEXT)
+  @Order(30)
+  protected String getConfiguredTooltipText() {
+    return null;
+  }
+
+  @ConfigProperty(ConfigProperty.BOOLEAN)
+  @Order(40)
+  protected boolean getConfiguredIconVisible() {
+    return false;
+  }
+
+  @ConfigProperty(ConfigProperty.TEXT)
+  @Order(50)
+  protected String getConfiguredDisplayStyle() {
+    return DISPLAY_STYLE_DEFAULT;
+  }
+
+  @ConfigProperty(ConfigProperty.BOOLEAN)
+  @Order(60)
+  protected boolean getConfiguredTabbable() {
+    return false;
+  }
+
+  @Override
+  public boolean isActivated() {
+    return propertySupport.getPropertyBool(PROP_ACTIVATED);
+  }
+
+  @Override
+  public void setActivated(boolean activated) {
+    propertySupport.setPropertyBool(PROP_ACTIVATED, activated);
+  }
+
+  @Override
+  public String getLabel() {
+    return propertySupport.getPropertyString(PROP_LABEL);
+  }
+
+  @Override
+  public void setLabel(String label) {
+    propertySupport.setPropertyString(PROP_LABEL, label);
+  }
+
+  @Override
+  public boolean isLabelHtmlEnabled() {
+    return propertySupport.getPropertyBool(PROP_LABEL_HTML_ENABLED);
+  }
+
+  @Override
+  public void setLabelHtmlEnabled(boolean labelHtmlEnabled) {
+    propertySupport.setPropertyBool(PROP_LABEL_HTML_ENABLED, labelHtmlEnabled);
+  }
+
+  @Override
+  public Boolean getLabelVisible() {
+    return propertySupport.getProperty(PROP_LABEL_VISIBLE, Boolean.class);
+  }
+
+  @Override
+  public void setLabelVisible(Boolean labelVisible) {
+    propertySupport.setProperty(PROP_LABEL_VISIBLE, labelVisible);
+  }
+
+  @Override
+  public String getTooltipText() {
+    return propertySupport.getPropertyString(PROP_TOOLTIP_TEXT);
+  }
+
+  @Override
+  public void setTooltipText(String tooltipText) {
+    propertySupport.setPropertyString(PROP_TOOLTIP_TEXT, tooltipText);
+  }
+
+  @Override
+  public boolean isIconVisible() {
+    return propertySupport.getPropertyBool(PROP_ICON_VISIBLE);
+  }
+
+  @Override
+  public void setIconVisible(boolean iconVisible) {
+    propertySupport.setPropertyBool(PROP_ICON_VISIBLE, iconVisible);
+  }
+
+  @Override
+  public String getDisplayStyle() {
+    return propertySupport.getPropertyString(PROP_DISPLAY_STYLE);
+  }
+
+  @Override
+  public void setDisplayStyle(String displayStyle) {
+    propertySupport.setPropertyString(PROP_DISPLAY_STYLE, displayStyle);
+  }
+
+  @Override
+  public boolean isTabbable() {
+    return propertySupport.getPropertyBool(PROP_TABBABLE);
+  }
+
+  @Override
+  public void setTabbable(boolean tabbable) {
+    propertySupport.setPropertyBool(PROP_TABBABLE, tabbable);
+  }
+
+  protected class P_UIFacade implements IToggleSwitchUIFacade {
+
+    @Override
+    public void setActivatedFromUI(boolean activated) {
+      if (!isEnabledIncludingParents()) {
+        return;
+      }
+      setActivated(activated);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/toggleswitch/IToggleSwitch.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/toggleswitch/IToggleSwitch.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.toggleswitch;
+
+import org.eclipse.scout.rt.client.ui.IWidget;
+
+public interface IToggleSwitch extends IWidget {
+
+  String PROP_ACTIVATED = "activated";
+  String PROP_LABEL = "label";
+  String PROP_LABEL_HTML_ENABLED = "labelHtmlEnabled";
+  String PROP_LABEL_VISIBLE = "labelVisible";
+  String PROP_TOOLTIP_TEXT = "tooltipText";
+  String PROP_ICON_VISIBLE = "iconVisible";
+  String PROP_DISPLAY_STYLE = "displayStyle";
+  String PROP_TABBABLE = "tabbable";
+
+  String DISPLAY_STYLE_DEFAULT = "default";
+  String DISPLAY_STYLE_SLIDER = "slider";
+
+  IToggleSwitchUIFacade getUIFacade();
+
+  boolean isActivated();
+
+  void setActivated(boolean activated);
+
+  String getLabel();
+
+  void setLabel(String label);
+
+  boolean isLabelHtmlEnabled();
+
+  void setLabelHtmlEnabled(boolean labelHtmlEnabled);
+
+  /**
+   * If this is {@code null}, the label is automatically visible when {@link #getLabel()} contains text.
+   */
+  Boolean getLabelVisible();
+
+  void setLabelVisible(Boolean labelVisible);
+
+  String getTooltipText();
+
+  void setTooltipText(String tooltipText);
+
+  boolean isIconVisible();
+
+  void setIconVisible(boolean iconVisible);
+
+  String getDisplayStyle();
+
+  void setDisplayStyle(String displayStyle);
+
+  boolean isTabbable();
+
+  void setTabbable(boolean tabbable);
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/toggleswitch/IToggleSwitchUIFacade.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/toggleswitch/IToggleSwitchUIFacade.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.toggleswitch;
+
+public interface IToggleSwitchUIFacade {
+
+  void setActivatedFromUI(boolean activated);
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/JsonObjectFactory.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/JsonObjectFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -115,6 +115,7 @@ import org.eclipse.scout.rt.client.ui.tile.ITile;
 import org.eclipse.scout.rt.client.ui.tile.ITileAccordion;
 import org.eclipse.scout.rt.client.ui.tile.ITileGrid;
 import org.eclipse.scout.rt.client.ui.tile.IWidgetTile;
+import org.eclipse.scout.rt.client.ui.toggleswitch.IToggleSwitch;
 import org.eclipse.scout.rt.client.uuidpool.IUuidPool;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.Order;
@@ -229,6 +230,7 @@ import org.eclipse.scout.rt.ui.html.json.tile.JsonTile;
 import org.eclipse.scout.rt.ui.html.json.tile.JsonTileAccordion;
 import org.eclipse.scout.rt.ui.html.json.tile.JsonTileGrid;
 import org.eclipse.scout.rt.ui.html.json.tile.JsonWidgetTile;
+import org.eclipse.scout.rt.ui.html.json.toggleswitch.JsonToggleSwitch;
 import org.eclipse.scout.rt.ui.html.json.tree.JsonTree;
 import org.eclipse.scout.rt.ui.html.uuidpool.JsonUuidPool;
 
@@ -512,6 +514,9 @@ public class JsonObjectFactory extends AbstractJsonObjectFactory {
     }
     if (model instanceof HybridManager) {
       return new JsonHybridManager<>((HybridManager) model, session, id, parent);
+    }
+    if (model instanceof IToggleSwitch) {
+      return new JsonToggleSwitch<>((IToggleSwitch) model, session, id, parent);
     }
     return null;
   }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/toggleswitch/JsonToggleSwitch.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/toggleswitch/JsonToggleSwitch.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html.json.toggleswitch;
+
+import org.eclipse.scout.rt.client.ui.toggleswitch.IToggleSwitch;
+import org.eclipse.scout.rt.ui.html.IUiSession;
+import org.eclipse.scout.rt.ui.html.json.AbstractJsonWidget;
+import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
+import org.eclipse.scout.rt.ui.html.json.JsonProperty;
+import org.json.JSONObject;
+
+public class JsonToggleSwitch<T extends IToggleSwitch> extends AbstractJsonWidget<T> {
+
+  public JsonToggleSwitch(T model, IUiSession uiSession, String id, IJsonAdapter<?> parent) {
+    super(model, uiSession, id, parent);
+  }
+
+  @Override
+  public String getObjectType() {
+    return "Switch";
+  }
+
+  @Override
+  protected void initJsonProperties(T model) {
+    super.initJsonProperties(model);
+    putJsonProperty(new JsonProperty<>(IToggleSwitch.PROP_ACTIVATED, model) {
+      @Override
+      protected Boolean modelValue() {
+        return getModel().isActivated();
+      }
+    });
+    putJsonProperty(new JsonProperty<>(IToggleSwitch.PROP_LABEL, model) {
+      @Override
+      protected String modelValue() {
+        return getModel().getLabel();
+      }
+    });
+    putJsonProperty(new JsonProperty<>(IToggleSwitch.PROP_LABEL_HTML_ENABLED, model) {
+      @Override
+      protected Boolean modelValue() {
+        return getModel().isLabelHtmlEnabled();
+      }
+    });
+    putJsonProperty(new JsonProperty<>(IToggleSwitch.PROP_LABEL_VISIBLE, model) {
+      @Override
+      protected Boolean modelValue() {
+        return getModel().getLabelVisible();
+      }
+    });
+    putJsonProperty(new JsonProperty<>(IToggleSwitch.PROP_TOOLTIP_TEXT, model) {
+      @Override
+      protected String modelValue() {
+        return getModel().getTooltipText();
+      }
+    });
+    putJsonProperty(new JsonProperty<>(IToggleSwitch.PROP_ICON_VISIBLE, model) {
+      @Override
+      protected Boolean modelValue() {
+        return getModel().isIconVisible();
+      }
+    });
+    putJsonProperty(new JsonProperty<>(IToggleSwitch.PROP_DISPLAY_STYLE, model) {
+      @Override
+      protected String modelValue() {
+        return getModel().getDisplayStyle();
+      }
+    });
+    putJsonProperty(new JsonProperty<>(IToggleSwitch.PROP_TABBABLE, model) {
+      @Override
+      protected Boolean modelValue() {
+        return getModel().isTabbable();
+      }
+    });
+  }
+
+  @Override
+  protected void handleUiPropertyChange(String propertyName, JSONObject data) {
+    if (IToggleSwitch.PROP_ACTIVATED.equals(propertyName)) {
+      boolean activated = data.getBoolean(propertyName);
+      addPropertyEventFilterCondition(propertyName, activated);
+      getModel().getUIFacade().setActivatedFromUI(activated);
+    }
+    else {
+      super.handleUiPropertyChange(propertyName, data);
+    }
+  }
+}


### PR DESCRIPTION
Note: classes and packages use the name "toggle switch", because "switch" is a reserved keyword in Java.

398685