### PR TITLE
TableField: don't return error status if a cell value is missing

### DIFF
--- a/eclipse-scout-core/src/form/fields/tablefield/TableFieldValidationResultProvider.ts
+++ b/eclipse-scout-core/src/form/fields/tablefield/TableFieldValidationResultProvider.ts
@@ -32,7 +32,7 @@ export class TableFieldValidationResultProvider extends FormFieldValidationResul
     let reveal = cellValidationResult.reveal || (() => {
       // nop
     });
-    let validByMandatory = !this.field.mandatory || !this.field.empty && cellValidationResult.validByMandatory;
+    let validByMandatory = (!this.field.mandatory || !this.field.empty) && cellValidationResult.validByMandatory;
     let validByErrorStatus = !errorStatus || errorStatus.isValid();
     return {
       valid: validByErrorStatus && validByMandatory,
@@ -83,8 +83,9 @@ export class TableFieldValidationResultProvider extends FormFieldValidationResul
       }
     }
     let label = arrays.format(Array.from(invalidCellLabels.values()), ', ');
-    if (invalidCellMessages.size > 1 || !validByMandatory) {
-      // If there are indistinct error message, clear the message to only show the column names
+    if (errorStatus && (invalidCellMessages.size > 1 || !validByMandatory)) {
+      // If there are indistinct error messages, clear the message to only show the column names.
+      // Also clear it if a mandatory cell is empty and another one invalid because the message only belongs to the invalid cell.
       errorStatus = scout.create(Status, $.extend({}, errorStatus, {message: ''}));
     }
     return {label, errorStatus, validByMandatory, reveal};

--- a/eclipse-scout-core/test/form/fields/tablefield/TableFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/tablefield/TableFieldSpec.ts
@@ -246,13 +246,19 @@ describe('TableField', () => {
 
       it('is false if mandatory cells are empty', () => {
         column0.setMandatory(true);
-        expect(tableField.getValidationResult().valid).toBe(true);
+        let result = tableField.getValidationResult();
+        expect(result.valid).toBe(true);
+        expect(result.validByMandatory).toBe(true);
 
         column0.setCellValue(table.rows[0], null);
-        expect(tableField.getValidationResult().valid).toBe(false);
+        result = tableField.getValidationResult();
+        expect(result.valid).toBe(false);
+        expect(result.validByMandatory).toBe(false);
 
         column0.setCellValue(table.rows[0], 'asdf');
-        expect(tableField.getValidationResult().valid).toBe(true);
+        result = tableField.getValidationResult();
+        expect(result.valid).toBe(true);
+        expect(result.validByMandatory).toBe(true);
       });
     });
 
@@ -307,6 +313,24 @@ describe('TableField', () => {
         // Another error with a different message
         column1.setCellErrorStatus(table.rows[1], Status.error('another error'));
         expect(tableField.getValidationResult().errorStatus.message).toBe('');
+
+        // Column 2 has no error but is mandatory without a value -> also remove message
+        column1.setCellErrorStatus(table.rows[1], null);
+        column1.setMandatory(true);
+        column1.setCellValue(table.rows[0], null);
+        expect(tableField.getValidationResult().errorStatus.message).toBe('');
+      });
+
+      it('is null if only mandatory cells are empty', () => {
+        column0.setMandatory(true);
+        let result = tableField.getValidationResult();
+        expect(result.errorStatus).toBe(null);
+        expect(result.validByMandatory).toBe(true);
+
+        column0.setCellValue(table.rows[0], null);
+        result = tableField.getValidationResult();
+        expect(result.errorStatus).toBe(null);
+        expect(result.validByMandatory).toBe(false);
       });
 
       it('uses the highest severity of all cell errors', () => {


### PR DESCRIPTION
The message of the error status should be cleared if there are multiple invalid cells with different messages. Unfortunately, an error status is created if mandatory cells have no value. In that case, only the flag validByMandatory must be set to false.

394805