### PR TITLE
Table: startCellEdit must not fail if row is not rendered or hiding

### DIFF
--- a/eclipse-scout-core/src/table/Table.js
+++ b/eclipse-scout-core/src/table/Table.js
@@ -3086,6 +3086,9 @@ export default class Table extends Widget {
     let popup = column.startCellEdit(row, field);
     this.cellEditorPopup = popup;
     this.$container.toggleClass('has-cell-editor-popup', !!popup);
+    if (!popup.rendered) {
+      this.cancelCellEdit();
+    }
     return popup;
   }
 
@@ -3118,7 +3121,17 @@ export default class Table extends Widget {
     field.destroy();
   }
 
+  /**
+   * Completes the cell editing with the following steps:
+   * - Triggers the `completeCellEdit` event. If `preventDefault()` is called on the event, the following steps are not executed.
+   * - Updates the cell value with the value from the cell editor.
+   * - Closes the cell editor.
+   */
   completeCellEdit() {
+    if (!this.cellEditorPopup) {
+      // No editing in progress
+      return;
+    }
     let field = this.cellEditorPopup.cell.field;
     let event = new Event({
       field: field,
@@ -3129,11 +3142,20 @@ export default class Table extends Widget {
     this.trigger('completeCellEdit', event);
 
     if (!event.defaultPrevented) {
-      return this.endCellEdit(field, true);
+      this.endCellEdit(field, true);
     }
   }
 
+  /**
+   * Cancels the cell editing with the following steps:
+   * - Triggers the `cancelCellEdit` event. If `preventDefault()` is called on the event, the following step is not executed.
+   * - Closes the cell editor without updating the cell's value.
+   */
   cancelCellEdit() {
+    if (!this.cellEditorPopup) {
+      // No editing in progress
+      return;
+    }
     let field = this.cellEditorPopup.cell.field;
     let event = new Event({
       field: field,

--- a/eclipse-scout-core/src/table/columns/Column.js
+++ b/eclipse-scout-core/src/table/columns/Column.js
@@ -386,15 +386,19 @@ export default class Column {
   }
 
   startCellEdit(row, field) {
-    let popup,
-      $row = row.$row,
-      cell = this.cell(row),
-      $cell = this.table.$cell(this, $row);
-
+    let cell = this.cell(row);
     cell.field = field;
     // Override field alignment with the cell's alignment
     cell.field.gridData.horizontalAlignment = cell.horizontalAlignment;
-    popup = this._createEditorPopup(row, cell);
+    let popup = this._createEditorPopup(row, cell);
+    if (!row.$row || row.$row.hasClass('hiding')) {
+      // Don't open popup if row has been removed or is being removed
+      return popup;
+    }
+    let $cell = this.table.$cell(this, row.$row);
+    if (!$cell) {
+      return popup;
+    }
     popup.$anchor = $cell;
     popup.open(this.table.$data);
     return popup;

--- a/eclipse-scout-core/src/table/editor/CellEditorPopup.js
+++ b/eclipse-scout-core/src/table/editor/CellEditorPopup.js
@@ -165,16 +165,19 @@ export default class CellEditorPopup extends Popup {
     this.$anchor.css('visibility', '');
   }
 
-  position() {
-    let $tableData = this.table.$data,
-      $row = this.row.$row,
-      $cell = this.$anchor,
-      insetsLeft = $tableData.cssPaddingLeft() + $row.cssMarginLeft() + $row.cssBorderLeftWidth();
+  position(switchIfNecessary) {
+    if (!this.rendered) {
+      return;
+    }
 
     this._alignWithSelection();
 
+    let $cell = this.$anchor;
     let cellBounds = graphics.bounds($cell);
+    let $row = this.row.$row;
     let rowBounds = graphics.bounds($row);
+    let $tableData = this.table.$data;
+    let insetsLeft = $tableData.cssPaddingLeft() + $row.cssMarginLeft() + $row.cssBorderLeftWidth();
     this.setLocation(new Point(insetsLeft + cellBounds.x, $tableData.scrollTop() + rowBounds.y));
   }
 


### PR DESCRIPTION
Use case:
- Filter is active which hides all rows
- table.focusCell() is called

Currently, an exception occurs because startCellEdit calls table.$cell() which fails because $row is null.

397551

If startCell is called while the row is still hiding because of the filtering, the exception does not occur immediately. Instead, the popup is positioned incorrectly and an exception occurs as soon as the popup is being repositioned (e.g. when the table is layouted or scrolled).

The rendered check at CellEditorPopup.position is not required to solve this error. It has been added to make it consistent with the super class. And to make it more failsafe because startCellEdit may return a popup that is not rendered.

350207