### PR TITLE
Allow named deferred queue flush jobs for simpler debugging

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/concurrent/FixtureDeferredOperationQueue.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/concurrent/FixtureDeferredOperationQueue.java
@@ -23,7 +23,11 @@ public class FixtureDeferredOperationQueue<E> extends DeferredOperationQueue<E> 
   private final AtomicBoolean m_scheduleFlushJobInvoked = new AtomicBoolean();
 
   public FixtureDeferredOperationQueue(String transactionMemberId, int batchSize, long maxDelayMillis, Consumer<List<E>> batchOperation) {
-    super(transactionMemberId, batchSize, maxDelayMillis, batchOperation);
+    this(transactionMemberId, batchSize, maxDelayMillis, batchOperation, null);
+  }
+
+  public FixtureDeferredOperationQueue(String transactionMemberId, int batchSize, long maxDelayMillis, Consumer<List<E>> batchOperation, String flushJobName) {
+    super(transactionMemberId, batchSize, maxDelayMillis, batchOperation, null, flushJobName);
   }
 
   @Override


### PR DESCRIPTION
- Adds parameter to name a deferred queue's flush job
- If no name's provided, the deferred queue's mandatory transaction member ID is used for the flush job's name