### PR TITLE
UiNotifications: don't poll during tests

### DIFF
--- a/eclipse-scout-core/src/testing/index.ts
+++ b/eclipse-scout-core/src/testing/index.ts
@@ -46,6 +46,7 @@ export * from './scoutMatchers';
 export * from './table/SpecTable';
 export * from './table/SpecTableAdapter';
 export * from './tree/SpecTree';
+export * from './uinotification/UiNotificationsMock';
 
 export default self;
 ObjectFactory.get().registerNamespace('scout', self);

--- a/eclipse-scout-core/src/testing/uinotification/UiNotificationsMock.ts
+++ b/eclipse-scout-core/src/testing/uinotification/UiNotificationsMock.ts
@@ -12,6 +12,7 @@ import {ObjectFactory, UiNotificationHandler, uiNotifications, UiNotificationSys
 import $ from 'jquery';
 
 export class UiNotificationsMock {
+
   static register() {
     // Remove systems so a call to uiNotifications.subscribe() will create new mocked systems.
     uiNotifications.tearDown();
@@ -28,12 +29,13 @@ export class UiNotificationsMock {
 }
 
 export class UiNotificationSystemMock extends UiNotificationSystem {
+
   override subscribe(topic: string, handler: UiNotificationHandler): JQuery.Promise<string> {
-    return $.Deferred().promise();
+    return $.resolvedPromise(topic);
   }
 
   override subscribeOne(topic: string, handler: UiNotificationHandler): JQuery.Promise<string> {
-    return $.Deferred().promise();
+    return $.resolvedPromise(topic);
   }
 
   override unsubscribe(topic: string, handler?: UiNotificationHandler) {

--- a/eclipse-scout-core/src/testing/uinotification/UiNotificationsMock.ts
+++ b/eclipse-scout-core/src/testing/uinotification/UiNotificationsMock.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {ObjectFactory, UiNotificationHandler, uiNotifications, UiNotificationSystem} from '../../index';
+import $ from 'jquery';
+
+export class UiNotificationsMock {
+  static register() {
+    // Remove systems so a call to uiNotifications.subscribe() will create new mocked systems.
+    uiNotifications.tearDown();
+
+    ObjectFactory.get().register(UiNotificationSystem, () => new UiNotificationSystemMock());
+  }
+
+  static unregister() {
+    // Remove mocked systems so a call to uiNotifications.subscribe() will create new real systems.
+    uiNotifications.tearDown();
+
+    ObjectFactory.get().unregister(UiNotificationSystem);
+  }
+}
+
+export class UiNotificationSystemMock extends UiNotificationSystem {
+  override subscribe(topic: string, handler: UiNotificationHandler): JQuery.Promise<string> {
+    return $.Deferred().promise();
+  }
+
+  override subscribeOne(topic: string, handler: UiNotificationHandler): JQuery.Promise<string> {
+    return $.Deferred().promise();
+  }
+
+  override unsubscribe(topic: string, handler?: UiNotificationHandler) {
+    // nop
+  }
+}

--- a/eclipse-scout-core/src/uinotification/UiNotificationSystem.ts
+++ b/eclipse-scout-core/src/uinotification/UiNotificationSystem.ts
@@ -12,6 +12,7 @@ import {Event, EventHandler, EventListener, EventSupport, InitModelOf, ObjectMod
 export class UiNotificationSystem implements UiNotificationSystemModel, ObjectWithType {
   declare model: UiNotificationSystemModel;
   declare initModel: UiNotificationSystemModel;
+
   poller: UiNotificationPoller;
   name: string;
   events: UiNotificationEventSupport;

--- a/eclipse-scout-core/src/uinotification/UiNotificationSystem.ts
+++ b/eclipse-scout-core/src/uinotification/UiNotificationSystem.ts
@@ -7,16 +7,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Event, EventHandler, EventListener, EventSupport, scout, systems, UiNotificationDo, UiNotificationHandler, UiNotificationPoller} from '../index';
+import {Event, EventHandler, EventListener, EventSupport, InitModelOf, ObjectModel, ObjectWithType, scout, systems, UiNotificationDo, UiNotificationHandler, UiNotificationPoller} from '../index';
 
-export class UiNotificationSystem {
+export class UiNotificationSystem implements UiNotificationSystemModel, ObjectWithType {
+  declare model: UiNotificationSystemModel;
+  declare initModel: UiNotificationSystemModel;
   poller: UiNotificationPoller;
   name: string;
   events: UiNotificationEventSupport;
+  objectType: string;
 
-  constructor(name: string) {
-    this.name = name;
+  constructor() {
     this.events = new UiNotificationEventSupport(this);
+  }
+
+  init(model: InitModelOf<this>) {
+    this.name = model?.name;
   }
 
   subscribe(topic: string, handler: UiNotificationHandler): JQuery.Promise<string> {
@@ -130,4 +136,8 @@ class UiNotificationEventSupport extends EventSupport {
     super.off(type, func);
     this.system.updatePoller();
   }
+}
+
+export interface UiNotificationSystemModel extends ObjectModel<UiNotificationSystem> {
+  name?: string;
 }

--- a/eclipse-scout-core/src/uinotification/uiNotifications.ts
+++ b/eclipse-scout-core/src/uinotification/uiNotifications.ts
@@ -75,10 +75,11 @@ export class UiNotifications {
     return Math.ceil(Math.random() * 1000 * reloadDelayWindow); // randomly delay the reload within the necessary time window (milliseconds)
   }
 
+  /**
+   * Unregisters all systems and closes the pending connections, if there are any.
+   */
   tearDown() {
-    for (const system of this.systems.values()) {
-      system.destroy();
-    }
+    this.systems.forEach(system => system.destroy());
     this.systems.clear();
   }
 

--- a/eclipse-scout-core/src/uinotification/uiNotifications.ts
+++ b/eclipse-scout-core/src/uinotification/uiNotifications.ts
@@ -7,10 +7,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {scout, System, systems, UiNotificationHandler, UiNotificationSystem} from '../index';
+import {objects, scout, System, systems, UiNotificationHandler, UiNotificationSystem} from '../index';
 
-export const uiNotifications = {
-  systems: new Map<string, UiNotificationSystem>(),
+export class UiNotifications {
+  systems = new Map<string, UiNotificationSystem>();
 
   /**
    * Subscribes for a specific topic and executes the given handler whenever a notification for that topic arrives.
@@ -27,8 +27,8 @@ export const uiNotifications = {
    * @returns a promise that will be resolved as soon as the subscription was successful and notifications can be received.
    */
   subscribe(topic: string, handler: UiNotificationHandler, system?: string): JQuery.Promise<string> {
-    return getOrInitSystem(system).subscribe(topic, handler);
-  },
+    return this._getOrInitSystem(system).subscribe(topic, handler);
+  }
 
   /**
    * Subscribes for a specific topic and executes the given handler when the first notification for that topic arrives.
@@ -37,8 +37,8 @@ export const uiNotifications = {
    * @see subscribe
    */
   subscribeOne(topic: string, handler: UiNotificationHandler, system?: string): JQuery.Promise<string> {
-    return getOrInitSystem(system).subscribeOne(topic, handler);
-  },
+    return this._getOrInitSystem(system).subscribeOne(topic, handler);
+  }
 
   /**
    * Unsubscribes the handler from a specific topic, so it won't be called anymore when a notification for that topic is published.
@@ -46,20 +46,20 @@ export const uiNotifications = {
    * If the last handler was removed for the given system, the connection will be closed and not opened again until a new topic will be subscribed.
    */
   unsubscribe(topic: string, handler?: UiNotificationHandler, system?: string) {
-    getOrInitSystem(system).unsubscribe(topic, handler);
-  },
+    this._getOrInitSystem(system).unsubscribe(topic, handler);
+  }
 
   /**
    * Unregisters the system and closes the pending connection, if there is any.
    */
   unregisterSystem(name: string) {
-    let system = uiNotifications.systems.get(name);
+    let system = this.systems.get(name);
     if (!system) {
       return;
     }
     system.destroy();
-    uiNotifications.systems.delete(name);
-  },
+    this.systems.delete(name);
+  }
 
   /**
    * Computes a reload delay for the current client which lies within the given time window.
@@ -73,32 +73,34 @@ export const uiNotifications = {
       return 0;
     }
     return Math.ceil(Math.random() * 1000 * reloadDelayWindow); // randomly delay the reload within the necessary time window (milliseconds)
-  },
+  }
 
   tearDown() {
-    for (const system of uiNotifications.systems.values()) {
+    for (const system of this.systems.values()) {
       system.destroy();
     }
-    uiNotifications.systems.clear();
+    this.systems.clear();
   }
-};
 
-function getOrInitSystem(system?: string): UiNotificationSystem {
-  system = system || System.MAIN_SYSTEM;
-  if (system !== System.MAIN_SYSTEM && !systems.exists(system)) {
-    // The custom system is not known (yet). Therefore, no custom baseUrl is present. The system will use the default endpoint url.
-    // To prevent having multiple notification systems (and therefore pollers) for the same endpoint url, the system is reset to main if unknown.
-    //
-    // This ignores the case when the main system is registered to a non-default baseUrl. E.g. main system has '/api-main' and other system has '/api'.
-    // Then subscribing to other system would not be possible before actually registering it even if the url would not require a registration (because it is default).
-    // But as this case is rather uncommon and the '/api' url should be considered to be the main system instead, this case is ignored as there is an easy workaround:
-    // register the other system first with default base url.
-    system = System.MAIN_SYSTEM;
+  protected _getOrInitSystem(system?: string): UiNotificationSystem {
+    system = system || System.MAIN_SYSTEM;
+    if (system !== System.MAIN_SYSTEM && !systems.exists(system)) {
+      // The custom system is not known (yet). Therefore, no custom baseUrl is present. The system will use the default endpoint url.
+      // To prevent having multiple notification systems (and therefore pollers) for the same endpoint url, the system is reset to main if unknown.
+      //
+      // This ignores the case when the main system is registered to a non-default baseUrl. E.g. main system has '/api-main' and other system has '/api'.
+      // Then subscribing to other system would not be possible before actually registering it even if the url would not require a registration (because it is default).
+      // But as this case is rather uncommon and the '/api' url should be considered to be the main system instead, this case is ignored as there is an easy workaround:
+      // register the other system first with default base url.
+      system = System.MAIN_SYSTEM;
+    }
+    let systemObj = this.systems.get(system);
+    if (!systemObj) {
+      systemObj = scout.create(UiNotificationSystem, {name: system});
+      this.systems.set(system, systemObj);
+    }
+    return systemObj;
   }
-  let systemObj = uiNotifications.systems.get(system);
-  if (!systemObj) {
-    systemObj = new UiNotificationSystem(system);
-    uiNotifications.systems.set(system, systemObj);
-  }
-  return systemObj;
 }
+
+export const uiNotifications: UiNotifications = objects.createSingletonProxy(UiNotifications);

--- a/eclipse-scout-core/test/uinotification/uiNotificationsSpec.ts
+++ b/eclipse-scout-core/test/uinotification/uiNotificationsSpec.ts
@@ -7,9 +7,20 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {BackgroundJobPollingStatus, dates, DoEntity, JsonObject, Session, systems, UiNotificationDo, UiNotificationPoller, UiNotificationResponse, uiNotifications} from '../../src';
+import {BackgroundJobPollingStatus, dates, DoEntity, JsonObject, Session, systems, UiNotificationDo, UiNotificationPoller, UiNotificationResponse, uiNotifications} from '../../src/index';
+import {UiNotificationsMock} from '../../src/testing/index';
 
 describe('uiNotifications', () => {
+
+  beforeAll(() => {
+    // Unregister mock installed by JasmineScout
+    UiNotificationsMock.unregister();
+  });
+
+  afterAll(() => {
+    // re-register mock to disable polling for other specs
+    UiNotificationsMock.register();
+  });
 
   beforeEach(() => {
     jasmine.Ajax.install();


### PR DESCRIPTION
If a component subscribes for a ui notification topic, the ui notification polling starts. These poll requests will fail and new poll requests will be scheduled, which leads to a lot of noise.

During tests, ui notifications are now disabled by default. If a specific test needs it to be enabled, the mock can be removed by calling UiNotificationMock.unregister(). To not influence other specs, it should be registered again afterward.

Also:
- uiNotifications is now an instance of the class UiNotifications, so it can be replaced using the object factory.
- UiNotificationSystem can now be replaced using the object factory.

388703