### PR TITLE
Charts: increase opacity for points in line charts

### DIFF
--- a/eclipse-scout-chart/src/chart/Chart.less
+++ b/eclipse-scout-chart/src/chart/Chart.less
@@ -505,7 +505,7 @@
 
     #scout.chart-auto-colors-schemes(@opacity: 20);
     #scout.chart-auto-stroke-colors-schemes();
-    #scout.chart-auto-colors-schemes(@opacity: 35, @additional-classes: ~".hover");
+    #scout.chart-auto-colors-schemes(@opacity: 60, @additional-classes: ~".hover");
 
     #scout.chart-auto-colors-schemes(@additional-classes: ~".legend");
   }


### PR DESCRIPTION
The hover points in a line chart were hardly recognizable as there opacity was very low. Increase the opacity to 60 in order to make them more visible. It is not increased even further so that there is still a recognizable difference between unchecked and checked points.

397045