### PR TITLE
NextStepUid is not reset and blocks the process

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/wizard/AbstractWizardStep.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/wizard/AbstractWizardStep.java
@@ -362,7 +362,11 @@ public abstract class AbstractWizardStep<FORM extends IForm> extends AbstractPro
           }
           switch (e.getType()) {
             case FormEvent.TYPE_CLOSED: {
-              setForm(null);
+              // Only reset form if it hasn't changed in the meantime.
+              // This can happen when interceptFormClosed within this listener created a new form for the current step as fallback for an exception or similar.
+              if (f == m_form) {
+                setForm(null);
+              }
               break;
             }
           }


### PR DESCRIPTION
On the FreeStep, the process is continued with a tile and an automatic step follows in the background, which throws an error. The user lands on the FreeStep again, but the nextStepUid is now already set so that the process is blocked.

312244