### PR TITLE
Improve DeferredOperationQueue

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/concurrent/FixtureDeferredOperationQueue.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/concurrent/FixtureDeferredOperationQueue.java
@@ -10,6 +10,9 @@
  */
 package org.eclipse.scout.rt.testing.platform.util.concurrent;
 
+import static java.util.Collections.unmodifiableList;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -22,6 +25,7 @@ import org.eclipse.scout.rt.platform.util.concurrent.DeferredOperationQueue;
 public class FixtureDeferredOperationQueue<E> extends DeferredOperationQueue<E> {
 
   private final AtomicBoolean m_scheduleFlushJobInvoked = new AtomicBoolean();
+  private final List<List<E>> m_executedBatches = new ArrayList<>();
 
   public FixtureDeferredOperationQueue(String transactionMemberId, int batchSize, long maxDelayMillis, Consumer<List<E>> batchOperation) {
     super(transactionMemberId, batchSize, maxDelayMillis, batchOperation);
@@ -35,5 +39,21 @@ public class FixtureDeferredOperationQueue<E> extends DeferredOperationQueue<E> 
 
   public boolean getAndResetScheduleFlushJobWasInvoked() {
     return m_scheduleFlushJobInvoked.getAndSet(false);
+  }
+
+  @Override
+  protected Consumer<List<E>> getBatchOperation() {
+    return (List<E> batch) -> {
+      m_executedBatches.add(batch);
+      super.getBatchOperation().accept(batch);
+    };
+  }
+
+  public List<List<E>> getExecutedBatches() {
+    return unmodifiableList(m_executedBatches);
+  }
+
+  public void resetExecutedBatches() {
+    m_executedBatches.clear();
   }
 }

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/concurrent/DeferredOperationQueueTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/concurrent/DeferredOperationQueueTest.java
@@ -12,12 +12,14 @@ package org.eclipse.scout.rt.platform.util.concurrent;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.eclipse.scout.rt.platform.util.Assertions.assertNotNull;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -33,6 +35,8 @@ import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.job.IFuture;
 import org.eclipse.scout.rt.platform.job.Jobs;
+import org.eclipse.scout.rt.platform.transaction.AbstractTransactionMember;
+import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.platform.util.SleepUtil;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
@@ -152,52 +156,81 @@ public class DeferredOperationQueueTest {
 
   @Test(timeout = 1000)
   public void testFlushDeferredQueueHasBatchSizeElements() {
-    List<String> batch = new ArrayList<>();
-    FixtureDeferredOperationQueue<String> queue = new FixtureDeferredOperationQueue<>(QUEUE_TRANSACTION_MEMBER_ID, 2, TimeUnit.HOURS.toMillis(10), batch::addAll);
-    RunContexts.empty().run(() -> {
-      queue.add("first");
-      queue.add("second");
-    });
-    queue.flushDeferred(true);
-    assertEquals(asList("first", "second"), batch);
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), false, queue -> {
+      queue.add("A");
+      queue.add("B");
+    }, List.of(List.of("A", "B")));
+  }
+
+  @Test(timeout = 1000)
+  public void testFlushDeferredQueueHasBatchSizeElementsSingleRun() {
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), true, queue -> {
+      queue.add("A");
+      queue.add("B");
+    }, List.of(List.of("A", "B")));
   }
 
   @Test(timeout = 1000)
   public void testFlushDeferredQueueHasBatchSizeElementsUsingAddAll() {
-    List<String> batch = new ArrayList<>();
-    FixtureDeferredOperationQueue<String> queue = new FixtureDeferredOperationQueue<>(QUEUE_TRANSACTION_MEMBER_ID, 2, TimeUnit.HOURS.toMillis(10), batch::addAll);
-    RunContexts.empty().run(() -> queue.addAll(Stream.of("first", "second")));
-    queue.flushDeferred(true);
-    assertEquals(asList("first", "second"), batch);
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), false, queue -> queue.addAll(Stream.of("A", "B")), List.of(List.of("A", "B")));
+  }
+
+  @Test(timeout = 1000)
+  public void testFlushDeferredQueueHasBatchSizeElementsUsingAddAllSingleRun() {
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), true, queue -> queue.addAll(Stream.of("A", "B")), List.of(List.of("A", "B")));
   }
 
   @Test(timeout = 1000)
   public void testFlushDeferredQueueHasBatchSizeElementsUsingAddAndAddAll() {
-    List<String> batch = new ArrayList<>();
-    FixtureDeferredOperationQueue<String> queue = new FixtureDeferredOperationQueue<>(QUEUE_TRANSACTION_MEMBER_ID, 2, TimeUnit.HOURS.toMillis(10), batch::addAll);
-    RunContexts.empty().run(() -> {
-      queue.add("first");
-      queue.addAll(Stream.of("second"));
-    });
-    queue.flushDeferred(true);
-    assertEquals(asList("first", "second"), batch);
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), false, queue -> {
+      queue.add("A");
+      queue.addAll(Stream.of("B"));
+    }, List.of(List.of("A", "B")));
   }
 
   @Test(timeout = 1000)
+  public void testFlushDeferredQueueHasBatchSizeElementsUsingAddAndAddAllSingleRun() {
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), true, queue -> {
+      queue.add("A");
+      queue.addAll(Stream.of("B"));
+    }, List.of(List.of("A", "B")));
+  }
+
+  @Test(timeout = 750)
   public void testFlushDeferredQueueHasLessThanBatchSizeElements() {
-    List<String> batch = new ArrayList<>();
-    FixtureDeferredOperationQueue<String> queue = new FixtureDeferredOperationQueue<>(QUEUE_TRANSACTION_MEMBER_ID, 2, 100, batch::addAll);
-    RunContexts.empty().run(() -> queue.add("single"));
-    queue.flushDeferred(true);
-    assertEquals(asList("single"), batch);
+    testFlushDeferredQueue(2, 500, false, (queue) -> queue.add("A"), List.of(List.of("A")));
+  }
+
+  @Test(timeout = 750)
+  public void testFlushDeferredQueueHasLessThanBatchSizeElementsSingleRun() {
+    testFlushDeferredQueue(2, 500, true, (queue) -> queue.add("A"), List.of(List.of("A")));
+  }
+
+  @Test(timeout = 750)
+  public void testFlushDeferredQueueHasMoreThanBatchSizeElements() {
+    testFlushDeferredQueue(2, 500, false, (queue) -> queue.addAll(Stream.of("A", "B", "C", "D", "E")), List.of(List.of("A", "B"), List.of("C", "D"), List.of("E")));
+  }
+
+  @Test(timeout = 1000)
+  public void testFlushDeferredQueueHasMoreThanBatchSizeElementsSingleRun() {
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), true, (queue) -> queue.addAll(Stream.of("A", "B", "C", "D", "E")), List.of(List.of("A", "B")));
   }
 
   @Test(timeout = 1000)
   public void testFlushDeferredQueueHasNoElements() {
-    List<String> batch = new ArrayList<>();
-    FixtureDeferredOperationQueue<String> queue = new FixtureDeferredOperationQueue<>(QUEUE_TRANSACTION_MEMBER_ID, 2, 100, batch::addAll);
-    queue.flushDeferred(true);
-    assertEquals(emptyList(), batch);
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), true, nop(), List.of());
+  }
+
+  @Test(timeout = 1000)
+  public void testFlushDeferredQueueHasNoElementsSingleRun() {
+    testFlushDeferredQueue(2, TimeUnit.HOURS.toMillis(10), true, nop(), List.of());
+  }
+
+  private <T> void testFlushDeferredQueue(int batchSize, long maxDelayMillis, boolean singleRun, Consumer<DeferredOperationQueue<T>> addElements, List<List<T>> expectedBatches) {
+    FixtureDeferredOperationQueue<T> queue = new FixtureDeferredOperationQueue<>(QUEUE_TRANSACTION_MEMBER_ID, batchSize, maxDelayMillis, b -> {});
+    RunContexts.empty().run(() -> addElements.accept(queue));
+    queue.flushDeferred(singleRun);
+    assertEquals(expectedBatches, queue.getExecutedBatches());
   }
 
   @Test(timeout = 3000)
@@ -326,6 +359,69 @@ public class DeferredOperationQueueTest {
 
     assertTrue(flushedLatch.await(2, TimeUnit.SECONDS));
     assertEquals(asList("first element", "second element"), batch);
+  }
+
+  @Test
+  public void testTransactionalBatchOperation() throws Exception {
+    List<List<String>> batches = new ArrayList<>();
+    CountDownLatch flushedLatch = new CountDownLatch(1);
+
+    DeferredOperationQueue<String> queue = new DeferredOperationQueue<>(QUEUE_TRANSACTION_MEMBER_ID, 2, 1000, batch -> getOrCreateTransactionMember(batches).addAll(batch)) {
+      @Override
+      protected void flushDeferred(boolean singleRun) {
+        super.flushDeferred(singleRun);
+        flushedLatch.countDown();
+      }
+    };
+
+    RunContexts.empty().run(() -> queue.addAll(Stream.of("A", "B", "C", "D", "E", "F")));
+
+    assertTrue(flushedLatch.await(1, TimeUnit.SECONDS));
+    assertEquals(List.of(
+        List.of("A", "B"),
+        List.of("C", "D"),
+        List.of("E", "F")), batches);
+  }
+
+  protected P_FixtureTransactionMember getOrCreateTransactionMember(List<List<String>> batches) {
+    ITransaction transaction = assertNotNull(ITransaction.CURRENT.get(), "Not running within a transaction");
+    P_FixtureTransactionMember transactionMember = (P_FixtureTransactionMember) transaction.getMember(P_FixtureTransactionMember.ID);
+    if (transactionMember == null) {
+      transactionMember = new P_FixtureTransactionMember(batches);
+      transaction.registerMember(transactionMember);
+    }
+    return transactionMember;
+  }
+
+  protected class P_FixtureTransactionMember extends AbstractTransactionMember {
+
+    public static final String ID = "P_FixtureTransactionMember";
+
+    private final List<List<String>> m_batches;
+    private final List<String> m_elements = new ArrayList<>();
+
+    public P_FixtureTransactionMember(List<List<String>> batches) {
+      super(ID);
+      m_batches = assertNotNull(batches);
+    }
+
+    public void add(String element) {
+      m_elements.add(element);
+    }
+
+    public void addAll(Collection<String> element) {
+      m_elements.addAll(element);
+    }
+
+    @Override
+    public boolean needsCommit() {
+      return !m_elements.isEmpty();
+    }
+
+    @Override
+    public void commitPhase2() {
+      m_batches.add(m_elements);
+    }
   }
 
   protected static <T> Consumer<T> nop() {

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/concurrent/DeferredOperationQueue.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/concurrent/DeferredOperationQueue.java
@@ -127,7 +127,7 @@ public class DeferredOperationQueue<E> {
   protected void scheduleFlushJob() {
     m_flushJobFuture = Jobs.schedule(
         () -> flushDeferred(false),
-        Jobs.newInput().withRunContext(getRunContextSupplier().get()));
+        Jobs.newInput().withRunContext(RunContexts.empty()));
   }
 
   /**
@@ -145,6 +145,11 @@ public class DeferredOperationQueue<E> {
       List<E> nextBatch = new ArrayList<>(batchSize);
       // get at most batchSize elements at once
       m_queue.drainTo(nextBatch, batchSize);
+
+      // do not wait another maxDelayMillis
+      if (nextBatch.isEmpty()) {
+        break;
+      }
 
       if (nextBatch.size() < batchSize) {
         // wait maxDelayMillis for additional elements
@@ -167,16 +172,17 @@ public class DeferredOperationQueue<E> {
         }
       }
 
-      if (nextBatch.isEmpty()) {
-        break;
-      }
-
-      try {
-        getBatchOperation().accept(nextBatch);
-      }
-      catch (RuntimeException e) {
-        LOG.error("Exception occurred while execution batch operation", e);
-      }
+      // Use a new run context for each execution. Consider e.g. transactional ClientNotifications sent after each
+      // batch. If there is only one run context for all batches the notifications will not be sent until the queue is
+      // completely empty (which may never be the case).
+      getRunContextSupplier().get().run(() -> {
+        try {
+          getBatchOperation().accept(nextBatch);
+        }
+        catch (RuntimeException e) {
+          LOG.error("Exception occurred while execution batch operation", e);
+        }
+      });
     }
     while (!interrupted && !singleRun);
 


### PR DESCRIPTION
The queue processes elements immediately if there are more than its batch size. If there are fewer elements it waits for a specified time for more elements to come and processes a last batch after this delay. Then, if the queue is empty, the flush job completes and is started again after new elements are added to the queue.

In order to minimize the number of loops that are executed, check at the beginning of each loop if the next batch and therefore the whole queue is empty and complete the flush job if it is. Otherwise, the flush job will wait the specified delay unnecessarily before completing.

The job itself used the run context created by the specified supplier. This results in one run context for all batches that are executed. As a queue may run forever, this can lead to an enormous amount of executions that are not committed in the same transaction. In addition, note that the job itself does not really need a run context as it just schedules the batch executions, which are the elements here that need an own run context.
Therefore, use an empty run context for the flush job and the run context created by the supplier for the batch executions.

391689