### PR TITLE
Improve DeferredOperationQueue

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/concurrent/DeferredOperationQueue.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/concurrent/DeferredOperationQueue.java
@@ -126,7 +126,7 @@ public class DeferredOperationQueue<E> {
   protected void scheduleFlushJob() {
     m_flushJobFuture = Jobs.schedule(
         () -> flushDeferred(false),
-        Jobs.newInput().withRunContext(getRunContextSupplier().get()));
+        Jobs.newInput().withRunContext(RunContexts.empty()));
   }
 
   /**
@@ -144,6 +144,11 @@ public class DeferredOperationQueue<E> {
       List<E> nextBatch = new ArrayList<>(batchSize);
       // get at most batchSize elements at once
       m_queue.drainTo(nextBatch, batchSize);
+
+      // do not wait another maxDelayMillis
+      if (nextBatch.isEmpty()) {
+        break;
+      }
 
       if (nextBatch.size() < batchSize) {
         // wait maxDelayMillis for additional elements
@@ -166,16 +171,17 @@ public class DeferredOperationQueue<E> {
         }
       }
 
-      if (nextBatch.isEmpty()) {
-        break;
-      }
-
-      try {
-        getBatchOperation().accept(nextBatch);
-      }
-      catch (RuntimeException e) {
-        LOG.error("Exception occurred while execution batch operation", e);
-      }
+      // Use a new run context for each execution. Consider e.g. transactional ClientNotifications sent after each
+      // batch. If there is only one run context for all batches the notifications will not be sent until the queue is
+      // completely empty (which may never be the case).
+      getRunContextSupplier().get().run(() -> {
+        try {
+          getBatchOperation().accept(nextBatch);
+        }
+        catch (RuntimeException e) {
+          LOG.error("Exception occurred while execution batch operation", e);
+        }
+      });
     }
     while (!interrupted && !singleRun);
 


### PR DESCRIPTION
The queue processes elements immediately if there are more than its batch size. If there are fewer elements it waits for a specified time for more elements to come and processes a last batch after this delay. Then, if the queue is empty, the flush job completes and is started again after new elements are added to the queue.

In order to minimize the number of loops that are executed, check at the beginning of each loop if the next batch and therefore the whole queue is empty and complete the flush job if it is. Otherwise, the flush job will wait the specified delay unnecessarily before completing.

The job itself used the run context created by the specified supplier. This results in one run context for all batches that are executed. As a queue may run forever, this can lead to an enormous amount of executions that are not committed in the same transaction. In addition, note that the job itself does not really need a run context as it just schedules the batch executions, which are the elements here that need an own run context.
Therefore, use an empty run context for the flush job and the run context created by the supplier for the batch executions.

391689