### PR TITLE
ClientNotificationNodeQueue maximum queue size

### DIFF
--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationNodeQueue.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationNodeQueue.java
@@ -100,7 +100,6 @@ public class ClientNotificationNodeQueue {
       }
     }
     if (!droppedNotifications.isEmpty()) {
-      if (LOG.isWarnEnabled()) {
         Function<Stream<? extends ClientNotificationMessage>, String> infoExtractor = s -> s
             .map(m -> m.getNotification().getClass().getSimpleName() + " -> " + m.getAddress().prettyPrint())
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
@@ -109,16 +108,16 @@ public class ClientNotificationNodeQueue {
             .map(e -> e.getKey() + " (" + e.getValue() + "x)")
             .collect(Collectors.joining(", ", "[", "]"));
 
-        LOG.warn("Notification queue capacity reached. Added {}, removed oldest {} notification messages. [clientNodeId={}, lastConsumeAccess={}, newNotifications={}, droppedNotifications={}]",
-            notifications.size(), droppedNotifications.size(), getNodeId(), getLastConsumeAccessFormatted(), infoExtractor.apply(notifications.stream()), infoExtractor.apply(droppedNotifications.stream()));
-      }
+      LOG.error("Notification queue capacity reached. Added {}, removed oldest {} notification messages. [clientNodeId={}, lastConsumeAccess={}, newNotifications={}, droppedNotifications={}]",
+          notifications.size(), droppedNotifications.size(), getNodeId(), getLastConsumeAccessFormatted(), infoExtractor.apply(notifications.stream()), infoExtractor.apply(droppedNotifications.stream()));
+
       if (LOG.isDebugEnabled()) {
-        Function<Stream<? extends ClientNotificationMessage>, String> infoExtractor = s -> s
+        Function<Stream<? extends ClientNotificationMessage>, String> detailInfoExtractor = s -> s
             .map(m -> m.toString())
             .collect(Collectors.joining("\n    ", "\n    ", ""));
 
         LOG.debug("Notification queue capacity reached. Details:\n  newNotifications={}\n  droppedNotifications={}",
-            infoExtractor.apply(notifications.stream()), infoExtractor.apply(droppedNotifications.stream()),
+            detailInfoExtractor.apply(notifications.stream()), detailInfoExtractor.apply(droppedNotifications.stream()),
             new Exception("stacktrace for further analysis"));
       }
     }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationProperties.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationProperties.java
@@ -23,12 +23,12 @@ public final class ClientNotificationProperties {
 
     @Override
     public Integer getDefaultValue() {
-      return 200;
+      return 10000;
     }
 
     @Override
     public String description() {
-      return "Capacity of the client notification queue. If maximum capacity is reached, notification messages are dropped. The default value is 200.";
+      return "Capacity of the client notification queue. If maximum capacity is reached, notification messages are dropped. The default value is 10000.";
     }
 
     @Override
@@ -59,12 +59,12 @@ public final class ClientNotificationProperties {
 
     @Override
     public Integer getDefaultValue() {
-      return 30;
+      return 100;
     }
 
     @Override
     public String description() {
-      return "The maximum number of client notifications that are consumed at once. The default is 30.";
+      return "The maximum number of client notifications that are consumed at once. The default is 100.";
     }
 
     @Override


### PR DESCRIPTION
Change the default value for the queue size and number of notifications that are processed at once. Several projects are already using this larger value, the old value is no longer up to date. In addition, change the log level from Warn to Error so that no project misses this error.

368114