### PR TITLE
Small fixes

### DIFF
--- a/eclipse-scout-core/src/encoder/PlainTextEncoder.ts
+++ b/eclipse-scout-core/src/encoder/PlainTextEncoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,7 +55,7 @@ export class PlainTextEncoder {
     text = text.replace(/<\/td>/gi, ' ');
 
     if (options.removeFontIcons) {
-      text = text.replace(/<span\s+class="[^"]*font-icon[^"]*">[^<]*<\/span>/gmi, '');
+      text = text.replace(/<span\s[^>]*class="[^"]*font-icon[^"]*"[^>]*>[^<]*<\/span>/gmi, '');
     }
 
     // Remove script and style contents

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -2215,7 +2215,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
    */
   protected _columnAtX(x: number): Column<any> {
     let columnOffsetRight = 0,
-      columnOffsetLeft = this.$data.offset().left + this.rowBorders.left + this.rowMargins.left,
+      columnOffsetLeft = this.$data.offset().left + graphics.insets(this.$data).left + this.rowBorders.left + this.rowMargins.left,
       scrollLeft = this.$data.scrollLeft();
 
     if (x < columnOffsetLeft) {

--- a/eclipse-scout-core/src/testing/table/SpecTable.ts
+++ b/eclipse-scout-core/src/testing/table/SpecTable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,5 +38,9 @@ export class SpecTable extends Table {
 
   override _showCellError(row: TableRow, $cell: JQuery, errorStatus: Status) {
     super._showCellError(row, $cell, errorStatus);
+  }
+
+  override _columnAtX(x: number): Column<any> {
+    return super._columnAtX(x);
   }
 }

--- a/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.ts
+++ b/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -139,6 +139,14 @@ describe('PlainTextEncoder', () => {
 
   it('removes font icons if configured', () => {
     let htmlText = '<span class="table-cell-icon font-icon"></span><span class="text">Text</span>';
+    expect(encoder.encode(htmlText)).toBe('Text');
+    expect(encoder.encode(htmlText, {removeFontIcons: true})).toBe('Text');
+
+    htmlText = '<span aria-label="Text" class="table-cell-icon font-icon"></span><span class="text">Text</span>';
+    expect(encoder.encode(htmlText)).toBe('Text');
+    expect(encoder.encode(htmlText, {removeFontIcons: true})).toBe('Text');
+
+    htmlText = '<span class="table-cell-icon font-icon" aria-label="Text"></span><span class="text">Text</span>';
     expect(encoder.encode(htmlText)).toBe('Text');
     expect(encoder.encode(htmlText, {removeFontIcons: true})).toBe('Text');
 

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -38,6 +38,11 @@ describe('Table', () => {
     $.fx.off = true; // generation of sum rows is animated. leads to misleading test failures.
     jasmine.Ajax.install();
     jasmine.clock().install();
+    $('<style>' +
+      '.table.with-padding > .table-data {' +
+      '  padding: 20px;' +
+      '}' +
+      '</style>').appendTo($('#sandbox'));
   });
 
   afterEach(() => {
@@ -3884,6 +3889,61 @@ describe('Table', () => {
         expect($(aggregateRow).attr('aria-description')).toBeTruthy();
         expect($(aggregateRow).attr('aria-describedby')).toBeFalsy();
       });
+    });
+  });
+
+  describe('_columnAtX', () => {
+
+    let table: SpecTable, column0: Column, column1: Column, $row: JQuery, offset: number;
+
+    beforeEach(() => {
+      const model = helper.createModelFixture(2, 1);
+      table = helper.createTable(model);
+      table.render();
+
+      [column0, column1] = table.columns;
+      $row = table.rows[0].$row;
+
+      offset = table.$data.offset().left;
+    });
+
+    it('returns the correct column', () => {
+      expect(table.$cell(column0, $row).cssWidth()).toBe(60);
+      expect(table.$cell(column1, $row).cssWidth()).toBe(60);
+
+      // left of first column -> returns first column
+      expect(table._columnAtX(0)).toBe(column0);
+      // first column
+      expect(table._columnAtX(offset)).toBe(column0);
+      expect(table._columnAtX(30 + offset)).toBe(column0);
+      expect(table._columnAtX(59 + offset)).toBe(column0);
+      // second column
+      expect(table._columnAtX(60 + offset)).toBe(column1);
+      expect(table._columnAtX(90 + offset)).toBe(column1);
+      expect(table._columnAtX(119 + offset)).toBe(column1);
+      // right of last column -> returns last column
+      expect(table._columnAtX(130 + offset)).toBe(column1);
+    });
+
+    it('returns the correct column when .table-data has padding', () => {
+      table.addCssClass('with-padding');
+      offset += 20;
+
+      expect(table.$cell(column0, $row).cssWidth()).toBe(60);
+      expect(table.$cell(column1, $row).cssWidth()).toBe(60);
+
+      // left of first column -> returns first column
+      expect(table._columnAtX(0)).toBe(column0);
+      // first column
+      expect(table._columnAtX(offset)).toBe(column0);
+      expect(table._columnAtX(30 + offset)).toBe(column0);
+      expect(table._columnAtX(59 + offset)).toBe(column0);
+      // second column
+      expect(table._columnAtX(60 + offset)).toBe(column1);
+      expect(table._columnAtX(90 + offset)).toBe(column1);
+      expect(table._columnAtX(119 + offset)).toBe(column1);
+      // right of last column -> returns last column
+      expect(table._columnAtX(130 + offset)).toBe(column1);
     });
   });
 });


### PR DESCRIPTION
Table: fix _columnAtX()

Consider the insets of the table data when calculating the column offset
as otherwise the returned column may be wrong e.g. the table-data has a
padding.

--------

PlainTextEncoder: improve encode

The font-icon-regex matched only spans with one or more css classes set
but no other attributes. Improve the regex in order to match spans that
have e.g. an aria-label.