### PR TITLE
Make createRow rowModel parameter optional

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -410,7 +410,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     return tableRow;
   }
 
-  protected _createRow(rowModel: TableRowModel): TableRow {
+  protected _createRow(rowModel?: TableRowModel): TableRow {
     let model = (rowModel || {}) as FullModelOf<TableRow>;
     model.objectType = scout.nvl(model.objectType, TableRow);
     model.parent = this;


### PR DESCRIPTION
The parameter rowModel is implemented as optional but not marked as
such. This leads to unnecessary transpiler warnings. This changes marks
the parameter as actually optional.