### PR TITLE
FocusManager: fix wrong focus after dragging an element

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.ts
+++ b/eclipse-scout-core/src/focus/FocusContext.ts
@@ -159,15 +159,6 @@ export class FocusContext {
    */
   protected _onFocusIn(event: FocusInEvent) {
     let $target = $(event.target);
-
-    // SPECIAL CASE: We consider elements with tabindex="-2" to be _never_ focusable, not even programmatically!
-    // Redirect the focus to the first focusable parent element.
-    if (Number($target.attr('tabindex')) === -2) {
-      // noinspection CssInvalidPseudoSelector (inspection seems to confuse $.fn.closest with the native Element.closest method)
-      let $newTarget = $target.parent().closest(':focusable');
-      focusUtils.focusLater($newTarget, {preventScroll: true});
-    }
-
     $target.on('remove', this._removeListener);
 
     let target = $target[0];

--- a/eclipse-scout-core/src/jquery/jquery-scout-selectors.js
+++ b/eclipse-scout-core/src/jquery/jquery-scout-selectors.js
@@ -15,7 +15,7 @@ import $ from 'jquery';
  * Part of this file is copied with some modifications from jQuery UI.
  */
 
-function focusable(element, requireTabbable) {
+function focusable(element, requireTabbable, excludeUnfocusable) {
   let tabIndex = Number($.attr(element, 'tabindex'));
   let hasTabIndex = !isNaN(tabIndex);
 
@@ -24,7 +24,7 @@ function focusable(element, requireTabbable) {
     return false;
   }
   // SPECIAL CASE: we consider elements with tabindex="-2" to be _never_ focusable, not even programmatically!
-  if (tabIndex === -2) {
+  if (tabIndex === -2 && excludeUnfocusable) {
     return false;
   }
 
@@ -46,6 +46,7 @@ function visible(element) {
 
 // Register selectors
 $.extend($.expr[':'], {
-  'focusable': element => focusable(element, false),
+  'focusable-native': element => focusable(element, false),
+  'focusable': element => focusable(element, false, true),
   'tabbable': element => focusable(element, true)
 });

--- a/eclipse-scout-core/src/menu/ContextMenuPopup.ts
+++ b/eclipse-scout-core/src/menu/ContextMenuPopup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -554,7 +554,7 @@ export class ContextMenuPopup extends Popup implements ContextMenuPopupModel {
   }
 
   /** @internal */
-  _adjustTextAlignment($body?: JQuery<HTMLElement>) {
+  _adjustTextAlignment($body?: JQuery) {
     $body = $body || this.$body;
     let $menuItems = this.$visibleMenuItems($body);
     let textOffset = this._calcTextOffset($menuItems);

--- a/eclipse-scout-core/src/tree/CompactTreeNode.ts
+++ b/eclipse-scout-core/src/tree/CompactTreeNode.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -43,7 +43,7 @@ export class CompactTreeNode extends TreeNode {
     }
 
     let formerClasses,
-      $node: JQuery<HTMLElement> = this.$node;
+      $node = this.$node;
 
     if ($node.hasClass('section')) {
       $node = $node.children('title');

--- a/eclipse-scout-core/src/tree/TreeNode.ts
+++ b/eclipse-scout-core/src/tree/TreeNode.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -277,7 +277,7 @@ export class TreeNode implements TreeNodeModel, ObjectWithType {
     this.$node.icon(this.iconId, $icon => $icon.insertBefore(this.$text));
   }
 
-  $icon(): JQuery<HTMLElement> {
+  $icon(): JQuery {
     return this.$node.children('.icon');
   }
 

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -955,7 +955,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
     this._renderDisabledStyleInternal(this.$container);
   }
 
-  protected _renderDisabledStyleInternal($element: JQuery<HTMLElement>) {
+  protected _renderDisabledStyleInternal($element: JQuery) {
     if (!$element) {
       return;
     }


### PR DESCRIPTION
The global mouse down listener of the focus manager is responsible to allow or prevent focus gain on mouse down. If an element is draggable, the focus gain cannot be prevented without preventing the dragstart event, too.

Therefore, the focus manager allows the focus gain but has to restore the focus afterward, so that the previously focused element will be focused again. This functionality broke with commit f318d652e5b6ec5b028f1f08fe762ead278e3951 (#381281).

To fix it, the logic from FocusContext to prevent the focus gain on elements with tabindex=-2 has to be integrated into the global mouse down handler. One advantage of this approach is that such elements now don't get the focus at all, not even temporary, except if a draggable element is clicked. As explained, the focus gain must be allowed and may temporarily be set on an element with tabindex=-2.

Also:
- removed unnecessary HTMLElement generic of the JQuery type because it is the default value
- simplified checks in isFocusableByMouse and isDraggable because closest also considers the current element not only the parents.

397963