### PR TITLE
FocusManager: fix wrong focus after dragging an element

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.ts
+++ b/eclipse-scout-core/src/focus/FocusContext.ts
@@ -164,15 +164,6 @@ export class FocusContext {
    */
   protected _onFocusIn(event: FocusInEvent) {
     let $target = $(event.target);
-
-    // SPECIAL CASE: We consider elements with tabindex="-2" to be _never_ focusable, not even programmatically!
-    // Redirect the focus to the first focusable parent element.
-    if (Number($target.attr('tabindex')) === -2) {
-      // noinspection CssInvalidPseudoSelector (inspection seems to confuse $.fn.closest with the native Element.closest method)
-      let $newTarget = $target.parent().closest(':focusable');
-      focusUtils.focusLater($newTarget, {preventScroll: true});
-    }
-
     $target.on('remove', this._removeListener);
 
     let target = $target[0];

--- a/eclipse-scout-core/src/focus/FocusManager.ts
+++ b/eclipse-scout-core/src/focus/FocusManager.ts
@@ -440,20 +440,44 @@ export class FocusManager implements FocusManagerOptions {
       return true;
     }
 
-    // Allow focus gain on elements with a focusable parent, e.g. when clicking on a row in a table.
-    if (focusUtils.containsParentFocusableByMouse($element, $element.entryPoint())) {
-      return true;
+    // Find the element which will most likely gain the focus if we let the browser execute its default behavior
+    let $entryPoint = $element.entryPoint();
+    let $target = focusUtils.closestFocusableByMouse($element, $entryPoint, true);
+    // The browser would focus elements with tabindex="-2" but we consider them to be unfocusable. In this case, set the focus to the nearest focusable parent element.
+    let $newTarget = $();
+    if (focusUtils.isFocusPrevented($target)) {
+      $newTarget = focusUtils.closestFocusableByMouse($target.parent(), $entryPoint);
     }
 
     // Allow dragstart event for draggable elements
     if (focusUtils.isDraggable($element)) {
-      // PreventDefault() would not only prevent focus gain but also the dragstart event, so we need to return true to allow the dragstart event.
-      // But now the browser tries to focus an element and since the draggable element is not focusable (otherwise it would have returned above), the desktop is likely to be focused.
-      // Because we can't prevent dragstart and allow focus, we need to re-focus the currently focused element later.
-      focusUtils.restoreFocusLater(this.session.$entryPoint);
+      // In order for the dragstart event to be triggered, we must _not_ prevent the default action for the mousedown event, which means that
+      // the $target will receive the focus. To fix this, we need to change the focus again later. If the native target element was found to be
+      // unfocusable (tabindex="-2"), we set the focus back to $newTarget. Otherwise, we change the focus back to the current active element.
+      if ($newTarget.length) {
+        focusUtils.focusLater($newTarget, {preventScroll: true});
+      } else {
+        focusUtils.restoreFocusLater($entryPoint, {preventScroll: true});
+      }
       return true;
     }
 
+    // If the clicked element is not draggable, we can safely prevent the default action for the mousedown event. This will prevent the focus
+    // from being set to the native $target. Instead, the focus is transferred to $newTarget (if present and available, otherwise the focus
+    // remains at the current element).
+    if ($newTarget.length) {
+      if (!$newTarget.is($element.activeElement())) {
+        focusUtils.focusLater($newTarget, {preventScroll: true});
+      }
+      return false;
+    }
+
+    // Allow focus gain on elements with a focusable parent, e.g. when clicking on the text element of a tab item
+    if (focusUtils.containsParentFocusableByMouse($element, $entryPoint)) {
+      return true;
+    }
+
+    // Click on an empty area should prevent the focus gain on the desktop
     return false;
   }
 

--- a/eclipse-scout-core/src/focus/focusUtils.ts
+++ b/eclipse-scout-core/src/focus/focusUtils.ts
@@ -17,23 +17,50 @@ export const focusUtils = {
    * @returns whether the given element is focusable by mouse.
    */
   isFocusableByMouse(element: HTMLElement | JQuery): boolean {
-    let $element = $(element);
-    return !$element.hasClass('unfocusable') && !$element.closest('.unfocusable').length;
+    return $.ensure(element).closest('.unfocusable').length === 0;
+  },
+
+  /**
+   * @returns whether the element must not gain the focus, even if it has a tabindex. This is only true for elements with tabindex="-2".
+   */
+  isFocusPrevented(element: HTMLElement | JQuery): boolean {
+    return Number($.ensure(element).attr('tabindex')) === -2;
+  },
+
+  /**
+   * @param $entryPoint the entry point of the current {@link Session}
+   * @param nativeFocusable whether to include elements that we consider to be unfocusable but would gain the focus by the browser if we did not prevent it (elements with tabindex="-2"). Default is false.
+   * @returns all parents that are focusable by mouse inside a focus boundary (marked by elements having the class .focus-boundary)
+   */
+  getParentsFocusableByMouse(element: HTMLElement | JQuery, $entryPoint: JQuery, nativeFocusable = false): JQuery {
+    return $.ensure(element)
+      .parentsUntil('.focus-boundary', nativeFocusable ? ':focusable-native' : ':focusable') // Stay inside focus boundaries (e.g. search forms should not consider parent table)
+      .not($entryPoint) // Exclude $entryPoint as all elements are its descendants. However, the $entryPoint is only focusable to provide Portlet support.
+      .filter((index, elem) => focusUtils.isFocusableByMouse(elem));
+  },
+
+  /**
+   * @param $entryPoint the entry point of the current {@link Session}
+   * @param nativeFocusable whether to include elements that we consider to be unfocusable but would gain the focus by the browser if we did not prevent it (elements with tabindex="-2"). Default is false.
+   * @returns the given element if it is focusable by mouse, or the first parent that is focusable by mouse.
+   */
+  closestFocusableByMouse(element: HTMLElement | JQuery, $entryPoint: JQuery, nativeFocusable = false): JQuery {
+    let $element = $.ensure(element);
+    if ($element.is(nativeFocusable ? ':focusable-native' : ':focusable') && focusUtils.isFocusableByMouse($element)) {
+      return $element;
+    }
+    return focusUtils.getParentsFocusableByMouse($element, $entryPoint, nativeFocusable).first();
   },
 
   /**
    * @returns whether the given element has a parent which is focusable by mouse.
    */
-  containsParentFocusableByMouse(element: HTMLElement | JQuery, entryPoint: JQuery): boolean {
-    let $focusableParentElements = $(element)
-      .parentsUntil('.focus-boundary', ':focusable') // Stay inside focus boundaries (e.g. search forms should not consider parent table)
-      .not(entryPoint) /* Exclude $entryPoint as all elements are its descendants. However, the $entryPoint is only focusable to provide Portlet support. */
-      .filter(() => focusUtils.isFocusableByMouse(this));
-    return $focusableParentElements.length > 0;
+  containsParentFocusableByMouse(element: HTMLElement | JQuery, $entryPoint: JQuery): boolean {
+    return focusUtils.getParentsFocusableByMouse(element, $entryPoint).length > 0;
   },
 
   /**
-   * @returns  whether the given element contains content which is selectable to the user, e.g. to be copied into clipboard.
+   * @returns whether the given element contains content which is selectable to the user, e.g. to be copied into clipboard.
    * It also returns true for disabled text-fields, because the user must be able to select and copy text from these text-fields.
    */
   isSelectableText(element: HTMLElement | JQuery): boolean {
@@ -80,13 +107,11 @@ export const focusUtils = {
    * @returns true if the element or one of its parents is draggable.
    */
   isDraggable(element: HTMLElement | JQuery): boolean {
-    let $element = $.ensure(element);
-    return $element.attr('draggable') === 'true' || $element.parents('[draggable="true"]').length > 0;
+    return $.ensure(element).closest('[draggable="true"]').length > 0;
   },
 
   /**
-   * Returns true if the given HTML element is the active element in its own document, false otherwise
-   * @param element
+   * @returns true if the given HTML element is the active element in its own document, false otherwise.
    */
   isActiveElement(element: HTMLElement | JQuery): boolean {
     if (!element) {
@@ -107,16 +132,20 @@ export const focusUtils = {
   /**
    * Stores the currently focused element and focuses this element again in the next animation frame if the focus changed to the entry point element.
    * This is useful if the current task would focus the entry point element which cannot be prevented.
+   *
+   * @param $entryPoint the entry point of the current {@link Session}
+   * @param options options to be passed to the {@link HTMLElement.focus} call
    */
-  restoreFocusLater($entryPoint: JQuery) {
+  restoreFocusLater($entryPoint: JQuery, options?: FocusOptions) {
     // queueMicrotask does not work, it looks like the microtask will be executed before the focus change.
     // requestAnimationFrame also prevents flickering (compared to setTimeout)
     let doc = $entryPoint.document(true);
     let prevFocusedElement = doc.activeElement as HTMLElement;
     requestAnimationFrame(() => {
-      let focusedElement = doc.activeElement;
-      if (focusedElement === $entryPoint[0]) {
-        prevFocusedElement.focus();
+      let focusedElement = doc.activeElement as HTMLElement;
+      // Restore previous focus if the current active element is an element we don't want to be focused (the $entryPoint or tabindex="-2")
+      if (focusedElement === $entryPoint[0] || focusUtils.isFocusPrevented(focusedElement)) {
+        prevFocusedElement.focus(options);
       }
     });
   },
@@ -126,7 +155,7 @@ export const focusUtils = {
    * This allows other event handlers to be fired before the focus is actually changed.
    *
    * @param target the element to be focused
-   * @param options options to be passed to the {@link HTMLElement#focus} call
+   * @param options options to be passed to the {@link HTMLElement.focus} call
    */
   focusLater(target: HTMLElement | JQuery, options?: FocusOptions) {
     let $target = $.ensure(target);
@@ -136,9 +165,12 @@ export const focusUtils = {
     let doc = $target.document(true);
     let prevFocusedElement = doc.activeElement;
     requestAnimationFrame(() => {
-      // Check if the active element is the same as before. If not, someone has changed the focus
-      // in the meantime and the scheduled "focusLater" request is probably obsolete.
-      if (doc.activeElement === prevFocusedElement) {
+      // Check if the active element is the same as before. If not, someone has changed the focus in the meantime and the
+      // scheduled focusLater() request is obsolete. If the active element is considered to be unfocusable via tabindex="-2",
+      // we always change the focus to the target element. (This can happen if the global mouse down handler did not suppress
+      // the default behavior to avoid cancelling other events, e.g. 'dragstart').
+      let focusedElement = doc.activeElement as HTMLElement;
+      if (focusedElement === prevFocusedElement || focusUtils.isFocusPrevented(focusedElement)) {
         $target[0].focus(options);
       }
     });

--- a/eclipse-scout-core/src/jquery/jquery-scout-selectors.js
+++ b/eclipse-scout-core/src/jquery/jquery-scout-selectors.js
@@ -15,7 +15,7 @@ import $ from 'jquery';
  * Part of this file is copied with some modifications from jQuery UI.
  */
 
-function focusable(element, requireTabbable) {
+function focusable(element, requireTabbable, excludeUnfocusable) {
   let tabIndex = Number($.attr(element, 'tabindex'));
   let hasTabIndex = !isNaN(tabIndex);
 
@@ -24,7 +24,7 @@ function focusable(element, requireTabbable) {
     return false;
   }
   // SPECIAL CASE: we consider elements with tabindex="-2" to be _never_ focusable, not even programmatically!
-  if (tabIndex === -2) {
+  if (tabIndex === -2 && excludeUnfocusable) {
     return false;
   }
 
@@ -46,6 +46,7 @@ function visible(element) {
 
 // Register selectors
 $.extend($.expr[':'], {
-  'focusable': element => focusable(element, false),
+  'focusable-native': element => focusable(element, false),
+  'focusable': element => focusable(element, false, true),
   'tabbable': element => focusable(element, true)
 });

--- a/eclipse-scout-core/src/menu/ContextMenuPopup.ts
+++ b/eclipse-scout-core/src/menu/ContextMenuPopup.ts
@@ -565,7 +565,7 @@ export class ContextMenuPopup extends Popup implements ContextMenuPopupModel {
   }
 
   /** @internal */
-  _adjustTextAlignment($body?: JQuery<HTMLElement>) {
+  _adjustTextAlignment($body?: JQuery) {
     $body = $body || this.$body;
     let $menuItems = this.$visibleMenuItems($body);
     let textOffset = this._calcTextOffset($menuItems);

--- a/eclipse-scout-core/src/testing/jquery-testing.ts
+++ b/eclipse-scout-core/src/testing/jquery-testing.ts
@@ -212,7 +212,7 @@ export const JQueryTesting = {
    * @param $elem a text node or a html element containing a text node
    * @param customWindow Needs to be specified if a text inside an iframe should be selected. Otherwise, the regular window object will be used.
    */
-  selectText($elem: JQuery<HTMLElement>, begin: number, end: number, customWindow?: Window) {
+  selectText($elem: JQuery, begin: number, end: number, customWindow?: Window) {
     let win = customWindow || $elem.window(true);
     let range = document.createRange();
     let textNode;

--- a/eclipse-scout-core/src/tree/CompactTreeNode.ts
+++ b/eclipse-scout-core/src/tree/CompactTreeNode.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -43,7 +43,7 @@ export class CompactTreeNode extends TreeNode {
     }
 
     let formerClasses,
-      $node: JQuery<HTMLElement> = this.$node;
+      $node = this.$node;
 
     if ($node.hasClass('section')) {
       $node = $node.children('title');

--- a/eclipse-scout-core/src/tree/TreeNode.ts
+++ b/eclipse-scout-core/src/tree/TreeNode.ts
@@ -284,7 +284,7 @@ export class TreeNode implements TreeNodeModel, ObjectWithType, FilterElement {
     this.$node.icon(this.iconId, $icon => $icon.insertBefore(this.$text));
   }
 
-  $icon(): JQuery<HTMLElement> {
+  $icon(): JQuery {
     return this.$node.children('.icon');
   }
 

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -953,7 +953,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
     this._renderDisabledStyleInternal(this.$container);
   }
 
-  protected _renderDisabledStyleInternal($element: JQuery<HTMLElement>) {
+  protected _renderDisabledStyleInternal($element: JQuery) {
     if (!$element) {
       return;
     }


### PR DESCRIPTION
The global mouse down listener of the focus manager is responsible to allow or prevent focus gain on mouse down. If an element is draggable, the focus gain cannot be prevented without preventing the dragstart event, too.

Therefore, the focus manager allows the focus gain but has to restore the focus afterward, so that the previously focused element will be focused again. This functionality broke with commit f318d652e5b6ec5b028f1f08fe762ead278e3951 (#381281).

To fix it, the logic from FocusContext to prevent the focus gain on elements with tabindex=-2 has to be integrated into the global mouse down handler. One advantage of this approach is that such elements now don't get the focus at all, not even temporary, except if a draggable element is clicked. As explained, the focus gain must be allowed and may temporarily be set on an element with tabindex=-2.

Also:
- removed unnecessary HTMLElement generic of the JQuery type because it is the default value
- simplified checks in isFocusableByMouse and isDraggable because closest also considers the current element not only the parents.

397963