### PR TITLE
FocusManager: fix wrong focus after dragging an element

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.js
+++ b/eclipse-scout-core/src/focus/FocusContext.js
@@ -145,15 +145,6 @@ export default class FocusContext {
    */
   _onFocusIn(event) {
     let $target = $(event.target);
-
-    // SPECIAL CASE: We consider elements with tabindex="-2" to be _never_ focusable, not even programmatically!
-    // Redirect the focus to the first focusable parent element.
-    if (Number($target.attr('tabindex')) === -2) {
-      // noinspection CssInvalidPseudoSelector (inspection seems to confuse $.fn.closest with the native Element.closest method)
-      let $newTarget = $target.parent().closest(':focusable');
-      focusUtils.focusLater($newTarget, {preventScroll: true});
-    }
-
     $target.on('remove', this._removeListener);
 
     let target = $target[0];

--- a/eclipse-scout-core/src/focus/FocusManager.js
+++ b/eclipse-scout-core/src/focus/FocusManager.js
@@ -401,38 +401,58 @@ export default class FocusManager {
    * Returns whether to accept a 'mousedown event'.
    */
   _acceptFocusChangeOnMouseDown($element) {
-    // 1. Prevent focus gain when glasspane is clicked.
-    //    Even if the glasspane is not focusable, this check is required because the glasspane might be contained in a focusable container
-    //    like table. Use case: outline modality with table-page as 'outlineContent'.
+    // Prevent focus gain when glasspane is clicked.
+    // Even if the glasspane is not focusable, this check is required because the glasspane might be contained in a focusable container
+    // like table. Use case: outline modality with table-page as 'outlineContent'.
     if ($element.hasClass('glasspane')) {
       return false;
     }
 
-    // 2. Prevent focus gain if covert by glasspane.
+    // Prevent focus gain if covert by glasspane.
     if (this.isElementCovertByGlassPane($element)) {
       return false;
     }
 
-    // 3. Prevent focus gain on elements excluded to gain focus by mouse, e.g. buttons.
+    // Prevent focus gain on elements excluded to gain focus by mouse, e.g. buttons.
     if (!focusUtils.isFocusableByMouse($element)) {
       return false;
     }
 
-    // 4. Allow focus gain on focusable elements.
+    // Allow focus gain on focusable elements.
     if ($element.is(':focusable')) {
       return true;
     }
 
-    // 5. Allow focus gain on elements with selectable content, e.g. the value of a label field.
+    // Allow focus gain on elements with selectable content, e.g. the value of a label field.
     if (focusUtils.isSelectableText($element)) {
       return true;
     }
 
-    // 6. Allow focus gain on elements with a focusable parent, e.g. when clicking on a row in a table.
-    if (focusUtils.containsParentFocusableByMouse($element, $element.entryPoint())) {
+    // Find the element which will most likely gain the focus if we let the browser execute its default behavior
+    let $entryPoint = $element.entryPoint();
+    let $target = focusUtils.closestFocusableByMouse($element, $entryPoint, true);
+    // The browser would focus elements with tabindex="-2" but we consider them to be unfocusable. In this case, set the focus to the nearest focusable parent element.
+    let $newTarget = $();
+    if (focusUtils.isFocusPrevented($target)) {
+      $newTarget = focusUtils.closestFocusableByMouse($target.parent(), $entryPoint);
+    }
+
+    // If the clicked element is not draggable, we can safely prevent the default action for the mousedown event. This will prevent the focus
+    // from being set to the native $target. Instead, the focus is transferred to $newTarget (if present and available, otherwise the focus
+    // remains at the current element).
+    if ($newTarget.length) {
+      if (!$newTarget.is($element.activeElement())) {
+        focusUtils.focusLater($newTarget, {preventScroll: true});
+      }
+      return false;
+    }
+
+    // Allow focus gain on elements with a focusable parent, e.g. when clicking on the text element of a tab item
+    if (focusUtils.containsParentFocusableByMouse($element, $entryPoint)) {
       return true;
     }
 
+    // Click on an empty area should prevent the focus gain on the desktop
     return false;
   }
 

--- a/eclipse-scout-core/src/focus/focusUtils.js
+++ b/eclipse-scout-core/src/focus/focusUtils.js
@@ -15,28 +15,53 @@ import $ from 'jquery';
  */
 
 /**
- * @return {boolean} whether the given element is focusable by mouse.
+ * @returns {boolean} whether the given element is focusable by mouse.
  */
 export function isFocusableByMouse(element) {
-  let $element = $(element);
-  return !$element.hasClass('unfocusable') && !$element.closest('.unfocusable').length;
+  return $.ensure(element).closest('.unfocusable').length === 0;
 }
 
 /**
- * @return {boolean} whether the given element has a parent which is focusable by mouse.
+ * @returns {boolean} whether the element must not gain the focus, even if it has a tabindex. This is only true for elements with tabindex="-2".
  */
-export function containsParentFocusableByMouse(element, entryPoint) {
-  let $focusableParentElements = $(element)
-    .parentsUntil('.focus-boundary', ':focusable') // Stay inside focus boundaries (e.g. search forms should not consider parent table)
-    .not(entryPoint) /* Exclude $entryPoint as all elements are its descendants. However, the $entryPoint is only focusable to provide Portlet support. */
-    .filter(function() {
-      return isFocusableByMouse(this);
-    });
-  return ($focusableParentElements.length > 0);
+export function isFocusPrevented(element) {
+  return Number($.ensure(element).attr('tabindex')) === -2;
 }
 
 /**
- * @return {boolean} whether the given element contains content which is selectable to the user, e.g. to be copied into clipboard.
+ * @param $entryPoint the entry point of the current {@link Session}
+ * @param nativeFocusable whether to include elements that we consider to be unfocusable but would gain the focus by the browser if we did not prevent it (elements with tabindex="-2"). Default is false.
+ * @returns all parents that are focusable by mouse inside a focus boundary (marked by elements having the class .focus-boundary)
+ */
+export function getParentsFocusableByMouse(element, $entryPoint, nativeFocusable = false) {
+  return $.ensure(element)
+    .parentsUntil('.focus-boundary', nativeFocusable ? ':focusable-native' : ':focusable') // Stay inside focus boundaries (e.g. search forms should not consider parent table)
+    .not($entryPoint) // Exclude $entryPoint as all elements are its descendants. However, the $entryPoint is only focusable to provide Portlet support.
+    .filter((index, elem) => isFocusableByMouse(elem));
+}
+
+/**
+ * @param $entryPoint the entry point of the current {@link Session}
+ * @param nativeFocusable whether to include elements that we consider to be unfocusable but would gain the focus by the browser if we did not prevent it (elements with tabindex="-2"). Default is false.
+ * @returns the given element if it is focusable by mouse, or the first parent that is focusable by mouse.
+ */
+export function closestFocusableByMouse(element, $entryPoint, nativeFocusable = false) {
+  let $element = $.ensure(element);
+  if ($element.is(nativeFocusable ? ':focusable-native' : ':focusable') && isFocusableByMouse($element)) {
+    return $element;
+  }
+  return getParentsFocusableByMouse($element, $entryPoint, nativeFocusable).first();
+}
+
+/**
+ * @returns {boolean} whether the given element has a parent which is focusable by mouse.
+ */
+export function containsParentFocusableByMouse(element, $entryPoint) {
+  return getParentsFocusableByMouse(element, $entryPoint).length > 0;
+}
+
+/**
+ * @returns {boolean} whether the given element contains content which is selectable to the user, e.g. to be copied into clipboard.
  * It also returns true for disabled text-fields, because the user must be able to select and copy text from these text-fields.
  */
 export function isSelectableText(element) {
@@ -80,8 +105,7 @@ export function isSelectableText(element) {
 }
 
 /**
- * Returns true if the given HTML element is the active element in its own document, false otherwise
- * @param element
+ * @returns true if the given HTML element is the active element in its own document, false otherwise.
  */
 export function isActiveElement(element) {
   if (!element) {
@@ -98,11 +122,32 @@ export function isActiveElement(element) {
 }
 
 /**
+ * Stores the currently focused element and focuses this element again in the next animation frame if the focus changed to the entry point element.
+ * This is useful if the current task would focus the entry point element which cannot be prevented.
+ *
+ * @param $entryPoint the entry point of the current {@link Session}
+ * @param options options to be passed to the {@link HTMLElement.focus} call
+ */
+export function restoreFocusLater($entryPoint, options) {
+  // queueMicrotask does not work, it looks like the microtask will be executed before the focus change.
+  // requestAnimationFrame also prevents flickering (compared to setTimeout)
+  let doc = $entryPoint.document(true);
+  let prevFocusedElement = doc.activeElement;
+  requestAnimationFrame(() => {
+    let focusedElement = doc.activeElement;
+    // Restore previous focus if the current active element is an element we don't want to be focused (the $entryPoint or tabindex="-2")
+    if (focusedElement === $entryPoint[0] || isFocusPrevented(focusedElement)) {
+      prevFocusedElement.focus(options);
+    }
+  });
+}
+
+/**
  * Sets the focus to the given target element just before the next repaint (using requestAnimationFrame).
  * This allows other event handlers to be fired before the focus is actually changed.
  *
  * @param target the element to be focused (html or jquery element)
- * @param options options to be passed to the {@link HTMLElement#focus} call
+ * @param options options to be passed to the {@link HTMLElement.focus} call
  */
 export function focusLater(target, options) {
   let $target = $.ensure(target);
@@ -112,18 +157,25 @@ export function focusLater(target, options) {
   let doc = $target.document(true);
   let prevFocusedElement = doc.activeElement;
   requestAnimationFrame(() => {
-    // Check if the active element is the same as before. If not, someone has changed the focus
-    // in the meantime and the scheduled "focusLater" request is probably obsolete.
-    if (doc.activeElement === prevFocusedElement) {
+    // Check if the active element is the same as before. If not, someone has changed the focus in the meantime and the
+    // scheduled focusLater() request is obsolete. If the active element is considered to be unfocusable via tabindex="-2",
+    // we always change the focus to the target element. (This can happen if the global mouse down handler did not suppress
+    // the default behavior to avoid cancelling other events, e.g. 'dragstart').
+    let focusedElement = doc.activeElement;
+    if (focusedElement === prevFocusedElement || isFocusPrevented(focusedElement)) {
       $target[0].focus(options);
     }
   });
 }
 
 export default {
-  containsParentFocusableByMouse,
-  isActiveElement,
   isFocusableByMouse,
+  isFocusPrevented,
+  getParentsFocusableByMouse,
+  closestFocusableByMouse,
+  containsParentFocusableByMouse,
   isSelectableText,
+  isActiveElement,
+  restoreFocusLater,
   focusLater
 };

--- a/eclipse-scout-core/src/jquery/jquery-scout-selectors.js
+++ b/eclipse-scout-core/src/jquery/jquery-scout-selectors.js
@@ -15,7 +15,7 @@ import $ from 'jquery';
  * Part of this file is copied with some modifications from jQuery UI.
  */
 
-function focusable(element, requireTabbable) {
+function focusable(element, requireTabbable, excludeUnfocusable) {
   let tabIndex = Number($.attr(element, 'tabindex'));
   let hasTabIndex = !isNaN(tabIndex);
 
@@ -24,7 +24,7 @@ function focusable(element, requireTabbable) {
     return false;
   }
   // SPECIAL CASE: we consider elements with tabindex="-2" to be _never_ focusable, not even programmatically!
-  if (tabIndex === -2) {
+  if (tabIndex === -2 && excludeUnfocusable) {
     return false;
   }
 
@@ -46,6 +46,7 @@ function visible(element) {
 
 // Register selectors
 $.extend($.expr[':'], {
-  'focusable': element => focusable(element, false),
+  'focusable-native': element => focusable(element, false),
+  'focusable': element => focusable(element, false, true),
   'tabbable': element => focusable(element, true)
 });


### PR DESCRIPTION
The global mouse down listener of the focus manager is responsible to allow or prevent focus gain on mouse down. If an element is draggable, the focus gain cannot be prevented without preventing the dragstart event, too.

Therefore, the focus manager allows the focus gain but has to restore the focus afterward, so that the previously focused element will be focused again. This functionality broke with commit f318d652e5b6ec5b028f1f08fe762ead278e3951 (#381281).

To fix it, the logic from FocusContext to prevent the focus gain on elements with tabindex=-2 has to be integrated into the global mouse down handler. One advantage of this approach is that such elements now don't get the focus at all, not even temporary, except if a draggable element is clicked. As explained, the focus gain must be allowed and may temporarily be set on an element with tabindex=-2.

Also:
- removed unnecessary HTMLElement generic of the JQuery type because it is the default value
- simplified checks in isFocusableByMouse and isDraggable because closest also considers the current element not only the parents.

397963