### PR TITLE
Add styles utility to extract CSS colors

### DIFF
--- a/eclipse-scout-core/src/util/styles.ts
+++ b/eclipse-scout-core/src/util/styles.ts
@@ -155,6 +155,20 @@ export const styles = {
     styles.styleMap = {};
   },
 
+  /**
+   * Extracts the given attribute from the given CSS class and returns its value.
+   *
+   * If the provided class does not exist, the computed element style of the provided
+   * attribute is returned. If the extracted value is unset, `null` is returned.
+   *
+   * @param cssClass any CSS class
+   * @param attribute optional CSS attribute to extract the color from, default is _backgroundColor_
+   */
+  getCssColor(cssClass: string, attribute = 'backgroundColor'): string {
+    let color = styles.get(cssClass, attribute)[attribute];
+    return color === 'unset' ? null : color;
+  },
+
   RGB_BLACK: {
     red: 0,
     green: 0,

--- a/eclipse-scout-core/test/util/stylesSpec.ts
+++ b/eclipse-scout-core/test/util/stylesSpec.ts
@@ -192,6 +192,23 @@ describe('styles', () => {
     expect($el.attr('style')).toBe('background-color: purple;');
   });
 
+  describe('get css colors', () => {
+    it('can get css class colors', () => {
+      expect(styles.getCssColor('inner-class')).toEqual('rgb(255, 0, 0)');
+      expect(styles.getCssColor('outer-class', 'borderColor')).toEqual('rgb(0, 0, 0)');
+    });
+
+    it('can handle unknown CSS classes and attributes', () => {
+      let computedStyle = window.getComputedStyle(styles.element);
+      expect(styles.getCssColor('invalid-class')).toBe(computedStyle.backgroundColor);
+      expect(styles.getCssColor('invalid-class', 'anyAttribute')).toBe(undefined);
+    });
+
+    it('can handle invalid rgba values', () => {
+      expect(styles.rgb(styles.getCssColor('inner-class', 'height'))).toBe(undefined);
+    });
+  });
+
   describe('rgb', () => {
     it('parses an rgb string', () => {
       expect(styles.rgb('rgb(255,100,200)')).toEqual({


### PR DESCRIPTION
- Adds function to extract a raw CSS rgb value from a CSS attribute
- Adds function to extract a raw CSS rgb value encoded as hex value from a CSS attribute