### PR TITLE
FocusManager: fix JS error when collapsing draggable table rows

### DIFF
--- a/eclipse-scout-core/src/focus/focusUtils.ts
+++ b/eclipse-scout-core/src/focus/focusUtils.ts
@@ -139,6 +139,10 @@ export const focusUtils = {
   restoreFocusLater($entryPoint: JQuery, options?: FocusOptions) {
     // queueMicrotask does not work, it looks like the microtask will be executed before the focus change.
     // requestAnimationFrame also prevents flickering (compared to setTimeout)
+    $entryPoint = $.ensure($entryPoint);
+    if (!$entryPoint.length) {
+      return; // nothing to do
+    }
     let doc = $entryPoint.document(true);
     let prevFocusedElement = doc.activeElement as HTMLElement;
     requestAnimationFrame(() => {


### PR DESCRIPTION
If a row in a hierarchical table is expanded or collapsed, the view port is re-rendered, which means all rows are removed and rendered again. The mousedown event still bubbles to the FocusManager with the original element. That element is no longer part of the DOM and thus does not have a parent element. In case of draggable tables, focusUtils .restoreFocusLater() is called, which could not handle this case and threw an error. An additional check in FocusManager is needed to prevent the focus from getting lost because the new target element for the focus cannot be determined.

401646