### PR TITLE
Tree: update node size on updateNodes

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -2408,6 +2408,15 @@ export class Tree extends Widget implements TreeModel {
       updatedNodes.push(oldNode);
     });
 
+    // recompute node size if horizontal scrolling is enabled
+    if (this.isHorizontalScrollingEnabled()) {
+      let nodesToResize = updatedNodes.filter(n => n.rendered);
+      if (arrays.hasElements(nodesToResize)) {
+        this._updateNodeSize(nodesToResize);
+        this.invalidateLayoutTree();
+      }
+    }
+
     this.trigger('nodesUpdated', {
       nodes: updatedNodes
     });
@@ -3056,6 +3065,10 @@ export class Tree extends Widget implements TreeModel {
   }
 
   protected _installNodes(nodes: TreeNode[]) {
+    this._updateNodeSize(nodes);
+  }
+
+  protected _updateNodeSize(nodes: TreeNode[]) {
     // The measuring is separated into 3 blocks for performance reasons -> separates reading and setting of styles
     // 1. Prepare style for measuring
     if (this.isHorizontalScrollingEnabled()) {

--- a/eclipse-scout-core/test/tree/TreeSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeSpec.ts
@@ -598,6 +598,19 @@ describe('Tree', () => {
         expect($checkbox(child0).isEnabled()).toBe(false);
       });
     });
+
+    it('updates node size', () => {
+      tree.render();
+
+      let origWidth = node0.width;
+      let origMaxNodeWidth =tree.maxNodeWidth;
+      let expectedText = 'a very'+ strings.repeat(' long', 100) + ' text';
+      node0.setText(expectedText);
+      tree.updateNode(node0);
+      expect(node0.$node.text()).toBe(expectedText);
+      expect(node0.width).toBeGreaterThan(origWidth);
+      expect(tree.maxNodeWidth).toBeGreaterThan(origMaxNodeWidth);
+    });
   });
 
   describe('changeNode', () => {


### PR DESCRIPTION
The size of a node must be recomputed when the text is changed and if scrollbars are used.

402635