### PR TITLE
ListBox: use multiSelect = true as new default

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/listbox/AbstractListBox.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/listbox/AbstractListBox.java
@@ -944,11 +944,6 @@ public abstract class AbstractListBox<KEY> extends AbstractValueField<Set<KEY>> 
     }
 
     @Override
-    protected boolean getConfiguredMultiSelect() {
-      return false;
-    }
-
-    @Override
     protected boolean getConfiguredCheckable() {
       return true;
     }


### PR DESCRIPTION
There is no obvious reason why multi select should be false. If it is true, the user can select all rows at once and check or uncheck them. Also, when using Scout JS, the default is already true, so this makes it more consistent.

385612