### PR TITLE
LookupBox: support code types

### DIFF
--- a/eclipse-scout-core/src/code/CodeLookupCall.ts
+++ b/eclipse-scout-core/src/code/CodeLookupCall.ts
@@ -11,7 +11,7 @@ import {Code, codes, CodeType, LookupCallModel, LookupRow, Predicate, scout, Sta
 
 export class CodeLookupCall<TCodeId> extends StaticLookupCall<TCodeId> {
   declare model: CodeLookupCallModel<TCodeId>;
-  codeType: string | (new() => CodeType<any>);
+  codeType: string | (new() => CodeType<TCodeId>);
 
   constructor() {
     super();
@@ -78,7 +78,7 @@ export class CodeLookupCall<TCodeId> extends StaticLookupCall<TCodeId> {
 
 export interface CodeLookupCallModel<TCodeId> extends LookupCallModel<TCodeId> {
   /**
-   * CodeTypeId {@link CodeType.id} or CodeType ref. See {@link codes.get}.
+   * The property accepts a {@link CodeType} class or a {@link CodeType.id} (see {@link CodeTypeCache.get}).
    */
-  codeType: string | (new() => CodeType<any>);
+  codeType: string | (new() => CodeType<TCodeId>);
 }

--- a/eclipse-scout-core/src/form/fields/LookupBox.ts
+++ b/eclipse-scout-core/src/form/fields/LookupBox.ts
@@ -7,7 +7,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AbstractLayout, arrays, HtmlComponent, InitModelOf, LookupBoxEventMap, LookupBoxModel, LookupCall, LookupCallOrModel, LookupResult, LookupRow, objects, PropertyChangeEvent, Status, strings, ValueField, Widget} from '../../index';
+import {
+  AbstractLayout, arrays, CodeLookupCall, CodeType, HtmlComponent, InitModelOf, LookupBoxEventMap, LookupBoxModel, LookupCall, LookupCallOrModel, LookupResult, LookupRow, objects, PropertyChangeEvent, scout, Status, strings, ValueField,
+  Widget
+} from '../../index';
 import $ from 'jquery';
 
 export abstract class LookupBox<TValue> extends ValueField<TValue[], TValue | TValue[]> implements LookupBoxModel<TValue> {
@@ -17,6 +20,7 @@ export abstract class LookupBox<TValue> extends ValueField<TValue[], TValue | TV
 
   filterBox: Widget;
   lookupCall: LookupCall<TValue>;
+  codeType: string | (new() => CodeType<TValue>);
   lookupStatus: Status;
 
   protected _currentLookupCall: LookupCall<TValue>;
@@ -56,6 +60,7 @@ export abstract class LookupBox<TValue> extends ValueField<TValue[], TValue | TV
     if (this.lookupCall) {
       this._setLookupCall(this.lookupCall);
     }
+    this._setCodeType(this.codeType);
     this._initStructure(value);
     super._initValue(value);
   }
@@ -168,6 +173,7 @@ export abstract class LookupBox<TValue> extends ValueField<TValue[], TValue | TV
     this.setLookupStatus(null);
   }
 
+  /** @see LookupBoxModel.lookupCall */
   setLookupCall(lookupCall: LookupCallOrModel<TValue>) {
     this.setProperty('lookupCall', lookupCall);
   }
@@ -178,6 +184,23 @@ export abstract class LookupBox<TValue> extends ValueField<TValue[], TValue | TV
     if (this.rendered) {
       this._ensureLookupCallExecuted();
     }
+  }
+
+  /** @see LookupBoxModel.codeType */
+  setCodeType(codeType: string | (new() => CodeType<TValue>)) {
+    this.setProperty('codeType', codeType);
+  }
+
+  protected _setCodeType(codeType: string | (new() => CodeType<TValue>)) {
+    this._setProperty('codeType', codeType);
+    if (!codeType) {
+      return;
+    }
+    let lookupCall = scout.create(CodeLookupCall<TValue>, {
+      session: this.session,
+      codeType: codeType
+    });
+    this.setLookupCall(lookupCall);
   }
 
   refreshLookup() {

--- a/eclipse-scout-core/src/form/fields/LookupBoxModel.ts
+++ b/eclipse-scout-core/src/form/fields/LookupBoxModel.ts
@@ -7,9 +7,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {LookupCallOrModel, ObjectOrChildModel, ValueFieldModel, Widget} from '../../index';
+import {CodeType, LookupCallOrModel, ObjectOrChildModel, ValueFieldModel, Widget} from '../../index';
 
 export interface LookupBoxModel<TValue> extends ValueFieldModel<TValue[], TValue | TValue[]> {
+  /**
+   * Configures a box that is shown below the list box and can be used to display filter options.
+   */
   filterBox?: ObjectOrChildModel<Widget>;
+  /**
+   * Configures the {@link LookupCall} that is used to load the data.
+   */
   lookupCall?: LookupCallOrModel<TValue>;
+  /**
+   * If set, a {@link CodeLookupCall} is created and used for the property {@link lookupCall}.
+   *
+   * The property accepts a {@link CodeType} class or a {@link CodeType.id} (see {@link CodeTypeCache.get}).
+   */
+  codeType?: string | (new() => CodeType<TValue>);
 }

--- a/eclipse-scout-core/src/form/fields/datefield/DateFieldModel.ts
+++ b/eclipse-scout-core/src/form/fields/datefield/DateFieldModel.ts
@@ -7,17 +7,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Popup, ValueFieldModel} from '../../../index';
+import {ValueFieldModel} from '../../../index';
 
 export interface DateFieldModel extends ValueFieldModel<Date, Date | string> {
-  popup?: Popup;
-  touchMode?: boolean;
   /**
-   * Configure the time picker steps. E.g. 15 for 15 minute steps starting with every full hour.
+   * Configures the time picker steps. E.g. 15 for 15 minute steps starting with every full hour.
+   *
    * If 60 % resolution != 0, the minute steps starts every hour with 00 and rise in resolution steps.
+   *
+   * Default is 30 minutes.
    */
   timePickerResolution?: number;
-  embedded?: boolean;
   /**
    * Date to be used when setting a value "automatically", e.g. when the date picker is opened initially or when a date or time is entered and the other component has to be filled.
    * If no auto date is set (which is the default), the current date (with time part "00:00:00.000") is used.
@@ -30,14 +30,13 @@ export interface DateFieldModel extends ValueFieldModel<Date, Date | string> {
    * If the list is empty or null, all dates are available again.
    */
   allowedDates?: (string | Date)[];
-
   hasDate?: boolean;
   dateHasText?: boolean;
   dateFocused?: boolean;
   dateFormatPattern?: string;
-
   hasTime?: boolean;
   timeHasText?: boolean;
   timeFocused?: boolean;
   timeFormatPattern?: string;
+  touchMode?: boolean;
 }

--- a/eclipse-scout-core/src/form/fields/listbox/ListBox.ts
+++ b/eclipse-scout-core/src/form/fields/listbox/ListBox.ts
@@ -68,7 +68,7 @@ export class ListBox<TValue> extends LookupBox<TValue> implements ListBoxModel<T
       if (row.checked) {
         valueArray.push(row.lookupRow.key);
       }
-    }, this);
+    });
 
     this.setValue(valueArray);
     this._valueSyncing = false;
@@ -125,9 +125,9 @@ export class ListBox<TValue> extends LookupBox<TValue> implements ListBoxModel<T
       tableRows = [],
       lookupRows = result.lookupRows;
 
-    lookupRows.forEach(function(lookupRow) {
+    lookupRows.forEach(lookupRow => {
       tableRows.push(this._createTableRow(lookupRow));
-    }, this);
+    });
 
     this.table.deleteAllRows();
     this.table.insertRows(tableRows);

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
@@ -21,7 +21,7 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
 
   popup: SmartFieldTouchPopup<TValue> | SmartFieldPopup<TValue>;
   lookupCall: LookupCall<TValue>;
-  codeType: string | (new() => CodeType<any>);
+  codeType: string | (new() => CodeType<TValue>);
   lookupRow: LookupRow<TValue>;
   browseHierarchy: boolean;
   browseMaxRowCount: number;
@@ -674,6 +674,7 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
     this.maxLengthHandler.render();
   }
 
+  /** @see SmartFieldModel.lookupCall */
   setLookupCall(lookupCall: LookupCallOrModel<TValue>) {
     this.setProperty('lookupCall', lookupCall);
   }
@@ -683,16 +684,21 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
     this._syncBrowseMaxRowCountWithLookupCall();
   }
 
-  protected _setCodeType(codeType: string | (new() => CodeType<any>)) {
+  /** @see SmartFieldModel.codeType */
+  setCodeType(codeType: string | (new() => CodeType<TValue>)) {
+    this.setProperty('codeType', codeType);
+  }
+
+  protected _setCodeType(codeType: string | (new() => CodeType<TValue>)) {
     this._setProperty('codeType', codeType);
     if (!codeType) {
       return;
     }
-    let lookupCall = scout.create(CodeLookupCall, {
+    let lookupCall = scout.create(CodeLookupCall<TValue>, {
       session: this.session,
       codeType: codeType
     });
-    this.setProperty('lookupCall', lookupCall);
+    this.setLookupCall(lookupCall);
   }
 
   protected override _formatValue(value: TValue): string | JQuery.Promise<string> {
@@ -930,7 +936,7 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
     // 'No data' case
     if (empty && result.byAll) {
       // When active filter is enabled we must always show the popup, because the user
-      // must be able to switch the filter properties. Otherwise a user could set the filter
+      // must be able to switch the filter properties. Otherwise, a user could set the filter
       // to 'inactive', and receives an empty result for that query, the popup is closed
       // and the user can not switch the filter back to 'active' again because the filter
       // control is not visible.

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldModel.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldModel.ts
@@ -10,63 +10,104 @@
 import {CodeType, ColumnDescriptor, LookupCallOrModel, LookupRow, SmartFieldActiveFilter, SmartFieldDisplayStyle, ValueFieldModel} from '../../../index';
 
 export interface SmartFieldModel<TValue> extends ValueFieldModel<TValue> {
+  /**
+   * Configures the {@link LookupCall} that is used to load the proposals.
+   */
   lookupCall?: LookupCallOrModel<TValue>;
   /**
-   * CodeTypeId {@link CodeType.id} or CodeType ref. See {@link codes.get}.
+   * If set, a {@link CodeLookupCall} is created and used for the property {@link lookupCall}.
+   *
+   * The property accepts a {@link CodeType} class or a {@link CodeType.id} (see {@link CodeTypeCache.get}).
    */
-  codeType?: string | (new() => CodeType<any>);
+  codeType?: string | (new() => CodeType<TValue>);
   lookupRow?: LookupRow<TValue>;
   /**
+   * Configures whether the proposals should be shown hierarchically using a {@link TreeProposalChooser}.
+   *
    * Default is false.
    */
   browseHierarchy?: boolean;
   /**
-   * A positive number, _not_ null or undefined!
+   * Configures the maximum number of proposals.
    *
-   * Default is SmartField.DEFAULT_BROWSE_MAX_COUNT.
+   * It needs to be a positive number, _not_ null or undefined.
+   *
+   * Default is {@link SmartField.DEFAULT_BROWSE_MAX_COUNT}.
    */
   browseMaxRowCount?: number;
   /**
-   * Valid when browseHierarchy is true.
+   * Configures whether the proposals should be expanded automatically.
+   *
+   * The property only has an effect if {@link browseHierarchy} is true.
    *
    * Default is true.
    */
   browseAutoExpandAll?: boolean;
   /**
-   * Valid when browseHierarchy is true.
+   * Configures whether the proposals should be loaded incrementally.
+   *
+   * The property only has an effect if {@link browseHierarchy} is true.
    *
    * Default is false.
    */
   browseLoadIncremental?: boolean;
   /**
-   * Configures whether this smartfield only shows proposals if a text search string has been entered.
+   * Configures whether proposals should only be shown if a text search string has been entered.
+   *
    * Set this property to true if you expect a large amount of data for an unconstrained search.
    *
    * Default value is false.
    */
   searchRequired?: boolean;
   /**
-   * true: inactive rows are display together with active rows
-   * false: inactive rows ae only displayed when selected by the model
+   * Configures whether the {@link ProposalChooser.activeFilterGroup} should be shown.
+   *
+   * If the group is shown, the user can choose whether all, only the active or only the inactive proposals should be displayed.
    *
    * Default is false.
    */
   activeFilterEnabled?: boolean;
+  /**
+   * Configures the default value of the {@link ProposalChooser.activeFilterGroup}.
+   *
+   * Only has an effect if {@link activeFilterEnabled} is set tot true.
+   */
   activeFilter?: SmartFieldActiveFilter;
+  /**
+   * Configures the labels used by the {@link ProposalChooser.activeFilterGroup}.
+   *
+   * If no labels are specified, default labels are used.
+   *
+   * Only has an effect if {@link activeFilterEnabled} is set tot true.
+   */
   activeFilterLabels?: string[];
   /**
-   * This property has only an effect when the smart field has a table proposal chooser.
-   * When the returned value is <code>null</code>, the table proposal chooser has only one column (showing the lookup row text) without column header.
-   * To change this default behavior, return an array of ColumnDescriptors.
+   * Configures the columns used by the {@link TableProposalChooser}.
+   *
+   * The property only has an effect if {@link browseHierarchy} is set to false, because otherwise a {@link Tree} is used instead of a {@link Table}.
+   *
+   * When the returned value is `null`, the table proposal chooser has only one column (showing the lookup row text) without column header.
+   * To change this default behavior, return an array of {@link ColumnDescriptor}s.
    */
   columnDescriptors?: ColumnDescriptor[];
   /**
-   * Default is SmartField.DisplayStyle.DEFAULT.
+   * Configures the {@link DisplayStyle} of the smart field.
+   *
+   * Default is {@link SmartField.DisplayStyle.DEFAULT}.
    */
   displayStyle?: SmartFieldDisplayStyle;
-  touchMode?: boolean;
-  embedded?: boolean;
   /**
+   * Configures whether the smart field should be displayed in a touch friendly mode.
+   *
+   * If the touch friendly mode is active, touching the smart field opens a popup on top of the screen to minimize overlapping issues with the on-screen keyboard.
+   * The user can search for and select proposals only in that popup.
+   *
+   * Default is false.
+   */
+  touchMode?: boolean;
+  /**
+   * Configures the maximum number of characters the user can enter.
+   *
    * Default is 500.
    */
   maxLength?: number;

--- a/eclipse-scout-core/src/table/columns/SmartColumn.ts
+++ b/eclipse-scout-core/src/table/columns/SmartColumn.ts
@@ -22,7 +22,7 @@ export class SmartColumn<TValue> extends Column<TValue> {
   declare eventMap: SmartColumnEventMap<TValue>;
   declare self: SmartColumn<any>;
 
-  codeType: string | (new() => CodeType<any>);
+  codeType: string | (new() => CodeType<TValue>);
   lookupCall: LookupCall<TValue>;
   browseHierarchy: boolean;
   browseMaxRowCount: number;
@@ -84,11 +84,11 @@ export class SmartColumn<TValue> extends Column<TValue> {
     }
   }
 
-  setCodeType(codeType: string | (new() => CodeType<any>)) {
+  setCodeType(codeType: string | (new() => CodeType<TValue>)) {
     this.setProperty('codeType', codeType);
   }
 
-  protected _setCodeType(codeType: string | (new() => CodeType<any>)) {
+  protected _setCodeType(codeType: string | (new() => CodeType<TValue>)) {
     this._setProperty('codeType', codeType);
     if (codeType) {
       let codeLookupCall = CodeLookupCall<TValue>;

--- a/eclipse-scout-core/src/table/columns/SmartColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/SmartColumnModel.ts
@@ -11,13 +11,38 @@ import {CodeType, ColumnModel, LookupCallOrModel} from '../../index';
 
 export interface SmartColumnModel<TValue> extends ColumnModel<TValue> {
   /**
-   * CodeTypeId {@link CodeType.id} or CodeType ref. See {@link codes.get}.
+   * Configures the {@link LookupCall} that is used to resolve the values and to load the proposals if the column is editable.
    */
-  codeType?: string | (new() => CodeType<any>);
   lookupCall?: LookupCallOrModel<TValue>;
+  /**
+   * If set, a {@link CodeLookupCall} is created and used for the property {@link lookupCall}.
+   *
+   * The property accepts a {@link CodeType} class or a {@link CodeType.id} (see {@link CodeTypeCache.get}).
+   */
+  codeType?: string | (new() => CodeType<TValue>);
+  /**
+   * Configures the {@link SmartFieldModel.browseHierarchy} of the cell editor if the column is editable.
+   * Does not have an effect otherwise.
+   */
   browseHierarchy?: boolean;
+  /**
+   * Configures the {@link SmartFieldModel.browseMaxRowCount} of the cell editor if the column is editable.
+   * Does not have an effect otherwise.
+   */
   browseMaxRowCount?: number;
+  /**
+   * Configures the {@link SmartFieldModel.browseAutoExpandAll} of the cell editor if the column is editable.
+   * Does not have an effect otherwise.
+   */
   browseAutoExpandAll?: boolean;
+  /**
+   * Configures the {@link SmartFieldModel.browseLoadIncremental} of the cell editor if the column is editable.
+   * Does not have an effect otherwise.
+   */
   browseLoadIncremental?: boolean;
+  /**
+   * Configures the {@link SmartFieldModel.activeFilterEnabled} of the cell editor if the column is editable.
+   * Does not have an effect otherwise.
+   */
   activeFilterEnabled?: boolean;
 }

--- a/eclipse-scout-core/test/form/fields/listbox/ListBoxSpec.ts
+++ b/eclipse-scout-core/test/form/fields/listbox/ListBoxSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ListBox, ListBoxModel, ListBoxTableAccessibilityRenderer, LookupCall, LookupResult, LookupRow, QueryBy, scout, Status} from '../../../../src/index';
+import {Code, CodeLookupCall, codes, CodeType, ListBox, ListBoxModel, ListBoxTableAccessibilityRenderer, LookupCall, LookupResult, LookupRow, QueryBy, scout, Status} from '../../../../src/index';
 import {DummyLookupCall, EmptyDummyLookupCall, ErroneousLookupCall, FormSpecHelper, LanguageDummyLookupCall} from '../../../../src/testing/index';
 import {InitModelOf, ObjectOrModel} from '../../../../src/scout';
 import $ from 'jquery';
@@ -21,10 +21,32 @@ describe('ListBox', () => {
     field = new ListBox();
     helper = new FormSpecHelper(session);
     jasmine.clock().install();
+    codes.add([{
+      id: 'ListBoxSpec_CodeType',
+      objectType: CodeType,
+      codes: [
+        {
+          id: 1,
+          objectType: Code,
+          texts: {
+            'de': 'value 1'
+          }
+        },
+        {
+          id: 2,
+          objectType: Code,
+          texts: {
+            'de': 'value 2'
+          }
+        }
+      ]
+    }
+    ]);
   });
 
   afterEach(() => {
     jasmine.clock().uninstall();
+    codes.remove('ListBoxSpec_CodeType');
   });
 
   class SpecListBox extends ListBox<any> {
@@ -291,6 +313,31 @@ describe('ListBox', () => {
       expect(field.displayText).toBe('Baz' + preparedPropertyValue);
 
       expect(eventCounter).toBe(1);
+    });
+
+    it('is set to CodeLookupCall if a codeType is set', async () => {
+      jasmine.clock().uninstall();
+      let listBox = scout.create(ListBox, {
+        parent: session.desktop,
+        codeType: 'ListBoxSpec_CodeType'
+      });
+      listBox.render();
+      await listBox.when('lookupCallDone');
+      expect(listBox.lookupCall).toBeInstanceOf(CodeLookupCall);
+      expect(listBox.table.rows.length).toBe(2);
+    });
+
+    it('is set to CodeLookupCall if a codeType is set, even dynamically', async () => {
+      jasmine.clock().uninstall();
+      let listBox = scout.create(ListBox, {
+        parent: session.desktop,
+        lookupCall: 'DummyLookupCall'
+      });
+      listBox.setCodeType('ListBoxSpec_CodeType');
+      listBox.render();
+      await listBox.when('lookupCallDone');
+      expect(listBox.lookupCall).toBeInstanceOf(CodeLookupCall);
+      expect(listBox.table.rows.length).toBe(2);
     });
   });
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/AbstractSmartField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/AbstractSmartField.java
@@ -196,8 +196,6 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
 
   /**
    * variant B: lookup by backend lookup service<br>
-   * 3.0: no support for {@code<eval>} tags anymore<br>
-   * 3.0: still valid are {@code<text><key><all><rec>} tags in lookup statements in the backend
    */
   @ConfigProperty(ConfigProperty.LOOKUP_CALL)
   @Order(250)
@@ -212,8 +210,11 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
   }
 
   /**
-   * @return true: inactive rows are display together with active rows<br>
-   *         false: inactive rows ae only displayed when selected by the model
+   * Configures whether the popup should show an active filter group.
+   * <p>
+   * If the group is shown, the user can choose whether all, only the active or only the inactive proposals should be displayed.
+   * <p>
+   * Default is false.
    */
   @ConfigProperty(ConfigProperty.BOOLEAN)
   @Order(270)
@@ -872,12 +873,12 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
 
   @Override
   public void lookupByRec(VALUE parentKey) {
-    doSearch(QueryParam.<VALUE> createByRec(parentKey), false);
+    doSearch(QueryParam.createByRec(parentKey), false);
   }
 
   @Override
   public void lookupByKey(VALUE key) {
-    doSearch(QueryParam.<VALUE> createByKey(key), false);
+    doSearch(QueryParam.createByKey(key), false);
   }
 
   @Override
@@ -1227,7 +1228,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
    * @see LookupCall#getDataByAllInBackground(RunContext, ILookupRowFetchedCallback)
    */
   protected ILookupRowProvider<VALUE> newByKeyLookupRowProvider(final VALUE key) {
-    return new ILookupRowProvider<VALUE>() {
+    return new ILookupRowProvider<>() {
 
       @Override
       public void beforeProvide(ILookupCall<VALUE> lookupCall) {
@@ -1274,7 +1275,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
    * @see LookupCall#getDataByAllInBackground(RunContext, ILookupRowFetchedCallback)
    */
   protected ILookupRowProvider<VALUE> newByAllLookupRowProvider(final TriState activeState) {
-    return new ILookupRowProvider<VALUE>() {
+    return new ILookupRowProvider<>() {
 
       @Override
       public void beforeProvide(ILookupCall<VALUE> lookupCall) {
@@ -1311,7 +1312,6 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
             .attr("activeState", activeState)
             .toString();
       }
-
     };
   }
 
@@ -1322,7 +1322,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
    * @see LookupCall#getDataByAllInBackground(RunContext, ILookupRowFetchedCallback)
    */
   protected ILookupRowProvider<VALUE> newByTextLookupRowProvider(final String text) {
-    return new ILookupRowProvider<VALUE>() {
+    return new ILookupRowProvider<>() {
 
       @Override
       public void beforeProvide(ILookupCall<VALUE> lookupCall) {
@@ -1366,7 +1366,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
    * @see LookupCall#getDataByRec()
    */
   protected ILookupRowProvider<VALUE> newByRecLookupRowProvider(final VALUE parentKey, final TriState activeState) {
-    return new ILookupRowProvider<VALUE>() {
+    return new ILookupRowProvider<>() {
 
       @SuppressWarnings("unchecked")
       @Override
@@ -1427,7 +1427,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
     lookupCall.setMaxRowCount(maxRowCount > 0 ? maxRowCount : getBrowseMaxRowCount());
 
     // Prepare processing of the fetched rows.
-    final ILookupRowFetchedCallback<VALUE> internalCallback = new ILookupRowFetchedCallback<VALUE>() {
+    final ILookupRowFetchedCallback<VALUE> internalCallback = new ILookupRowFetchedCallback<>() {
 
       @Override
       public void onSuccess(final List<? extends ILookupRow<VALUE>> rows) {
@@ -1452,7 +1452,7 @@ public abstract class AbstractSmartField<VALUE> extends AbstractValueField<VALUE
               return;
             }
             ModelJobs.schedule(() -> updateField(rows, exception), ModelJobs.newInput(callerRunContext)
-                .withName("Updating {}", AbstractSmartField.this.getClass().getName()))
+                    .withName("Updating {}", AbstractSmartField.this.getClass().getName()))
                 .awaitDone(); // block the current thread until completed
           }
           catch (ThreadInterruptedError e) { // NOSONAR


### PR DESCRIPTION
A CodeType can now be passed to a ListBox and TreeBox to automatically create a CodeLookupCall.

Also:
- improved some JsDoc
- removed internal flags (embedded, popup) from the SmartField and DateField model because they are only intended for the touch popup
- used correct data type for the CodeType property instead of 'any'
- cleaned up some warnings in AbstractSmartField

389534