### PR TITLE
Update Scout homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Eclipse Scout - RT
 
-[Eclipse Scout](https://www.eclipse.org/scout/) is a mature and open framework for modern business applications on the web. It substantially boosts developer productivity and is simple to learn.
+[Eclipse Scout](https://eclipse.dev/scout/) is a mature and open framework for modern business applications on the web. It substantially boosts developer productivity and is simple to learn.
 
 This repository contains the source code of the runtime components, the actual framework code.
 
 ## Getting Started
 
-If you are completely new and wondering what Eclipse Scout is, please visit our [website](https://www.eclipse.org/scout/).
+If you are completely new and wondering what Eclipse Scout is, please visit our [website](https://eclipse.dev/scout/).
 
 To get started with Scout, follow our [Get Started Guide](https://eclipsescout.github.io/stable/getstarted.html).
 

--- a/eclipse-scout-chart/README.md
+++ b/eclipse-scout-chart/README.md
@@ -1,17 +1,17 @@
 <p align="center">
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
 </p>
 
 <p align="center">
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?compact_message&jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/chart" target="_blank" rel="noopener noreferrer"><img alt="npm" src="https://img.shields.io/npm/dm/@eclipse-scout/chart"></a>
   <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank" rel="noopener noreferrer"><img alt="NPM" src="https://img.shields.io/npm/l/@eclipse-scout/chart"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/chart" target="_blank" rel="noopener noreferrer"><img alt="npm (scoped)" src="https://img.shields.io/npm/v/@eclipse-scout/chart"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/chart" target="_blank" rel="noopener noreferrer"><img alt="node" src="https://img.shields.io/node/v/@eclipse-scout/chart"></a>
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fwww.eclipse.org%2Fscout%2F"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Feclipse.dev%2Fscout%2F"></a>
 </p>
 
 # Eclipse Scout - Chart
 
-Extends the [Eclipse Scout](https://www.eclipse.org/scout/) framework with charts based on [Chart.js](https://www.chartjs.org/).
+Extends the [Eclipse Scout](https://eclipse.dev/scout/) framework with charts based on [Chart.js](https://www.chartjs.org/).

--- a/eclipse-scout-chart/package.json
+++ b/eclipse-scout-chart/package.json
@@ -3,7 +3,7 @@
   "version": "25.1.0-snapshot",
   "description": "Eclipse Scout chart",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/eclipse-scout-cli/README.md
+++ b/eclipse-scout-cli/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
 </p>
 
 <p align="center">
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?compact_message&jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/cli" target="_blank" rel="noopener noreferrer"><img alt="npm" src="https://img.shields.io/npm/dm/@eclipse-scout/cli"></a>
   <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank" rel="noopener noreferrer"><img alt="NPM" src="https://img.shields.io/npm/l/@eclipse-scout/cli"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/cli" target="_blank" rel="noopener noreferrer"><img alt="npm (scoped)" src="https://img.shields.io/npm/v/@eclipse-scout/cli"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/cli" target="_blank" rel="noopener noreferrer"><img alt="node" src="https://img.shields.io/node/v/@eclipse-scout/cli"></a>
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fwww.eclipse.org%2Fscout%2F"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Feclipse.dev%2Fscout%2F"></a>
 </p>
 
 # Eclipse Scout - CLI

--- a/eclipse-scout-cli/package.json
+++ b/eclipse-scout-cli/package.json
@@ -3,7 +3,7 @@
   "version": "25.1.0-snapshot",
   "description": "CLI for Eclipse Scout",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/eclipse-scout-core/README.md
+++ b/eclipse-scout-core/README.md
@@ -1,27 +1,27 @@
 <p align="center">
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
 </p>
 
 <p align="center">
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?compact_message&jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/core" target="_blank" rel="noopener noreferrer"><img alt="npm" src="https://img.shields.io/npm/dm/@eclipse-scout/core"></a>
   <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank" rel="noopener noreferrer"><img alt="NPM" src="https://img.shields.io/npm/l/@eclipse-scout/core"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/core" target="_blank" rel="noopener noreferrer"><img alt="npm (scoped)" src="https://img.shields.io/npm/v/@eclipse-scout/core"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/core" target="_blank" rel="noopener noreferrer"><img alt="node" src="https://img.shields.io/node/v/@eclipse-scout/core"></a>
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fwww.eclipse.org%2Fscout%2F"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Feclipse.dev%2Fscout%2F"></a>
 </p>
 
 
 # Eclipse Scout - Core
 
-[Eclipse Scout](https://www.eclipse.org/scout/) is a mature and open framework for modern business applications on the web. It substantially boosts developer productivity and is simple to learn.
+[Eclipse Scout](https://eclipse.dev/scout/) is a mature and open framework for modern business applications on the web. It substantially boosts developer productivity and is simple to learn.
 
 This module contains the web runtime components running in the browser.
 
 ## Getting Started
 
-If you are completely new and wondering what Eclipse Scout is, please visit our [website](https://www.eclipse.org/scout/).
+If you are completely new and wondering what Eclipse Scout is, please visit our [website](https://eclipse.dev/scout/).
 
 To get started with Scout, follow our [Get Started Guide](https://eclipsescout.github.io/stable/getstarted.html).
 

--- a/eclipse-scout-core/package.json
+++ b/eclipse-scout-core/package.json
@@ -3,7 +3,7 @@
   "version": "25.1.0-snapshot",
   "description": "Eclipse Scout runtime",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/eclipse-scout-core/test/form/fields/htmlfield/HtmlFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/htmlfield/HtmlFieldSpec.ts
@@ -26,7 +26,7 @@ describe('HtmlField', () => {
       field.render();
       field.setValue('<ul>\n' +
         '  <li>AppLink: <span class="app-link" data-ref="param1=XY&param2=YZ">Click me</span></li>\n' +
-        '  <li>HTML Link: <a href="https://www.eclipse.org/scout" target="_blank">eclipse.org/scout</a></li>\n' +
+        '  <li>HTML Link: <a href="https://eclipse.dev/scout/" target="_blank">eclipse.dev/scout/</a></li>\n' +
         '</ul>\n' +
         '<!-- This is an invisible comment -->\n');
       let origValue = field.value;

--- a/eclipse-scout-migrate/README.md
+++ b/eclipse-scout-migrate/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
 </p>
 
 <p align="center">
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?compact_message&jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/migrate" target="_blank" rel="noopener noreferrer"><img alt="npm" src="https://img.shields.io/npm/dm/@eclipse-scout/migrate"></a>
   <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank" rel="noopener noreferrer"><img alt="NPM" src="https://img.shields.io/npm/l/@eclipse-scout/migrate"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/migrate" target="_blank" rel="noopener noreferrer"><img alt="npm (scoped)" src="https://img.shields.io/npm/v/@eclipse-scout/migrate"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/migrate" target="_blank" rel="noopener noreferrer"><img alt="node" src="https://img.shields.io/node/v/@eclipse-scout/migrate"></a>
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fwww.eclipse.org%2Fscout%2F"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Feclipse.dev%2Fscout%2F"></a>
 </p>
 
 # Eclipse Scout - Migrate

--- a/eclipse-scout-migrate/package.json
+++ b/eclipse-scout-migrate/package.json
@@ -3,7 +3,7 @@
   "version": "25.1.0-snapshot",
   "description": "TypeScript migration module",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/eclipse-scout-releng/README.md
+++ b/eclipse-scout-releng/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
 </p>
 
 <p align="center">
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?compact_message&jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/releng" target="_blank" rel="noopener noreferrer"><img alt="npm" src="https://img.shields.io/npm/dm/@eclipse-scout/releng"></a>
   <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank" rel="noopener noreferrer"><img alt="NPM" src="https://img.shields.io/npm/l/@eclipse-scout/releng"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/releng" target="_blank" rel="noopener noreferrer"><img alt="npm (scoped)" src="https://img.shields.io/npm/v/@eclipse-scout/releng"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/releng" target="_blank" rel="noopener noreferrer"><img alt="node" src="https://img.shields.io/node/v/@eclipse-scout/releng"></a>
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fwww.eclipse.org%2Fscout%2F"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Feclipse.dev%2Fscout%2F"></a>
 </p>
 
 # Eclipse Scout - Releng

--- a/eclipse-scout-releng/package.json
+++ b/eclipse-scout-releng/package.json
@@ -3,7 +3,7 @@
   "version": "24.1.1",
   "description": "Release engineering module for Eclipse Scout",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/eclipse-scout-tsconfig/README.md
+++ b/eclipse-scout-tsconfig/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
 </p>
 
 <p align="center">
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?compact_message&jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/tsconfig" target="_blank" rel="noopener noreferrer"><img alt="npm" src="https://img.shields.io/npm/dm/@eclipse-scout/tsconfig"></a>
   <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank" rel="noopener noreferrer"><img alt="NPM" src="https://img.shields.io/npm/l/@eclipse-scout/tsconfig"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/tsconfig" target="_blank" rel="noopener noreferrer"><img alt="npm (scoped)" src="https://img.shields.io/npm/v/@eclipse-scout/tsconfig"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/tsconfig" target="_blank" rel="noopener noreferrer"><img alt="node" src="https://img.shields.io/node/v/@eclipse-scout/tsconfig"></a>
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fwww.eclipse.org%2Fscout%2F"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Feclipse.dev%2Fscout%2F"></a>
 </p>
 
 # Eclipse Scout - TSConfig

--- a/eclipse-scout-tsconfig/package.json
+++ b/eclipse-scout-tsconfig/package.json
@@ -3,7 +3,7 @@
   "version": "25.1.0-snapshot",
   "description": "TSConfig for scout projects",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/eslint-config/README.md
+++ b/eslint-config/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
 </p>
 
 <p align="center">
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?compact_message&jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/eslint-config" target="_blank" rel="noopener noreferrer"><img alt="npm" src="https://img.shields.io/npm/dm/@eclipse-scout/eslint-config"></a>
   <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank" rel="noopener noreferrer"><img alt="NPM" src="https://img.shields.io/npm/l/@eclipse-scout/eslint-config"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/eslint-config" target="_blank" rel="noopener noreferrer"><img alt="npm (scoped)" src="https://img.shields.io/npm/v/@eclipse-scout/eslint-config"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/eslint-config" target="_blank" rel="noopener noreferrer"><img alt="node" src="https://img.shields.io/node/v/@eclipse-scout/eslint-config"></a>
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fwww.eclipse.org%2Fscout%2F"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Feclipse.dev%2Fscout%2F"></a>
 </p>
 
 # Eclipse Scout - ESLint

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -3,7 +3,7 @@
   "version": "25.1.0-snapshot",
   "description": "ESLint shareable config for the Scout style",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/karma-jasmine-scout/README.md
+++ b/karma-jasmine-scout/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img src="https://eclipsescout.github.io/assets/img/eclipse-scout-logo.svg"></a>
 </p>
 
 <p align="center">
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
-  <a href="https://ci.eclipse.org/scout/view/Scout%20Nightly%20Jobs/job/scout-integration-22.0-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?compact_message&jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fview%2FScout%2520Nightly%2520Jobs%2Fjob%2Fscout-integration-22.0-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins" src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
+  <a href="https://ci.eclipse.org/scout/job/scout-integration-25.1-RT-nightly_pipeline/" target="_blank" rel="noopener noreferrer"><img alt="Jenkins tests" src="https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fscout%2Fjob%2Fscout-integration-25.1-RT-nightly_pipeline%2F"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/karma-jasmine-scout" target="_blank" rel="noopener noreferrer"><img alt="npm" src="https://img.shields.io/npm/dm/@eclipse-scout/karma-jasmine-scout"></a>
   <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank" rel="noopener noreferrer"><img alt="NPM" src="https://img.shields.io/npm/l/@eclipse-scout/karma-jasmine-scout"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/karma-jasmine-scout" target="_blank" rel="noopener noreferrer"><img alt="npm (scoped)" src="https://img.shields.io/npm/v/@eclipse-scout/karma-jasmine-scout"></a>
   <a href="https://www.npmjs.com/package/@eclipse-scout/karma-jasmine-scout" target="_blank" rel="noopener noreferrer"><img alt="node" src="https://img.shields.io/node/v/@eclipse-scout/karma-jasmine-scout"></a>
-  <a href="https://www.eclipse.org/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fwww.eclipse.org%2Fscout%2F"></a>
+  <a href="https://eclipse.dev/scout/" target="_blank" rel="noopener noreferrer"><img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Feclipse.dev%2Fscout%2F"></a>
 </p>
 
 # Eclipse Scout - Karma Jasmine Scout

--- a/karma-jasmine-scout/package.json
+++ b/karma-jasmine-scout/package.json
@@ -3,7 +3,7 @@
   "version": "25.1.0-snapshot",
   "description": "Scout plugin for Jasmine in Karma",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/UriBuilderTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/UriBuilderTest.java
@@ -35,7 +35,7 @@ public class UriBuilderTest {
   private static final String PATH = "/";
   private static final String SIMPLE_URL = HTTP + "://" + HOST;
   private static final String SIMPLE_URL_PATH = HTTP + "://" + HOST + PATH;
-  private static final String TEST_URI_PATH = "http://acme.com:1234/scout";
+  private static final String TEST_URI_PATH = "https://acme.com:1234/scout";
 
   private static final String NAME1 = "name1";
   private static final String NAME2 = "name2";
@@ -138,7 +138,7 @@ public class UriBuilderTest {
     String query = "?a=%3D";
     UriBuilder builder = new UriBuilder(TEST_URI_PATH + query);
     final String url = builder.createURL().toString();
-    assertTrue(url.toString(), url.toString().endsWith(query));
+    assertTrue(url, url.endsWith(query));
   }
 
   @Test
@@ -152,7 +152,7 @@ public class UriBuilderTest {
     assertEquals("ftp", builder.getScheme());
     //
     builder = new UriBuilder(TEST_URI_PATH);
-    assertEquals("http", builder.getScheme());
+    assertEquals("https", builder.getScheme());
   }
 
   @Test
@@ -189,7 +189,7 @@ public class UriBuilderTest {
     builder.port(-15);
     assertEquals(-1, builder.getPort());
     //
-    builder = new UriBuilder("http://www.ecipse.org:1234/scout");
+    builder = new UriBuilder("https://www.ecipse.org:1234/scout");
     assertEquals(1234, builder.getPort());
     //
     builder.port(42);
@@ -207,7 +207,7 @@ public class UriBuilderTest {
     builder.path(path);
     assertEquals(path, builder.getPath());
     //
-    builder = new UriBuilder("http://acme.com:1234/scout/test/3");
+    builder = new UriBuilder("https://acme.com:1234/scout/test/3");
     assertEquals("/scout/test/3", builder.getPath());
   }
 
@@ -225,11 +225,11 @@ public class UriBuilderTest {
     builder.addPath(path);
     assertEquals(path, builder.getPath());
     //
-    builder = new UriBuilder("http://acme.com:1234/scout/test/3");
+    builder = new UriBuilder("https://acme.com:1234/scout/test/3");
     builder.addPath("test");
     assertEquals("/scout/test/3/test", builder.getPath());
     //
-    builder = new UriBuilder("http://acme.com:1234");
+    builder = new UriBuilder("https://acme.com:1234");
     builder.addPath("test");
     assertEquals("/test", builder.getPath());
   }
@@ -245,7 +245,7 @@ public class UriBuilderTest {
     builder.fragment(fragment);
     assertEquals(fragment, builder.getFragment());
     //
-    builder = new UriBuilder("http://acme.com:1234/scout/test/3#bottomPart");
+    builder = new UriBuilder("https://acme.com:1234/scout/test/3#bottomPart");
     assertEquals("bottomPart", builder.getFragment());
   }
 
@@ -266,7 +266,7 @@ public class UriBuilderTest {
     //
     assertSame(builder, builder.parameter(null, null));
     //
-    builder = new UriBuilder("http://acme.com:1234/scout?name1=value1&name2=value2");
+    builder = new UriBuilder("https://acme.com:1234/scout?name1=value1&name2=value2");
     assertEquals(2, builder.getParameters().size());
     assertEquals(VALUE1, builder.getParameters().get(NAME1));
     assertEquals(VALUE2, builder.getParameters().get(NAME2));
@@ -340,7 +340,7 @@ public class UriBuilderTest {
     builder.scheme(SCHEME).host(HOST).path(PATH_TO_SCHEME).fragment(ANCHOR).parameter("key", "äöü");
     assertEquals("scheme://host/path/to?key=%E4%F6%FC#anchor", builder.createURI(StandardCharsets.ISO_8859_1.name()).toASCIIString());
     //
-    URI baseUri = new URI("http://www.eclipse.org/scout");
+    URI baseUri = new URI("https://eclipse.dev/scout/");
     builder = new UriBuilder(baseUri);
     assertEquals(baseUri, builder.createURI());
   }
@@ -368,7 +368,7 @@ public class UriBuilderTest {
         .parameter("five", " x ");
 
     String s = builder.createURL().toString();
-    assertEquals("http://acme.com:1234/scout?one=x&three&four=+&five=+x+", s);
+    assertEquals("https://acme.com:1234/scout?one=x&three&four=+&five=+x+", s);
   }
 
   @Test

--- a/org.eclipse.scout.rt.svg.ui.html/package.json
+++ b/org.eclipse.scout.rt.svg.ui.html/package.json
@@ -3,7 +3,7 @@
   "version": "25.1.0-snapshot",
   "description": "Eclipse Scout",
   "author": "BSI Business Systems Integration AG",
-  "homepage": "https://www.eclipse.org/scout",
+  "homepage": "https://eclipse.dev/scout/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-scout/scout.rt.git"

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/form/fields/browserfield/JsonBrowserFieldTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/form/fields/browserfield/JsonBrowserFieldTest.java
@@ -64,7 +64,7 @@ public class JsonBrowserFieldTest extends BaseFormFieldTest {
 
   @Test
   public void testPostMessage() throws JSONException {
-    String origin = "https://eclipse.org/scout/";
+    String origin = "https://eclipse.dev/scout/";
     String data = "42";
     Map<String, String> map = new HashMap<>();
     map.put("origin", origin);

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -1138,7 +1138,7 @@
       </plugin>
     </plugins>
   </reporting>
-  <url>https://eclipse.org/scout</url>
+  <url>https://eclipse.dev/scout/</url>
 
   <!-- primarily for license header generation -->
   <inceptionYear>2010</inceptionYear>

--- a/scout-hellojs-app/pom.xml
+++ b/scout-hellojs-app/pom.xml
@@ -25,7 +25,7 @@
 
   <name>Scout JS Sample Application</name>
   <description>Creates a Hello World sample application using Scout JS (UI written in JavaScript)</description>
-  <url>https://eclipse.org/scout</url>
+  <url>https://eclipse.dev/scout/</url>
 
   <properties>
     <org.eclipse.scout.rt_version>25.1-SNAPSHOT</org.eclipse.scout.rt_version>

--- a/scout-helloworld-app/pom.xml
+++ b/scout-helloworld-app/pom.xml
@@ -25,7 +25,7 @@
 
   <name>Scout Hello World Sample Application</name>
   <description>Creates a Hello World sample application using Scout Classic (UI written in Java)</description>
-  <url>https://eclipse.org/scout</url>
+  <url>https://eclipse.dev/scout/</url>
 
   <properties>
     <org.eclipse.scout.rt_version>25.1-SNAPSHOT</org.eclipse.scout.rt_version>

--- a/scout-jaxws-module/pom.xml
+++ b/scout-jaxws-module/pom.xml
@@ -25,7 +25,7 @@
 
   <name>Scout JaxWs Module</name>
   <description>Maven Archetype which creates an empty Scout JaxWs Module</description>
-  <url>https://eclipse.org/scout</url>
+  <url>https://eclipse.dev/scout/</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The Eclipse Scout homepage changed
from https://www.eclipse.org/scout to https://eclipse.dev/scout/

Also update the shield.io URLs to reflect the current version.