### PR TITLE
Clean DataObject: improve extensibility

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectHelperTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
+import org.eclipse.scout.rt.dataobject.fixture.CleanableEntityFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.CollectionFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.EntityFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.ListEntityContributionFixtureDo;
@@ -411,6 +412,40 @@ public class DataObjectHelperTest {
     assertFalse(testObj.otherEntities().get(1).id().exists());
     assertTrue(testObj.otherEntities().get(1).nestedOtherEntity().exists());
     assertFalse(testObj.otherEntities().get(1).nestedOtherEntity().get().id().exists());
+  }
+
+  @Test
+  public void testCleanOfCleanableObjects() {
+    EntityFixtureDo testObj = BEANS.get(CleanableEntityFixtureDo.class)
+        .withId(null)
+        .withOtherEntity(BEANS.get(OtherEntityFixtureDo.class)
+            .withId(null)
+            .withItems())
+        .withOtherEntities( // Other entities are marked as cleanable -> should be removed
+            BEANS.get(OtherEntityFixtureDo.class)
+                .withId("test"));
+
+    assertTrue(testObj.id().exists());
+
+    assertTrue(testObj.otherEntity().exists());
+    assertTrue(testObj.otherEntity().get().id().exists());
+    assertTrue(testObj.otherEntity().get().items().exists());
+    assertEquals(0, testObj.otherEntity().get().items().size());
+
+    assertTrue(testObj.otherEntities().exists());
+    assertEquals(1, testObj.otherEntities().get().size());
+
+    assertNotNull(testObj.otherEntities().get(0));
+    assertTrue(testObj.otherEntities().get(0).id().exists());
+    assertFalse(testObj.otherEntities().get(0).items().exists());
+    assertEquals(0, testObj.otherEntities().get(0).items().size());
+
+    m_helper.clean(testObj);
+
+    assertFalse(testObj.id().exists());
+    assertFalse(testObj.otherEntity().exists());
+    assertFalse(testObj.otherEntities().exists());
+    assertTrue(testObj.isEmpty());
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectHelperTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectHelperTest.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
+import org.eclipse.scout.rt.dataobject.fixture.CleanableEntityFixtureContributionDo;
 import org.eclipse.scout.rt.dataobject.fixture.CleanableEntityFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.CollectionFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.EntityFixtureDo;
@@ -421,7 +422,7 @@ public class DataObjectHelperTest {
         .withOtherEntity(BEANS.get(OtherEntityFixtureDo.class)
             .withId("test")
             .withItems())
-        .withOtherEntities( // Other entities are marked as cleanable -> should be removed
+        .withOtherEntities( // Other entities are marked as cleanable by the implementation of ICleanableDataObject -> should be removed in all cases
             BEANS.get(OtherEntityFixtureDo.class)
                 .withId("test"));
 
@@ -458,7 +459,7 @@ public class DataObjectHelperTest {
         .withOtherEntity(BEANS.get(OtherEntityFixtureDo.class)
             .withId(null)
             .withItems())
-        .withOtherEntities( // Other entities are marked as cleanable -> should be removed
+        .withOtherEntities( // Other entities are marked as cleanable by the implementation of ICleanableDataObject -> should be removed in all cases
             BEANS.get(OtherEntityFixtureDo.class)
                 .withId("test"));
 
@@ -483,6 +484,33 @@ public class DataObjectHelperTest {
     assertFalse(testObj.otherEntity().exists());
     assertFalse(testObj.otherEntities().exists());
     assertTrue(testObj.isEmpty());
+  }
+
+  @Test
+  public void testCompleteCleanOfCleanableContributions() {
+    EntityFixtureDo testObj = BEANS.get(CleanableEntityFixtureDo.class)
+        .withId(null);
+
+    testObj
+        .contribution(CleanableEntityFixtureContributionDo.class)
+        .withId(null)
+        .withOtherEntity(BEANS.get(OtherEntityFixtureDo.class)
+            .withId("test"));
+
+    assertTrue(testObj.id().exists());
+    assertFalse(testObj.otherEntity().exists());
+    assertFalse(testObj.otherEntities().exists());
+
+    assertTrue(testObj.hasContributions());
+    assertTrue(testObj.hasContribution(CleanableEntityFixtureContributionDo.class));
+
+    m_helper.clean(testObj);
+
+    assertFalse(testObj.id().exists());
+
+    assertTrue(testObj.hasContributions());
+    assertNotNull(testObj.getContribution(CleanableEntityFixtureContributionDo.class));
+    assertTrue(testObj.getContribution(CleanableEntityFixtureContributionDo.class).isEmpty());
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectHelperTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectHelperTest.java
@@ -419,6 +419,43 @@ public class DataObjectHelperTest {
     EntityFixtureDo testObj = BEANS.get(CleanableEntityFixtureDo.class)
         .withId(null)
         .withOtherEntity(BEANS.get(OtherEntityFixtureDo.class)
+            .withId("test")
+            .withItems())
+        .withOtherEntities( // Other entities are marked as cleanable -> should be removed
+            BEANS.get(OtherEntityFixtureDo.class)
+                .withId("test"));
+
+    assertTrue(testObj.id().exists());
+
+    assertTrue(testObj.otherEntity().exists());
+    assertTrue(testObj.otherEntity().get().id().exists());
+    assertTrue(testObj.otherEntity().get().items().exists());
+    assertEquals(0, testObj.otherEntity().get().items().size());
+
+    assertTrue(testObj.otherEntities().exists());
+    assertEquals(1, testObj.otherEntities().get().size());
+
+    assertNotNull(testObj.otherEntities().get(0));
+    assertTrue(testObj.otherEntities().get(0).id().exists());
+    assertFalse(testObj.otherEntities().get(0).items().exists());
+    assertEquals(0, testObj.otherEntities().get(0).items().size());
+
+    m_helper.clean(testObj);
+
+    assertFalse(testObj.id().exists());
+
+    assertTrue(testObj.otherEntity().exists());
+    assertTrue(testObj.getOtherEntity().id().exists());
+    assertFalse(testObj.getOtherEntity().items().exists());
+
+    assertFalse(testObj.otherEntities().exists());
+  }
+
+  @Test
+  public void testCompleteCleanOfCleanableObjects() {
+    EntityFixtureDo testObj = BEANS.get(CleanableEntityFixtureDo.class)
+        .withId(null)
+        .withOtherEntity(BEANS.get(OtherEntityFixtureDo.class)
             .withId(null)
             .withItems())
         .withOtherEntities( // Other entities are marked as cleanable -> should be removed

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/CleanableEntityFixtureContributionDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/CleanableEntityFixtureContributionDo.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.fixture;
+
+import org.eclipse.scout.rt.dataobject.ContributesTo;
+import org.eclipse.scout.rt.dataobject.DoNode;
+import org.eclipse.scout.rt.dataobject.ICleanableDataObject;
+import org.eclipse.scout.rt.dataobject.IDoEntityContribution;
+
+@ContributesTo(CleanableEntityFixtureDo.class)
+public final class CleanableEntityFixtureContributionDo extends EntityFixtureDo implements ICleanableDataObject, IDoEntityContribution {
+
+  @Override
+  public boolean isNodeCleanable(DoNode<?> node) {
+    // Make other entity clearable
+    if (node.equals(otherEntity())) {
+      return true;
+    }
+    return ICleanableDataObject.super.isNodeCleanable(node);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/CleanableEntityFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/CleanableEntityFixtureDo.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.fixture;
+
+import org.eclipse.scout.rt.dataobject.DoNode;
+import org.eclipse.scout.rt.dataobject.ICleanableDataObject;
+
+public class CleanableEntityFixtureDo extends EntityFixtureDo implements ICleanableDataObject {
+
+  @Override
+  public boolean isNodeCleanable(DoNode<?> node) {
+    // Make other entities clearable
+    if (node.equals(otherEntities())) {
+      return true;
+    }
+    return ICleanableDataObject.super.isNodeCleanable(node);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DataObjectHelper.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DataObjectHelper.java
@@ -197,7 +197,7 @@ public class DataObjectHelper {
    *
    * @return the unwrapped value (never <code>null</code>)
    * @throws AssertionException
-   *           if the given {@link DoValue} is null, does not exist, or has no value
+   *     if the given {@link DoValue} is null, does not exist, or has no value
    */
   public <T> T assertValue(DoValue<T> doValue) {
     Assertions.assertNotNull(doValue);
@@ -211,7 +211,7 @@ public class DataObjectHelper {
    *
    * @return the unwrapped value (never <code>null</code> or empty)
    * @throws AssertionException
-   *           if the given {@link DoValue} is null, does not exist, or has no text
+   *     if the given {@link DoValue} is null, does not exist, or has no text
    */
   public String assertValueHasText(DoValue<String> doValue) {
     String value = assertValue(doValue);
@@ -224,7 +224,7 @@ public class DataObjectHelper {
    * {@link DoCollection}. This is useful to have a comparable output if the same data object is serialized twice.
    *
    * @param dataObject
-   *          Data object to normalize.
+   *     Data object to normalize.
    */
   public void normalize(IDataObject dataObject) {
     new P_NormalizationDataObjectVisitor().normalize(dataObject);
@@ -290,7 +290,7 @@ public class DataObjectHelper {
    * {@link IDoCollection} nodes containing an empty collection. This is useful to have a minimal data object.
    *
    * @param dataObject
-   *          Data object to clean.
+   *     Data object to clean.
    */
   public void clean(IDataObject dataObject) {
     new P_CleanDataObjectVisitor().clean(dataObject);
@@ -312,14 +312,14 @@ public class DataObjectHelper {
         // (1a) Clean do values and do list
         if (cleanablePredicate.test(node)) {
           emptyNodes.add(node);
+          continue;
         }
         // (1b) Clean nested entities
-        else {
-          caseDoEntityNode(node);
-          // Remove node if it is empty after clean
-          if (node.get() instanceof IDoEntity && ((IDoEntity) node.get()).isEmpty()) {
-            emptyNodes.add(node);
-          }
+        caseDoEntityNode(node);
+
+        // (1c) Remove nested node if it is empty after clean
+        if (node.get() instanceof IDoEntity && ((IDoEntity) node.get()).isEmpty()) {
+          emptyNodes.add(node);
         }
       }
       entity.removeIf(emptyNodes::contains);
@@ -337,11 +337,11 @@ public class DataObjectHelper {
   }
 
   protected boolean isNodeCleanable(DoNode<?> node) {
-    // (1) clean null values
+    // clean null values
     if (node instanceof DoValue && node.get() == null) {
       return true;
     }
-    // (1b) clean empty collections (i.e. DoCollection, DoList, DoSet)
+    // clean empty collections (i.e. DoCollection, DoList, DoSet)
     if (node instanceof IDoCollection && ((IDoCollection) node).isEmpty()) {
       return true;
     }
@@ -399,9 +399,9 @@ public class DataObjectHelper {
    * available. The operation is not recursive.
    *
    * @param target
-   *          target entity that is extended with attributes from the {@code template}. Must not be {@code null}.
+   *     target entity that is extended with attributes from the {@code template}. Must not be {@code null}.
    * @param template
-   *          entity missing attributes are taken from. It is not modified and can be {@code null}.
+   *     entity missing attributes are taken from. It is not modified and can be {@code null}.
    * @return the {@code target} object that was potentially modified
    */
   public <E extends IDoEntity> E extend(E target, IDoEntity template) {
@@ -413,9 +413,9 @@ public class DataObjectHelper {
    * values in @code target} entity. The operation is not recursive.
    *
    * @param target
-   *          target entity where attributes from the {@code template} are applied. Must not be {@code null}.
+   *     target entity where attributes from the {@code template} are applied. Must not be {@code null}.
    * @param template
-   *          entity all attributes are taken from. It is not modified and can be {@code null}.
+   *     entity all attributes are taken from. It is not modified and can be {@code null}.
    * @return the {@code target} object that was potentially modified
    */
   public <E extends IDoEntity> E applyValues(E target, IDoEntity template) {

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/ICleanableDataObject.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/ICleanableDataObject.java
@@ -13,6 +13,13 @@ import org.eclipse.scout.rt.platform.BEANS;
 
 public interface ICleanableDataObject {
 
+  /**
+   * Returns true, if the provided node has no relevant value and can be removed from the json structure.
+   *
+   * @param node
+   *     the node to be checked
+   * @return true when the node can be cleaned
+   */
   default boolean isNodeCleanable(DoNode<?> node) {
     return BEANS.get(DataObjectHelper.class).isNodeCleanable(node);
   }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/ICleanableDataObject.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/ICleanableDataObject.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject;
+
+import org.eclipse.scout.rt.platform.BEANS;
+
+public interface ICleanableDataObject {
+
+  default boolean isNodeCleanable(DoNode<?> node) {
+    return BEANS.get(DataObjectHelper.class).isNodeCleanable(node);
+  }
+}


### PR DESCRIPTION
The cleaning of data objects can now be better extended. By implementing the ICleanableDataObject interface, the developer can decide by himself which properties can be cleaned or not.

351317