### PR TITLE
Fix incorrect rendering of components on saturday

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.less
+++ b/eclipse-scout-core/src/calendar/Calendar.less
@@ -502,6 +502,7 @@
 
 .calendar-week {
   position: relative;
+  overflow: hidden;
 }
 
 .calendar-week-name {

--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -316,11 +316,11 @@ export class Calendar extends Widget implements CalendarModel {
   protected _setRangeSelectionAllowed(rangeSelectionAllowed: boolean) {
     this.rangeSelectionAllowed = rangeSelectionAllowed;
     if (!this.rangeSelectionAllowed) {
-      this._setSelectedRange(null);
+      this.setSelectedRange(null);
     }
   }
 
-  protected _setSelectedRange(range: DateRange | JsonDateRange) {
+  setSelectedRange(range: DateRange | JsonDateRange) {
     let selectedRange = DateRange.ensure(range);
     if (selectedRange && selectedRange.from && selectedRange.to) {
       this.selectorStart = new Date(selectedRange.from);
@@ -820,6 +820,17 @@ export class Calendar extends Widget implements CalendarModel {
       return;
     }
 
+    // When left click on component was made, which was covered by a range selection, apply the selection on the component
+    let componentPartElement = document.elementsFromPoint(event.pageX, event.pageY).find(e => e.classList.contains('calendar-component'));
+    if (event.button === 0 && componentPartElement) {
+      let $part = $(componentPartElement as HTMLElement);
+      let component = $part.data('component') as CalendarComponent;
+      if (component) {
+        component.applySelection($part, true, event.originalEvent.clientY);
+        return;
+      }
+    }
+
     // Check if date is valid
     if (!selectedDate.valueOf()) {
       return;
@@ -979,7 +990,7 @@ export class Calendar extends Widget implements CalendarModel {
       this._updateTopGrid();
     }
 
-    this._setSelectedRange(this.selectedRange);
+    this.setSelectedRange(this.selectedRange);
   }
 
   layoutSize(animate?: boolean) {

--- a/eclipse-scout-core/src/calendar/CalendarComponent.ts
+++ b/eclipse-scout-core/src/calendar/CalendarComponent.ts
@@ -322,6 +322,10 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
   }
 
   protected _onMouseDown(event: JQuery.MouseDownEvent) {
+    this.applySelection($(event.delegateTarget), event.button === 0, event.originalEvent.clientY);
+  }
+
+  applySelection($part: JQuery, openPopup: boolean, popupY: number) {
     // don't show popup if dragging is in process
     if (this.parent._moveData && this.parent._moveData.moving) {
       return;
@@ -332,10 +336,11 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
       return;
     }
 
-    let $part = $(event.delegateTarget);
     this.updateSelectedComponent($part, false);
 
-    if (event.button === 0) {
+    this.parent.setSelectedRange(null);
+
+    if (openPopup) {
       let popup = scout.create((WidgetPopup<Label>), {
         parent: this.parent,
         $anchor: $part,
@@ -352,7 +357,7 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
         cssClass: 'popup',
         scrollType: 'remove',
         location: {
-          y: event.originalEvent.clientY
+          y: popupY
         },
         content: {
           objectType: Label,


### PR DESCRIPTION
When switching from DisplayMode Day to WorkWeek, the components on Saturday were rendered on the right hand side. This is not desired, the overflow should be invisible.

404100