### PR TITLE
Calendar: fix static range selection

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -2380,7 +2380,7 @@ export class Calendar extends Widget implements CalendarModel {
       }
 
       start.setHours(0, this._getHours(start) * 60);
-      end.setHours(0, this._getHours(end) * 60 + 30);
+      end.setHours(0, this._getHours(end) * 60 + (60 / this.numberOfHourDivisions));
 
       this.selectedRange = new DateRange(start, end);
     } else {


### PR DESCRIPTION
The range selection was only able to support a resolution of 30 minutes. When the numberOfHourDivisions were set to a value > 2, the selection was rounded up to the next half hour.

404446