### PR TITLE
Backport: Avoid endless loops in Widget#isRemovalPending

### DIFF
--- a/eclipse-scout-core/src/popup/PopupManagerAdapter.ts
+++ b/eclipse-scout-core/src/popup/PopupManagerAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ModelAdapter} from '../index';
+import {ModelAdapter, PopupManager} from '../index';
 
 export class PopupManagerAdapter extends ModelAdapter {
+
+  declare widget: PopupManager;
+
+  protected _syncPopups(popups: any[]) {
+    // Wait for every other event in the current response to be processed first.
+    // This ensures the anchor will be created first and not by the popup. If the popup created it, the popup would be used as parent.
+    // Example case: the popup anchor is a menu widget and its parent should be a menu bar.
+    // If the parent was the popup it would generate an endless loop in Widget#isRemovalPending().
+    this.session.onEventsProcessed(() => this.widget.setPopups(popups));
+  }
+
 }


### PR DESCRIPTION
Endless loops may occur in Widget#isRemovalPending() when a popup has a menu as anchor and both widgets are rendered for the first time.

Backport to 23.2 to fix duplicate rendering of forms which are opened by a popup (355880).

382670