### PR TITLE
Remove deprecated meta tag "apple-mobile-web-app-capable"

### DIFF
--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app/src/main/resources/WebContent/includes/head.html
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.app/src/main/resources/WebContent/includes/head.html
@@ -1,4 +1,3 @@
-<meta name="apple-mobile-web-app-capable" content="yes"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 <!-- BEGIN favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-touch-icon-57x57.png">

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html/src/main/resources/WebContent/includes/head.html
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.ui.html/src/main/resources/WebContent/includes/head.html
@@ -1,4 +1,3 @@
-<meta name="apple-mobile-web-app-capable" content="yes"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 <!-- BEGIN favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-touch-icon-57x57.png">


### PR DESCRIPTION
The meta tag "apple-mobile-web-app-capable" has been deprecated in iOS for several years. Chrome recently started reporting this with a warning on the console. Because the meta tag had no effect, we can simply remove it from all apps.

Mobile browsers will still offer the possibility to add a home screen icon for the application (which will just be a bookmark, opened in the regular browser). To properly configure it as an "app", consider adding a PWA manifest (https://developer.mozilla.org/en-US/docs/Web/Manifest).

393084