### PR TITLE
Button: fix accidentally visible label when labelVisible=false

### DIFF
--- a/eclipse-scout-core/src/tile/fields/FormFieldTile.ts
+++ b/eclipse-scout-core/src/tile/fields/FormFieldTile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -50,7 +50,7 @@ export class FormFieldTile extends WidgetTile {
   }
 
   protected _setDisplayStyle(displayStyle: FormFieldTileDisplayStyle) {
-    this._setProperty('displayStyle', this.displayStyle);
+    this._setProperty('displayStyle', displayStyle);
     if (this.tileWidget && this.displayStyle === FormFieldTile.DisplayStyle.DASHBOARD) {
       this.tileWidget.setLabelPosition(FormField.LabelPosition.TOP);
       this.tileWidget.setMandatory(false);

--- a/eclipse-scout-core/src/tile/fields/button/TileButton.ts
+++ b/eclipse-scout-core/src/tile/fields/button/TileButton.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -79,6 +79,13 @@ export class TileButton extends Button {
     this.invalidateLayoutTree();
   }
 
+  override get$Icon(): JQuery {
+    if (this.$iconContainer) {
+      return this.$iconContainer.children('.icon');
+    }
+    return super.get$Icon();
+  }
+
   protected override _renderSubmenuIcon() {
     if (!this._isInDashboardTile()) {
       super._renderSubmenuIcon();
@@ -101,6 +108,16 @@ export class TileButton extends Button {
 
   protected override _renderLabelVisible() {
     super._renderLabelVisible();
+    this._updateLabelAndIconStyle();
+  }
+
+  protected override _updateLabelAndIconStyle() {
+    if (!this._isInDashboardTile()) {
+      super._updateLabelAndIconStyle();
+      return;
+    }
+    // Because dashboard tile buttons don't use $icon or $submenuIcon, we can simply toggle
+    // the visibility of the $buttonLabel depending on the labelVisible property.
     this._renderChildVisible(this.$buttonLabel, this.labelVisible);
   }
 }

--- a/eclipse-scout-core/test/form/fields/button/ButtonSpec.ts
+++ b/eclipse-scout-core/test/form/fields/button/ButtonSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -257,6 +257,298 @@ describe('Button', () => {
       expect(button.$field).toHaveAttr('aria-pressed', 'false');
       button.setSelected(true);
       expect(button.$field).toHaveAttr('aria-pressed', 'true');
+    });
+  });
+
+  describe('labelVisible', () => {
+
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // These tests assert the current behavior of the 'Button' widget. Unlike most other form fields,
+    // it does not have a $label element, even when labelVisible=true. Instead, the label is rendered
+    // inside the button as $buttonLabel. As a result, the 'labelVisible' property has no effect.
+    // Unfortunately, this cannot be fixed without potentially breaking existing applications.
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    it('does not render label as $label', () => {
+      let button = scout.create(Button, {
+        parent: session.desktop,
+        label: 'Test'
+      });
+      button.render();
+
+      expect(button.labelVisible).toBe(true);
+      expect(button.label).toBe('Test');
+      expect(button.$label).toBe(null);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Test');
+    });
+
+    it('shows the $buttonLabel when labelVisible=true, expect if only an icon icon is present', () => {
+      let button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: null,
+        iconId: null
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: 'Options',
+        iconId: null
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon().length).toBe(0);
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: null,
+        iconId: icons.GEAR
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(false);
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: 'Options',
+        iconId: icons.GEAR
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(true);
+
+      // Menus should behave like icons
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: null,
+        menus: [{objectType: Menu, text: 'Click me'}]
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+      expect(button.$submenuIcon).toBeTruthy();
+      expect(button.$submenuIcon.hasClass('with-label')).toBe(false);
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: 'Options',
+        menus: [{objectType: Menu, text: 'Click me'}]
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon().length).toBe(0);
+      expect(button.$submenuIcon).toBeTruthy();
+      expect(button.$submenuIcon.hasClass('with-label')).toBe(true);
+
+      // Icons and menus combined
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: null,
+        iconId: icons.GEAR,
+        menus: [{objectType: Menu, text: 'Click me'}]
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(false);
+      expect(button.$submenuIcon).toBeFalsy(); // no indicator when _only_ the icon is visible
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: 'Options',
+        iconId: icons.GEAR,
+        menus: [{objectType: Menu, text: 'Click me'}]
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(true);
+      expect(button.$submenuIcon).toBeTruthy();
+      expect(button.$submenuIcon.hasClass('with-label')).toBe(true);
+    });
+
+    it('shows the $buttonLabel when no icon is present, even if labelVisible=false', () => {
+      let button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: null,
+        iconId: null
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible(); // <--
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: 'Options',
+        iconId: null
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible(); // <--
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon().length).toBe(0);
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: null,
+        iconId: icons.GEAR
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(false);
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: 'Options',
+        iconId: icons.GEAR
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible(); // <--
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(true);
+
+      // Menus should behave like icons
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: null,
+        menus: [{objectType: Menu, text: 'Click me'}]
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+      expect(button.$submenuIcon).toBeTruthy();
+      expect(button.$submenuIcon.hasClass('with-label')).toBe(false);
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: 'Options',
+        menus: [{objectType: Menu, text: 'Click me'}]
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible(); // <--
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon().length).toBe(0);
+      expect(button.$submenuIcon).toBeTruthy();
+      expect(button.$submenuIcon.hasClass('with-label')).toBe(true);
+
+      // Icons and menus combined
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: null,
+        iconId: icons.GEAR,
+        menus: [{objectType: Menu, text: 'Click me'}]
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(false);
+      expect(button.$submenuIcon).toBeFalsy(); // no indicator when _only_ the icon is visible
+
+      button = scout.create(Button, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: 'Options',
+        iconId: icons.GEAR,
+        menus: [{objectType: Menu, text: 'Click me'}]
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible(); // <--
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(true);
+      expect(button.$submenuIcon).toBeTruthy();
+      expect(button.$submenuIcon.hasClass('with-label')).toBe(true);
+    });
+
+    it('does not change the label dynamically when labelVisible property changes', () => {
+      let button = scout.create(Button, {
+        parent: session.desktop
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setLabel('Options');
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setIconId(icons.GEAR);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(true);
+
+      button.setLabel(null);
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(false);
+
+      button.setIconId(null);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setLabelVisible(false);
+      expect(button.$buttonLabel).toBeVisible(); // still visible
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setLabel('Options');
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setIconId(icons.GEAR);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(true);
+
+      button.setLabelVisible(true);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+      expect(button.get$Icon().hasClass('with-label')).toBe(true);
     });
   });
 });

--- a/eclipse-scout-core/test/tile/fields/button/TileButtonSpec.ts
+++ b/eclipse-scout-core/test/tile/fields/button/TileButtonSpec.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {icons, scout, TileButton} from '../../../../src';
+
+describe('TileButton', () => {
+  let session: SandboxSession;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+  });
+
+  class SpecTileButton extends TileButton {
+    protected override _isInDashboardTile(): boolean {
+      // Simulate surrounding dashboard tile (otherwise, the TileButton behaves more like a normal Button)
+      return true;
+    }
+  }
+
+  describe('labelVisible', () => {
+
+    it('does not render label as $label', () => {
+      let button = scout.create(SpecTileButton, {
+        parent: session.desktop,
+        label: 'Test'
+      });
+      button.render();
+
+      expect(button.labelVisible).toBe(true);
+      expect(button.label).toBe('Test');
+      expect(button.$label).toBe(null);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Test');
+    });
+
+    it('shows the $buttonLabel when labelVisible=true', () => {
+      let button = scout.create(SpecTileButton, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: null
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+
+      button = scout.create(SpecTileButton, {
+        parent: session.desktop,
+        labelVisible: true,
+        label: 'Options'
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+    });
+
+    it('never shows the label if labelVisible=false', () => {
+      // Note: This behaves differently from a normal Button widget.
+
+      let button = scout.create(SpecTileButton, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: null
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeHidden(); // <--
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+
+      button = scout.create(SpecTileButton, {
+        parent: session.desktop,
+        labelVisible: false,
+        label: 'Options'
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeHidden(); // <--
+      expect(button.$buttonLabel.html()).toBe('Options');
+    });
+
+    it('shows or hides the label dynamically when the properties change', () => {
+      // Note: This behaves differently from a normal Button widget.
+
+      let button = scout.create(SpecTileButton, {
+        parent: session.desktop
+      });
+      button.render();
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setLabel('Options');
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setIconId(icons.GEAR);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+
+      button.setLabel(null);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon()).toBeVisible();
+
+      button.setIconId(null);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setLabelVisible(false);
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('&nbsp;');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setLabel('Options');
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon().length).toBe(0);
+
+      button.setIconId(icons.GEAR);
+      expect(button.$buttonLabel).toBeHidden();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+
+      button.setLabelVisible(true);
+      expect(button.$buttonLabel).toBeVisible();
+      expect(button.$buttonLabel.html()).toBe('Options');
+      expect(button.get$Icon()).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
If labelVisible=false, the $buttonLabel should never be shown, even when a label is set. Jasmine tests were added to test all combinations of label, labelVisible, iconId and menus.

393740