### PR TITLE
fix clipboard form selection for first text

### DIFF
--- a/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.less
+++ b/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.less
@@ -13,6 +13,9 @@
   padding: @text-field-padding-y @text-field-padding-x;
   #scout.user-select(text);
   white-space: pre-wrap;
+  
+  // fix text selection bug in chrome
+  position: relative;
 
   & > img {
     display: none;

--- a/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.less
+++ b/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.less
@@ -14,7 +14,7 @@
   #scout.user-select(text);
   white-space: pre-wrap;
   
-  // fix text selection bug in chrome
+  // fix text selection bug in chrome (https://issues.chromium.org/issues/388616185)
   position: relative;
 
   & > img {


### PR DESCRIPTION
- make clipboard field positioning static so double click text selection works properly for the first text in the field

405372