### PR TITLE
LookupBox: make customizing easier

### DIFF
--- a/eclipse-scout-core/src/form/fields/LookupBox.ts
+++ b/eclipse-scout-core/src/form/fields/LookupBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/eclipse-scout-core/src/form/fields/listbox/ListBox.ts
+++ b/eclipse-scout-core/src/form/fields/listbox/ListBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, Column, InitModelOf, ListBoxLayout, ListBoxModel, ListBoxTableAccessibilityRenderer, LookupBox, lookupField, LookupResult, LookupRow, scout, Table, TableRowModel, TableRowsCheckedEvent, Widget} from '../../../index';
+import {
+  arrays, Column, InitModelOf, ListBoxLayout, ListBoxModel, ListBoxTableAccessibilityRenderer, LookupBox, lookupField, LookupResult, LookupRow, ObjectOrChildModel, objects, scout, Table, TableModel, TableRowModel, TableRowsCheckedEvent,
+  Widget
+} from '../../../index';
+import $ from 'jquery';
 
 export class ListBox<TValue> extends LookupBox<TValue> implements ListBoxModel<TValue> {
   declare model: ListBoxModel<TValue>;
@@ -168,9 +172,25 @@ export class ListBox<TValue> extends LookupBox<TValue> implements ListBoxModel<T
     return row;
   }
 
+  protected override _prepareWidgetProperty(propertyName: string, models: ObjectOrChildModel<Widget>): Widget;
+  protected override _prepareWidgetProperty(propertyName: string, models: ObjectOrChildModel<Widget>[]): Widget[];
+  protected override _prepareWidgetProperty(propertyName: string, models: ObjectOrChildModel<Widget> | ObjectOrChildModel<Widget>[]): Widget | Widget[] {
+    if (propertyName === 'table' && objects.isPojo(models)) {
+      // Enhance given model with list box specific defaults
+      models = $.extend(this._createDefaultListBoxTableModel(), models);
+    }
+    return super._prepareWidgetProperty(propertyName, models as ObjectOrChildModel<Widget>);
+  }
+
   protected _createDefaultListBoxTable(): Table {
     return scout.create(Table, {
       parent: this,
+      ...this._createDefaultListBoxTableModel()
+    });
+  }
+
+  protected _createDefaultListBoxTableModel(): TableModel {
+    return {
       autoResizeColumns: true,
       checkable: true,
       checkableStyle: Table.CheckableStyle.CHECKBOX_TABLE_ROW,
@@ -179,7 +199,7 @@ export class ListBox<TValue> extends LookupBox<TValue> implements ListBoxModel<T
       columns: [{
         objectType: Column
       }]
-    });
+    };
   }
 
   override getDelegateScrollable(): Widget {

--- a/eclipse-scout-core/src/form/fields/treebox/TreeBox.ts
+++ b/eclipse-scout-core/src/form/fields/treebox/TreeBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, InitModelOf, LookupBox, LookupResult, LookupRow, objects, scout, Tree, TreeBoxLayout, TreeBoxModel, TreeNode, TreeNodesCheckedEvent, TreeNodeUncheckOptions, Widget} from '../../../index';
+import {arrays, InitModelOf, LookupBox, LookupResult, LookupRow, ObjectOrChildModel, objects, scout, Tree, TreeBoxLayout, TreeBoxModel, TreeModel, TreeNode, TreeNodesCheckedEvent, TreeNodeUncheckOptions, Widget} from '../../../index';
+import $ from 'jquery';
 
 export class TreeBox<TValue> extends LookupBox<TValue> implements TreeBoxModel<TValue> {
   tree: Tree;
@@ -194,11 +195,27 @@ export class TreeBox<TValue> extends LookupBox<TValue> implements TreeBoxModel<T
     return node;
   }
 
+  protected override _prepareWidgetProperty(propertyName: string, models: ObjectOrChildModel<Widget>): Widget;
+  protected override _prepareWidgetProperty(propertyName: string, models: ObjectOrChildModel<Widget>[]): Widget[];
+  protected override _prepareWidgetProperty(propertyName: string, models: ObjectOrChildModel<Widget> | ObjectOrChildModel<Widget>[]): Widget | Widget[] {
+    if (propertyName === 'tree' && objects.isPojo(models)) {
+      // Enhance given model with tree box specific defaults
+      models = $.extend(this._createDefaultTreeBoxTreeModel(), models);
+    }
+    return super._prepareWidgetProperty(propertyName, models as ObjectOrChildModel<Widget>);
+  }
+
   protected _createDefaultTreeBoxTree(): Tree {
     return scout.create(Tree, {
       parent: this,
-      checkable: true
+      ...this._createDefaultTreeBoxTreeModel()
     });
+  }
+
+  protected _createDefaultTreeBoxTreeModel(): TreeModel {
+    return {
+      checkable: true
+    };
   }
 
   override getDelegateScrollable(): Widget {

--- a/eclipse-scout-core/src/table/columns/LookupEditor.ts
+++ b/eclipse-scout-core/src/table/columns/LookupEditor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -152,7 +152,6 @@ export class LookupEditor<TValue> extends ValueField<TValue[]> implements Lookup
         statusVisible: false,
         tree: {
           objectType: Tree,
-          checkable: true,
           autoCheckChildren: true
         }
       };
@@ -166,11 +165,6 @@ export class LookupEditor<TValue> extends ValueField<TValue[]> implements Lookup
       statusVisible: false,
       table: {
         objectType: Table,
-        parent: this,
-        checkable: true,
-        checkableStyle: Table.CheckableStyle.CHECKBOX_TABLE_ROW,
-        headerVisible: false,
-        footerVisible: false,
         columns: [{
           objectType: Column,
           autoOptimizeWidth: true,

--- a/eclipse-scout-core/test/form/fields/listbox/ListBoxSpec.ts
+++ b/eclipse-scout-core/test/form/fields/listbox/ListBoxSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Code, CodeLookupCall, codes, CodeType, ListBox, ListBoxModel, ListBoxTableAccessibilityRenderer, LookupCall, LookupResult, LookupRow, QueryBy, scout, Status} from '../../../../src/index';
+import {Code, CodeLookupCall, codes, CodeType, ListBox, ListBoxModel, ListBoxTableAccessibilityRenderer, LookupCall, LookupResult, LookupRow, QueryBy, scout, Status, Table} from '../../../../src/index';
 import {DummyLookupCall, EmptyDummyLookupCall, ErroneousLookupCall, FormSpecHelper, LanguageDummyLookupCall} from '../../../../src/testing/index';
 import {InitModelOf, ObjectOrModel} from '../../../../src/scout';
 import $ from 'jquery';
@@ -478,7 +478,28 @@ describe('ListBox', () => {
       expect(listBox.value).toEqual([]);
       expect(listBox.displayText).toBe('');
     });
+  });
 
+  describe('table', () => {
+    it('uses list box specific default values', () => {
+      let listBox = scout.create(ListBox, {
+        parent: session.desktop
+      });
+      expect(listBox.table.checkable).toBe(true);
+      expect(listBox.table.headerVisible).toBe(false);
+    });
+
+    it('can be customized', () => {
+      let listBox = scout.create(ListBox, {
+        parent: session.desktop,
+        table: {
+          objectType: Table,
+          headerVisible: true
+        }
+      });
+      expect(listBox.table.checkable).toBe(true); // Must stay true
+      expect(listBox.table.headerVisible).toBe(true);
+    });
   });
 
   describe('aria properties', () => {

--- a/eclipse-scout-core/test/form/fields/treebox/TreeBoxSpec.ts
+++ b/eclipse-scout-core/test/form/fields/treebox/TreeBoxSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {LookupCall, LookupCallModel, LookupResult, LookupRow, QueryBy, scout, Status, TreeBox, TreeBoxModel} from '../../../../src/index';
+import {LookupCall, LookupCallModel, LookupResult, LookupRow, QueryBy, scout, Status, Tree, TreeBox, TreeBoxModel} from '../../../../src/index';
 import {DummyLookupCall, EmptyDummyLookupCall, ErroneousLookupCall, FormSpecHelper, LanguageDummyLookupCall} from '../../../../src/testing/index';
 import {InitModelOf} from '../../../../src/scout';
 
@@ -440,6 +440,28 @@ describe('TreeBox', () => {
       jasmine.clock().tick(300);
       expect(treeBox.value).toEqual([]);
       expect(treeBox.displayText).toBe('');
+    });
+  });
+
+  describe('tree', () => {
+    it('uses tree box specific default values', () => {
+      let treeBox = scout.create(TreeBox, {
+        parent: session.desktop
+      });
+      expect(treeBox.tree.checkable).toBe(true);
+      expect(treeBox.tree.checkableStyle).toBe(Tree.CheckableStyle.CHECKBOX_TREE_NODE);
+    });
+
+    it('can be customized', () => {
+      let treeBox = scout.create(TreeBox, {
+        parent: session.desktop,
+        tree: {
+          objectType: Tree,
+          checkableStyle: Tree.CheckableStyle.CHECKBOX
+        }
+      });
+      expect(treeBox.tree.checkable).toBe(true); // Must stay true
+      expect(treeBox.tree.checkableStyle).toBe(Tree.CheckableStyle.CHECKBOX);
     });
   });
 


### PR DESCRIPTION
The table inside a list box uses other default values for some properties than the regular table, for example checkable is set to true. If such a table needs to be customized, the default values should be preserved, so they don't have to be copied.

385612