### PR TITLE
Fix icon color of node with tile overview in mobile mode

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.less
+++ b/eclipse-scout-core/src/desktop/outline/Outline.less
@@ -363,6 +363,10 @@
     color: @desktop-navigation-color;
     border-bottom: 0;
 
+    & > .font-icon {
+      color: @outline-node-font-icon-color;
+    }
+
     & .tile-overview-content {
       margin-left: 20px;
     }


### PR DESCRIPTION
Normally, selected nodes have a special background color to indicate the selected state and to distinguish them from child nodes. When the node has showTileOverview=true, a tile grid is shown instead of child nodes. This view has a different background, which does not look good with the selection background color. Therefore, the background color is removed in this case. However, because the background is now no longer solid, the text color has to be reverted as well. This was done for the node label, but not for the font icon.

395207