### PR TITLE
Speedo chart: allow custom colors for inverted display

### DIFF
--- a/eclipse-scout-chart/src/chart/Chart.less
+++ b/eclipse-scout-chart/src/chart/Chart.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -689,6 +689,63 @@ path.speedo-chart-arc, path.pointer {
 
   &.red {
     stroke: @speedo-chart-red;
+  }
+
+  .color-alternative & {
+
+    &.dark-green {
+      stroke: @speedo-chart-dark-green-alternative;
+    }
+
+    &.light-green {
+      stroke: @speedo-chart-green-alternative;
+    }
+
+    &.yellow {
+      stroke: @speedo-chart-yellow-alternative;
+    }
+
+    &.red {
+      stroke: @speedo-chart-red-alternative;
+    }
+  }
+
+  .inverted & {
+
+    &.dark-green {
+      stroke: @speedo-chart-dark-green-inverted;
+    }
+
+    &.light-green {
+      stroke: @speedo-chart-green-inverted;
+    }
+
+    &.yellow {
+      stroke: @speedo-chart-yellow-inverted;
+    }
+
+    &.red {
+      stroke: @speedo-chart-red-inverted;
+    }
+
+    .color-alternative& {
+
+      &.dark-green {
+        stroke: @speedo-chart-dark-green-alternative-inverted;
+      }
+
+      &.light-green {
+        stroke: @speedo-chart-green-alternative-inverted;
+      }
+
+      &.yellow {
+        stroke: @speedo-chart-yellow-alternative-inverted;
+      }
+
+      &.red {
+        stroke: @speedo-chart-red-alternative-inverted;
+      }
+    }
   }
 }
 

--- a/eclipse-scout-chart/src/style/colors.less
+++ b/eclipse-scout-chart/src/style/colors.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -86,6 +86,18 @@
 @speedo-chart-green: @palette-green-3;
 @speedo-chart-yellow: @palette-orange-3;
 @speedo-chart-red: @palette-red-3;
+@speedo-chart-dark-green-alternative: @speedo-chart-dark-green;
+@speedo-chart-green-alternative: @speedo-chart-green;
+@speedo-chart-yellow-alternative: @speedo-chart-yellow;
+@speedo-chart-red-alternative: @speedo-chart-red;
+@speedo-chart-dark-green-inverted: @speedo-chart-dark-green;
+@speedo-chart-green-inverted: @speedo-chart-green;
+@speedo-chart-yellow-inverted: @speedo-chart-yellow;
+@speedo-chart-red-inverted: @speedo-chart-red;
+@speedo-chart-dark-green-alternative-inverted: @speedo-chart-dark-green;
+@speedo-chart-green-alternative-inverted: @speedo-chart-green;
+@speedo-chart-yellow-alternative-inverted: @speedo-chart-yellow;
+@speedo-chart-red-alternative-inverted: @speedo-chart-red;
 @salesfunnel-bar-label-color: @palette-white;
 @salesfunnel-alternative-bar-label-color: @salesfunnel-bar-label-color;
 @salesfunnel-inverted-bar-label-color: @tile-default-inverted-background-color;


### PR DESCRIPTION
Add LESS constants for .inverted and .color-alternative.inverted styles. This allows users to adjust the colors individually (e.g. if one of the colors conflicts with the background color). By default, the new color variables are set the existing variables.

327244