### PR TITLE
AbstractWidgetPopup: update parent of the current content correctly

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/popup/AbstractWidgetPopup.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/popup/AbstractWidgetPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -107,7 +107,13 @@ public abstract class AbstractWidgetPopup<T extends IWidget> extends AbstractPop
   }
 
   public void setContent(T content) {
+    if (m_content != null) {
+      m_content.setParentInternal(null);
+    }
     m_content = content;
+    if (m_content != null) {
+      m_content.setParentInternal(this);
+    }
   }
 
   @Override


### PR DESCRIPTION
The popup is the parent of its content. Therefore, the popup needs to set itself as the contents parent when a new content is set. In addition, it needs to set the parent of its old content to null if a new content is set.

350626