### PR TITLE
UiNotifications: wait for subscribe

### DIFF
--- a/eclipse-scout-core/src/App.ts
+++ b/eclipse-scout-core/src/App.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -615,6 +615,8 @@ export class App extends EventEmitter {
           promises.push(promise);
         });
     }
+
+    this.trigger('fail', {error});
 
     // Reject with original rejection arguments
     return $.promiseAll(promises).then(errorInfo => $.rejectedPromise(error, ...args));

--- a/eclipse-scout-core/src/AppEventMap.ts
+++ b/eclipse-scout-core/src/AppEventMap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,10 @@ export interface AppSessionReadyEvent<T = App> extends Event<T> {
   session: Session;
 }
 
+export interface AppFailEvent<T = App> extends Event<T> {
+  error: any;
+}
+
 export interface AppEventMap extends EventMap {
   'prepare': AppInitEvent;
   'init': AppInitEvent;
@@ -36,4 +40,5 @@ export interface AppEventMap extends EventMap {
   'bootstrap': AppBootstrapEvent;
   'desktopReady': AppDesktopReadyEvent;
   'sessionReady': AppSessionReadyEvent;
+  'fail': AppFailEvent;
 }

--- a/eclipse-scout-core/src/code/CodeTypeCache.ts
+++ b/eclipse-scout-core/src/code/CodeTypeCache.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,8 +57,8 @@ export class CodeTypeCache extends EventEmitter implements ObjectModel<CodeTypeC
       return $.resolvedPromise();
     }
     this.url = url;
-    uiNotifications.subscribe('codeTypeUpdate', event => this._onCodeTypeUpdateNotify(event));
-    return this.loadCodeTypes().then(codes => undefined);
+    return uiNotifications.subscribe('codeTypeUpdate', event => this._onCodeTypeUpdateNotify(event))
+      .then(() => this.loadCodeTypes().then(codes => undefined));
   }
 
   /**

--- a/eclipse-scout-core/src/security/AccessControl.ts
+++ b/eclipse-scout-core/src/security/AccessControl.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,16 +40,16 @@ export class AccessControl extends PropertyEventEmitter implements AccessControl
   }
 
   bootstrap(): JQuery.Promise<void> {
-    this._subscribeForNotifications();
-    return this._load();
+    return this._subscribeForNotifications()
+      .then(() => this._load());
   }
 
   destroy() {
     this._unsubscribeFromNotifications();
   }
 
-  protected _subscribeForNotifications() {
-    uiNotifications.subscribe('permissionsUpdate', this._permissionUpdateEventHandler);
+  protected _subscribeForNotifications(): JQuery.Promise<string> {
+    return uiNotifications.subscribe('permissionsUpdate', this._permissionUpdateEventHandler);
   }
 
   protected _unsubscribeFromNotifications() {

--- a/eclipse-scout-core/src/testing/JasmineScout.ts
+++ b/eclipse-scout-core/src/testing/JasmineScout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,7 +9,7 @@
  */
 import {
   AdapterData, App, arrays, Desktop, FullModelOf, HtmlEnvironment, InitModelOf, JsonErrorResponse, ModelAdapter, ModelOf, ObjectFactory, PermissionCollectionType, RemoteEvent, RemoteRequest, RemoteResponse, scout, Session,
-  SessionStartupResponse, Widget, WidgetModel
+  SessionStartupResponse, uiNotifications, Widget, WidgetModel
 } from '../index';
 import {jasmineScoutMatchers, JasmineScoutUtil, LocaleSpecHelper, TestingApp, UiNotificationsMock} from './index';
 import 'jasmine-jquery';
@@ -256,8 +256,9 @@ export const JasmineScout = {
         (session.layoutValidator as { _postValidateFunctions: (() => void)[] })._postValidateFunctions = [];
         session.layoutValidator.desktop = null;
       }
-      // Remove every handler to avoid a memory leak because widgets are not destroyed properly after tests, so they won't unregister their handlers
+      // Cleanup global objects and remove every handler to avoid a memory leak because widgets are not destroyed properly after tests, so they won't unregister their handlers
       HtmlEnvironment.get().off('propertyChange');
+      uiNotifications.tearDown();
     });
 
     context.keys().forEach(context);

--- a/eclipse-scout-core/src/testing/security/accessSpecHelper.ts
+++ b/eclipse-scout-core/src/testing/security/accessSpecHelper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -59,8 +59,8 @@ class StaticAccessControl extends AccessControl {
     return $.resolvedPromise();
   }
 
-  protected override _subscribeForNotifications() {
-    // nop
+  protected override _subscribeForNotifications(): JQuery.Promise<string> {
+    return $.resolvedPromise();
   }
 
   protected override _unsubscribeFromNotifications() {

--- a/eclipse-scout-core/src/testing/uinotification/UiNotificationsMock.ts
+++ b/eclipse-scout-core/src/testing/uinotification/UiNotificationsMock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,37 +8,65 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {ObjectFactory, UiNotificationHandler, uiNotifications, UiNotificationSystem} from '../../index';
+import {ObjectFactory, SomePartial, System, UiNotificationDo, uiNotifications, UiNotificationSystem} from '../../index';
 import $ from 'jquery';
 
 export class UiNotificationsMock {
-
+  /**
+   * Replaces the default {@link UiNotificationSystem} with {@link LocalUiNotificationSystem}.
+   */
   static register() {
     // Remove systems so a call to uiNotifications.subscribe() will create new mocked systems.
     uiNotifications.tearDown();
 
-    ObjectFactory.get().register(UiNotificationSystem, () => new UiNotificationSystemMock());
+    ObjectFactory.get().register(UiNotificationSystem, () => new LocalUiNotificationSystem());
   }
 
+  /**
+   * Unregisters the {@link LocalUiNotificationSystem} so the default {@link UiNotificationSystem} will be active.
+   */
   static unregister() {
     // Remove mocked systems so a call to uiNotifications.subscribe() will create new real systems.
     uiNotifications.tearDown();
 
     ObjectFactory.get().unregister(UiNotificationSystem);
   }
+
+  /**
+   * Simulates publishing a notification that will trigger the subscribed handlers without issuing any http requests.
+   * The required {@link LocalUiNotificationSystem} is registered automatically during tests unless {@link UiNotificationsMock.unregister} is called explicitly.
+   */
+  static putNotification(notification: SomePartial<UiNotificationDo, 'id' | 'nodeId' | 'creationTime'>, system?: string) {
+    system = system || System.MAIN_SYSTEM;
+    let systemObj = uiNotifications.systems.get(system);
+    if (!(systemObj instanceof LocalUiNotificationSystem)) {
+      throw new Error('You need to register the local system first using UiNotificationsMock.registerLocalSystem');
+    }
+    systemObj.put(notification);
+  }
 }
 
-export class UiNotificationSystemMock extends UiNotificationSystem {
+/**
+ * A local system that does not use a {@link UiNotificationPoller} and therefore does not issue any http requests.
+ * Publishing a notification can be simulated by using {@link putNotification}.
+ */
+export class LocalUiNotificationSystem extends UiNotificationSystem {
 
-  override subscribe(topic: string, handler: UiNotificationHandler): JQuery.Promise<string> {
+  override whenSubscriptionStart(topic: string): JQuery.Promise<string> {
     return $.resolvedPromise(topic);
   }
 
-  override subscribeOne(topic: string, handler: UiNotificationHandler): JQuery.Promise<string> {
-    return $.resolvedPromise(topic);
+  override updatePoller() {
+    // Don't create a poller
   }
 
-  override unsubscribe(topic: string, handler?: UiNotificationHandler) {
-    // nop
+  put(notification: SomePartial<UiNotificationDo, 'id' | 'nodeId' | 'creationTime'>) {
+    super._dispatch([
+      $.extend({
+        id: '1',
+        creationTime: new Date(),
+        nodeId: 'node1'
+      }, notification)
+    ]);
   }
 }

--- a/eclipse-scout-core/src/uinotification/uiNotifications.ts
+++ b/eclipse-scout-core/src/uinotification/uiNotifications.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {objects, scout, System, systems, UiNotificationHandler, UiNotificationSystem} from '../index';
+import {App, objects, scout, System, systems, UiNotificationHandler, UiNotificationSystem} from '../index';
 
 export class UiNotifications {
   systems = new Map<string, UiNotificationSystem>();
@@ -105,3 +105,8 @@ export class UiNotifications {
 }
 
 export const uiNotifications: UiNotifications = objects.createSingletonProxy(UiNotifications);
+
+App.addListener('fail', event => {
+  // Stop polling if application could not be started
+  uiNotifications.tearDown();
+});

--- a/eclipse-scout-core/test/security/AccessControlSpec.ts
+++ b/eclipse-scout-core/test/security/AccessControlSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,8 +29,8 @@ describe('AccessControl', () => {
       return super._load();
     }
 
-    protected override _subscribeForNotifications() {
-      // nop
+    protected override _subscribeForNotifications(): JQuery.Promise<string> {
+      return $.resolvedPromise();
     }
 
     protected override _unsubscribeFromNotifications() {


### PR DESCRIPTION
The subscribe request needs to be awaited to avoid race conditions and to improve error handling.

Example what happens without waiting for subscribe():
1. Call subscribe(). A notification for that topic would reload a local cache.
2. Subscribe request is still pending.
3. Load data to fill a local cache.
4. Publish a notification to invalidate the cache.
4. Subscribe request now ends. -> The notification is not received because subscribe() finished after
   the notification was published. The local cache is not invalidated
   and contains old data.

Error handling:
Subscribe now rejects the promise if the request fails. Previously, the request was retried but may have failed again resulting in an unsuccessful subscriptions -> notification for that topic were never received.

Also: UiNotificationsMock now registers a local system which makes it possible to simulate publishing notifications without needing ajax mocks.

408087