### PR TITLE
HybridManager: add context element converters for table rows and columns

### DIFF
--- a/eclipse-scout-core/src/desktop/hybrid/converter/HybridActionContextElementConverter.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/converter/HybridActionContextElementConverter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
 import {HybridActionContextElementConverters, ModelAdapter} from '../../../index';
 
 /**
- * Instances of this class are used to convert a model element to a JSON representation and vice-versa. Each
+ * Instances of this class are used to convert a model element to a JSON representation and vice versa. Each
  * instance typically only handles a specific type of element. Because elements have no common structure, they are
  * always accompanied by the widget that owns them (here represented by the corresponding {@link ModelAdapter}).
  *

--- a/eclipse-scout-core/src/desktop/hybrid/converter/TableColumnContextElementConverter.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/converter/TableColumnContextElementConverter.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {Column, HybridActionContextElementConverter, HybridActionContextElementConverters, ModelAdapter, objects, scout, strings, TableAdapter} from '../../../index';
+
+export class TableColumnContextElementConverter extends HybridActionContextElementConverter<TableAdapter, string, Column> {
+
+  static JSON_ELEMENT_PREFIX = 'col:';
+
+  override _acceptAdapter(adapter: ModelAdapter): adapter is TableAdapter {
+    return adapter instanceof TableAdapter;
+  }
+
+  override _acceptJsonElement(jsonElement: any): jsonElement is string {
+    return objects.isString(jsonElement) && strings.startsWith(jsonElement, TableColumnContextElementConverter.JSON_ELEMENT_PREFIX);
+  }
+
+  override _acceptModelElement(element: any): element is Column {
+    return element instanceof Column;
+  }
+
+  override _jsonToElement(adapter: TableAdapter, jsonElement: string): Column {
+    let table = adapter.widget;
+    let columnId = strings.removePrefix(jsonElement, TableColumnContextElementConverter.JSON_ELEMENT_PREFIX);
+    return scout.assertValue(table.columnById(columnId), `Unknown column with id "${columnId}" in table ${adapter.id}`);
+  }
+
+  override _elementToJson(adapter: TableAdapter, element: Column): string {
+    let columnId = element.id;
+    return strings.addPrefix(columnId, TableColumnContextElementConverter.JSON_ELEMENT_PREFIX);
+  }
+}
+
+HybridActionContextElementConverters.get().register(TableColumnContextElementConverter);

--- a/eclipse-scout-core/src/desktop/hybrid/converter/TableRowContextElementConverter.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/converter/TableRowContextElementConverter.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {HybridActionContextElementConverter, HybridActionContextElementConverters, ModelAdapter, objects, scout, strings, TableAdapter, TableRow} from '../../../index';
+
+export class TableRowContextElementConverter extends HybridActionContextElementConverter<TableAdapter, string, TableRow> {
+
+  static JSON_ELEMENT_PREFIX = 'row:';
+
+  override _acceptAdapter(adapter: ModelAdapter): adapter is TableAdapter {
+    return adapter instanceof TableAdapter;
+  }
+
+  override _acceptJsonElement(jsonElement: any): jsonElement is string {
+    return objects.isString(jsonElement) && strings.startsWith(jsonElement, TableRowContextElementConverter.JSON_ELEMENT_PREFIX);
+  }
+
+  override _acceptModelElement(element: any): element is TableRow {
+    return element instanceof TableRow;
+  }
+
+  override _jsonToElement(adapter: TableAdapter, jsonElement: string): TableRow {
+    let table = adapter.widget;
+    let rowId = strings.removePrefix(jsonElement, TableRowContextElementConverter.JSON_ELEMENT_PREFIX);
+    return scout.assertValue(table.rowById(rowId), `Unknown row with id "${rowId}" in table ${adapter.id}`);
+  }
+
+  override _elementToJson(adapter: TableAdapter, element: TableRow): string {
+    let rowId = element.id;
+    return strings.addPrefix(rowId, TableRowContextElementConverter.JSON_ELEMENT_PREFIX);
+  }
+}
+
+HybridActionContextElementConverters.get().register(TableRowContextElementConverter);

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1028,6 +1028,8 @@ export * from './desktop/hybrid/HybridActionContextElement';
 export * from './desktop/hybrid/HybridActionContextElements';
 export * from './desktop/hybrid/converter/HybridActionContextElementConverters';
 export * from './desktop/hybrid/converter/HybridActionContextElementConverter';
+export * from './desktop/hybrid/converter/TableColumnContextElementConverter';
+export * from './desktop/hybrid/converter/TableRowContextElementConverter';
 export * from './desktop/hybrid/converter/TreeNodeContextElementConverter';
 export * from './desktop/navigation/DesktopNavigation';
 export * from './desktop/navigation/DesktopNavigationModel';

--- a/eclipse-scout-core/src/util/strings.ts
+++ b/eclipse-scout-core/src/util/strings.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -379,20 +379,36 @@ export const strings = {
     return strings.equals(a, b, true);
   },
 
-  removePrefix(string: string, prefix: string): string {
-    let s = string;
-    if (strings.startsWith(string, prefix)) {
-      s = string.substring(prefix.length);
-    }
-    return s;
+  /**
+   * Adds the given prefix to the start of the given string and returns the result.
+   * If either of the given arguments is null or empty, the original string is returned unchanged, i.e. without prefix.
+   */
+  addPrefix(string: string, prefix: string): string {
+    return string && prefix ? prefix + string : string;
   },
 
+  /**
+   * Adds the given suffix to the end of the given string and returns the result.
+   * If either of the given arguments is null or empty, the original string is returned unchanged, i.e. without suffix.
+   */
+  addSuffix(string: string, suffix: string): string {
+    return string && suffix ? string + suffix : string;
+  },
+
+  /**
+   * If the given string starts with the given prefix, the prefix is removed and the remaining string is returned.
+   * Otherwise, the string is returned unchanged. This method is case-sensitive and null-safe.
+   */
+  removePrefix(string: string, prefix: string): string {
+    return strings.startsWith(string, prefix) ? string.substring(prefix.length) : string;
+  },
+
+  /**
+   * If the given string ends with the given suffix, the suffix is removed and the remaining string is returned.
+   * Otherwise, the string is returned unchanged. This method is case-sensitive and null-safe.
+   */
   removeSuffix(string: string, suffix: string): string {
-    let s = string;
-    if (strings.endsWith(string, suffix)) {
-      s = string.substring(0, string.length - suffix.length);
-    }
-    return s;
+    return strings.endsWith(string, suffix) ? string.substring(0, string.length - suffix.length) : string;
   },
 
   /**

--- a/eclipse-scout-core/test/util/stringsSpec.ts
+++ b/eclipse-scout-core/test/util/stringsSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -447,18 +447,82 @@ describe('strings', () => {
 
   });
 
-  describe('removePrefix and removeSuffix', () => {
-
-    it('removePrefix', () => {
-      expect(strings.removePrefix('crm.CodeType', 'crm.')).toBe('CodeType');
-      expect(strings.removePrefix('crm.CodeType', 'foo.')).toBe('crm.CodeType');
+  describe('prefixes and suffixes', () => {
+    it('addPrefix adds a prefix', () => {
+      expect(strings.addPrefix(null, 'prefix')).toBe(null);
+      expect(strings.addPrefix(undefined, 'prefix')).toBe(undefined);
+      expect(strings.addPrefix(null, null)).toBe(null);
+      expect(strings.addPrefix(undefined, null)).toBe(undefined);
+      expect(strings.addPrefix('', null)).toBe('');
+      expect(strings.addPrefix('', undefined)).toBe('');
+      expect(strings.addPrefix('', 'prefix')).toBe('');
+      expect(strings.addPrefix(' ', ' ')).toBe('  ');
+      expect(strings.addPrefix(' ', 'prefix')).toBe('prefix ');
+      expect(strings.addPrefix('test', null)).toBe('test');
+      expect(strings.addPrefix('test', undefined)).toBe('test');
+      expect(strings.addPrefix('test', '')).toBe('test');
+      expect(strings.addPrefix('test', 'prefix-')).toBe('prefix-test');
+      expect(strings.addPrefix('test', 'test')).toBe('testtest');
+      expect(strings.addPrefix('CodeType', 'foo.')).toBe('foo.CodeType');
     });
 
-    it('removeSuffix', () => {
-      expect(strings.removeSuffix('avatar.gif', '.gif')).toBe('avatar');
-      expect(strings.removeSuffix('avatar.gif', '.exe')).toBe('avatar.gif');
+    it('addSuffix adds a suffix', () => {
+      expect(strings.addSuffix(null, 'suffix')).toBe(null);
+      expect(strings.addSuffix(undefined, 'suffix')).toBe(undefined);
+      expect(strings.addSuffix(null, null)).toBe(null);
+      expect(strings.addSuffix(undefined, null)).toBe(undefined);
+      expect(strings.addSuffix('', null)).toBe('');
+      expect(strings.addSuffix('', undefined)).toBe('');
+      expect(strings.addSuffix('', 'suffix')).toBe('');
+      expect(strings.addSuffix(' ', ' ')).toBe('  ');
+      expect(strings.addSuffix(' ', 'suffix')).toBe(' suffix');
+      expect(strings.addSuffix('test', null)).toBe('test');
+      expect(strings.addSuffix('test', undefined)).toBe('test');
+      expect(strings.addSuffix('test', '')).toBe('test');
+      expect(strings.addSuffix('test', '-suffix')).toBe('test-suffix');
+      expect(strings.addSuffix('test', 'test')).toBe('testtest');
+      expect(strings.addSuffix('avatar', '.jpg')).toBe('avatar.jpg');
     });
 
+    it('removePrefix removes a prefix', () => {
+      expect(strings.removePrefix(null, 'prefix')).toBe(null);
+      expect(strings.removePrefix(undefined, 'prefix')).toBe(undefined);
+      expect(strings.removePrefix(null, null)).toBe(null);
+      expect(strings.removePrefix(undefined, null)).toBe(undefined);
+      expect(strings.removePrefix('', 'prefix')).toBe('');
+      expect(strings.removePrefix('test', null)).toBe('test');
+      expect(strings.removePrefix('test', undefined)).toBe('test');
+      expect(strings.removePrefix('test', '')).toBe('test');
+      expect(strings.removePrefix('test', 'abc')).toBe('test');
+      expect(strings.removePrefix('test', 'tester')).toBe('test');
+      expect(strings.removePrefix('test', 'T')).toBe('test');
+      expect(strings.removePrefix('test', 't')).toBe('est');
+      expect(strings.removePrefix('test', 'te')).toBe('st');
+      expect(strings.removePrefix('test', 'test')).toBe('');
+      expect(strings.removePrefix('foo.CodeType', 'foo.')).toBe('CodeType');
+      expect(strings.removePrefix('foo.CodeType', 'bar.')).toBe('foo.CodeType');
+      expect(strings.removePrefix('CodeType', 'codeType')).toBe('CodeType');
+    });
+
+    it('removeSuffix removes a suffix', () => {
+      expect(strings.removeSuffix(null, 'suffix')).toBe(null);
+      expect(strings.removeSuffix(undefined, 'suffix')).toBe(undefined);
+      expect(strings.removeSuffix(null, null)).toBe(null);
+      expect(strings.removeSuffix(undefined, null)).toBe(undefined);
+      expect(strings.removeSuffix('', 'suffix')).toBe('');
+      expect(strings.removeSuffix('test', null)).toBe('test');
+      expect(strings.removeSuffix('test', undefined)).toBe('test');
+      expect(strings.removeSuffix('test', '')).toBe('test');
+      expect(strings.removeSuffix('test', 'abc')).toBe('test');
+      expect(strings.removeSuffix('test', 'tester')).toBe('test');
+      expect(strings.removeSuffix('test', 'T')).toBe('test');
+      expect(strings.removeSuffix('test', 't')).toBe('tes');
+      expect(strings.removeSuffix('test', 'st')).toBe('te');
+      expect(strings.removeSuffix('test', 'test')).toBe('');
+      expect(strings.removeSuffix('avatar.jpg', '.jpg')).toBe('avatar');
+      expect(strings.removeSuffix('avatar.jpg', '.gif')).toBe('avatar.jpg');
+      expect(strings.removeSuffix('avatar.jpg', '.JPG')).toBe('avatar.jpg');
+    });
   });
 
   describe('truncateText', () => {

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/StringUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/StringUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -320,7 +320,7 @@ public class StringUtilityTest {
         + "<meta name=\"date.modified\" content=\"20130314\"/>";
     assertEquals("", StringUtility.replaceTags(input, "meta", "").trim());
 
-    // ingore case test
+    // ignore case test
     assertEquals("xbybz", StringUtility.replaceTags("x<A>asdf</A>y<a>jkl</a>z", "a", true, "b"));
   }
 
@@ -329,14 +329,16 @@ public class StringUtilityTest {
    */
   @Test
   public void testNewLines() {
-    String text = "lorem " + '\n' + "ipsum";
-    assertTrue(StringUtility.containsNewLines(text));
-    text = "lorem" + System.getProperty("line.separator") + "ipsum";
-    assertTrue(StringUtility.containsNewLines(text));
-    text = "";
-    assertFalse(StringUtility.containsNewLines(text));
-    text = null;
-    assertFalse(StringUtility.containsNewLines(text));
+    assertTrue(StringUtility.containsNewLines("lorem " + '\n' + "ipsum"));
+    assertTrue(StringUtility.containsNewLines("lorem" + System.lineSeparator() + "ipsum"));
+    assertTrue(StringUtility.containsNewLines("lorem\nipsum"));
+    assertTrue(StringUtility.containsNewLines("lorem\n\nipsum"));
+    assertTrue(StringUtility.containsNewLines("lorem\ripsum"));
+    assertTrue(StringUtility.containsNewLines("lorem\r\nipsum"));
+    assertTrue(StringUtility.containsNewLines("\n"));
+    assertFalse(StringUtility.containsNewLines("lorem ipsum"));
+    assertFalse(StringUtility.containsNewLines(""));
+    assertFalse(StringUtility.containsNewLines(null));
   }
 
   /**
@@ -793,5 +795,71 @@ public class StringUtilityTest {
 
     assertEquals("Company", StringUtility.removeSuffixes("CompanyFormData", "Form", "Data"));
     assertEquals("CompanyForm", StringUtility.removeSuffixes("CompanyFormData", "Data", "Form"));
+  }
+
+  @Test
+  public void testAddPrefix() {
+    assertEquals(null, StringUtility.addPrefix(null, "prefix"));
+    assertEquals(null, StringUtility.addPrefix(null, null));
+    assertEquals("", StringUtility.addPrefix("", null));
+    assertEquals("", StringUtility.addPrefix("", "prefix"));
+    assertEquals("  ", StringUtility.addPrefix(" ", " "));
+    assertEquals("prefix ", StringUtility.addPrefix(" ", "prefix"));
+    assertEquals("test", StringUtility.addPrefix("test", null));
+    assertEquals("test", StringUtility.addPrefix("test", ""));
+    assertEquals("prefix-test", StringUtility.addPrefix("test", "prefix-"));
+    assertEquals("testtest", StringUtility.addPrefix("test", "test"));
+    assertEquals("foo.CodeType", StringUtility.addPrefix("CodeType", "foo."));
+  }
+
+  @Test
+  public void testAddSuffix() {
+    assertEquals(null, StringUtility.addSuffix(null, "suffix"));
+    assertEquals(null, StringUtility.addSuffix(null, null));
+    assertEquals("", StringUtility.addSuffix("", null));
+    assertEquals("", StringUtility.addSuffix("", "suffix"));
+    assertEquals("  ", StringUtility.addSuffix(" ", " "));
+    assertEquals(" suffix", StringUtility.addSuffix(" ", "suffix"));
+    assertEquals("test-suffix", StringUtility.addSuffix("test", "-suffix"));
+    assertEquals("test", StringUtility.addSuffix("test", null));
+    assertEquals("test", StringUtility.addSuffix("test", ""));
+    assertEquals("testtest", StringUtility.addSuffix("test", "test"));
+    assertEquals("avatar.jpg", StringUtility.addSuffix("avatar", ".jpg"));
+  }
+
+  @Test
+  public void testRemovePrefix() {
+    assertEquals(null, StringUtility.removePrefix(null, "prefix"));
+    assertEquals(null, StringUtility.removePrefix(null, null));
+    assertEquals("", StringUtility.removePrefix("", "prefix"));
+    assertEquals("test", StringUtility.removePrefix("test", null));
+    assertEquals("test", StringUtility.removePrefix("test", ""));
+    assertEquals("test", StringUtility.removePrefix("test", "abc"));
+    assertEquals("test", StringUtility.removePrefix("test", "tester"));
+    assertEquals("test", StringUtility.removePrefix("test", "T"));
+    assertEquals("est", StringUtility.removePrefix("test", "t"));
+    assertEquals("st", StringUtility.removePrefix("test", "te"));
+    assertEquals("", StringUtility.removePrefix("test", "test"));
+    assertEquals("CodeType", StringUtility.removePrefix("foo.CodeType", "foo."));
+    assertEquals("foo.CodeType", StringUtility.removePrefix("foo.CodeType", "bar."));
+    assertEquals("CodeType", StringUtility.removePrefix("CodeType", "codeType"));
+  }
+
+  @Test
+  public void testRemoveSuffix() {
+    assertEquals(null, StringUtility.removeSuffix(null, "suffix"));
+    assertEquals(null, StringUtility.removeSuffix(null, null));
+    assertEquals("", StringUtility.removeSuffix("", "suffix"));
+    assertEquals("test", StringUtility.removeSuffix("test", null));
+    assertEquals("test", StringUtility.removeSuffix("test", ""));
+    assertEquals("test", StringUtility.removeSuffix("test", "abc"));
+    assertEquals("test", StringUtility.removeSuffix("test", "tester"));
+    assertEquals("test", StringUtility.removeSuffix("test", "T"));
+    assertEquals("tes", StringUtility.removeSuffix("test", "t"));
+    assertEquals("te", StringUtility.removeSuffix("test", "st"));
+    assertEquals("", StringUtility.removeSuffix("test", "test"));
+    assertEquals("avatar", StringUtility.removeSuffix("avatar.jpg", ".jpg"));
+    assertEquals("avatar.jpg", StringUtility.removePrefix("avatar.jpg", ".gif"));
+    assertEquals("avatar.jpg", StringUtility.removePrefix("avatar.jpg", ".JPG"));
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/StringUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/StringUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1653,6 +1653,38 @@ public final class StringUtility {
     }
 
     return out.toString();
+  }
+
+  /**
+   * Adds the given prefix to the start of the given string and returns the result.
+   * If either of the given arguments is null or empty, the original string is returned unchanged, i.e. without prefix.
+   */
+  public static String addPrefix(String s, String prefix) {
+    return isNullOrEmpty(s) || isNullOrEmpty(prefix) ? s : prefix + s;
+  }
+
+  /**
+   * Adds the given suffix to the end of the given string and returns the result.
+   * If either of the given arguments is null or empty, the original string is returned unchanged, i.e. without suffix.
+   */
+  public static String addSuffix(String s, String suffix) {
+    return isNullOrEmpty(s) || isNullOrEmpty(suffix) ? s : s + suffix;
+  }
+
+  /**
+   * If the given string starts with the given prefix, the prefix is removed and the remaining string is returned.
+   * Otherwise, the string is returned unchanged. This method is case-sensitive and null-safe.
+   */
+  public static String removePrefix(String s, String prefix) {
+    return startsWith(s, prefix) ? s.substring(prefix.length()) : s;
+  }
+
+  /**
+   * If the given string ends with the given suffix, the suffix is removed and the remaining string is returned.
+   * Otherwise, the string is returned unchanged. This method is case-sensitive and null-safe.
+   */
+  public static String removeSuffix(String s, String suffix) {
+    return endsWith(s, suffix) ? s.substring(0, s.length() - suffix.length()) : s;
   }
 
   /**

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/converter/AbstractHybridActionContextElementConverter.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/converter/AbstractHybridActionContextElementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -61,15 +61,27 @@ public abstract class AbstractHybridActionContextElementConverter<ADAPTER extend
   }
 
   protected boolean acceptAdapter(IJsonAdapter<?> adapter) {
-    return getAdapterClass().isInstance(adapter);
+    return getAdapterClass().isInstance(adapter) && acceptAdapterImpl(getAdapterClass().cast(adapter));
+  }
+
+  protected boolean acceptAdapterImpl(ADAPTER adapter) {
+    return true;
   }
 
   protected boolean acceptJsonElement(Object jsonElement) {
-    return getJsonElementClass().isInstance(jsonElement);
+    return getJsonElementClass().isInstance(jsonElement) && acceptJsonElementImpl(getJsonElementClass().cast(jsonElement));
+  }
+
+  protected boolean acceptJsonElementImpl(JSON_ELEMENT jsonElement) {
+    return true;
   }
 
   protected boolean acceptModelElement(Object modelElement) {
-    return getModelElementClass().isInstance(modelElement);
+    return getModelElementClass().isInstance(modelElement) && acceptModelElementImpl(getModelElementClass().cast(modelElement));
+  }
+
+  protected boolean acceptModelElementImpl(MODEL_ELEMENT element) {
+    return true;
   }
 
   /**

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/converter/IHybridActionContextElementConverter.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/converter/IHybridActionContextElementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@ import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
 
 /**
- * Instances of this interface are used to convert a model element to a JSON representation and vice-versa. Each
+ * Instances of this interface are used to convert a model element to a JSON representation and vice versa. Each
  * instance typically only handles a specific type of element. Because elements have no common structure, they are
  * always accompanied by the widget that owns them (here represented by the corresponding {@link IJsonAdapter}).
  * <p>
@@ -21,7 +21,8 @@ import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
  * <ul>
  * <li>Create a subclass of the abstract class {@link AbstractHybridActionContextElementConverter}.
  * <li>Specify the types of the generic parameters {@link ADAPTER}, {@link JSON_ELEMENT} and {@link MODEL_ELEMENT}.
- * <li>Implement the abstract methods `jsonToElement` and `elementToJson`.
+ * <li>Implement the abstract methods `jsonToElement` and `elementToJson`. They are only called if the arguments were
+ * accepted by the corresponding methods. Otherwise, the task is delegated to the next converter.
  * </ul>
  *
  * @param <ADAPTER>

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/converter/TableColumnContextElementConverter.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/converter/TableColumnContextElementConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html.json.desktop.hybrid.converter;
+
+import org.eclipse.scout.rt.client.ui.basic.table.columns.IColumn;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.ui.html.json.table.JsonTable;
+
+public class TableColumnContextElementConverter extends AbstractHybridActionContextElementConverter<JsonTable<?>, String, IColumn<?>> {
+
+  protected static final String JSON_ELEMENT_PREFIX = "col:";
+
+  @Override
+  protected boolean acceptJsonElementImpl(String jsonElement) {
+    return StringUtility.startsWith(jsonElement, JSON_ELEMENT_PREFIX);
+  }
+
+  @Override
+  protected IColumn<?> jsonToElement(JsonTable<?> adapter, String jsonElement) {
+    String columnId = StringUtility.removePrefix(jsonElement, JSON_ELEMENT_PREFIX);
+    return adapter.getColumn(columnId);
+  }
+
+  @Override
+  protected String elementToJson(JsonTable<?> adapter, IColumn<?> element) {
+    adapter.processBufferedEvents();
+    String columnId = adapter.getColumnId(element);
+    return StringUtility.addPrefix(columnId, JSON_ELEMENT_PREFIX);
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/converter/TableRowContextElementConverter.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/hybrid/converter/TableRowContextElementConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html.json.desktop.hybrid.converter;
+
+import org.eclipse.scout.rt.client.ui.basic.table.ITableRow;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.ui.html.json.table.JsonTable;
+
+public class TableRowContextElementConverter extends AbstractHybridActionContextElementConverter<JsonTable<?>, String, ITableRow> {
+
+  protected static final String JSON_ELEMENT_PREFIX = "row:";
+
+  @Override
+  protected boolean acceptJsonElementImpl(String jsonElement) {
+    return StringUtility.startsWith(jsonElement, JSON_ELEMENT_PREFIX);
+  }
+
+  @Override
+  protected ITableRow jsonToElement(JsonTable<?> adapter, String jsonElement) {
+    String rowId = StringUtility.removePrefix(jsonElement, JSON_ELEMENT_PREFIX);
+    return adapter.getTableRow(rowId);
+  }
+
+  @Override
+  protected String elementToJson(JsonTable<?> adapter, ITableRow element) {
+    adapter.processBufferedEvents();
+    String rowId = adapter.getTableRowId(element);
+    return StringUtility.addPrefix(rowId, JSON_ELEMENT_PREFIX);
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/table/JsonTable.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/table/JsonTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1159,7 +1159,7 @@ public class JsonTable<T extends ITable> extends AbstractJsonWidget<T> implement
     return m_columns.get(columnId);
   }
 
-  protected IColumn<?> getColumn(String columnId) {
+  public IColumn<?> getColumn(String columnId) {
     IColumn<?> column = m_columns.get(columnId);
     if (column == null) {
       throw new UiException("No column found for id " + columnId);
@@ -1185,7 +1185,7 @@ public class JsonTable<T extends ITable> extends AbstractJsonWidget<T> implement
   /**
    * Returns a tableRow for the given rowId, or null when no row is found for the given rowId.
    */
-  protected ITableRow optTableRow(String rowId) {
+  public ITableRow optTableRow(String rowId) {
     return m_tableRows.get(rowId);
   }
 
@@ -1195,7 +1195,7 @@ public class JsonTable<T extends ITable> extends AbstractJsonWidget<T> implement
    * @throws UiException
    *     when no row is found for the given rowId
    */
-  protected ITableRow getTableRow(String rowId) {
+  public ITableRow getTableRow(String rowId) {
     ITableRow row = optTableRow(rowId);
     if (row == null) {
       throw new UiException("No table-row found for ID " + rowId);
@@ -1500,6 +1500,7 @@ public class JsonTable<T extends ITable> extends AbstractJsonWidget<T> implement
       return;
     }
     Collection<ITableRow> disposedRows = null;
+    // noinspection SizeReplaceableByIsEmpty
     if (m_listeners.list(JsonTableEvent.TYPE_ROWS_DELETED).size() > 0) {
       disposedRows = new ArrayList<>(m_tableRows.values());
     }


### PR DESCRIPTION
- Add a 'col:' and 'row:' prefix to element ids to be able to identify the correct converter on the other side.
- Add utility methods to add and remove prefixes/suffixes from strings.

389630