### PR TITLE
Planner: don't produce invalid view dates

### DIFF
--- a/eclipse-scout-core/src/planner/Planner.less
+++ b/eclipse-scout-core/src/planner/Planner.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -44,6 +44,9 @@
     position: relative;
     white-space: nowrap;
     padding: 0 0 0 5px;
+    // Ensure texts of scale items next to each other don't overlap
+    // overflow-y needs to be visible for scale-item-lines
+    overflow-x: clip;
 
     &.label-invisible {
       color: transparent;

--- a/eclipse-scout-core/src/planner/Planner.ts
+++ b/eclipse-scout-core/src/planner/Planner.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -273,8 +273,9 @@ export class Planner extends Widget implements PlannerModel {
   }
 
   protected _navigateDate(direction: PlannerDirection) {
-    let viewRange = new DateRange(this.viewRange.from, this.viewRange.to),
-      displayMode = Planner.DisplayMode;
+    let viewRange = new DateRange(this.viewRange.from, this.viewRange.to);
+    let displayMode = Planner.DisplayMode;
+    let daysDiff = dates.compareDays(this.viewRange.to, this.viewRange.from);
 
     if (this.displayMode === displayMode.DAY) {
       viewRange.from = dates.shift(this.viewRange.from, 0, 0, direction);
@@ -282,11 +283,11 @@ export class Planner extends Widget implements PlannerModel {
     } else if (scout.isOneOf(this.displayMode, displayMode.WEEK, displayMode.WORK_WEEK)) {
       viewRange.from = dates.shift(this.viewRange.from, 0, 0, direction * 7);
       viewRange.from = dates.ensureMonday(viewRange.from, -1 * direction);
-      viewRange.to = dates.shift(this.viewRange.to, 0, 0, direction * 7);
+      viewRange.to = dates.shift(viewRange.from, 0, 0, daysDiff);
     } else if (scout.isOneOf(this.displayMode, displayMode.MONTH, displayMode.CALENDAR_WEEK)) {
       viewRange.from = dates.shift(this.viewRange.from, 0, direction, 0);
       viewRange.from = dates.ensureMonday(viewRange.from, -1 * direction);
-      viewRange.to = dates.shift(this.viewRange.to, 0, direction, 0);
+      viewRange.to = dates.shift(viewRange.from, 0, 0, daysDiff);
     } else if (this.displayMode === displayMode.YEAR) {
       viewRange.from = dates.shift(this.viewRange.from, 0, 3 * direction, 0);
       viewRange.to = dates.shift(this.viewRange.to, 0, 3 * direction, 0);
@@ -415,7 +416,10 @@ export class Planner extends Widget implements PlannerModel {
     this._reconcileScrollPos();
   }
 
-  protected _reconcileScrollPos() {
+  /**
+   * @internal
+   */
+  _reconcileScrollPos() {
     // When scrolling horizontally scroll scale as well
     let scrollLeft = this.$grid.scrollLeft();
     this.$scale.scrollLeft(scrollLeft);
@@ -1410,11 +1414,11 @@ export class Planner extends Widget implements PlannerModel {
   }
 
   protected _renderAvailableDisplayModes() {
-    // done by PlannerHeader.js
+    // done by PlannerHeader.ts
   }
 
   protected _renderDisplayMode() {
-    // done by PlannerHeader.js
+    // done by PlannerHeader.ts
   }
 
   protected _setViewRange(viewRange: DateRange | JsonDateRange) {

--- a/eclipse-scout-core/src/planner/PlannerLayout.ts
+++ b/eclipse-scout-core/src/planner/PlannerLayout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -66,6 +66,8 @@ export class PlannerLayout extends AbstractLayout {
     this._layoutScaleLines();
     // immediate update to prevent flickering, due to reset in layoutScaleLines
     scrollbars.update(this.planner.$grid, true);
+    // If scroll position did not change planner._onGridScroll is not called -> ensure scrollLeft of $scale is correct
+    this.planner._reconcileScrollPos();
     this.planner.layoutYearPanel();
   }
 
@@ -91,17 +93,15 @@ export class PlannerLayout extends AbstractLayout {
    * Positions the scale lines and set to correct height
    */
   protected _layoutScaleLines() {
-    let height, $smallScaleItems, $largeScaleItems, scrollLeft,
-      $timelineSmall = this.planner.$timelineSmall,
-      $timelineLarge = this.planner.$timelineLarge;
-
+    let $timelineSmall = this.planner.$timelineSmall;
     if (!$timelineSmall) {
       // May be null if no view range is rendered
       return;
     }
 
-    $smallScaleItems = $timelineSmall.children('.scale-item');
-    $largeScaleItems = $timelineLarge.children('.scale-item');
+    let $timelineLarge = this.planner.$timelineLarge;
+    let $smallScaleItems = $timelineSmall.children('.scale-item');
+    let $largeScaleItems = $timelineLarge.children('.scale-item');
 
     // First loop through every item and set height to 0 in order to get the correct scrollHeight
     $largeScaleItems.each(function() {
@@ -118,8 +118,8 @@ export class PlannerLayout extends AbstractLayout {
     scrollbars.reset(this.planner.$grid);
 
     // Loop again and update height and left
-    height = this.planner.$grid[0].scrollHeight;
-    scrollLeft = this.planner.$scale[0].scrollLeft;
+    let height = this.planner.$grid[0].scrollHeight;
+    let scrollLeft = this.planner.$scale[0].scrollLeft;
     $largeScaleItems.each(function() {
       let $scaleItem = $(this),
         $scaleItemLine = $scaleItem.data('scale-item-line');

--- a/eclipse-scout-core/test/planner/PlannerSpec.ts
+++ b/eclipse-scout-core/test/planner/PlannerSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,9 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {DateRange, dates, ObjectFactory, Planner, PlannerActivity, PlannerModel, PlannerResourceModel, Widget} from '../../src/index';
-import {ObjectType} from '../../src/ObjectFactory';
-import {PlannerResource} from '../../src/planner/Planner';
+import {DateRange, dates, ObjectFactory, Planner, PlannerActivity, PlannerDirection, PlannerResource, PlannerResourceModel} from '../../src/index';
 import {InitModelOf} from '../../src/scout';
 
 describe('Planner', () => {
@@ -36,10 +34,14 @@ describe('Planner', () => {
     override _dateFormat(date: Date, pattern: string): string {
       return super._dateFormat(date, pattern);
     }
+
+    override _navigateDate(direction: PlannerDirection) {
+      super._navigateDate(direction);
+    }
   }
 
-  function createPlannerModel(numResources): PlannerModel & { id: string; objectType: ObjectType<Planner>; parent: Widget; session: SandboxSession } {
-    let model = createSimpleModel('Planner', session) as PlannerModel & { id: string; objectType: ObjectType<Planner>; parent: Widget; session: SandboxSession };
+  function createPlannerModel(numResources = 0): InitModelOf<Planner> {
+    let model = createSimpleModel('Planner', session) as InitModelOf<Planner>;
     model.resources = [];
     for (let i = 0; i < numResources; i++) {
       model.resources[i] = createResource('resource' + i);
@@ -80,7 +82,7 @@ describe('Planner', () => {
   }
 
   describe('deleteResources', () => {
-    let model: PlannerModel & { id: string; objectType: ObjectType<Planner>; parent: Widget; session: SandboxSession };
+    let model: InitModelOf<Planner>;
     let planner: SpecPlanner;
     let resource0: PlannerResource;
     let resource1: PlannerResource;
@@ -139,7 +141,7 @@ describe('Planner', () => {
   });
 
   describe('updateResources', () => {
-    let model: PlannerModel & { id: string; objectType: ObjectType<Planner>; parent: Widget; session: SandboxSession };
+    let model: InitModelOf<Planner>;
     let planner: SpecPlanner;
     let resource0: PlannerResource;
     let resource1: PlannerResource;
@@ -204,7 +206,7 @@ describe('Planner', () => {
   });
 
   describe('renderScale', () => {
-    let model: PlannerModel & { id: string; objectType: ObjectType<Planner>; parent: Widget; session: SandboxSession };
+    let model: InitModelOf<Planner>;
     let planner: SpecPlanner;
 
     beforeEach(() => {
@@ -817,6 +819,56 @@ describe('Planner', () => {
         expect(planner.viewRange.from.toISOString()).toBe(dates.create('2021-03-22').toISOString()); // Monday (today will use first day of week)
         expect(planner.viewRange.to.toISOString()).toBe(dates.create('2021-04-03').toISOString());
       });
+    });
+  });
+
+  describe('_navigateDate', () => {
+    it('does not produce invalid view ranges for week and work_week', () => {
+      let planner = createPlanner(createPlannerModel());
+      planner.setDisplayMode(Planner.DisplayMode.WEEK);
+      assert();
+
+      planner.setDisplayMode(Planner.DisplayMode.WORK_WEEK);
+      assert();
+
+      function assert() {
+        planner.setViewRange(new DateRange(new Date('2017-08-12'), new Date('2017-08-13')));
+        expect(planner.viewRange.from.toISOString()).toBe(new Date('2017-08-12').toISOString()); // Saturday
+        expect(planner.viewRange.to.toISOString()).toBe(new Date('2017-08-13').toISOString());
+
+        planner._navigateDate(Planner.Direction.BACKWARD);
+        expect(planner.viewRange.from.toISOString()).toBe(new Date('2017-08-07').toISOString()); // Monday (only 5 days back, not 7)
+        expect(planner.viewRange.to.toISOString()).toBe(new Date('2017-08-08').toISOString()); // Needs to be 5 days back as well -> keep distance to from date
+
+        planner.setViewRange(new DateRange(new Date('2017-08-12'), new Date('2017-08-13'))); // Back to Saturday
+        planner._navigateDate(Planner.Direction.FORWARD);
+        expect(planner.viewRange.from.toISOString()).toBe(new Date('2017-08-14').toISOString()); // Monday
+        expect(planner.viewRange.to.toISOString()).toBe(new Date('2017-08-15').toISOString());
+      }
+    });
+
+    it('does not produce invalid view ranges for month and calendar_week', () => {
+      let planner = createPlanner(createPlannerModel());
+      planner.setDisplayMode(Planner.DisplayMode.MONTH);
+      assert();
+
+      planner.setDisplayMode(Planner.DisplayMode.CALENDAR_WEEK);
+      assert();
+
+      function assert() {
+        planner.setViewRange(new DateRange(new Date('2017-08-12'), new Date('2017-08-13')));
+        expect(planner.viewRange.from.toISOString()).toBe(new Date('2017-08-12').toISOString()); // Saturday
+        expect(planner.viewRange.to.toISOString()).toBe(new Date('2017-08-13').toISOString());
+
+        planner._navigateDate(Planner.Direction.BACKWARD);
+        expect(planner.viewRange.from.toISOString()).toBe(new Date('2017-07-17').toISOString()); // Monday
+        expect(planner.viewRange.to.toISOString()).toBe(new Date('2017-07-18').toISOString());
+
+        planner.setViewRange(new DateRange(new Date('2017-08-12'), new Date('2017-08-13'))); // Back to Saturday
+        planner._navigateDate(Planner.Direction.FORWARD);
+        expect(planner.viewRange.from.toISOString()).toBe(new Date('2017-09-11').toISOString()); // Monday
+        expect(planner.viewRange.to.toISOString()).toBe(new Date('2017-09-12').toISOString());
+      }
     });
   });
 });


### PR DESCRIPTION
Pressing the navigate buttons moves the view range backwards or forwards, setting the from-date preferably on a Monday. The problem is that the to-date is not adjusted if the from-date is set to a Monday, causing an invalid view range resulting in the error Invalid viewRange provided.
-> _navigateDate() has to preserve the distance between from and to when navigating (it does not know the default distance for each display mode, e.g. with display mode = month the distance is 2 months which is defined in AbstractPlanner.execDisplayModeChanged and may be customized as well. So it is not an option to use that information to calculate the to-date).

Also fixed overlapping of scale-items if there is not enough space to draw the text.

397589