### PR TITLE
AnonymousAccessController: don't create http session for ui-notificat…

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/TrivialAccessController.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/TrivialAccessController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -129,7 +129,7 @@ public class TrivialAccessController implements IAccessController {
     }
 
     // Is request path excluded from authentication?
-    if (m_config.getPathInfoFilter().accepts(StringUtility.emptyIfNull(request.getServletPath()) + StringUtility.emptyIfNull(request.getPathInfo()))) {
+    if (m_config.getExclusionFilter().accepts(StringUtility.emptyIfNull(request.getServletPath()) + StringUtility.emptyIfNull(request.getPathInfo()))) {
       chain.doFilter(request, response);
       return true;
     }
@@ -209,7 +209,15 @@ public class TrivialAccessController implements IAccessController {
       return this;
     }
 
+    /**
+     * @deprecated use {@link #getExclusionFilter()}
+     */
+    @Deprecated
     public PathInfoFilter getPathInfoFilter() {
+      return getExclusionFilter();
+    }
+
+    public PathInfoFilter getExclusionFilter() {
       return m_exclusionFilter;
     }
 


### PR DESCRIPTION
…ions

On a session timeout the ui-notification poller should stop polling. It stops if the server returns 401/403 or a json based session timeout. In AnonymousAccessController is active, it does not stop because a new http session is created automatically. The json?poll request returns session timeout because it cannot find a valid UiSession anymore (it contains the ui session id which is used to look up the UiSession on the HttpSession which does not exist anymore).

The AnonymousAccessController now aborts in that case without creating a http session. The ui-notification request is forwarded to the login page which is not allowed and a json based session timeout returned instead.

409813