### PR TITLE
SimpleTab: remove accidentally inserted space character

### DIFF
--- a/eclipse-scout-core/src/tabbox/SimpleTab.less
+++ b/eclipse-scout-core/src/tabbox/SimpleTab.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -98,7 +98,9 @@
     margin: @simple-tab-padding;
     display: none;
 
-    :hover &,
+    // @formatter:off
+    :hover&,
+    // @formatter:on
     .closable.selected& {
       display: inline-block;
     }


### PR DESCRIPTION
The recent commit "Release 25.1: Reformat Code & Organize Imports" inserted a space after ":hover" (automatic code formatter). However, the absence of a space between ":hover" and "&" is intentional, because otherwise the semantics of the rule would change.

Revert this change and disable the code formatter for that particular line until a better solution is found.