### PR TITLE
Revert "Fix PlainText calc. for html with ">" in tag attribute value"

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
@@ -51,10 +51,6 @@ public class HtmlHelperTest {
     assertEquals("Header 1\nHeader 2", helper.toPlainText("<h1>Header 1</h1><h1>Header 2</h1>")); // Headers
     assertEquals("List 1\nList 2\nTableHeader 1 TableHeader 2\nData 1 Data 2",
         helper.toPlainText("<ul><li>List 1</li><li>List 2</li></ul><table><tr><th>TableHeader 1</th><th>TableHeader 2</th></tr><tr><td>Data 1</td><td>Data 2</td></tr></table>")); // List and tables
-    assertEquals("Lorem ipsum dolor",
-        helper.toPlainText("<a href=\"\" rel=\"noreferrer noopener\" title=\"Donec: > mattis >> metus lorem\" style=\"color:rgb(0, 0, 0);text-decoration:none;\">Lorem ipsum dolor</a>"));
-    assertEquals("Lorem ipsum dolor",
-        helper.toPlainText("<a href='' rel='noreferrer noopener' title='Donec: > mattis >> metus lorem' style='color:rgb(0, 0, 0);text-decoration:none;'>Lorem ipsum dolor</a>"));
 
     // Simple documents
     assertEquals("", helper.toPlainText("<html>"));

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
@@ -24,7 +24,7 @@ public class HtmlHelper {
   @SuppressWarnings("bsiRulesDefinition:htmlInString")
   private static final Pattern HTML_PARAGRAPH_END_TAGS = Pattern.compile("<br/?></div>|</div>|<br/?>|</p>|<p/>|</tr>|</h[1-6]>|</dt>|</dd>|</dl>|</table>|</li>|</head>", Pattern.CASE_INSENSITIVE);
   private static final Pattern HTML_SPACE_END_TAGS = Pattern.compile("</td>|</th>", Pattern.CASE_INSENSITIVE);
-  private static final Pattern HTML_TAGS = Pattern.compile("<(\"[^\"]*\"|'[^']*'|[^>])+>", Pattern.DOTALL);
+  private static final Pattern HTML_TAGS = Pattern.compile("<[^>]+>", Pattern.DOTALL);
   private static final Pattern HTML_SCRIPTS = Pattern.compile("<script\\b[^<]*(?:(?!</script>)<[^<]*)*</script>", Pattern.CASE_INSENSITIVE);
   private static final Pattern HTML_STYLES = Pattern.compile("<style\\b[^<]*(?:(?!</style>)<[^<]*)*</style>", Pattern.CASE_INSENSITIVE);
   private static final Pattern MULTIPLE_SPACES = Pattern.compile("[ ]+");


### PR DESCRIPTION
This reverts commit 6f9146639272058502dc2516dab7b5dc1a4e9dc2. Revert since this can cause StackOverflowError for LONG strings inside tag.

406821