### PR TITLE
ServerSessionProviderWithCache: Stop sessions if another is available

### DIFF
--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/ServerSessionProviderWithCache.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/ServerSessionProviderWithCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -97,6 +97,8 @@ public class ServerSessionProviderWithCache extends ServerSessionProvider {
     // 4. Cache the new server session, or return present session if created by another thread in the meantime (optimistic locking).
     @SuppressWarnings("unchecked") final SESSION cachedServerSession = (SESSION) m_cache.putIfAbsent(sessionCacheKey, serverSession);
     if (cachedServerSession != null) {
+      LOG.trace("Found a cached server session, using that one instead - stopping the replaced one.");
+      serverSession.stop();
       serverSession = cachedServerSession;
     }
 


### PR DESCRIPTION
With multiple requests multiple sessions for one user may be initialized
 at the same time but only one should win. The other ones need to be
 stopped as they have also been started by super.provide method.

408216