### PR TITLE
HybridManager: consider a replaced widget as added and removed

### DIFF
--- a/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -62,13 +62,13 @@ export class HybridManager extends Widget {
 
     const removedWidgets: Record<string, Widget> = {};
     for (const [id, widget] of Object.entries(this.widgets)) {
-      if (!widgets[id]) {
+      if (!widgets[id] || widgets[id] !== widget) {
         removedWidgets[id] = widget;
       }
     }
     const addedWidgets: Record<string, Widget> = {};
     for (const [id, widget] of Object.entries(widgets as Record<string, Widget>)) {
-      if (!this.widgets[id]) {
+      if (!this.widgets[id] || this.widgets[id] !== widget) {
         addedWidgets[id] = widget;
       }
     }


### PR DESCRIPTION
A widget added to the HybridManager is added as a child and a widget removed from the HybridManager is destroyed. In addition, there will be events for all widgets that are added or removed. Now consider a widget that is replaced, i.e. the property widgets is updated with a map where an already existing key points to a different Widget. This needs to be handled as if the old widget is removed and the new widget is added to ensure that the new widget is set as a child, the old widget is destroyed and all necessary events are triggered.

391967