### PR TITLE
Add value migration handler to remove a DO entity contribution

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDataObjectMigrator.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDataObjectMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,5 +22,13 @@ public class TestDataObjectMigrator extends DataObjectMigrator {
   @Override
   public boolean applyStructureMigration(DataObjectMigrationContext ctx, IDataObject dataObject, NamespaceVersion toVersion) {
     return super.applyStructureMigration(ctx, dataObject, toVersion);
+  }
+
+  /**
+   * Override to change visibility from protected to public.
+   */
+  @Override
+  public <T extends IDataObject> DataObjectMigratorResult<T> applyValueMigration(DataObjectMigrationContext ctx, T dataObject) {
+    return super.applyValueMigration(ctx, dataObject);
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandlerTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandlerTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) BSI Business Systems Integration AG. All rights reserved.
+ * http://www.bsiag.com/
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.fixture.FirstSimpleContributionFixtureDo;
+import org.eclipse.scout.rt.dataobject.fixture.SecondSimpleContributionFixtureDo;
+import org.eclipse.scout.rt.dataobject.fixture.SimpleFixtureDo;
+import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrator.DataObjectMigratorResult;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_2;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests {@link AbstractRemoveDoEntityContributionValueMigrationHandler}
+ */
+public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
+
+  protected static IDataObjectMapper s_dataObjectMapper;
+
+  @BeforeClass
+  public static void beforeClass() {
+    s_dataObjectMapper = BEANS.get(IDataObjectMapper.class);
+  }
+
+  /**
+   * Tests that data object is not changed if there is no contribution.
+   */
+  @Test
+  public void testMigrationOfDoEntityWithoutContribution() {
+    SimpleFixtureDo fixture = createSimpleFixtureDo();
+
+    String fixtureJson = s_dataObjectMapper.writeValue(fixture);
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class).putGlobal(BEANS.get(DoValueMigrationIdsContextData.class).withAppliedValueMigrationIds(getAppliedValueMigrations()));
+    DataObjectMigratorResult<SimpleFixtureDo> result = BEANS.get(DataObjectMigrator.class).migrateDataObject(ctx, fixtureJson, SimpleFixtureDo.class);
+    assertFalse(result.isChanged());
+    assertEquals(fixture, result.getDataObject());
+  }
+
+  /**
+   * Tests that data object is not changed if there is no matching contribution.
+   */
+  @Test
+  public void testMigrationOfDoEntityWithDifferentContribution() {
+    SimpleFixtureDo fixture = createSimpleFixtureDo();
+    fixture.contribution(SecondSimpleContributionFixtureDo.class)
+        .withSecondValue("mySecondValue");
+
+    String fixtureJson = s_dataObjectMapper.writeValue(fixture);
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class).putGlobal(BEANS.get(DoValueMigrationIdsContextData.class).withAppliedValueMigrationIds(getAppliedValueMigrations()));
+    DataObjectMigratorResult<SimpleFixtureDo> result = BEANS.get(DataObjectMigrator.class).migrateDataObject(ctx, fixtureJson, SimpleFixtureDo.class);
+    assertFalse(result.isChanged());
+    assertEquals(fixture, result.getDataObject());
+  }
+
+  /**
+   * Tests that the DO is not changed because the contribution to be removed still exists in the code.
+   */
+  @Test
+  public void testMigrationOfDoWithMatchingAndStillExistingContribution() {
+    SimpleFixtureDo dataObject = createDataObjectWithExistingContribution();
+
+    String json = s_dataObjectMapper.writeValue(dataObject);
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class).putGlobal(BEANS.get(DoValueMigrationIdsContextData.class).withAppliedValueMigrationIds(getAppliedValueMigrations()));
+    DataObjectMigratorResult<SimpleFixtureDo> result = BEANS.get(DataObjectMigrator.class).migrateDataObject(ctx, json, SimpleFixtureDo.class);
+    assertFalse(result.isChanged());
+    assertEquals(dataObject, result.getDataObject());
+  }
+
+  /**
+   * Tests that the contribution is removed from the data object.
+   */
+  @Test
+  public void testMigrationOfDoWithMatchingAndNonExistingContribution() {
+    testMigration(createDataObjectWithUnknownContribution(), createSimpleFixtureDo());
+  }
+
+  /**
+   * Combination of multiple contributions.
+   */
+  @Test
+  public void testMigrationOfDoWithMultipleContributions() {
+    // Existing contribution 1 - should not be removed because the contribution still exists in the code
+    IDoEntity expectedExistingContribution1 = BEANS.get(DoEntity.class);
+    expectedExistingContribution1.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.FirstSimpleContributionFixture");
+    expectedExistingContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    expectedExistingContribution1.put("firstValue", "myFirstValue");
+
+    // Existing contribution 2 - no migration handler
+    IDoEntity expectedExistingContribution2 = BEANS.get(DoEntity.class);
+    expectedExistingContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SecondSimpleContributionFixture");
+    expectedExistingContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    expectedExistingContribution2.put("secondValue", "mySecondValue");
+
+    // Unknown contribution 1 - should not be removed because of different type version
+    IDoEntity expectedUnknownContribution1 = BEANS.get(DoEntity.class);
+    expectedUnknownContribution1.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
+    expectedUnknownContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_2.VERSION.unwrap());
+    expectedUnknownContribution1.put("testValue", "myTestValue");
+
+    // Unknown contribution 2 - no migration handler
+    IDoEntity expectedUnknownContribution2 = BEANS.get(DoEntity.class);
+    expectedUnknownContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyOtherTestContribution");
+    expectedUnknownContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    expectedUnknownContribution2.put("otherTestValue", "myOtherTestValue");
+
+    // build the DO manually, because we want to add unknown/invalid contributions
+    IDoEntity expectedDataObject = BEANS.get(DoEntity.class);
+    expectedDataObject.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SimpleFixture");
+    expectedDataObject.put("name1", "myName1");
+    expectedDataObject.putList("_contributions", CollectionUtility.arrayList(expectedExistingContribution1, expectedExistingContribution2, expectedUnknownContribution1, expectedUnknownContribution2));
+
+    // serialize and deserialize the DO, so that we get a SimpleFixtureDo instead of a DoEntity
+    IDoEntity expected = s_dataObjectMapper.readValue(s_dataObjectMapper.writeValue(expectedDataObject), IDoEntity.class);
+
+    testMigration(createDataObjectWithMultipleContributions(), expected);
+  }
+
+  protected void testMigration(IDoEntity value, IDoEntity expected) {
+    String json = s_dataObjectMapper.writeValue(value);
+    DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class).putGlobal(BEANS.get(DoValueMigrationIdsContextData.class).withAppliedValueMigrationIds(getAppliedValueMigrations()));
+    DataObjectMigratorResult<IDoEntity> result = BEANS.get(DataObjectMigrator.class).migrateDataObject(ctx, json, IDoEntity.class);
+    assertTrue("Data object migration didn't change the data object", result.isChanged());
+    assertEquals(expected, result.getDataObject());
+  }
+
+  /**
+   * @return the set of all available value migration IDs, except the migrations to be tested. This is to make sure that no other value
+   * migrations than the expected ones will be applied.
+   */
+  protected Set<DoValueMigrationId> getAppliedValueMigrations() {
+    return BEANS.get(DataObjectMigrationInventory.class).getValueMigrationHandlers().stream()
+        .map(IDoValueMigrationHandler::id)
+        .filter(id -> !MyTestContributionRemoveDoEntityContributionValueMigrationHandler.ID.equals(id))
+        .filter(id -> !FirstSimpleContributionFixtureRemoveDoEntityContributionValueMigrationHandler.ID.equals(id))
+        .collect(Collectors.toSet());
+  }
+
+  protected SimpleFixtureDo createSimpleFixtureDo() {
+    return BEANS.get(SimpleFixtureDo.class)
+        .withName1("myName1");
+  }
+
+  protected SimpleFixtureDo createDataObjectWithExistingContribution() {
+    SimpleFixtureDo fixture = createSimpleFixtureDo();
+    fixture.contribution(FirstSimpleContributionFixtureDo.class)
+        .withFirstValue("myFirstValue");
+    return fixture;
+  }
+
+  protected IDoEntity createDataObjectWithUnknownContribution() {
+    // Unknown contribution
+    IDoEntity contribution = BEANS.get(DoEntity.class);
+    contribution.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
+    contribution.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    contribution.put("testValue", "myTestValue");
+
+    // build the DO manually, because we want to add unknown/invalid contributions
+    IDoEntity dataObject = BEANS.get(DoEntity.class);
+    dataObject.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SimpleFixture");
+    dataObject.put("name1", "myName1");
+    dataObject.putList("_contributions", Collections.singletonList(contribution));
+    return dataObject;
+  }
+
+  protected IDoEntity createDataObjectWithMultipleContributions() {
+    // Existing contribution
+    IDoEntity simpleContribution1 = BEANS.get(DoEntity.class);
+    simpleContribution1.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.FirstSimpleContributionFixture");
+    simpleContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    simpleContribution1.put("firstValue", "myFirstValue");
+
+    // Existing contribution
+    IDoEntity simpleContribution2 = BEANS.get(DoEntity.class);
+    simpleContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SecondSimpleContributionFixture");
+    simpleContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    simpleContribution2.put("secondValue", "mySecondValue");
+
+    // Unknown contribution 1
+    IDoEntity nonExistingContribution1 = BEANS.get(DoEntity.class);
+    nonExistingContribution1.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
+    nonExistingContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    nonExistingContribution1.put("testValue", "myTestValue");
+
+    IDoEntity nonExistingContribution2 = BEANS.get(DoEntity.class);
+    nonExistingContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
+    nonExistingContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_2.VERSION.unwrap());
+    nonExistingContribution2.put("testValue", "myTestValue");
+
+    // Unknown contribution 3
+    IDoEntity nonExistingContribution3 = BEANS.get(DoEntity.class);
+    nonExistingContribution3.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyOtherTestContribution");
+    nonExistingContribution3.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    nonExistingContribution3.put("otherTestValue", "myOtherTestValue");
+
+    // build the DO manually, because we want to add unknown/invalid contributions
+    SimpleFixtureDo dataObject = BEANS.get(SimpleFixtureDo.class);
+    dataObject.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SimpleFixture");
+    dataObject.put("name1", "myName1");
+    dataObject.putList("_contributions", CollectionUtility.arrayList(simpleContribution1, simpleContribution2, nonExistingContribution1, nonExistingContribution2, nonExistingContribution3));
+
+    BEANS.get(IDataObjectMapper.class).readValue(BEANS.get(IDataObjectMapper.class).writeValue(dataObject), IDoEntity.class);
+
+    return dataObject;
+  }
+
+  /**
+   * Migration handler that removes an unknown contribution
+   */
+  public static class MyTestContributionRemoveDoEntityContributionValueMigrationHandler extends AbstractRemoveDoEntityContributionValueMigrationHandler<SimpleFixtureDo> {
+
+    public static final DoValueMigrationId ID = DoValueMigrationId.of("44d6e9bb-210d-47b3-bf75-8fc28a314361");
+
+    @Override
+    public DoValueMigrationId id() {
+      return ID;
+    }
+
+    @Override
+    public Class<? extends ITypeVersion> typeVersionClass() {
+      return AlfaFixture_1.class;
+    }
+
+    @Override
+    protected String getContributionTypeName() {
+      return "scout.MyTestContribution";
+    }
+
+    @Override
+    protected Class<? extends ITypeVersion> getContributionTypeVersionClass() {
+      return AlfaFixture_1.class;
+    }
+  }
+
+  /**
+   * Migration handler that tries to remove the contribution {@link FirstSimpleContributionFixtureDo} that still exists in the code -> migration will not do anything
+   */
+  public static class FirstSimpleContributionFixtureRemoveDoEntityContributionValueMigrationHandler extends AbstractRemoveDoEntityContributionValueMigrationHandler<SimpleFixtureDo> {
+
+    public static final DoValueMigrationId ID = DoValueMigrationId.of("1f386486-203c-4a6e-ba3d-9186b5766c71");
+
+    @Override
+    public DoValueMigrationId id() {
+      return ID;
+    }
+
+    @Override
+    public Class<? extends ITypeVersion> typeVersionClass() {
+      return AlfaFixture_1.class;
+    }
+
+    @Override
+    protected String getContributionTypeName() {
+      return "scout.FirstSimpleContributionFixture";
+    }
+
+    @Override
+    protected Class<? extends ITypeVersion> getContributionTypeVersionClass() {
+      return AlfaFixture_1.class;
+    }
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandlerTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandlerTest.java
@@ -1,12 +1,16 @@
 /*
- * Copyright (c) BSI Business Systems Integration AG. All rights reserved.
- * http://www.bsiag.com/
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.scout.rt.dataobject.migration;
 
 import static org.junit.Assert.*;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -44,11 +48,10 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
   public void testMigrationOfDoEntityWithoutContribution() {
     SimpleFixtureDo fixture = createSimpleFixtureDo();
 
-    String fixtureJson = s_dataObjectMapper.writeValue(fixture);
     DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class).putGlobal(BEANS.get(DoValueMigrationIdsContextData.class).withAppliedValueMigrationIds(getAppliedValueMigrations()));
-    DataObjectMigratorResult<SimpleFixtureDo> result = BEANS.get(DataObjectMigrator.class).migrateDataObject(ctx, fixtureJson, SimpleFixtureDo.class);
+    DataObjectMigratorResult<SimpleFixtureDo> result = new TestDataObjectMigrator().applyValueMigration(ctx, fixture);
     assertFalse(result.isChanged());
-    assertEquals(fixture, result.getDataObject());
+    assertSame(fixture, result.getDataObject());
   }
 
   /**
@@ -60,25 +63,23 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
     fixture.contribution(SecondSimpleContributionFixtureDo.class)
         .withSecondValue("mySecondValue");
 
-    String fixtureJson = s_dataObjectMapper.writeValue(fixture);
     DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class).putGlobal(BEANS.get(DoValueMigrationIdsContextData.class).withAppliedValueMigrationIds(getAppliedValueMigrations()));
-    DataObjectMigratorResult<SimpleFixtureDo> result = BEANS.get(DataObjectMigrator.class).migrateDataObject(ctx, fixtureJson, SimpleFixtureDo.class);
+    DataObjectMigratorResult<SimpleFixtureDo> result = new TestDataObjectMigrator().applyValueMigration(ctx, fixture);
     assertFalse(result.isChanged());
-    assertEquals(fixture, result.getDataObject());
+    assertSame(fixture, result.getDataObject());
   }
 
   /**
-   * Tests that the DO is not changed because the contribution to be removed still exists in the code.
+   * Tests that the data object is not changed because the contribution to be removed still exists in the code.
    */
   @Test
   public void testMigrationOfDoWithMatchingAndStillExistingContribution() {
     SimpleFixtureDo dataObject = createDataObjectWithExistingContribution();
 
-    String json = s_dataObjectMapper.writeValue(dataObject);
     DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class).putGlobal(BEANS.get(DoValueMigrationIdsContextData.class).withAppliedValueMigrationIds(getAppliedValueMigrations()));
-    DataObjectMigratorResult<SimpleFixtureDo> result = BEANS.get(DataObjectMigrator.class).migrateDataObject(ctx, json, SimpleFixtureDo.class);
+    DataObjectMigratorResult<SimpleFixtureDo> result = new TestDataObjectMigrator().applyValueMigration(ctx, dataObject);
     assertFalse(result.isChanged());
-    assertEquals(dataObject, result.getDataObject());
+    assertSame(dataObject, result.getDataObject());
   }
 
   /**
@@ -95,16 +96,10 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
   @Test
   public void testMigrationOfDoWithMultipleContributions() {
     // Existing contribution 1 - should not be removed because the contribution still exists in the code
-    IDoEntity expectedExistingContribution1 = BEANS.get(DoEntity.class);
-    expectedExistingContribution1.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.FirstSimpleContributionFixture");
-    expectedExistingContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
-    expectedExistingContribution1.put("firstValue", "myFirstValue");
+    FirstSimpleContributionFixtureDo expectedExistingContribution1 = createFirstSimpleContribution();
 
-    // Existing contribution 2 - no migration handler
-    IDoEntity expectedExistingContribution2 = BEANS.get(DoEntity.class);
-    expectedExistingContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SecondSimpleContributionFixture");
-    expectedExistingContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
-    expectedExistingContribution2.put("secondValue", "mySecondValue");
+    // Existing contribution 2 - should not be removed because the contribution still exists in the code and there is no migration handler to remove the contribution
+    SecondSimpleContributionFixtureDo expectedExistingContribution2 = createSecondSimpleContribution();
 
     // Unknown contribution 1 - should not be removed because of different type version
     IDoEntity expectedUnknownContribution1 = BEANS.get(DoEntity.class);
@@ -112,28 +107,22 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
     expectedUnknownContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_2.VERSION.unwrap());
     expectedUnknownContribution1.put("testValue", "myTestValue");
 
-    // Unknown contribution 2 - no migration handler
+    // Unknown contribution 2 - should not be removed because there is no migration handler to remove the contribution
     IDoEntity expectedUnknownContribution2 = BEANS.get(DoEntity.class);
     expectedUnknownContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyOtherTestContribution");
     expectedUnknownContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
     expectedUnknownContribution2.put("otherTestValue", "myOtherTestValue");
 
-    // build the DO manually, because we want to add unknown/invalid contributions
-    IDoEntity expectedDataObject = BEANS.get(DoEntity.class);
-    expectedDataObject.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SimpleFixture");
-    expectedDataObject.put("name1", "myName1");
-    expectedDataObject.putList("_contributions", CollectionUtility.arrayList(expectedExistingContribution1, expectedExistingContribution2, expectedUnknownContribution1, expectedUnknownContribution2));
-
-    // serialize and deserialize the DO, so that we get a SimpleFixtureDo instead of a DoEntity
-    IDoEntity expected = s_dataObjectMapper.readValue(s_dataObjectMapper.writeValue(expectedDataObject), IDoEntity.class);
+    SimpleFixtureDo expected = createSimpleFixtureDo();
+    //noinspection deprecation
+    expected.getAllContributions().addAll(CollectionUtility.arrayList(expectedExistingContribution1, expectedExistingContribution2, expectedUnknownContribution1, expectedUnknownContribution2));
 
     testMigration(createDataObjectWithMultipleContributions(), expected);
   }
 
   protected void testMigration(IDoEntity value, IDoEntity expected) {
-    String json = s_dataObjectMapper.writeValue(value);
     DataObjectMigrationContext ctx = BEANS.get(DataObjectMigrationContext.class).putGlobal(BEANS.get(DoValueMigrationIdsContextData.class).withAppliedValueMigrationIds(getAppliedValueMigrations()));
-    DataObjectMigratorResult<IDoEntity> result = BEANS.get(DataObjectMigrator.class).migrateDataObject(ctx, json, IDoEntity.class);
+    DataObjectMigratorResult<IDoEntity> result = new TestDataObjectMigrator().applyValueMigration(ctx, value);
     assertTrue("Data object migration didn't change the data object", result.isChanged());
     assertEquals(expected, result.getDataObject());
   }
@@ -162,33 +151,25 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
     return fixture;
   }
 
-  protected IDoEntity createDataObjectWithUnknownContribution() {
+  protected SimpleFixtureDo createDataObjectWithUnknownContribution() {
     // Unknown contribution
     IDoEntity contribution = BEANS.get(DoEntity.class);
     contribution.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
     contribution.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
     contribution.put("testValue", "myTestValue");
 
-    // build the DO manually, because we want to add unknown/invalid contributions
-    IDoEntity dataObject = BEANS.get(DoEntity.class);
-    dataObject.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SimpleFixture");
-    dataObject.put("name1", "myName1");
-    dataObject.putList("_contributions", Collections.singletonList(contribution));
+    SimpleFixtureDo dataObject = createSimpleFixtureDo();
+    //noinspection deprecation
+    dataObject.getAllContributions().add(contribution);
     return dataObject;
   }
 
-  protected IDoEntity createDataObjectWithMultipleContributions() {
+  protected SimpleFixtureDo createDataObjectWithMultipleContributions() {
     // Existing contribution
-    IDoEntity simpleContribution1 = BEANS.get(DoEntity.class);
-    simpleContribution1.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.FirstSimpleContributionFixture");
-    simpleContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
-    simpleContribution1.put("firstValue", "myFirstValue");
+    FirstSimpleContributionFixtureDo simpleContribution1 = createFirstSimpleContribution();
 
     // Existing contribution
-    IDoEntity simpleContribution2 = BEANS.get(DoEntity.class);
-    simpleContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SecondSimpleContributionFixture");
-    simpleContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
-    simpleContribution2.put("secondValue", "mySecondValue");
+    SecondSimpleContributionFixtureDo simpleContribution2 = createSecondSimpleContribution();
 
     // Unknown contribution 1
     IDoEntity nonExistingContribution1 = BEANS.get(DoEntity.class);
@@ -196,6 +177,7 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
     nonExistingContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
     nonExistingContribution1.put("testValue", "myTestValue");
 
+    // Unknown contribution 2 with different type version
     IDoEntity nonExistingContribution2 = BEANS.get(DoEntity.class);
     nonExistingContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
     nonExistingContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_2.VERSION.unwrap());
@@ -207,15 +189,21 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
     nonExistingContribution3.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
     nonExistingContribution3.put("otherTestValue", "myOtherTestValue");
 
-    // build the DO manually, because we want to add unknown/invalid contributions
-    SimpleFixtureDo dataObject = BEANS.get(SimpleFixtureDo.class);
-    dataObject.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.SimpleFixture");
-    dataObject.put("name1", "myName1");
-    dataObject.putList("_contributions", CollectionUtility.arrayList(simpleContribution1, simpleContribution2, nonExistingContribution1, nonExistingContribution2, nonExistingContribution3));
-
-    BEANS.get(IDataObjectMapper.class).readValue(BEANS.get(IDataObjectMapper.class).writeValue(dataObject), IDoEntity.class);
+    SimpleFixtureDo dataObject = createSimpleFixtureDo();
+    //noinspection deprecation
+    dataObject.getAllContributions().addAll(CollectionUtility.arrayList(simpleContribution1, simpleContribution2, nonExistingContribution1, nonExistingContribution2, nonExistingContribution3));
 
     return dataObject;
+  }
+
+  protected FirstSimpleContributionFixtureDo createFirstSimpleContribution() {
+    return BEANS.get(FirstSimpleContributionFixtureDo.class)
+        .withFirstValue("myFirstValue");
+  }
+
+  protected SecondSimpleContributionFixtureDo createSecondSimpleContribution() {
+    return BEANS.get(SecondSimpleContributionFixtureDo.class)
+        .withSecondValue("mySecondValue");
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractDataObjectVisitor.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractDataObjectVisitor.java
@@ -74,7 +74,8 @@ public abstract class AbstractDataObjectVisitor {
   protected void caseDoEntity(IDoEntity entity) {
     applyVisitorExtension(entity);
     caseDoEntityNodes(entity.allNodes().values());
-    caseDoEntityContributions(entity.getContributions());
+    //noinspection deprecation
+    caseDoEntityContributions(entity.getAllContributions());
   }
 
   protected void caseDoEntityNodes(Collection<DoNode<?>> nodes) {
@@ -99,8 +100,8 @@ public abstract class AbstractDataObjectVisitor {
     }
   }
 
-  protected void caseDoEntityContributions(Collection<IDoEntityContribution> contributions) {
-    for (IDoEntityContribution contribution : contributions) {
+  protected void caseDoEntityContributions(Collection<IDoEntity> contributions) {
+    for (IDoEntity contribution : contributions) {
       visit(contribution);
     }
   }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractReplacingDataObjectVisitor.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractReplacingDataObjectVisitor.java
@@ -51,7 +51,7 @@ public abstract class AbstractReplacingDataObjectVisitor extends AbstractDataObj
   }
 
   @Override
-  protected void caseDoEntityContributions(Collection<IDoEntityContribution> contributions) {
+  protected void caseDoEntityContributions(Collection<IDoEntity> contributions) {
     updateCollection(contributions);
   }
 

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DataObjectHelper.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DataObjectHelper.java
@@ -252,7 +252,7 @@ public class DataObjectHelper {
     }
 
     @Override
-    protected void caseDoEntityContributions(Collection<IDoEntityContribution> contributions) {
+    protected void caseDoEntityContributions(Collection<IDoEntity> contributions) {
       super.caseDoEntityContributions(contributions); // deep first
       normalizeInternal(contributions);
     }
@@ -322,7 +322,8 @@ public class DataObjectHelper {
       entity.removeIf(emptyNodes::contains);
 
       // (2) clean all contributions (i.e. itself implementations of DoEntity)
-      caseDoEntityContributions(entity.getContributions());
+      //noinspection deprecation
+      caseDoEntityContributions(entity.getAllContributions());
     }
   }
 

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoEntity.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoEntity.java
@@ -21,6 +21,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -51,7 +52,7 @@ public class DoEntity implements IDoEntity {
 
   private final Map<String, DoNode<?>> m_attributes = new LinkedHashMap<>();
 
-  private List<IDoEntityContribution> m_contributions; // lazy init, because contributions are used rarely
+  private List<IDoEntity> m_contributions; // lazy init, because contributions are used rarely
 
   /**
    * @return Node of attribute {@code attributeName} or {@code null}, if attribute is not available.
@@ -180,6 +181,16 @@ public class DoEntity implements IDoEntity {
 
   @Override
   public Collection<IDoEntityContribution> getContributions() {
+    return getAllContributions().stream()
+        .filter(IDoEntityContribution.class::isInstance)
+        .map(IDoEntityContribution.class::cast)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Override
+  @Deprecated
+  @SuppressWarnings("deprecation")
+  public Collection<IDoEntity> getAllContributions() {
     if (m_contributions == null) {
       m_contributions = new ArrayList<>(); // create on first access
     }
@@ -202,8 +213,8 @@ public class DoEntity implements IDoEntity {
     }
 
     // handle null and empty contributions the same way (lazy init of m_contributions)
-    List<IDoEntityContribution> contributions = hasContributions() ? m_contributions : null;
-    List<IDoEntityContribution> otherContributions = doEntity.hasContributions() ? doEntity.m_contributions : null;
+    List<IDoEntity> contributions = hasContributions() ? m_contributions : null;
+    List<IDoEntity> otherContributions = doEntity.hasContributions() ? doEntity.m_contributions : null;
     if (!CollectionUtility.equalsCollection(contributions, otherContributions, false)) { // element order is not relevant
       return false;
     }
@@ -214,7 +225,7 @@ public class DoEntity implements IDoEntity {
   @Override
   public int hashCode() {
     int result = m_attributes.hashCode();
-    Collection<? extends IDoEntityContribution> contributions = hasContributions() ? m_contributions : null; // handle null and empty contributions the same way (lazy init of m_contributions)
+    Collection<? extends IDoEntity> contributions = hasContributions() ? m_contributions : null; // handle null and empty contributions the same way (lazy init of m_contributions)
     result = 31 * result + CollectionUtility.hashCodeCollection(contributions); // element order is not relevant
     return result;
   }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/IDoEntity.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/IDoEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -363,7 +363,7 @@ public interface IDoEntity extends IDataObject {
    * method might create an internal representation to store contributions which is usually not necessary if used
    * read-only.
    *
-   * @return A mutable collection of DO all entity contributions (never <code>null</code>).
+   * @return A mutable collection of all DO entity contributions (never <code>null</code>).
    * @deprecated This method returns ALL contributions of the DO, including the unknown ones, that may not implement {@link IDoEntityContribution}.
    * This method should only be used internally or for special DO migrations that need to access ALL contributions. To get the known contributions use {@link #getContributions} instead.
    */

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/IDoEntity.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/IDoEntity.java
@@ -350,13 +350,25 @@ public interface IDoEntity extends IDataObject {
   boolean hasContributions();
 
   /**
+   * A read-only collection of the known contributions. It's recommended to call {@link #hasContributions()} before calling this method because this
+   * method might create an internal representation to store contributions which is usually not necessary if used
+   * read-only.
+   *
+   * @return An immutable collection of known DO entity contributions (never <code>null</code>).
+   */
+  Collection<IDoEntityContribution> getContributions();
+
+  /**
    * For read-only calls it's recommended to call {@link #hasContributions()} before calling this method because this
    * method might create an internal representation to store contributions which is usually not necessary if used
    * read-only.
    *
-   * @return An mutable collection of DO entity contributions (never <code>null</code>).
+   * @return A mutable collection of DO all entity contributions (never <code>null</code>).
+   * @deprecated This method returns ALL contributions of the DO, including the unknown ones, that may not implement {@link IDoEntityContribution}.
+   * This method should only be used internally or for special DO migrations that need to access ALL contributions. To get the known contributions use {@link #getContributions} instead.
    */
-  Collection<IDoEntityContribution> getContributions();
+  @Deprecated
+  Collection<IDoEntity> getAllContributions();
 
   /**
    * @return Existing DO entity contribution for this contribution class if available, otherwise creates a new DO entity
@@ -404,7 +416,7 @@ public interface IDoEntity extends IDataObject {
   default void putContribution(IDoEntityContribution contribution) {
     assertNotNull(contribution, "contribution is required");
     removeContribution(contribution.getClass());
-    getContributions().add(contribution);
+    getAllContributions().add(contribution);
   }
 
   /**
@@ -414,6 +426,6 @@ public interface IDoEntity extends IDataObject {
     if (!hasContributions()) {
       return false;
     }
-    return getContributions().removeIf(contribution -> contributionClass.equals(contribution.getClass()));
+    return getAllContributions().removeIf(contribution -> contributionClass.equals(contribution.getClass()));
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandler.java
@@ -48,9 +48,12 @@ public abstract class AbstractRemoveDoEntityContributionValueMigrationHandler<T 
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public T migrate(DataObjectMigrationContext ctx, T value) {
-    T clone = BEANS.get(DataObjectHelper.class).clone(value);
-    //noinspection deprecation
+    if (value.getAllContributions().stream().noneMatch(this::matchesContribution)) {
+      return value; // nothing to migrate
+    }
+    T clone = BEANS.get(DataObjectHelper.class).cloneLenient(value);
     clone.getAllContributions().removeIf(this::matchesContribution);
     return clone;
   }
@@ -59,7 +62,7 @@ public abstract class AbstractRemoveDoEntityContributionValueMigrationHandler<T 
     if (contribution == null) {
       return false;
     }
-    return getContributionTypeName().equals(contribution.get(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, String.class))
-        && getContributionTypeVersion().equals(contribution.get(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, String.class));
+    return getContributionTypeName().equals(contribution.getString(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME))
+        && getContributionTypeVersion().equals(contribution.getString(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME));
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.migration;
+
+import org.eclipse.scout.rt.dataobject.DataObjectHelper;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.IDoEntityContribution;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.TypeVersion;
+import org.eclipse.scout.rt.platform.BEANS;
+
+/**
+ * Abstract implementation of a {@link IDoValueMigrationHandler} to remove an {@link IDoEntityContribution} that does not exist anymore in the code.
+ * <p>
+ * In case the {@link IDoEntityContribution} still exists in the code this abstract implementation will not do anything, because in this case the migration handler does not know the original {@link TypeVersion} of the contribution.<br>
+ * If you still want to remove the contribution - even if it still exists in the code - you need to create your own migration handler.
+ *
+ * @param <T>
+ *     The {@link IDoEntity} that contains the contribution to be removed.
+ */
+public abstract class AbstractRemoveDoEntityContributionValueMigrationHandler<T extends IDoEntity> extends AbstractDoValueMigrationHandler<T> {
+
+  /**
+   * @return value of {@link TypeName} of the contribution to be removed, e.g. "scout.MyContribution"
+   */
+  protected abstract String getContributionTypeName();
+
+  /**
+   * @return value of {@link TypeVersion} of the contribution to be removed
+   */
+  protected abstract Class<? extends ITypeVersion> getContributionTypeVersionClass();
+
+  protected String getContributionTypeVersion() {
+    return BEANS.get(getContributionTypeVersionClass()).getVersion().unwrap();
+  }
+
+  @Override
+  public double primarySortOrder() {
+    return REMOVE_CONTRIBUTION_PRIMARY_SORT_ORDER;
+  }
+
+  @Override
+  public T migrate(DataObjectMigrationContext ctx, T value) {
+    T clone = BEANS.get(DataObjectHelper.class).clone(value);
+    //noinspection deprecation
+    clone.getAllContributions().removeIf(this::matchesContribution);
+    return clone;
+  }
+
+  protected boolean matchesContribution(IDoEntity contribution) {
+    if (contribution == null) {
+      return false;
+    }
+    return getContributionTypeName().equals(contribution.get(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, String.class))
+        && getContributionTypeVersion().equals(contribution.get(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, String.class));
+  }
+}

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoValueMigrationHandler.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/migration/IDoValueMigrationHandler.java
@@ -140,6 +140,13 @@ import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 public interface IDoValueMigrationHandler<T> {
 
   /**
+   * Primary sort order for value migrations removing contributions, used by {@link AbstractRemoveDoEntityContributionValueMigrationHandler}.
+   *
+   * @see #primarySortOrder()
+   */
+  double REMOVE_CONTRIBUTION_PRIMARY_SORT_ORDER = 500.0;
+
+  /**
    * Primary sort order for untyped value migrations, used by {@link AbstractDoValueUntypedMigrationHandler}.
    *
    * @see #primarySortOrder()

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JsonDataObjectsSerializationTest.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.eclipse.scout.rt.dataobject.DataObjectHelper;
 import org.eclipse.scout.rt.dataobject.DoCollection;
@@ -2832,10 +2833,59 @@ public class JsonDataObjectsSerializationTest {
 
     // no node for contributions in typed mode
     assertFalse(marshalledDoEntity.has(ScoutDataObjectModule.DEFAULT_CONTRIBUTIONS_ATTRIBUTE_NAME));
-    // doesn't fail even if internal instance is of type IDoEntity instead of IDoEntityContribution due to unknown type name
+    // no known contributions
+    assertTrue(marshalledDoEntity.getContributions().isEmpty());
+    //noinspection deprecation
+    assertEquals(1, marshalledDoEntity.getAllContributions().size());
+    //noinspection deprecation
+    IDoEntity contribution = CollectionUtility.firstElement(marshalledDoEntity.getAllContributions());
+    assertSame("Unknown contribution is not loaded raw", DoEntity.class, contribution.getClass());
+    assertEquals("two", contribution.getString("name"));
+
+    String unmarshalledJson = s_dataObjectMapper.writeValueAsString(marshalledDoEntity);
+    s_testHelper.assertJsonEquals(json, unmarshalledJson);
+  }
+
+  @Test
+  public void testDeserialize_DoEntityWithUnknownAndKnownContribution() throws Exception {
+    String json = readResourceAsString("TestDoEntityWithUnknownAndKnownContribution.json");
+    TestItemDo marshalledDoEntity = s_dataObjectMapper.readValue(json, TestItemDo.class);
+    assertEquals("123456789", marshalledDoEntity.getId());
+
+    // no node for contributions in typed mode
+    assertFalse(marshalledDoEntity.has(ScoutDataObjectModule.DEFAULT_CONTRIBUTIONS_ATTRIBUTE_NAME));
+
     assertEquals(1, marshalledDoEntity.getContributions().size());
-    // throws due to tried casting
-    assertThrows(ClassCastException.class, () -> CollectionUtility.firstElement(marshalledDoEntity.getContributions()).getString("name"));
+    TestItemContributionOneDo knownContribution = marshalledDoEntity.getContribution(TestItemContributionOneDo.class);
+    assertEquals(knownContribution, CollectionUtility.firstElement(marshalledDoEntity.getContributions()));
+    assertEquals("sid", knownContribution.getName());
+
+    // doesn't fail even if internal instance is of type IDoEntity instead of IDoEntityContribution due to unknown type name
+    //noinspection deprecation
+    assertEquals(2, marshalledDoEntity.getAllContributions().size());
+
+    // get the known contribution
+    //noinspection deprecation
+    TestItemContributionOneDo contribution1 = marshalledDoEntity.getAllContributions().stream()
+        .filter(TestItemContributionOneDo.class::isInstance)
+        .map(TestItemContributionOneDo.class::cast)
+        .findFirst()
+        .orElse(null);
+    assertNotNull("Known contribution is missing", contribution1);
+    assertSame(knownContribution, contribution1);
+
+    // get the unknown contribution
+    //noinspection deprecation
+    IDoEntity contribution2 = marshalledDoEntity.getAllContributions().stream()
+        .filter(Predicate.not(TestItemContributionOneDo.class::isInstance))
+        .findFirst()
+        .orElse(null);
+
+    assertNotNull("Unknown contribution is missing", contribution2);
+    assertSame("Unknown contribution is not loaded raw", DoEntity.class, contribution2.getClass());
+
+    String unmarshalledJson = s_dataObjectMapper.writeValueAsString(marshalledDoEntity);
+    s_testHelper.assertJsonEquals(json, unmarshalledJson);
   }
 
   @Test

--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestCustomImplementedEntityDo.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/fixture/TestCustomImplementedEntityDo.java
@@ -43,7 +43,7 @@ import org.eclipse.scout.rt.platform.util.CollectionUtility;
 public class TestCustomImplementedEntityDo implements IDoEntity {
 
   private final Map<String, DoNode<?>> m_attributes = new LinkedHashMap<>();
-  private List<IDoEntityContribution> m_contributions;
+  private List<IDoEntity> m_contributions;
 
   // attributes
   private static final String DATE_ATTRIBUTE = "dateAttribute";
@@ -128,6 +128,15 @@ public class TestCustomImplementedEntityDo implements IDoEntity {
 
   @Override
   public Collection<IDoEntityContribution> getContributions() {
+    return getAllContributions().stream()
+        .filter(IDoEntityContribution.class::isInstance)
+        .map(IDoEntityContribution.class::cast)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public Collection<IDoEntity> getAllContributions() {
     if (m_contributions == null) {
       m_contributions = new ArrayList<>();
     }

--- a/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestDoEntityWithUnknownAndKnownContribution.json
+++ b/org.eclipse.scout.rt.jackson.test/src/test/resources/org/eclipse/scout/rt/jackson/dataobject/TestDoEntityWithUnknownAndKnownContribution.json
@@ -1,0 +1,11 @@
+{
+  "_type" : "TestItem",
+  "id" : "123456789",
+  "_contributions" : [ {
+    "_type" : "scout.TestUnknownContribution",
+    "name" : "dolor"
+  }, {
+    "_type" : "scout.TestItemContributionOne",
+    "name" : "sid"
+  } ]
+}

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DefaultDoEntityDeserializerTypeStrategy.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DefaultDoEntityDeserializerTypeStrategy.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import org.eclipse.scout.rt.dataobject.DataObjectInventory;
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
-import org.eclipse.scout.rt.dataobject.IDoEntityContribution;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -59,8 +58,9 @@ public class DefaultDoEntityDeserializerTypeStrategy implements IDoEntityDeseria
     }
     else {
       // add contributions to corresponding list in do entity
-      //noinspection unchecked
-      doEntity.getContributions().addAll((Collection<? extends IDoEntityContribution>) contributions);
+      //noinspection deprecation,unchecked
+      doEntity.getAllContributions()
+          .addAll((Collection<? extends IDoEntity>) contributions);
     }
   }
 }

--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/DoEntitySerializer.java
@@ -93,7 +93,8 @@ public class DoEntitySerializer extends StdSerializer<IDoEntity> {
 
   protected void serializeContributions(JsonGenerator gen, IDoEntity entity, SerializerProvider provider) throws IOException {
     if (entity.hasContributions()) {
-      Collection<IDoEntityContribution> contributions = entity.getContributions();
+      //noinspection deprecation
+      Collection<IDoEntity> contributions = entity.getAllContributions();
       validateContributions(entity, contributions);
       gen.writeObjectField(m_context.getContributionsAttributeName(), contributions);
     }
@@ -235,8 +236,12 @@ public class DoEntitySerializer extends StdSerializer<IDoEntity> {
         .filter(AttributeType::isKnown); // filter completely unknown types, forcing to use the default behavior for unknown types
   }
 
-  protected void validateContributions(IDoEntity doEntity, Collection<IDoEntityContribution> contributions) {
-    for (IDoEntityContribution contribution : contributions) {
+  protected void validateContributions(IDoEntity doEntity, Collection<IDoEntity> contributions) {
+    for (IDoEntity contribution0 : contributions) {
+      if (!(contribution0 instanceof IDoEntityContribution)) {
+        continue; // Skip validation for unknown contributions
+      }
+      IDoEntityContribution contribution = (IDoEntityContribution) contribution0;
       Set<Class<? extends IDoEntity>> containerClasses = m_dataObjectInventory.get().getContributionContainers(contribution.getClass());
       Class<? extends IDoEntityContribution> contributionClass = contribution.getClass();
       assertTrue(containerClasses.stream().anyMatch(containerClass -> containerClass.isInstance(doEntity)), "{} is not a valid container class of {}", doEntity.getClass().getSimpleName(), contributionClass.getSimpleName());


### PR DESCRIPTION
- Add AbstractRemoveDoEntityContributionValueMigrationHandler that can be used to remove a DO contribution that has been deleted from the code
- Add IDoEntity#getAllContributions to get all contributions (incl. unknown contributions)
- IDoEntity#getContributions only returns known contributions (i.e. contributions existing in the code)
- This also fixes a ClassCastException when trying to access a contribution of a DO that also contains unknown contributions

404315