### PR TITLE
Form: don't close a form created by the ui server

### DIFF
--- a/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
@@ -120,7 +120,7 @@ export class HybridManager extends Widget {
     widget.trigger(eventType, {data});
   }
 
-  protected _onHybridFormEvent(form: Form, eventType: string, data: object) {
+  protected _onHybridFormEvent(form: HybridForm, eventType: string, data: object) {
     if (eventType === 'reset') {
       form.setData(data);
       form.trigger('reset');
@@ -128,7 +128,9 @@ export class HybridManager extends Widget {
       form.setData(data);
       form.trigger('save');
     } else if (eventType === 'close') {
-      form.trigger('close');
+      if (!form.__closeTriggered) { // form.close() may be called by JS code, don't trigger close again
+        form.trigger('close');
+      }
     } else {
       this._onHybridWidgetEvent(form, eventType, data);
     }
@@ -187,7 +189,7 @@ export class HybridManager extends Widget {
    */
   openForm(modelVariant: string, data?: object): JQuery.Promise<Form> {
     const id = this.callAction(`openForm:${modelVariant}`, data);
-    return this.when(`widgetAdd:${id}`).then(event => event.widget as Form);
+    return this.when(`widgetAdd:${id}`).then(event => this._onFormAdd(event.widget as Form));
   }
 
   /**
@@ -199,7 +201,14 @@ export class HybridManager extends Widget {
    */
   createForm(modelVariant: string, data?: object): JQuery.Promise<Form> {
     const id = this.callAction(`createForm:${modelVariant}`, data);
-    return this.when(`widgetAdd:${id}`).then(event => event.widget as Form);
+    return this.when(`widgetAdd:${id}`).then(event => this._onFormAdd(event.widget as Form));
+  }
+
+  protected _onFormAdd(form: HybridForm) {
+    form.one('close', () => {
+      form.__closeTriggered = true;
+    });
+    return form;
   }
 
   // event support
@@ -219,4 +228,11 @@ export class HybridManager extends Widget {
   override when<K extends string & keyof EventMapOf<this['self']>>(type: K | `${K}:${string}`): JQuery.Promise<EventMapOf<this>[K] & Event<this>> {
     return super.when(type as K);
   }
+}
+
+interface HybridForm extends Form {
+  /**
+   * @returns true if {@link FormEventMap.close} event was triggered at least once for this form.
+   */
+  __closeTriggered?: boolean;
 }

--- a/eclipse-scout-core/src/form/FormAdapter.ts
+++ b/eclipse-scout-core/src/form/FormAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -43,6 +43,10 @@ export class FormAdapter extends ModelAdapter {
   }
 
   protected _onWidgetClose(event: Event<Form>) {
+    // Don't let the form be destroyed, only the server is allowed to do it.
+    event.preventDefault();
+    // Close the form on the UI server.
+    // It will send a disposeAdapter and formHide event back to eventually destroy and remove the form.
     this._send('close');
   }
 

--- a/eclipse-scout-core/src/form/js/JsFormAdapter.ts
+++ b/eclipse-scout-core/src/form/js/JsFormAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -96,14 +96,6 @@ export class JsFormAdapter extends FormAdapter {
     this._send(type, {
       outputData: data
     });
-  }
-
-  protected override _onWidgetClose(event: Event<Form>) {
-    // marks the end of the js lifecycle
-    // prevent remove/destroy of the widget as it will be done by the UI server
-    event.preventDefault();
-    // fromClosing will trigger a 'formHide' event on the desktop which then removes the widget
-    this._send('formClosing');
   }
 
   protected override _onWidgetAbort(event: Event<Form>) {

--- a/eclipse-scout-core/test/desktop/hybrid/HybridManagerSpec.ts
+++ b/eclipse-scout-core/test/desktop/hybrid/HybridManagerSpec.ts
@@ -46,18 +46,12 @@ describe('HybridManager', () => {
           id: '222',
           objectType: 'StringField'
         }]),
-        events: [
-          {
-            target: hybridManager.id,
-            type: 'property',
-            properties: {
-              widgets: {
-                123: '111',
-                234: '222'
-              }
-            }
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            123: '111',
+            234: '222'
           }
-        ]
+        })]
       });
       let labelField = hybridManager.widgets['123'] as Widget;
       let stringField = hybridManager.widgets['234'] as Widget;
@@ -69,17 +63,11 @@ describe('HybridManager', () => {
 
       // Widget '111' is not in the list anymore -> it needs to be destroyed
       session._processSuccessResponse({
-        events: [
-          {
-            target: hybridManager.id,
-            type: 'property',
-            properties: {
-              widgets: {
-                234: '222'
-              }
-            }
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            234: '222'
           }
-        ]
+        })]
       });
       expect(Object.entries(hybridManager.widgets).length).toBe(1);
       expect(labelField.destroyed).toBe(true);
@@ -97,17 +85,11 @@ describe('HybridManager', () => {
           id: 'labelField',
           objectType: 'LabelField'
         }]),
-        events: [
-          {
-            target: hybridManager.id,
-            type: 'property',
-            properties: {
-              widgets: {
-                1: 'labelField'
-              }
-            }
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            1: 'labelField'
           }
-        ]
+        })]
       });
 
       // LabelField is the only widget of the HybridManager
@@ -123,18 +105,12 @@ describe('HybridManager', () => {
           id: 'stringField',
           objectType: 'StringField'
         }]),
-        events: [
-          {
-            target: hybridManager.id,
-            type: 'property',
-            properties: {
-              widgets: {
-                1: 'labelField',
-                2: 'stringField'
-              }
-            }
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            1: 'labelField',
+            2: 'stringField'
           }
-        ]
+        })]
       });
 
       // HybridManager contains StringField and LabelField that was created earlier
@@ -152,18 +128,12 @@ describe('HybridManager', () => {
           id: 'numberField',
           objectType: 'NumberField'
         }]),
-        events: [
-          {
-            target: hybridManager.id,
-            type: 'property',
-            properties: {
-              widgets: {
-                1: 'numberField',
-                2: 'stringField'
-              }
-            }
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            1: 'numberField',
+            2: 'stringField'
           }
-        ]
+        })]
       });
 
       // HybridManager contains StringField and NumberField, LabelField that was created earlier is destroyed
@@ -178,17 +148,11 @@ describe('HybridManager', () => {
       // remove StringField
       const stringFieldRemovePromise = hybridManager.when('widgetRemove:2').then(event => event.widget);
       session._processSuccessResponse({
-        events: [
-          {
-            target: hybridManager.id,
-            type: 'property',
-            properties: {
-              widgets: {
-                1: 'numberField'
-              }
-            }
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            1: 'numberField'
           }
-        ]
+        })]
       });
 
       // NumberField is the only widget of the HybridManager, all other fields that where created earlier are destroyed
@@ -237,17 +201,43 @@ describe('HybridManager', () => {
       });
       const form = formHelper.createFormWithOneField();
       session._processSuccessResponse({
-        events: [
-          {
-            target: HybridManager.get(session).id,
-            type: 'property',
-            properties: {
-              widgets: {
-                42: form
-              }
-            }
+        events: [createPropertyChangeEvent(HybridManager.get(session), {
+          widgets: {
+            42: form
           }
-        ]
+        })]
+      });
+    });
+  });
+
+  describe('form close event', () => {
+    it('is not triggered when close() was initiated by JS', done => {
+      const id = '42';
+      UuidPool.get(session).uuids.push(id);
+      HybridManager.get(session).openForm('Dummy').then(form => {
+        let closeCount = 0;
+        form.on('close', () => closeCount++);
+        form.close();
+        session._processSuccessResponse({
+          events: [
+            {
+              target: HybridManager.get(session).id,
+              type: 'hybridWidgetEvent',
+              id,
+              eventType: 'close'
+            }
+          ]
+        });
+        expect(closeCount).toBe(1);
+        done();
+      });
+      const form = formHelper.createFormWithOneField();
+      session._processSuccessResponse({
+        events: [createPropertyChangeEvent(HybridManager.get(session), {
+          widgets: {
+            42: form
+          }
+        })]
       });
     });
   });

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/JsonForm.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/JsonForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -349,12 +349,7 @@ public class JsonForm<FORM extends IForm> extends AbstractJsonWidget<FORM> {
   }
 
   public void handleUiClose(JsonEvent event) {
-    // Dispose the form adapter. This prevents "formHide" and "disposeAdapter" events
-    // to be sent back to the UI. Because the "close" event is only sent when the form
-    // is already destroyed in the UI, those events would cause errors in the UI.
-    dispose();
-    // Close the form in the model, without possibility of a veto. This will not
-    // generate any UI events, because the JsonForm adapter is already disposed.
+    // Close the form in the model, without possibility of a veto
     getModel().getUIFacade().fireFormKilledFromUI();
   }
 


### PR DESCRIPTION
Use case:
- A form is created by the hybrid manager
- The form is used as a detail form of a page
- Reloading the table page deletes the nodes which destroys the form.
- The same response contains a property change event referencing the form that was closed by JS when nodes were deleted -> form cannot be resolved anymore. -> Only the server is allowed to close the form.

In a specific case the problematic form was used as a child of a detail form. The form was explicitly closed using form.close(). A detail form is currently closed using destroy() by Page.ts. This should be adjusted in the future.

The change in HybridManager.ts ensures that the close event is not triggered twice if the form was closed by JS. Normally, closing the form with Java only triggers destroy() on JS side. The hybrid manager triggers close() explicitly to make it possible to listen for the close event for forms opened using the hybrid manager.

409972