### PR TITLE
Adjust order of ExceptionFilterContributor and AuthFilterContributor

### DIFF
--- a/org.eclipse.scout.rt.server.app/src/main/java/org/eclipse/scout/rt/server/app/ServerServletContributors.java
+++ b/org.eclipse.scout.rt.server.app/src/main/java/org/eclipse/scout/rt/server/app/ServerServletContributors.java
@@ -28,7 +28,7 @@ public final class ServerServletContributors {
   private ServerServletContributors() {
   }
 
-  @Order(1000)
+  @Order(750)
   public static class ExceptionFilterContributor implements IServletFilterContributor {
 
     @Override
@@ -44,7 +44,7 @@ public final class ServerServletContributors {
    * <p>
    * The paths provided by {@link #getFilterExcludes()} should be excluded from authentication.
    */
-  @Order(2000)
+  @Order(1000)
   public static class AuthFilterContributor implements IServletFilterContributor {
 
     /**


### PR DESCRIPTION
Set AuthFilterContributor back to its former order 1000 to prevent unexpected behavior in other filter contributors. Move new ExceptionFilterContributor before AuthFilterContributor.