### PR TITLE
Add LookupColumn

### DIFF
--- a/eclipse-scout-core/src/index.less
+++ b/eclipse-scout-core/src/index.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -126,6 +126,7 @@
 @import "table/controls/TableControl";
 @import "table/editor/CellEditorPopup";
 @import "table/columns/CompactColumn";
+@import "table/columns/LookupEditor";
 @import "tagbar/TagBar";
 @import "tagbar/TagBarOverflowPopup";
 @import "timepicker/TimePicker";

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -520,9 +520,15 @@ export * from './table/columns/IconColumn';
 export * from './table/columns/NumberColumn';
 export * from './table/columns/NumberColumnModel';
 export * from './table/columns/NumberColumnEventMap';
+export * from './table/columns/LookupCallColumn';
+export * from './table/columns/LookupCallColumnEventMap';
+export * from './table/columns/LookupCallColumnModel';
 export * from './table/columns/SmartColumn';
 export * from './table/columns/SmartColumnModel';
 export * from './table/columns/SmartColumnEventMap';
+export * from './table/columns/LookupColumn';
+export * from './table/columns/LookupColumnEventMap';
+export * from './table/columns/LookupColumnModel';
 export * from './table/controls/TableControlActionKeyStroke';
 export * from './table/controls/TableControl';
 export * from './table/controls/TableControlModel';
@@ -864,6 +870,10 @@ export * from './form/fields/wrappedform/WrappedFormField';
 export * from './form/fields/wrappedform/WrappedFormFieldModel';
 export * from './form/fields/wrappedform/WrappedFormFieldEventMap';
 export * from './form/fields/wrappedform/WrappedFormFieldAdapter';
+export * from './table/columns/LookupEditor';
+export * from './table/columns/LookupEditorEventMap';
+export * from './table/columns/LookupEditorModel';
+export * from './table/columns/LookupEditorTreeLayout';
 export * from './switch/Switch';
 export * from './switch/SwitchModel';
 export * from './switch/SwitchEventMap';

--- a/eclipse-scout-core/src/lookup/LookupRow.ts
+++ b/eclipse-scout-core/src/lookup/LookupRow.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -56,6 +56,10 @@ export class LookupRow<TKey> implements LookupRowModel<TKey> {
 
   setParentKey(parentKey: TKey) {
     this.parentKey = parentKey;
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
   }
 
   setCssClass(cssClass: string) {

--- a/eclipse-scout-core/src/lookup/StaticLookupCall.ts
+++ b/eclipse-scout-core/src/lookup/StaticLookupCall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -181,6 +181,24 @@ export class StaticLookupCall<TKey> extends LookupCall<TKey> implements StaticLo
       this._deferred.resolve({
         queryBy: QueryBy.KEY,
         lookupRows: [lookupRow]
+      });
+    } else {
+      this._deferred.reject();
+    }
+  }
+
+  protected override _getByKeys(keys: TKey[]): JQuery.Promise<LookupResult<TKey>> {
+    this._deferred = $.Deferred();
+    setTimeout(() => this._queryByKeys(keys), this.delay);
+    return this._deferred.promise();
+  }
+
+  protected _queryByKeys(keys: TKey[]) {
+    const lookupRows = arrays.ensure(keys).map(key => this._lookupRowByKey(key)).filter(row => !!row);
+    if (lookupRows.length) {
+      this._deferred.resolve({
+        queryBy: QueryBy.KEY,
+        lookupRows
       });
     } else {
       this._deferred.reject();

--- a/eclipse-scout-core/src/table/columns/Column.ts
+++ b/eclipse-scout-core/src/table/columns/Column.ts
@@ -1032,7 +1032,7 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
     }
   }
 
-  isContentValid(row: TableRow): { valid: boolean; validByMandatory: boolean; errorStatus: Status } {
+  isContentValid(row: TableRow): ColumnValidationResult {
     const cell = this.cell(row),
       validByErrorStatus = !cell.errorStatus || cell.errorStatus.isValid(),
       validByMandatory = !cell.mandatory || this._hasCellValue(cell);
@@ -1061,3 +1061,5 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
     return this._realWidth || this.width;
   }
 }
+
+export type ColumnValidationResult = { valid: boolean; validByMandatory: boolean; errorStatus: Status };

--- a/eclipse-scout-core/src/table/columns/LookupCallColumn.ts
+++ b/eclipse-scout-core/src/table/columns/LookupCallColumn.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {CodeLookupCall, Column, InitModelOf, LookupCall, LookupCallColumnEventMap, LookupCallColumnModel, LookupCallOrModel, scout, SmartField, TableRow, ValueField} from '../../index';
+
+export class LookupCallColumn<TValue, TKey = TValue> extends Column<TValue> implements LookupCallColumnModel<TValue, TKey> {
+  declare model: LookupCallColumnModel<TValue, TKey>;
+  declare eventMap: LookupCallColumnEventMap<TValue, TKey>;
+
+  lookupCall: LookupCall<TKey> = null;
+  codeType: string = null;
+  browseHierarchy = false;
+  browseMaxRowCount = SmartField.DEFAULT_BROWSE_MAX_COUNT;
+
+  protected override _init(model: InitModelOf<this>) {
+    super._init(model);
+    this._setLookupCall(this.lookupCall);
+    this._setCodeType(this.codeType);
+  }
+
+  setLookupCall(lookupCall: LookupCallOrModel<TKey>) {
+    this.setProperty('lookupCall', lookupCall);
+  }
+
+  protected _setLookupCall(lookupCall: LookupCallOrModel<TKey>) {
+    let call = LookupCall.ensure(lookupCall, this.session);
+    this._setProperty('lookupCall', call);
+  }
+
+  setCodeType(codeType: string) {
+    this.setProperty('codeType', codeType);
+  }
+
+  protected _setCodeType(codeType: string) {
+    this._setProperty('codeType', codeType);
+    if (codeType) {
+      this.lookupCall = scout.create(CodeLookupCall<TKey>, {
+        session: this.session,
+        codeType
+      });
+    }
+  }
+
+  setBrowseHierarchy(browseHierarchy: boolean) {
+    this.setProperty('browseHierarchy', browseHierarchy);
+  }
+
+  setBrowseMaxRowCount(browseMaxRowCount: number) {
+    this.setProperty('browseMaxRowCount', browseMaxRowCount);
+  }
+
+  protected override _updateCellFromValidEditor(row: TableRow, field: ValueField<TValue>) {
+    // The following code is only necessary to prevent flickering because the text is updated async.
+    // Instead of only calling setCellValue which itself would update the display text, we set the text manually before calling setCellValue.
+    // This works because in most of the cases the text computed by the column will be the same as the one computed by the editor field.
+
+    // Clear error status first (regular behavior)
+    this.setCellErrorStatus(row, null);
+
+    // Update cell text
+    // We cannot use setCellText to not trigger updateRows yet -> it has to be done after the value and row.status are updated correctly.
+    let cell = this.cell(row);
+    let oldText = cell.text;
+    let newText = field.displayText;
+    cell.setText(newText);
+
+    // Update cell value
+    // We cannot use setCellValue since it would add the update event to the updateBuffer, but we need the row update to be sync to prevent the flickering
+    this._setCellValue(row, field.value, cell);
+
+    // Update row -> Render row, trigger update event
+    // Only trigger update row event if text has changed (same as setCellText would do)
+    if (row.initialized && oldText !== newText && cell.text === newText) {
+      this.table.updateRow(row);
+    }
+
+    // Ensure display text is correct (for the rare case that the column computes a different text than the editor field).
+    this._updateCellText(row, cell);
+  }
+}
+

--- a/eclipse-scout-core/src/table/columns/LookupCallColumnEventMap.ts
+++ b/eclipse-scout-core/src/table/columns/LookupCallColumnEventMap.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {ColumnEventMap, Event, LookupCall, LookupCallColumn, LookupResult, PropertyChangeEvent, TableRow} from '../../index';
+
+export interface LookupCallColumnLookupCallDoneEvent<TValue = any, TKey = TValue, TSource extends LookupCallColumn<TValue, TKey> = LookupCallColumn<TValue, TKey>> extends Event<TSource> {
+  result: LookupResult<TKey>;
+}
+
+export interface LookupCallColumnPrepareLookupCallEvent<TValue = any, TKey = TValue, TSource extends LookupCallColumn<TValue, TKey> = LookupCallColumn<TValue, TKey>> extends Event<TSource> {
+  lookupCall: LookupCall<TKey>;
+  row?: TableRow;
+}
+
+export interface LookupCallColumnEventMap<TValue, TKey = TValue> extends ColumnEventMap {
+  'lookupCallDone': LookupCallColumnLookupCallDoneEvent<TValue, TKey>;
+  'prepareLookupCall': LookupCallColumnPrepareLookupCallEvent<TValue, TKey>;
+  'propertyChange:browseHierarchy': PropertyChangeEvent<boolean>;
+  'propertyChange:browseMaxRowCount': PropertyChangeEvent<number>;
+  'propertyChange:codeType': PropertyChangeEvent<string>;
+  'propertyChange:lookupCall': PropertyChangeEvent<LookupCall<TKey>>;
+}

--- a/eclipse-scout-core/src/table/columns/LookupCallColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/LookupCallColumnModel.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {codes, CodeType, ColumnModel, LookupCallOrModel} from '../../index';
+
+export interface LookupCallColumnModel<TValue, TKey = TValue> extends ColumnModel<TValue> {
+  /**
+   * Configures the {@link LookupCall} that is used to resolve the values and to load the proposals if the column is editable.
+   */
+  lookupCall?: LookupCallOrModel<TKey>;
+  /**
+   * If set, a {@link CodeLookupCall} is created and used for the property {@link lookupCall}.
+   *
+   * The property accepts a {@link CodeType.id} (see {@link codes.get}).
+   */
+  codeType?: string;
+  /**
+   * Configures the {@link SmartFieldModel.browseHierarchy} of the cell editor if the column is editable.
+   * Does not have an effect otherwise.
+   */
+  browseHierarchy?: boolean;
+  /**
+   * Configures the {@link SmartFieldModel.browseMaxRowCount} of the cell editor if the column is editable.
+   * Does not have an effect otherwise.
+   */
+  browseMaxRowCount?: number;
+}

--- a/eclipse-scout-core/src/table/columns/LookupColumn.ts
+++ b/eclipse-scout-core/src/table/columns/LookupColumn.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {arrays, Cell, ColumnValidationResult, LookupBox, LookupCallColumn, LookupColumnEventMap, LookupColumnModel, LookupEditor, scout, Status, TableRow, ValueField} from '../../index';
+
+/**
+ * This column is a multivalued LookupCallColumn. If editable it opens a popup containing a {@link LookupBox} in order to select multiple values.
+ */
+export class LookupColumn<TValue> extends LookupCallColumn<TValue[], TValue> implements LookupColumnModel<TValue> {
+  declare model: LookupColumnModel<TValue>;
+  declare eventMap: LookupColumnEventMap<TValue>;
+
+  distinct = false;
+
+  /** @see LookupColumnModel.distinct */
+  setDistinct(distinct: boolean) {
+    this.setProperty('distinct', distinct);
+  }
+
+  protected override _createEditor(row: TableRow): LookupEditor<TValue> {
+    const editor = scout.create(LookupEditor<TValue>, {
+      parent: this.table,
+      lookupCall: this.lookupCall,
+      codeType: this.codeType,
+      browseHierarchy: this.browseHierarchy,
+      browseMaxRowCount: this.browseMaxRowCount
+    });
+
+    editor.on('lookupCallDone', e => {
+      if (!this.distinct) {
+        return;
+      }
+
+      const valuesInOtherRows = [];
+      this.table.rows.forEach(r => {
+        if (r === row) {
+          return;
+        }
+        valuesInOtherRows.push(...arrays.ensure(this.cellValue(r)));
+      });
+      arrays.removeAll(valuesInOtherRows, this.cellValue(row));
+      e.result.lookupRows.forEach(lookupRow => {
+        if (scout.isOneOf(lookupRow.key, valuesInOtherRows)) {
+          lookupRow.setEnabled(false);
+        }
+      });
+    });
+
+    // pass editor events to column
+    editor.on('prepareLookupCall', e => this.trigger('prepareLookupCall', {
+      lookupCall: e.lookupCall,
+      row
+    }));
+    editor.on('lookupCallDone', e => this.trigger('lookupCallDone', {
+      result: e.result
+    }));
+
+    return editor;
+  }
+
+  protected override _updateEditorFromValidCell(field: ValueField<TValue[]>, cell: Cell<TValue[]>) {
+    super._updateEditorFromValidCell(field, cell);
+    field.setDisplayText(cell.text);
+  }
+
+  override isContentValid(row: TableRow): ColumnValidationResult {
+    const validationResult = super.isContentValid(row);
+
+    if (!this.distinct) {
+      return validationResult;
+    }
+
+    const cell = this.cell(row);
+    if (!this.table.rows.find(r => r !== row && arrays.containsAny(cell.value, this.cellValue(r)))) {
+      return validationResult;
+    }
+
+    const distinctErrorStatus = Status.error(this.session.text('ui.LookupColumnDistinctErrorMessage'));
+    const errorStatus = validationResult.errorStatus ? Status.error({children: [distinctErrorStatus, validationResult.errorStatus]}) : distinctErrorStatus;
+    return {
+      ...validationResult,
+      valid: errorStatus.isValid(),
+      errorStatus
+    };
+  }
+
+  protected override _formatValue(value: TValue[], row?: TableRow): string | JQuery.Promise<string> {
+    return LookupEditor.formatValues(value, this.lookupCall, lookupCall => this.trigger('prepareLookupCall', {lookupCall, row}));
+  }
+}
+

--- a/eclipse-scout-core/src/table/columns/LookupColumnEventMap.ts
+++ b/eclipse-scout-core/src/table/columns/LookupColumnEventMap.ts
@@ -7,10 +7,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {LookupCallColumnModel} from '../../index';
+import {LookupCallColumnEventMap, PropertyChangeEvent} from '../../index';
 
-export interface SmartColumnModel<TValue> extends LookupCallColumnModel<TValue> {
-  browseAutoExpandAll?: boolean;
-  browseLoadIncremental?: boolean;
-  activeFilterEnabled?: boolean;
+export interface LookupColumnEventMap<TValue> extends LookupCallColumnEventMap<TValue[], TValue> {
+  'propertyChange:distinct': PropertyChangeEvent<boolean>;
 }

--- a/eclipse-scout-core/src/table/columns/LookupColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/LookupColumnModel.ts
@@ -9,8 +9,11 @@
  */
 import {LookupCallColumnModel} from '../../index';
 
-export interface SmartColumnModel<TValue> extends LookupCallColumnModel<TValue> {
-  browseAutoExpandAll?: boolean;
-  browseLoadIncremental?: boolean;
-  activeFilterEnabled?: boolean;
+export interface LookupColumnModel<TValue> extends LookupCallColumnModel<TValue[], TValue> {
+  /**
+   * Whether the same value can be selected in multiple rows or not.
+   *
+   * Default is `false`.
+   */
+  distinct?: boolean;
 }

--- a/eclipse-scout-core/src/table/columns/LookupEditor.less
+++ b/eclipse-scout-core/src/table/columns/LookupEditor.less
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+.lookup-cell-editor-popup {
+  #scout.chooser-popup();
+  max-height: 350px;
+
+  & > .list-box {
+    border-radius: inherit;
+
+    & > .field > .table {
+      border: none;
+      display: inline-block;
+
+      & > .table-data {
+        display: inline-block;
+        padding: @proposal-chooser-padding-y @proposal-chooser-padding-x;
+
+        & > .table-row {
+          min-width: 150px;
+        }
+      }
+    }
+  }
+
+  & > .tree-box {
+    border-radius: inherit;
+
+    & > .field > .tree {
+      border: none;
+      display: inline-block;
+
+      & > .tree-data {
+        display: inline-block;
+        padding: @proposal-chooser-padding-y @proposal-chooser-padding-x;
+
+        & > .tree-node {
+          min-width: 150px;
+        }
+      }
+    }
+  }
+
+  &.animate-open {
+    #scout.transform(scaleY(0.5));
+    #scout.animation-name(grow-y);
+    #scout.animation-duration(0.125s);
+
+    &.bottom {
+      #scout.transform-origin(top);
+    }
+
+    &.top {
+      #scout.transform-origin(bottom);
+    }
+  }
+}

--- a/eclipse-scout-core/src/table/columns/LookupEditor.ts
+++ b/eclipse-scout-core/src/table/columns/LookupEditor.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {
+  CellEditorPopup, CellEditorRenderedOptions, ChildModelOf, Column, InitModelOf, ListBox, LookupBox, LookupCall, LookupEditorEventMap, LookupEditorModel, LookupEditorTreeLayout, Popup, PopupLayout, scout, scrollbars, SmartField, strings,
+  Table, Tree, TreeBox, ValueField, WidgetPopup
+} from '../../index';
+
+export class LookupEditor<TValue> extends ValueField<TValue[]> implements LookupEditorModel<TValue> {
+  declare model: LookupEditorModel<TValue>;
+  declare eventMap: LookupEditorEventMap<TValue>;
+
+  lookupCall: LookupCall<TValue> = null;
+  codeType: string = null;
+  browseHierarchy = false;
+  browseMaxRowCount = SmartField.DEFAULT_BROWSE_MAX_COUNT;
+
+  protected _popup: WidgetPopup<LookupBox<TValue>> = null;
+
+  protected override _init(model: InitModelOf<this>) {
+    super._init(model);
+
+    this.lookupCall = LookupCall.ensure(this.lookupCall, this.session);
+    this.lookupCall?.setMaxRowCount(this.browseMaxRowCount);
+    this.clearable = ValueField.Clearable.ALWAYS;
+  }
+
+  protected override _render() {
+    super._render();
+    this.$field.addClass('input-field focused');
+  }
+
+  protected override _formatValue(value: TValue[]): string | JQuery.Promise<string> {
+    if (this._popup) {
+      return this._popup.content.displayText;
+    }
+    return LookupEditor.formatValues(value, this.lookupCall, lookupCall => this.trigger('prepareLookupCall', {lookupCall}));
+  }
+
+  static formatValues<TValue>(values: TValue[], lookupCall: LookupCall<TValue>, prepareLookupCall?: (lookupCall: LookupCall<TValue>) => void): string | JQuery.Promise<string> {
+    if (!values?.length || !lookupCall) {
+      return '';
+    }
+    lookupCall = lookupCall.clone();
+    prepareLookupCall?.(lookupCall);
+    return lookupCall.textsByKeys(values)
+      .then(result => strings.join(', ', ...Object.values(result)));
+  }
+
+  protected override _renderDisplayText() {
+    super._renderDisplayText();
+    this.$field.text(this.displayText || '');
+  }
+
+  protected override _clear() {
+    this._popup?.widget('LookupBox', LookupBox<TValue>).setValue(null);
+  }
+
+  onCellEditorRendered(options: CellEditorRenderedOptions<TValue[]>) {
+    this._openPopup(options.cellEditorPopup);
+  }
+
+  protected _openPopup(cellEditorPopup: CellEditorPopup<TValue[]>): void {
+    this._popup = scout.create(WidgetPopup<LookupBox<TValue>>, {
+      parent: this,
+      anchor: this,
+      horizontalAlignment: Popup.Alignment.LEFTEDGE,
+      verticalAlignment: Popup.Alignment.BOTTOM,
+      closeOnAnchorMouseDown: false,
+      cssClass: 'lookup-cell-editor-popup',
+      animateResize: false,
+      scrollType: 'layoutAndPosition', // popup must not be closed when cell editor scrolls into view
+      content: {
+        ...this._createLookupBoxModel(),
+        id: 'LookupBox'
+      }
+    });
+
+    const lookupBox = this._popup.widget('LookupBox', LookupBox<TValue>);
+    lookupBox.on('propertyChange:lookupCall', e => e.newValue?.setMaxRowCount(this.browseMaxRowCount));
+
+    // sync value
+    lookupBox.on('propertyChange:value', e => this.setValue(e.newValue));
+
+    // pass popup events to editor
+    lookupBox.on('prepareLookupCall', e => this.trigger('prepareLookupCall', {
+      lookupCall: e.lookupCall
+    }));
+    lookupBox.on('lookupCallDone', e => this.trigger('lookupCallDone', {
+      result: e.result
+    }));
+
+    lookupBox.one('lookupCallDone', e => this._popup.open());
+
+    if (this.browseHierarchy) {
+      const tree = (lookupBox as TreeBox<TValue>).tree;
+      tree.on('render', e => tree.htmlComp.setLayout(new LookupEditorTreeLayout(tree)));
+      tree.on('nodesInserted', e => {
+        tree.setNodeExpandedRecursive(e.nodes, true);
+        tree.invalidateLayoutTree();
+      });
+    }
+
+    this._popup.on('render', e => {
+      if (!cellEditorPopup.rendered) {
+        return;
+      }
+      // Ensure cell editor is fully visible.
+      // This is important when tabbing through the cells to show the cell editor if it is not visible yet.
+      // The LookupBoxPopup also requires the center of its anchor (cell editor) to be visible, otherwise it will get invisible (see Popup._validateVisibility)
+      // This is only necessary because the cell editor itself will never be focused. Otherwise the browser would scroll it into view automatically, as it happens for cell editors of other columns.
+      scrollbars.scrollTo(cellEditorPopup.table.$data, cellEditorPopup.$container);
+      scrollbars.scrollHorizontalTo(cellEditorPopup.table.$data, cellEditorPopup.$container);
+
+      // the focus will always be inside the _popup and therefore the keyStrokes that are meant for the cellEditorPopup need to be transferred
+      // this is done by changing the $bindTarget of the cellEditorPopup's keyStrokeContext
+      const keyStrokeContext = cellEditorPopup.keyStrokeContext;
+      this.session.keyStrokeManager.uninstallKeyStrokeContext(keyStrokeContext);
+      keyStrokeContext.$bindTarget = this._popup.$container;
+      this.session.keyStrokeManager.installKeyStrokeContext(keyStrokeContext);
+
+      // Workaround for unexpected reset of popup size when lookup structure resizes (collapse/expand of tree nodes)
+      // TODO [25.1]: Remove when a better solution has been implemented (#379394)
+      this.session.layoutValidator.schedulePostValidateFunction(() => {
+        if (!this._popup) {
+          return;
+        }
+        const layout = this._popup.htmlComp.layout as PopupLayout;
+        layout.autoSize = false;
+        this._popup.position();
+      });
+    });
+
+    lookupBox.refreshLookup();
+  }
+
+  protected _createLookupBoxModel(): ChildModelOf<LookupBox<TValue>> {
+    if (this.browseHierarchy) {
+      return {
+        objectType: TreeBox<TValue>,
+        lookupCall: this.lookupCall,
+        codeType: this.codeType,
+        value: this.value,
+        cssClass: 'no-mandatory-indicator',
+        labelVisible: false,
+        statusVisible: false,
+        tree: {
+          objectType: Tree,
+          checkable: true,
+          autoCheckChildren: true
+        }
+      };
+    }
+    return {
+      objectType: ListBox<TValue>,
+      lookupCall: this.lookupCall,
+      value: this.value,
+      cssClass: 'no-mandatory-indicator',
+      labelVisible: false,
+      statusVisible: false,
+      table: {
+        objectType: Table,
+        parent: this,
+        checkable: true,
+        checkableStyle: Table.CheckableStyle.CHECKBOX_TABLE_ROW,
+        headerVisible: false,
+        footerVisible: false,
+        columns: [{
+          objectType: Column,
+          autoOptimizeWidth: true,
+          autoOptimizeMaxWidth: 450
+        }]
+      }
+    };
+  }
+}

--- a/eclipse-scout-core/src/table/columns/LookupEditorEventMap.ts
+++ b/eclipse-scout-core/src/table/columns/LookupEditorEventMap.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {Event, LookupCall, LookupEditor, LookupResult, ValueFieldEventMap} from '../../index';
+
+export interface LookupEditorLookupCallDoneEvent<TValue = any, TSource extends LookupEditor<TValue> = LookupEditor<TValue>> extends Event<TSource> {
+  result: LookupResult<TValue>;
+}
+
+export interface LookupEditorPrepareLookupCallEvent<TValue = any, TSource extends LookupEditor<TValue> = LookupEditor<TValue>> extends Event<TSource> {
+  lookupCall: LookupCall<TValue>;
+}
+
+export interface LookupEditorEventMap<TValue> extends ValueFieldEventMap<TValue[]> {
+  'lookupCallDone': LookupEditorLookupCallDoneEvent<TValue>;
+  'prepareLookupCall': LookupEditorPrepareLookupCallEvent<TValue>;
+}

--- a/eclipse-scout-core/src/table/columns/LookupEditorModel.ts
+++ b/eclipse-scout-core/src/table/columns/LookupEditorModel.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {LookupCallOrModel, ValueFieldModel} from '../../index';
+
+export interface LookupEditorModel<TValue> extends ValueFieldModel<TValue[]> {
+  /**
+   * @see LookupCallColumnModel.lookupCall
+   */
+  lookupCall?: LookupCallOrModel<TValue>;
+  /**
+   * @see LookupCallColumnModel.codeType
+   */
+  codeType?: string;
+  /**
+   * @see LookupCallColumnModel.browseHierarchy
+   */
+  browseHierarchy?: boolean;
+  /**
+   * @see LookupCallColumnModel.browseMaxRowCount
+   */
+  browseMaxRowCount?: number;
+}

--- a/eclipse-scout-core/src/table/columns/LookupEditorTreeLayout.ts
+++ b/eclipse-scout-core/src/table/columns/LookupEditorTreeLayout.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {Dimension, HtmlCompPrefSizeOptions, TreeLayout} from '../../index';
+
+export class LookupEditorTreeLayout extends TreeLayout {
+
+  override preferredLayoutSize($container: JQuery, options?: HtmlCompPrefSizeOptions): Dimension {
+    // reset the height to auto as a fixed height limits the view range which would only render the first few nodes
+    // this limitation needs to be removed in order to get the preferred width of all tree nodes
+    const height = this.tree.$data.css('height');
+    this.tree.$data.css('height', 'auto');
+    this.tree.setViewRangeSize(this.tree.calculateViewRangeSize());
+    const prefSize = super.preferredLayoutSize($container, options);
+    this.tree.$data.css('height', height);
+    return prefSize;
+  }
+}

--- a/eclipse-scout-core/src/table/columns/SmartColumn.ts
+++ b/eclipse-scout-core/src/table/columns/SmartColumn.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Cell, CodeLookupCall, codes, Column, InitModelOf, LookupCall, LookupCallOrModel, LookupRow, objects, scout, SmartColumnEventMap, SmartColumnModel, SmartField, TableRow} from '../../index';
+import {Cell, codes, LookupCallColumn, LookupCallOrModel, LookupRow, objects, scout, SmartColumnEventMap, SmartColumnModel, SmartField, TableRow} from '../../index';
 
 /**
  * Column where each cell fetches its value using a lookup call.
@@ -17,15 +17,11 @@ import {Cell, CodeLookupCall, codes, Column, InitModelOf, LookupCall, LookupCall
  * It should be used instead of the property selectedRows from Table.js which must not be used here.
  * 'row' can be null or undefined in some cases. Hence some care is needed when listening to this event.
  */
-export class SmartColumn<TValue> extends Column<TValue> {
+export class SmartColumn<TValue> extends LookupCallColumn<TValue> {
   declare model: SmartColumnModel<TValue>;
   declare eventMap: SmartColumnEventMap<TValue>;
   declare self: SmartColumn<any>;
 
-  codeType: string;
-  lookupCall: LookupCall<TValue>;
-  browseHierarchy: boolean;
-  browseMaxRowCount: number;
   browseAutoExpandAll: boolean;
   browseLoadIncremental: boolean;
   activeFilterEnabled: boolean;
@@ -34,20 +30,10 @@ export class SmartColumn<TValue> extends Column<TValue> {
 
   constructor() {
     super();
-    this.codeType = null;
-    this.lookupCall = null;
-    this.browseHierarchy = false;
-    this.browseMaxRowCount = SmartField.DEFAULT_BROWSE_MAX_COUNT;
     this.browseAutoExpandAll = true;
     this.browseLoadIncremental = false;
     this.activeFilterEnabled = false;
     this._lookupCallBatchContext = null;
-  }
-
-  protected override _init(model: InitModelOf<this>) {
-    super._init(model);
-    this._setLookupCall(this.lookupCall);
-    this._setCodeType(this.codeType);
   }
 
   protected override _initCell(cell: Cell<TValue>): Cell<TValue> {
@@ -68,42 +54,18 @@ export class SmartColumn<TValue> extends Column<TValue> {
     this.table.rows.map(row => this.cell(row)).forEach(cell => cell.setSortCode(this._calculateCellSortCode(cell)));
   }
 
-  setLookupCall(lookupCall: LookupCallOrModel<TValue>) {
-    this.setProperty('lookupCall', lookupCall);
-  }
-
-  protected _setLookupCall(lookupCall: LookupCallOrModel<TValue>) {
-    let call = LookupCall.ensure(lookupCall, this.session);
-    this._setProperty('lookupCall', call);
+  protected override _setLookupCall(lookupCall: LookupCallOrModel<TValue>) {
+    super._setLookupCall(lookupCall);
     if (this.initialized) {
       this._updateAllCellSortCodes();
     }
   }
 
-  setCodeType(codeType: string) {
-    this.setProperty('codeType', codeType);
-  }
-
-  protected _setCodeType(codeType: string) {
-    this._setProperty('codeType', codeType);
-    if (codeType) {
-      let codeLookupCall = CodeLookupCall<TValue>;
-      this.lookupCall = scout.create(codeLookupCall, {
-        session: this.session,
-        codeType: codeType
-      });
-    }
+  protected override _setCodeType(codeType: string) {
+    super._setCodeType(codeType);
     if (this.initialized) {
       this._updateAllCellSortCodes();
     }
-  }
-
-  setBrowseHierarchy(browseHierarchy: boolean) {
-    this.setProperty('browseHierarchy', browseHierarchy);
-  }
-
-  setBrowseMaxRowCount(browseMaxRowCount: number) {
-    this.setProperty('browseMaxRowCount', browseMaxRowCount);
   }
 
   setBrowseAutoExpandAll(browseAutoExpandAll: boolean) {
@@ -220,35 +182,6 @@ export class SmartColumn<TValue> extends Column<TValue> {
     });
 
     return field;
-  }
-
-  protected override _updateCellFromValidEditor(row: TableRow, field: SmartField<TValue>) {
-    // The following code is only necessary to prevent flickering because the text is updated async.
-    // Instead of only calling setCellValue which itself would update the display text, we set the text manually before calling setCellValue.
-    // This works because in most of the cases the text computed by the column will be the same as the one computed by the editor field.
-
-    // Clear error status first (regular behavior)
-    this.setCellErrorStatus(row, null);
-
-    // Update cell text
-    // We cannot use setCellText to not trigger updateRows yet -> it has to be done after the value and row.status are updated correctly.
-    let cell = this.cell(row);
-    let oldText = cell.text;
-    let newText = field.displayText;
-    cell.setText(newText);
-
-    // Update cell value
-    // We cannot use setCellValue since it would add the update event to the updateBuffer but we need the row update to be sync to prevent the flickering
-    this._setCellValue(row, field.value, cell);
-
-    // Update row -> Render row, trigger update event
-    // Only trigger update row event if text has changed (same as setCellText would do)
-    if (row.initialized && oldText !== newText && cell.text === newText) {
-      this.table.updateRow(row);
-    }
-
-    // Ensure display text is correct (for the rare case that the column computes a different text than the editor field).
-    this._updateCellText(row, cell);
   }
 
   /**

--- a/eclipse-scout-core/src/table/columns/SmartColumnEventMap.ts
+++ b/eclipse-scout-core/src/table/columns/SmartColumnEventMap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,25 +7,26 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ColumnEventMap, Event, LookupCall, LookupResult, PropertyChangeEvent, SmartColumn, TableRow} from '../../index';
+import {LookupCallColumnEventMap, LookupCallColumnLookupCallDoneEvent, LookupCallColumnPrepareLookupCallEvent, PropertyChangeEvent, SmartColumn} from '../../index';
 
-export interface SmartColumnCallDoneEvent<TValue = any, S extends SmartColumn<TValue> = SmartColumn<TValue>> extends Event<S> {
-  result: LookupResult<TValue>;
+/**
+ * @deprecated use {@link LookupCallColumnLookupCallDoneEvent} instead
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SmartColumnCallDoneEvent<TValue = any, S extends SmartColumn<TValue> = SmartColumn<TValue>> extends LookupCallColumnLookupCallDoneEvent<TValue, TValue, S> {
 }
 
-export interface SmartColumnPrepareLookupCallEvent<TValue = any, S extends SmartColumn<TValue> = SmartColumn<TValue>> extends Event<S> {
-  lookupCall: LookupCall<TValue>;
-  row?: TableRow;
+/**
+ * @deprecated use {@link LookupCallColumnPrepareLookupCallEvent} instead
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SmartColumnPrepareLookupCallEvent<TValue = any, S extends SmartColumn<TValue> = SmartColumn<TValue>> extends LookupCallColumnPrepareLookupCallEvent<TValue, TValue, S> {
 }
 
-export interface SmartColumnEventMap<TValue> extends ColumnEventMap {
+export interface SmartColumnEventMap<TValue> extends LookupCallColumnEventMap<TValue> {
   'lookupCallDone': SmartColumnCallDoneEvent<TValue>;
   'prepareLookupCall': SmartColumnPrepareLookupCallEvent<TValue>;
   'propertyChange:activeFilterEnabled': PropertyChangeEvent<boolean>;
   'propertyChange:browseAutoExpandAll': PropertyChangeEvent<boolean>;
-  'propertyChange:browseHierarchy': PropertyChangeEvent<boolean>;
   'propertyChange:browseLoadIncremental': PropertyChangeEvent<boolean>;
-  'propertyChange:browseMaxRowCount': PropertyChangeEvent<number>;
-  'propertyChange:codeType': PropertyChangeEvent<string>;
-  'propertyChange:lookupCall': PropertyChangeEvent<LookupCall<any>>;
 }

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -2362,7 +2362,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
    *          an optional options object. Shorthand version: If a string is passed instead
    *          of an object, the value is automatically converted to the option {@link ScrollToOptions.align}.
    */
-  reveal(options: ScrollToOptions | string) {
+  reveal(options?: ScrollToOptions | string) {
     if (!this.rendered) {
       return;
     }

--- a/eclipse-scout-core/test/table/columns/LookupColumnSpec.ts
+++ b/eclipse-scout-core/test/table/columns/LookupColumnSpec.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {TableSpecHelper} from '../../../src/testing/index';
+import {LookupCall, LookupColumn, LookupResult, scout, StaticLookupCall} from '../../../src';
+
+describe('LookupColumn', () => {
+  let session: SandboxSession, helper: TableSpecHelper, lookupCall: LookupCall<number>;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    helper = new TableSpecHelper(session);
+    lookupCall = scout.create(StaticLookupCall<number>, {
+      session,
+      data: [
+        [1, 'A'],
+        [2, 'B'],
+        [3, 'C'],
+        [4, 'D'],
+        [5, 'E']
+      ]
+    });
+  });
+
+  describe('formatValue', () => {
+
+    it('concatenates all selected values', async () => {
+      const table = helper.createTable({
+        columns: [{
+          objectType: LookupColumn,
+          lookupCall
+        }]
+      });
+
+      table.insertRow({
+        cells: [null]
+      });
+      const column = table.columns[0];
+      const row = table.rows[0];
+
+      expect(column.cellText(row)).toBe('');
+
+      column.setCellValue(row, [2]);
+      await table.when('rowsUpdated');
+      expect(column.cellText(row)).toBe('B');
+
+      column.setCellValue(row, [1, 3, 4]);
+      await table.when('rowsUpdated');
+      expect(column.cellText(row)).toBe('A, C, D');
+
+      column.setCellValue(row, [5, 6]);
+      await table.when('rowsUpdated');
+      expect(column.cellText(row)).toBe('E');
+    });
+  });
+
+  describe('isContentValid', () => {
+
+    it('checks if values are distinct if distinct-flag is set', () => {
+      const table = helper.createTable({
+        columns: [{
+          objectType: LookupColumn,
+          lookupCall
+        }]
+      });
+
+      table.insertRows([
+        {cells: [null]},
+        {cells: [[1]]},
+        {cells: [[2, 3]]},
+        {cells: [[4, 5]]}
+      ]);
+      const column = table.columns[0] as LookupColumn<number>;
+      const [row0, row1, row2, row3] = table.rows;
+
+      expect(column.isContentValid(row0).valid).toBeTrue();
+      expect(column.isContentValid(row1).valid).toBeTrue();
+      expect(column.isContentValid(row2).valid).toBeTrue();
+      expect(column.isContentValid(row3).valid).toBeTrue();
+
+      column.setDistinct(true);
+
+      expect(column.isContentValid(row0).valid).toBeTrue();
+      expect(column.isContentValid(row1).valid).toBeTrue();
+      expect(column.isContentValid(row2).valid).toBeTrue();
+      expect(column.isContentValid(row3).valid).toBeTrue();
+
+      column.setDistinct(false);
+      table.insertRow({cells: [[1, 5]]});
+      const row4 = table.rows[4];
+
+      expect(column.isContentValid(row0).valid).toBeTrue();
+      expect(column.isContentValid(row1).valid).toBeTrue();
+      expect(column.isContentValid(row2).valid).toBeTrue();
+      expect(column.isContentValid(row3).valid).toBeTrue();
+      expect(column.isContentValid(row4).valid).toBeTrue();
+
+      column.setDistinct(true);
+
+      expect(column.isContentValid(row0).valid).toBeTrue();
+      expect(column.isContentValid(row1).valid).toBeFalse();
+      expect(column.isContentValid(row2).valid).toBeTrue();
+      expect(column.isContentValid(row3).valid).toBeFalse();
+      expect(column.isContentValid(row4).valid).toBeFalse();
+    });
+  });
+
+  describe('editor', () => {
+
+    it('disables already selected rows if distinct-flag is set', async () => {
+      const table = helper.createTable({
+        columns: [{
+          objectType: LookupColumn,
+          editable: true,
+          lookupCall
+        }]
+      });
+      table.render();
+
+      table.insertRows([
+        {cells: [null]},
+        {cells: [[1]]},
+        {cells: [[2, 3]]},
+        {cells: [[1]]}
+      ]);
+      const column = table.columns[0] as LookupColumn<number>;
+      const [row0, row1, row2, row3] = table.rows;
+
+      table.prepareCellEdit(column, row0);
+      await expectLookupResultEnabledState(column, new Map([[1, true], [2, true], [3, true], [4, true], [5, true]]));
+      table.completeCellEdit();
+
+      table.prepareCellEdit(column, row1);
+      await expectLookupResultEnabledState(column, new Map([[1, true], [2, true], [3, true], [4, true], [5, true]]));
+      table.completeCellEdit();
+
+      table.prepareCellEdit(column, row2);
+      await expectLookupResultEnabledState(column, new Map([[1, true], [2, true], [3, true], [4, true], [5, true]]));
+      table.completeCellEdit();
+
+      table.prepareCellEdit(column, row3);
+      await expectLookupResultEnabledState(column, new Map([[1, true], [2, true], [3, true], [4, true], [5, true]]));
+      table.completeCellEdit();
+
+      column.setDistinct(true);
+
+      table.prepareCellEdit(column, row0);
+      await expectLookupResultEnabledState(column, new Map([[1, false], [2, false], [3, false], [4, true], [5, true]]));
+      table.completeCellEdit();
+
+      table.prepareCellEdit(column, row1);
+      await expectLookupResultEnabledState(column, new Map([[1, true], [2, false], [3, false], [4, true], [5, true]]));
+      table.completeCellEdit();
+
+      table.prepareCellEdit(column, row2);
+      await expectLookupResultEnabledState(column, new Map([[1, false], [2, true], [3, true], [4, true], [5, true]]));
+      table.completeCellEdit();
+
+      table.prepareCellEdit(column, row3);
+      await expectLookupResultEnabledState(column, new Map([[1, true], [2, false], [3, false], [4, true], [5, true]]));
+      table.completeCellEdit();
+    });
+
+    async function expectLookupResultEnabledState(column: LookupColumn<number>, expectedEnabledState: Map<number, boolean>) {
+      const lookupCallDoneEvent = await column.when('lookupCallDone');
+      const enabledState = getLookupResultEnabledState(lookupCallDoneEvent.result);
+      expect(enabledState).toEqual(expectedEnabledState);
+    }
+
+    function getLookupResultEnabledState(result: LookupResult<number>): Map<number, boolean> {
+      const enabledState = new Map();
+      result.lookupRows.forEach(row => enabledState.set(row.key, row.enabled));
+      return enabledState;
+    }
+  });
+});

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts.properties
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+# Copyright (c) 2010, 2025 BSI Business Systems Integration AG
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -82,6 +82,7 @@ ui.Login=Log in
 ui.LoginAgain=Log in again
 ui.LoginFailed=Login failed
 ui.LogoutSuccessful=You have successfully logged out.\r\nSee you soon\!
+ui.LookupColumnDistinctErrorMessage=The same value may not be selected in more than one row.
 ui.Map=Map
 ui.Maximum=Maximum
 ui.Minimum=Minimum

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_de.properties
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_de.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+# Copyright (c) 2010, 2025 BSI Business Systems Integration AG
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -82,6 +82,7 @@ ui.Login=Anmelden
 ui.LoginAgain=Erneut anmelden
 ui.LoginFailed=Anmeldung fehlgeschlagen
 ui.LogoutSuccessful=Sie haben sich erfolgreich abgemeldet.\r\nAuf Wiedersehen\!
+ui.LookupColumnDistinctErrorMessage=Derselbe Wert darf nicht in mehr als einer Zeile ausgewählt werden.
 ui.Map=Karte
 ui.Maximum=Maximum
 ui.Minimum=Minimum


### PR DESCRIPTION
The column is a multivalued smart column that displays a LookupBox (List or Tree) when editable.
The column supports distinct selection, i.e. the same value is not selectable in more than one row.
Move shared code for SmartColumn and LookupColumn to LookupCallColumn.

Implement StaticLookupCall._getByKeys as it is used by e.g. LookupColumn.formatValues.