### PR TITLE
UiNotificationResource: prevent NPE when request is null

### DIFF
--- a/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationResource.java
+++ b/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,6 +49,9 @@ public class UiNotificationResource implements IRestResource {
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   public void get(UiNotificationRequest request, @Suspended AsyncResponse asyncResponse, @Context HttpServletRequest httpReq) {
+    if (request == null) {
+      throw new BadRequestException("Request must not be null");
+    }
     String userId = getUserId();
     List<TopicDo> topics = request.getTopics();
     LOG.debug("Received request for topics {} and user {}", topics, userId);


### PR DESCRIPTION
There may be cases where the request body is lost somewhere on the way. This should not result in an NPE because this is translated to HTTP status 500 Internal Server Error. Instead, this should be treated like an empty list of topics -> HTTP status 400 Bad Request.

412226