### PR TITLE
UiNotificationPoller: reduce log level on error

### DIFF
--- a/eclipse-scout-core/src/uinotification/UiNotificationPoller.ts
+++ b/eclipse-scout-core/src/uinotification/UiNotificationPoller.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  ajax, AjaxCall, AjaxError, arrays, BackgroundJobPollingStatus, config, ConfigProperties, ErrorHandler, InitModelOf, JsonErrorResponse, MainConfigProperties, objects, PropertyEventEmitter, scout, Session, TopicDo, UiNotificationDo,
-  UiNotificationPollerEventMap, UiNotificationRequest, UiNotificationResponse, UiNotificationSystem
+  ajax, AjaxCall, AjaxError, App, arrays, BackgroundJobPollingStatus, config, ConfigProperties, ErrorHandler, InitModelOf, JsonErrorResponse, LogLevel, MainConfigProperties, objects, PropertyEventEmitter, scout, Session, TopicDo,
+  UiNotificationDo, UiNotificationPollerEventMap, UiNotificationRequest, UiNotificationResponse, UiNotificationSystem
 } from '../index';
 import $ from 'jquery';
 
@@ -128,11 +128,12 @@ export class UiNotificationPoller extends PropertyEventEmitter {
 
   protected _poll() {
     this._call?.abort(); // abort in case there is already a call running
-    const request = scout.create(UiNotificationRequest, {topics: this.topicsWithLastNotifications});
-    this._call = ajax.createCallDataObject({
+    const ajaxOptions = {
       url: this.url,
       timeout: this.requestTimeout
-    }, request, {
+    };
+    const request = scout.create(UiNotificationRequest, {topics: this.topicsWithLastNotifications});
+    this._call = ajax.createCallDataObject(ajaxOptions, request, {
       maxRetries: -1, // unlimited retries on connection errors
       retryIntervals: UiNotificationPoller.CONNECTION_ERROR_RETRY_INTERVALS
     });
@@ -230,7 +231,11 @@ export class UiNotificationPoller extends PropertyEventEmitter {
     }
 
     this.trigger('error', {error});
-    scout.create(ErrorHandler, {displayError: false, sendError: true}).handle(error);
+
+    App.get().errorHandler.analyzeError(error).then(errorInfo => {
+      scout.getSession().sendLogRequest(`UI notification poller failed, call will be retried in ${UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL} ms.\nError message:\n${errorInfo.log}\n()`, LogLevel.INFO);
+    });
+
     this._schedulePoll(UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL);
   }
 

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonMessageRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonMessageRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -288,7 +288,7 @@ public class JsonMessageRequestHandler extends AbstractUiServletRequestHandler {
   protected String truncateLogMessage(String message) {
     if (message.length() > 10_000) {
       // Truncate the message to prevent log inflation by malicious log requests
-      return message.substring(0, 10_000) + "...";
+      return message.substring(0, 9_500) + "[---------- " + (message.length() - 10_000) + " characters omitted ----------]" + message.substring(message.length() - 500);
     }
     return message;
   }


### PR DESCRIPTION
When a notification poll request fails, it is automatically retried. It is therefore not necessary to log the error on level ERROR, since no immediate action has to be taken to resolve this error. However, the error is still logged on level info to be able to analyze connection problems.

The server-side logger truncates the message for security reasons. To help with analysis, the message is now truncated 500 characters before the end.

412262