### PR TITLE
Page: remove destroyed detail form and table from page

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -137,9 +137,11 @@ export class Page extends TreeNode implements PageModel {
     super._destroy();
     if (this.detailTable) {
       this.detailTable.destroy();
+      this.detailTable = null;
     }
     if (this.detailForm) {
       this.detailForm.destroy();
+      this.detailForm = null;
     }
     this.trigger('destroy');
   }
@@ -433,6 +435,11 @@ export class Page extends TreeNode implements PageModel {
     }
     this.detailForm = form;
     if (form) {
+      form.one('destroy', () => {
+        if (this.detailForm === form) {
+          this.detailForm = null;
+        }
+      });
       this._initDetailForm(form);
     }
     this.triggerPropertyChange('detailForm', oldDetailForm, form);
@@ -457,6 +464,11 @@ export class Page extends TreeNode implements PageModel {
     }
     this.detailTable = table;
     if (table) {
+      table.one('destroy', () => {
+        if (this.detailTable === table) {
+          this.detailTable = null;
+        }
+      });
       this._initDetailTable(table);
     }
     this.triggerPropertyChange('detailTable', oldDetailTable, table);

--- a/eclipse-scout-core/test/desktop/outline/pages/PageSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, Form, GroupBox, Outline, Page, PageWithTable, scout, Table, Widget} from '../../../../src';
+import {arrays, Form, GroupBox, Outline, Page, PageWithNodes, PageWithTable, scout, Table, Widget} from '../../../../src';
 import {MenuSpecHelper, OutlineSpecHelper, TableSpecHelper} from '../../../../src/testing';
 import {ChildModelOf} from '../../../../src/scout';
 
@@ -73,6 +73,47 @@ describe('Page', () => {
     page.setDetailTable(newTable);
     expect(oldTable.destroyed).toBe(true);
     expect(newTable.destroyed).toBe(false);
+  });
+
+  it('detailTable and detailForm are destroyed when page is destroyed', () => {
+    session.desktop.setBenchVisible(true);
+    session.desktop.setOutline(outline);
+
+    let parentPage = scout.create(PageWithNodes, {
+      parent: outline,
+      childNodes: [
+        {
+          objectType: Page,
+          detailForm: {
+            objectType: Form,
+            rootGroupBox: {
+              objectType: GroupBox
+            }
+          },
+          detailFormVisible: true,
+          detailTable: {
+            objectType: Table
+          },
+          detailTableVisible: true
+        }
+      ]
+    });
+    outline.insertNode(parentPage);
+    outline.expandNode(parentPage);
+    let page = parentPage.childNodes[0];
+    outline.selectNode(page);
+
+    expect(page.detailTable).toBeInstanceOf(Table);
+    expect(page.detailForm).toBeInstanceOf(Widget);
+    let detailTable = page.detailTable;
+    let detailForm = page.detailForm;
+
+    outline.deleteNode(page);
+    expect(page.destroyed).toBe(true);
+    expect(detailForm.destroyed).toBe(true);
+    expect(detailTable.destroyed).toBe(true);
+    expect(page.detailForm).toBe(null);
+    expect(page.detailTable).toBe(null);
   });
 
   it('detailTable and detailForm are enhanced with parent table page menus', () => {


### PR DESCRIPTION
A page may reference a detailForm or a detailTable. If the corresponding widget is destroyed, the member should also be set to null. Otherwise, it may happen that the destroyed widget is still accessed, creating the potential for unexpected errors ('Widget is destroyed').

For example, if a node page with both a detail form and a detail table is destroyed while still being selected, the DesktopBench will be triggered by a pageChanged event and tries to update the outline content with an already destroyed widget.

(cherry picked from commit 08be3bb1f4fdafce4f5c71d78e08f90a31cb7044)