### PR TITLE
ForceHttp2DefaultAsyncHttpClientManager increase max connections

### DIFF
--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/ForceHttp2DefaultAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/ForceHttp2DefaultAsyncHttpClientManager.java
@@ -12,6 +12,8 @@ package org.eclipse.scout.rt.shared.http.async;
 import org.apache.hc.client5.http.config.TlsConfig;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
+import org.eclipse.scout.rt.platform.config.AbstractIntegerConfigProperty;
+import org.eclipse.scout.rt.platform.config.CONFIG;
 
 /**
  * Extension of {@link DefaultAsyncHttpClientManager} to force HTTP/2 protocol.
@@ -29,5 +31,62 @@ public class ForceHttp2DefaultAsyncHttpClientManager extends DefaultAsyncHttpCli
   protected void interceptCreateConnectionManager(PoolingAsyncClientConnectionManagerBuilder builder) {
     // this setting seems to be used also for non-encrypted connections
     builder.setDefaultTlsConfig(TlsConfig.custom().setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_2).build());
+
+    Integer maxTotal = CONFIG.getPropertyValue(AsyncForceHttp2MaxConnectionsTotalProperty.class);
+    if (maxTotal != null && maxTotal > 0) {
+      builder.setMaxConnTotal(maxTotal);
+    }
+    Integer defaultMaxPerRoute = CONFIG.getPropertyValue(AsyncForceHttp2MaxConnectionsPerRouteProperty.class);
+    if (defaultMaxPerRoute > 0) {
+      builder.setMaxConnPerRoute(defaultMaxPerRoute);
+    }
+  }
+
+  /**
+   * <p>
+   * Configuration property to define the default maximum connections per route property for the {@link ForceHttp2DefaultAsyncHttpClientManager}.
+   * </p>
+   */
+  public static class AsyncForceHttp2MaxConnectionsPerRouteProperty extends AbstractIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 2048;
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.http.async.forceHttp2.maxConnectionsPerRoute";
+    }
+
+    @Override
+    @SuppressWarnings("findbugs:VA_FORMAT_STRING_USES_NEWLINE")
+    public String description() {
+      return String.format("Specifies the default maximum connections per route property for the default async force-http2 HTTP client.\n"
+          + "Default value is %d.", getDefaultValue());
+    }
+  }
+
+  /**
+   * Configuration property to define the default maximum connections property for the {@link ForceHttp2DefaultAsyncHttpClientManager}.
+   */
+  public static class AsyncForceHttp2MaxConnectionsTotalProperty extends AbstractIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 2048;
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.http.async.forceHttp2.maxConnectionsTotal";
+    }
+
+    @Override
+    @SuppressWarnings("findbugs:VA_FORMAT_STRING_USES_NEWLINE")
+    public String description() {
+      return String.format("Specifies the default total maximum connections property for the default async force-http2 HTTP client.\n"
+          + "The default value is %d.", getDefaultValue());
+    }
   }
 }


### PR DESCRIPTION
Introduce new properties AsyncForceHttp2MaxConnectionsTotalProperty and AsyncForceHttp2MaxConnectionsPerRouteProperty using 2048 as default.

407759