### PR TITLE
App: prevent endless page reloads

### DIFF
--- a/eclipse-scout-core/src/App.ts
+++ b/eclipse-scout-core/src/App.ts
@@ -221,8 +221,8 @@ export class App extends EventEmitter {
     ].filter(bootstrapper => !!bootstrapper);
 
     return $.promiseAll(this._doBootstrap())
-      .then(this._bootstrapDone.bind(this, options))
-      .catch(this._bootstrapFail.bind(this, options));
+      .catch(this._bootstrapFail.bind(this, options))
+      .then(this._bootstrapDone.bind(this, options)); // BootstrapDone must only be executed if there are no boostrap errors
   }
 
   protected _defaultBootstrappers(options: AppBootstrapOptions): (() => JQuery.Promise<void>)[] {


### PR DESCRIPTION
If a bootstrap event handler fails, _bootstrapFail is executed which reloads the page because _bootstrapDone removed
bootstrapErrorPageReload from the web storage.
-> _bootstrapFail must not be called for errors inside bootstrapDone.