### PR TITLE
ServiceTunnel: use signed ids when necessary

### DIFF
--- a/org.eclipse.scout.rt.server.test/pom.xml
+++ b/org.eclipse.scout.rt.server.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+  ~ Copyright (c) 2010, 2025 BSI Business Systems Integration AG
   ~
   ~ This program and the accompanying materials are made
   ~ available under the terms of the Eclipse Public License 2.0
@@ -38,6 +38,14 @@
       <groupId>org.eclipse.scout.rt</groupId>
       <artifactId>org.eclipse.scout.rt.shared.test</artifactId>
     </dependency>
+
+    <!-- Jackson used to execute tests using JSON-serialization -->
+    <dependency>
+      <groupId>org.eclipse.scout.rt</groupId>
+      <artifactId>org.eclipse.scout.rt.jackson.test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/server/servicetunnel/EchoService.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/server/servicetunnel/EchoService.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.servicetunnel;
+
+public class EchoService implements IEchoService {
+
+  @Override
+  public Object echo(Object o) {
+    return o;
+  }
+}

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/server/servicetunnel/IEchoService.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/server/servicetunnel/IEchoService.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.servicetunnel;
+
+import org.eclipse.scout.rt.platform.service.IService;
+import org.eclipse.scout.rt.shared.TunnelToServer;
+
+@TunnelToServer
+public interface IEchoService extends IService {
+
+  Object echo(Object o);
+}

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/server/servicetunnel/SingleIdDo.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/server/servicetunnel/SingleIdDo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.servicetunnel;
+
+import jakarta.annotation.Generated;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.id.IId;
+
+@TypeName("scout.SingleId")
+public class SingleIdDo extends DoEntity {
+
+  public DoValue<IId> id() {
+    return doValue("id");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public SingleIdDo withId(IId id) {
+    id().set(id);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IId getId() {
+    return id().get();
+  }
+}

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelIdSignatureTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelIdSignatureTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.servicetunnel;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.*;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.eclipse.scout.rt.dataobject.DataObjectHolder;
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoEntityHolder;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureIntegerId;
+import org.eclipse.scout.rt.dataobject.id.IdCodec;
+import org.eclipse.scout.rt.dataobject.id.IdCodec.IdCodecFlag;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.platform.context.RunContexts;
+import org.eclipse.scout.rt.platform.exception.PlatformException;
+import org.eclipse.scout.rt.platform.util.ImmutablePair;
+import org.eclipse.scout.rt.platform.util.Pair;
+import org.eclipse.scout.rt.server.ServiceTunnelServlet;
+import org.eclipse.scout.rt.server.TestServerSession;
+import org.eclipse.scout.rt.server.commons.BufferedServletInputStream;
+import org.eclipse.scout.rt.server.commons.BufferedServletOutputStream;
+import org.eclipse.scout.rt.shared.SharedConfigProperties.ServiceTunnelTargetUrlProperty;
+import org.eclipse.scout.rt.shared.http.AbstractHttpTransportManager;
+import org.eclipse.scout.rt.shared.http.IHttpTransportManager;
+import org.eclipse.scout.rt.shared.servicetunnel.IServiceTunnelContentHandler;
+import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelOptions;
+import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
+import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelResponse;
+import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelUtility;
+import org.eclipse.scout.rt.shared.servicetunnel.http.HttpServiceTunnel;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.eclipse.scout.rt.testing.platform.mock.BeanMock;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.eclipse.scout.rt.testing.server.TestHttpSession;
+import org.eclipse.scout.rt.testing.server.runner.RunWithServerSession;
+import org.eclipse.scout.rt.testing.server.runner.ServerTestRunner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+
+@RunWith(ServerTestRunner.class)
+@RunWithServerSession(TestServerSession.class)
+@RunWithSubject("default")
+public class ServiceTunnelIdSignatureTest {
+
+  protected static List<IBean<?>> s_beans;
+
+  @BeanMock
+  private ServiceTunnelTargetUrlProperty mockUrl;
+
+  @BeforeClass
+  public static void beforeClass() {
+    s_beans = BeanTestingHelper.get().registerBeans(
+        new BeanMetaData(P_IdCodec.class).withReplace(true),
+        new BeanMetaData(P_HttpServiceTunnel.class).withReplace(true).withApplicationScoped(true)
+    );
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    BeanTestingHelper.get().unregisterBeans(s_beans);
+  }
+
+  @Test
+  public void testServiceTunnel() throws IOException {
+    // unsigned request
+    var echoResponseIdSignatureRequestHeaderPair = callServiceTunnelEchoService(new EchoBean(createSingleIdDo()), new EchoBean(createSingleIdDoRaw(false)), false);
+    var echoBean = assertInstance(echoResponseIdSignatureRequestHeaderPair.getLeft(), EchoBean.class);
+    assertEchoBean(createSingleIdDo(), echoBean);
+    assertFalse(Boolean.TRUE.toString().equals(echoResponseIdSignatureRequestHeaderPair.getRight()));
+
+    assertThrows(PlatformException.class, () -> callServiceTunnelEchoService(new EchoBean(createSingleIdDo()), new EchoBean(createSingleIdDoRaw(true)), false));
+
+    // signed request
+    assertThrows(PlatformException.class, () -> callServiceTunnelEchoService(new EchoBean(createSingleIdDo()), new EchoBean(createSingleIdDoRaw(false)), true));
+
+    echoResponseIdSignatureRequestHeaderPair = callServiceTunnelEchoService(new EchoBean(createSingleIdDo()), new EchoBean(createSingleIdDoRaw(true)), true);
+    echoBean = assertInstance(echoResponseIdSignatureRequestHeaderPair.getLeft(), EchoBean.class);
+    assertEchoBean(createSingleIdDo(), echoBean);
+    assertTrue(Boolean.TRUE.toString().equals(echoResponseIdSignatureRequestHeaderPair.getRight()));
+  }
+
+  protected Pair<Object /* echo response */, String /* id signature request header */> callServiceTunnelEchoService(Object o, Object echoResponseRaw, boolean idSignature) throws IOException {
+    when(mockUrl.getValue()).thenReturn("http://localhost");
+
+    var serviceTunnelContentHandler = BEANS.get(IServiceTunnelContentHandler.class);
+    serviceTunnelContentHandler.initialize();
+
+    // create service tunnel response
+    var serviceTunnelResponseOutputStream = new ByteArrayOutputStream();
+    serviceTunnelContentHandler.writeResponse(serviceTunnelResponseOutputStream, new ServiceTunnelResponse(echoResponseRaw));
+
+    // create http response returning service tunnel response
+    var response = new MockLowLevelHttpResponse().setContent(serviceTunnelResponseOutputStream.toByteArray());
+    BEANS.get(P_HttpServiceTunnel.class).setNextLowLevelHttpResponse(response);
+
+    // call echo service
+    var echoResponse = ServiceTunnelUtility.createProxy(IEchoService.class, ServiceTunnelOptions.create().withIdSignature(idSignature)).echo(o);
+
+    // get id signature request header
+    var request = BEANS.get(P_HttpServiceTunnel.class).getLastHttpResponse().getRequest();
+    var idSignatureRequestHeader = (String) request.getHeaders().get(HttpServiceTunnel.ID_SIGNATURE_HTTP_HEADER);
+
+    return ImmutablePair.of(echoResponse, idSignatureRequestHeader);
+  }
+
+  @Test
+  public void testServiceTunnelServlet() throws IOException, ServletException {
+    // unsigned request
+    assertServiceTunnelResponse(createSingleIdDo(), callServiceTunnelServletEchoService(new EchoBean(createSingleIdDo()), false));
+    assertServiceTunnelResponse(createSingleIdDo(), callServiceTunnelServletEchoService(new EchoBean(createSingleIdDoRaw(false)), false));
+    assertNull(callServiceTunnelServletEchoService(new EchoBean(createSingleIdDoRaw(true)), false));
+
+    // signed request
+    assertServiceTunnelResponse(createSingleIdDo(), callServiceTunnelServletEchoService(new EchoBean(createSingleIdDo()), true));
+    assertNull(callServiceTunnelServletEchoService(new EchoBean(createSingleIdDoRaw(false)), true));
+    assertServiceTunnelResponse(createSingleIdDo(), callServiceTunnelServletEchoService(new EchoBean(createSingleIdDoRaw(true)), true));
+  }
+
+  protected ServiceTunnelResponse callServiceTunnelServletEchoService(Object o, boolean idSignature) throws IOException, ServletException {
+    // create service tunnel request
+    var serviceTunnelRequest = new ServiceTunnelRequest(IEchoService.class.getName(), "echo", new Class[]{Object.class}, new Object[]{o});
+    serviceTunnelRequest.setUserAgent("UNKNOWN|UNKNOWN|UNKNOWN|UNKNOWN|UNKNOWN");
+    serviceTunnelRequest.setSessionId("4242");
+
+    var serviceTunnelContentHandler = BEANS.get(IServiceTunnelContentHandler.class);
+    serviceTunnelContentHandler.initialize();
+
+    // create servlet input stream returning the service tunnel request
+    var serviceTunnelRequestOutputStream = new ByteArrayOutputStream();
+    RunContexts.copyCurrent()
+        .withProperty(ServiceTunnelOptions.ID_SIGNATURE_PROP, idSignature)
+        .run(() -> serviceTunnelContentHandler.writeRequest(serviceTunnelRequestOutputStream, serviceTunnelRequest));
+    var servletInputStream = new BufferedServletInputStream(new ByteArrayInputStream(serviceTunnelRequestOutputStream.toByteArray()));
+
+    // create request returning the servlet input stream
+    var httpSession = new TestHttpSession("42");
+    var request = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(request.getMethod()).thenReturn("POST");
+    Mockito.when(request.getInputStream()).thenReturn(servletInputStream);
+    Mockito.when(request.getSession()).thenReturn(httpSession);
+    Mockito.when(request.getSession(false)).thenReturn(httpSession);
+    Mockito.when(request.getHeader(HttpServiceTunnel.ID_SIGNATURE_HTTP_HEADER)).thenReturn("" + idSignature);
+
+    // create servlet output stream and response to collect service tunnel response
+    var servletOutputStream = new BufferedServletOutputStream();
+    var response = Mockito.mock(HttpServletResponse.class);
+    Mockito.when(response.getOutputStream()).thenReturn(servletOutputStream);
+
+    // call service tunnel servlet
+    new ServiceTunnelServlet().service(request, response);
+
+    // error occurred -> no response to read
+    if (servletOutputStream.getContent().length == 0) {
+      return null;
+    }
+
+    // read service tunnel response
+    return RunContexts.copyCurrent()
+        .withProperty(ServiceTunnelOptions.ID_SIGNATURE_PROP, idSignature)
+        .call(() -> serviceTunnelContentHandler.readResponse(new ByteArrayInputStream(servletOutputStream.getContent())));
+  }
+
+  protected static void assertServiceTunnelResponse(IDoEntity expectedDoEntity, ServiceTunnelResponse serviceTunnelResponse) {
+    assertNotNull(serviceTunnelResponse);
+
+    assertNotNull(serviceTunnelResponse.getData());
+    assertNull(serviceTunnelResponse.getException());
+
+    var echoBean = assertInstance(serviceTunnelResponse.getData(), EchoBean.class);
+    assertEchoBean(expectedDoEntity, echoBean);
+  }
+
+  protected static void assertEchoBean(IDoEntity expectedDoEntity, EchoBean echoBean) {
+    assertEquals(expectedDoEntity, echoBean.getDoEntity());
+    assertEquals(expectedDoEntity, echoBean.getDoEntityDoEntityHolder());
+    assertEquals(expectedDoEntity, echoBean.getDoEntityDataObjectHolder());
+  }
+
+  protected SingleIdDo createSingleIdDo() {
+    return BEANS.get(SingleIdDo.class)
+        .withId(FixtureIntegerId.of(42));
+  }
+
+  protected IDoEntity createSingleIdDoRaw(boolean idSignature) {
+    var singleIdDoRaw = BEANS.get(DoEntity.class);
+    singleIdDoRaw.put("_type", "scout.SingleId");
+    singleIdDoRaw.put("id", BEANS.get(IdCodec.class).toQualified(FixtureIntegerId.of(42), idSignature ? IdCodecFlag.SIGNATURE : null));
+    return singleIdDoRaw;
+  }
+
+  protected static class EchoBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final IDoEntity m_doEntity;
+    private final DoEntityHolder<IDoEntity> m_doEntityDoEntityHolder = new DoEntityHolder<>();
+    private final DataObjectHolder<IDoEntity> m_doEntityDataObjectHolder = new DataObjectHolder<>();
+
+    public EchoBean(IDoEntity doEntity) {
+      m_doEntity = doEntity;
+      m_doEntityDoEntityHolder.setValue(doEntity);
+      m_doEntityDataObjectHolder.setValue(doEntity);
+    }
+
+    public IDoEntity getDoEntity() {
+      return m_doEntity;
+    }
+
+    public IDoEntity getDoEntityDoEntityHolder() {
+      return m_doEntityDoEntityHolder.getValue();
+    }
+
+    public IDoEntity getDoEntityDataObjectHolder() {
+      return m_doEntityDataObjectHolder.getValue();
+    }
+  }
+
+  protected static class P_IdCodec extends IdCodec {
+
+    @Override
+    protected byte[] getIdSignaturePassword() {
+      return "42".getBytes(StandardCharsets.UTF_8);
+    }
+  }
+
+  protected static class P_HttpServiceTunnel extends HttpServiceTunnel {
+
+    private MockHttpTransport m_transport;
+    private HttpResponse m_lastResponse;
+
+    public void setNextLowLevelHttpResponse(MockLowLevelHttpResponse response) {
+      m_transport = new MockHttpTransport.Builder()
+          .setLowLevelHttpResponse(response)
+          .build();
+    }
+
+    public HttpResponse getLastHttpResponse() {
+      return m_lastResponse;
+    }
+
+    @Override
+    protected HttpResponse executeRequestInternal(ServiceTunnelRequest call, byte[] callData) throws IOException {
+      m_lastResponse = null;
+
+      m_lastResponse = super.executeRequestInternal(call, callData);
+      m_transport = null;
+
+      return m_lastResponse;
+    }
+
+    @Override
+    protected IHttpTransportManager getHttpTransportManager() {
+
+      return new AbstractHttpTransportManager() {
+
+        @Override
+        public String getName() {
+          return "scout.transport.test-service-tunnel-id-signature";
+        }
+
+        @Override
+        public HttpTransport getHttpTransport() {
+          return m_transport;
+        }
+
+        @Override
+        public HttpRequestFactory getHttpRequestFactory() {
+          return m_transport.createRequestFactory(createHttpRequestInitializer());
+        }
+      };
+    }
+  }
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/ServiceTunnelServlet.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/ServiceTunnelServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@ import static org.eclipse.scout.rt.server.commons.opentelemetry.SpanNamePropagat
 
 import java.io.IOException;
 import java.security.AccessController;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
 
@@ -47,8 +48,10 @@ import org.eclipse.scout.rt.server.context.RunMonitorCancelRegistry.IRegistratio
 import org.eclipse.scout.rt.server.context.ServerRunContext;
 import org.eclipse.scout.rt.server.context.ServerRunContexts;
 import org.eclipse.scout.rt.shared.servicetunnel.IServiceTunnelContentHandler;
+import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelOptions;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelResponse;
+import org.eclipse.scout.rt.shared.servicetunnel.http.HttpServiceTunnel;
 import org.eclipse.scout.rt.shared.ui.UserAgents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,6 +131,7 @@ public class ServiceTunnelServlet extends AbstractHttpServlet {
       m_serverRunContextProducer.get()
           .getInnerRunContextProducer()
           .produce(servletRequest, servletResponse)
+          .withProperties(enableSignature(servletRequest) ? Map.of(ServiceTunnelOptions.ID_SIGNATURE_PROP, true) : Map.of())
           .run(() -> {
             ServiceTunnelRequest serviceRequest = deserializeServiceRequest();
             ServiceTunnelResponse serviceResponse = doPost(serviceRequest);
@@ -177,6 +181,14 @@ public class ServiceTunnelServlet extends AbstractHttpServlet {
         servletResponse.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       }
     }
+  }
+
+  /**
+   * Check the {@link HttpServletRequest} if signature creation needs to be enabled. Default implementation checks
+   * the {@link HttpServiceTunnel#ID_SIGNATURE_HTTP_HEADER}.
+   */
+  protected boolean enableSignature(HttpServletRequest servletRequest) {
+    return Boolean.TRUE.toString().equalsIgnoreCase(servletRequest.getHeader(HttpServiceTunnel.ID_SIGNATURE_HTTP_HEADER));
   }
 
   protected ServiceTunnelResponse doPost(ServiceTunnelRequest serviceRequest) {

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/servicetunnel/RegisterTunnelToServerPlatformListenerTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/servicetunnel/RegisterTunnelToServerPlatformListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  */
 package org.eclipse.scout.rt.shared.servicetunnel;
 
+import static org.eclipse.scout.rt.platform.util.Assertions.assertInstance;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -53,6 +54,8 @@ public class RegisterTunnelToServerPlatformListenerTest {
     indexClass(indexer, IFixtureTunnelToServerEx2.class);
     indexClass(indexer, IFixtureTunnelToServerEx3.class);
     indexClass(indexer, FixtureTunnelToServerEx3Impl.class);
+    indexClass(indexer, ISignedTunnelToServer.class);
+    indexClass(indexer, IUnsignedTunnelToServer.class);
     s_classInventory = new JandexClassInventory(indexer.complete());
   }
 
@@ -143,6 +146,19 @@ public class RegisterTunnelToServerPlatformListenerTest {
     assertReplaceEx2();
   }
 
+  @Test
+  public void testIdSignatureTunnelToServer() {
+    registerTunnelToServerBeans(ISignedTunnelToServer.class, IUnsignedTunnelToServer.class);
+
+    var beanInstanceProducer = m_beanManager.getRegisteredBean(ISignedTunnelToServer.class).getBeanInstanceProducer();
+    var serviceTunnelProxyProducer = assertInstance(beanInstanceProducer, ServiceTunnelProxyProducer.class);
+    assertTrue(serviceTunnelProxyProducer.getOptions().isIdSignature());
+
+    beanInstanceProducer = m_beanManager.getRegisteredBean(IUnsignedTunnelToServer.class).getBeanInstanceProducer();
+    serviceTunnelProxyProducer = assertInstance(beanInstanceProducer, ServiceTunnelProxyProducer.class);
+    assertFalse(serviceTunnelProxyProducer.getOptions().isIdSignature());
+  }
+
   private void assertReplaceEx2() {
     assertPing("return IFixtureTunnelToServerEx2#ping", IFixtureTunnelToServerEx2.class);
   }
@@ -200,5 +216,13 @@ public class RegisterTunnelToServerPlatformListenerTest {
     public String ping() {
       return "pong";
     }
+  }
+
+  @TunnelToServer(idSignature = true)
+  public interface ISignedTunnelToServer extends IService {
+  }
+
+  @TunnelToServer
+  public interface IUnsignedTunnelToServer extends IService {
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/AnnotationFactory.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/AnnotationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,11 @@ public final class AnnotationFactory {
     @Override
     public Class<? extends Annotation> annotationType() {
       return TunnelToServer.class;
+    }
+
+    @Override
+    public boolean idSignature() {
+      return false;
     }
 
     @Override

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/TunnelToServer.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/TunnelToServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.eclipse.scout.rt.dataobject.IDataObject;
 import org.eclipse.scout.rt.platform.BeanInvocationHint;
+import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelOptions;
 
 /**
  * Marks an interface (typically a service) that is capable of being called as client proxy to the back-end server if
@@ -29,4 +31,8 @@ import org.eclipse.scout.rt.platform.BeanInvocationHint;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TunnelToServer {
 
+  /**
+   * Whether the interface uses signature creation for serialization/deserialization of {@link IDataObject}s in the service tunnel (see {@link ServiceTunnelOptions#withIdSignature(Boolean)}).
+   */
+  boolean idSignature() default false;
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/AbstractServiceTunnel.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/AbstractServiceTunnel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/DataObjectHolderWrapper.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/DataObjectHolderWrapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.servicetunnel;
+
+import static org.eclipse.scout.rt.shared.servicetunnel.DataObjectWrapperUtility.mapper;
+
+import java.io.Serializable;
+
+import org.eclipse.scout.rt.dataobject.DataObjectHolder;
+import org.eclipse.scout.rt.dataobject.IDataObject;
+
+/**
+ * Wrapper for {@link DataObjectHolder} used by service tunnel.
+ * <p>
+ * Do not use this internal class.
+ *
+ * @see ServiceTunnelObjectReplacer
+ */
+// Package-private because shouldn't be used except by ServiceTunnelObjectReplacer.
+class DataObjectHolderWrapper implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  // Not using transient DataObjectHolder along with writeObject/readObject like DataObjectHolder, because the string is read exactly once after deserialization.
+  private final String m_dataObjectJson;
+
+  DataObjectHolderWrapper(DataObjectHolder obj) {
+    m_dataObjectJson = mapper().writeValue(obj.getValue());
+  }
+
+  public DataObjectHolder<? extends IDataObject> getDataObjectHolder() {
+    return new DataObjectHolder<>(null, mapper().readValue(m_dataObjectJson, IDataObject.class));
+  }
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/DataObjectWrapperUtility.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/DataObjectWrapperUtility.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.servicetunnel;
+
+import java.util.Optional;
+
+import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
+import org.eclipse.scout.rt.dataobject.IIdSignatureDataObjectMapper;
+import org.eclipse.scout.rt.platform.context.RunContext;
+import org.eclipse.scout.rt.platform.util.LazyValue;
+
+/**
+ * Utility for wrappers of objects that are serialized using an {@link IDataObjectMapper}.
+ * <p>
+ * Do not use this internal class.
+ *
+ * @see ServiceTunnelObjectReplacer
+ */
+// Package-private because shouldn't be used except by ServiceTunnelObjectReplacer.
+final class DataObjectWrapperUtility {
+
+  private static final LazyValue<IDataObjectMapper> MAPPER = new LazyValue<>(IDataObjectMapper.class);
+  private static final LazyValue<IIdSignatureDataObjectMapper> ID_SIGNATURE_MAPPER = new LazyValue<>(IIdSignatureDataObjectMapper.class);
+
+  private DataObjectWrapperUtility() {
+  }
+
+  static IDataObjectMapper mapper() {
+    // check the current run context for the id signature property ...
+    return Optional.ofNullable(RunContext.CURRENT.get())
+        .map(rc -> rc.getPropertyOrDefault(ServiceTunnelOptions.ID_SIGNATURE_PROP, false))
+        // ... and return an object mapper using signatures if the property is set to true
+        .map(idSignature -> idSignature ? ID_SIGNATURE_MAPPER : MAPPER)
+        .orElse(MAPPER)
+        .get();
+  }
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/DoEntityHolderWrapper.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/DoEntityHolderWrapper.java
@@ -13,27 +13,28 @@ import static org.eclipse.scout.rt.shared.servicetunnel.DataObjectWrapperUtility
 
 import java.io.Serializable;
 
+import org.eclipse.scout.rt.dataobject.DoEntityHolder;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 
 /**
- * Wrapper for {@link IDoEntity} used by service tunnel.
+ * Wrapper for {@link DoEntityHolder} used by service tunnel.
  * <p>
  * Do not use this internal class.
  *
  * @see ServiceTunnelObjectReplacer
  */
 // Package-private because shouldn't be used except by ServiceTunnelObjectReplacer.
-class DoEntityWrapper implements Serializable {
+class DoEntityHolderWrapper implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  // Not using transient IDoEntity along with writeObject/readObject like DoEntityHolder, because the string is read exactly once after deserialization.
+  // Not using transient DoEntityHolder along with writeObject/readObject like DoEntityHolder, because the string is read exactly once after deserialization.
   private final String m_doEntityJson;
 
-  DoEntityWrapper(IDoEntity obj) {
-    m_doEntityJson = mapper().writeValue(obj);
+  DoEntityHolderWrapper(DoEntityHolder obj) {
+    m_doEntityJson = mapper().writeValue(obj.getValue());
   }
 
-  public IDoEntity getDoEntity() {
-    return mapper().readValue(m_doEntityJson, IDoEntity.class);
+  public DoEntityHolder<? extends IDoEntity> getDoEntityHolder() {
+    return new DoEntityHolder<>(null, mapper().readValue(m_doEntityJson, IDoEntity.class));
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/RegisterTunnelToServerPlatformListener.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/RegisterTunnelToServerPlatformListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
 package org.eclipse.scout.rt.shared.servicetunnel;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
@@ -94,7 +95,14 @@ public class RegisterTunnelToServerPlatformListener implements IPlatformListener
    * Creates a new {@link BeanMetaData} for the given class.
    */
   protected BeanMetaData createBeanMetaData(Class<?> c) {
-    ServiceTunnelProxyProducer<?> tunnelProxyProducer = new ServiceTunnelProxyProducer<>(c);
+    ServiceTunnelProxyProducer<?> tunnelProxyProducer = new ServiceTunnelProxyProducer<>(
+        c,
+        ServiceTunnelOptions.create()
+            .withIdSignature(Optional.ofNullable(c)
+                .map(clazz -> clazz.getAnnotation(TunnelToServer.class))
+                .map(TunnelToServer::idSignature)
+                .orElse(false))
+    );
     return new BeanMetaData(c).withApplicationScoped(true).withProducer(tunnelProxyProducer);
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelObjectReplacer.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelObjectReplacer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,8 @@ import java.security.Permission;
 import java.security.Permissions;
 import java.util.Date;
 
+import org.eclipse.scout.rt.dataobject.DataObjectHolder;
+import org.eclipse.scout.rt.dataobject.DoEntityHolder;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.platform.serialization.IObjectReplacer;
 import org.eclipse.scout.rt.platform.util.date.UTCDate;
@@ -41,6 +43,12 @@ public class ServiceTunnelObjectReplacer implements IObjectReplacer {
     if (obj instanceof IDoEntity) {
       return new DoEntityWrapper((IDoEntity) obj);
     }
+    if (obj instanceof DoEntityHolder) {
+      return new DoEntityHolderWrapper((DoEntityHolder<?>) obj);
+    }
+    if (obj instanceof DataObjectHolder) {
+      return new DataObjectHolderWrapper((DataObjectHolder<?>) obj);
+    }
     return obj;
   }
 
@@ -54,6 +62,12 @@ public class ServiceTunnelObjectReplacer implements IObjectReplacer {
     }
     if (obj instanceof DoEntityWrapper) {
       return ((DoEntityWrapper) obj).getDoEntity();
+    }
+    if (obj instanceof DoEntityHolderWrapper) {
+      return ((DoEntityHolderWrapper) obj).getDoEntityHolder();
+    }
+    if (obj instanceof DataObjectHolderWrapper) {
+      return ((DataObjectHolderWrapper) obj).getDataObjectHolder();
     }
     return obj;
   }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelOptions.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelOptions.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.servicetunnel;
+
+import static org.eclipse.scout.rt.platform.util.BooleanUtility.nvl;
+
+import org.eclipse.scout.rt.dataobject.IDataObject;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+
+public class ServiceTunnelOptions {
+  public static final String ID_SIGNATURE_PROP = "ServiceTunnelOptions.idSignature";
+
+  private Boolean m_idSignature;
+
+  public static ServiceTunnelOptions create() {
+    return new ServiceTunnelOptions();
+  }
+
+  /**
+   * Whether the service tunnel uses signature creation for serialization/deserialization of {@link IDataObject}s or not.
+   * When enabled the transferred {@link IDoEntity}s are serialized using signature creation and therefore the transferred data changes.
+   * <p>
+   * Consider a {@link IDoEntity} which is transferred from the backend server to the ui server and afterward to the browser where it might be used for REST calls directly to a REST endpoint in the backend server.
+   * In this case the serialization between the ui server and the browser and between the browser and the REST endpoint use signatures.
+   * If now the type of the {@link IDoEntity} is only known to the backend and not the ui server the serialization between the backend and the ui server needs to use signatures or otherwise the REST endpoint will not accept the
+   * {@link IDoEntity} as it contains unsigned attributes.
+   */
+  public ServiceTunnelOptions withIdSignature(Boolean idSignature) {
+    m_idSignature = idSignature;
+    return this;
+  }
+
+  /**
+   * see {@link #withIdSignature(Boolean)}
+   */
+  public Boolean getIdSignature() {
+    return m_idSignature;
+  }
+
+  /**
+   * see {@link #withIdSignature(Boolean)}
+   */
+  public boolean isIdSignature() {
+    return nvl(getIdSignature());
+  }
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelProxyProducer.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelProxyProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,13 +9,18 @@
  */
 package org.eclipse.scout.rt.shared.servicetunnel;
 
+import static org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelOptions.ID_SIGNATURE_PROP;
+
 import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.IBeanInstanceProducer;
+import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.interceptor.DecoratingProxy;
 import org.eclipse.scout.rt.platform.interceptor.IInstanceInvocationHandler;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.VerboseUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,9 +35,15 @@ public class ServiceTunnelProxyProducer<T> implements IBeanInstanceProducer<T>, 
   private final DecoratingProxy<T> m_proxy;
 
   private final Class<?> m_interfaceClass;
+  private final ServiceTunnelOptions m_options;
 
   public ServiceTunnelProxyProducer(Class<?> interfaceClass) {
+    this(interfaceClass, null);
+  }
+
+  public ServiceTunnelProxyProducer(Class<?> interfaceClass, ServiceTunnelOptions options) {
     m_interfaceClass = interfaceClass;
+    m_options = ObjectUtility.nvlOpt(options, ServiceTunnelOptions::create);
     m_proxy = DecoratingProxy.newInstance(this, interfaceClass);
   }
 
@@ -47,10 +58,24 @@ public class ServiceTunnelProxyProducer<T> implements IBeanInstanceProducer<T>, 
       LOG.debug("Tunnel call to {}.{}({})", getInterfaceClass(), method.getName(), VerboseUtility.dumpObjects(args));
     }
 
-    return BEANS.get(IServiceTunnel.class).invokeService(getInterfaceClass(), method, args);
+    Callable<Object> invokeService = () -> BEANS.get(IServiceTunnel.class).invokeService(getInterfaceClass(), method, args);
+
+    // check the idSignature flag
+    if (getOptions().isIdSignature()) {
+      // add run context property
+      return RunContexts.copyCurrent()
+          .withProperty(ID_SIGNATURE_PROP, true)
+          .call(invokeService);
+    }
+
+    return invokeService.call();
   }
 
   protected Class<?> getInterfaceClass() {
     return m_interfaceClass;
+  }
+
+  public ServiceTunnelOptions getOptions() {
+    return m_options;
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelUtility.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,11 @@ public final class ServiceTunnelUtility {
   }
 
   public static <T> T createProxy(Class<T> serviceInterfaceClass) {
-    ServiceTunnelProxyProducer<?> tunnelProxyProducer = new ServiceTunnelProxyProducer<>(serviceInterfaceClass);
+    return createProxy(serviceInterfaceClass, null);
+  }
+
+  public static <T> T createProxy(Class<T> serviceInterfaceClass, ServiceTunnelOptions options) {
+    ServiceTunnelProxyProducer<?> tunnelProxyProducer = new ServiceTunnelProxyProducer<>(serviceInterfaceClass, options);
     BeanMetaData metaData = new BeanMetaData(serviceInterfaceClass).withApplicationScoped(true).withProducer(tunnelProxyProducer);
     IBean<T> bean = new BeanImplementor<>(metaData);
 

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnel.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/http/HttpServiceTunnel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.shared.servicetunnel.http;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import org.eclipse.scout.rt.platform.BEANS;
@@ -30,6 +31,7 @@ import org.eclipse.scout.rt.shared.opentelemetry.HttpServiceTunnelInstrumenterFa
 import org.eclipse.scout.rt.shared.servicetunnel.AbstractServiceTunnel;
 import org.eclipse.scout.rt.shared.servicetunnel.BinaryServiceTunnelContentHandler;
 import org.eclipse.scout.rt.shared.servicetunnel.IServiceTunnelContentHandler;
+import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelOptions;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelResponse;
 import org.slf4j.Logger;
@@ -54,6 +56,7 @@ public class HttpServiceTunnel extends AbstractServiceTunnel {
   private static final Logger LOG = LoggerFactory.getLogger(HttpServiceTunnel.class);
 
   public static final String TOKEN_AUTH_HTTP_HEADER = "X-ScoutAccessToken";
+  public static final String ID_SIGNATURE_HTTP_HEADER = "X-ScoutIdSignature";
 
   private IServiceTunnelContentHandler m_contentHandler;
   private final URL m_serverUrl;
@@ -164,13 +167,14 @@ public class HttpServiceTunnel extends AbstractServiceTunnel {
    * @param callData
    *     data as byte array
    * @throws IOException
-   *           exception
+   *     exception
    * @since 6.0
    */
   protected void addCustomHeaders(HttpRequest httpRequest, ServiceTunnelRequest call, byte[] callData) throws IOException {
     addSignatureHeader(httpRequest, callData);
     addCorrelationId(httpRequest);
     addOpenTelemetryContextHeader(httpRequest);
+    addIdSignatureHeader(httpRequest);
   }
 
   protected void addSignatureHeader(HttpRequest httpRequest, byte[] callData) throws IOException {
@@ -206,6 +210,17 @@ public class HttpServiceTunnel extends AbstractServiceTunnel {
   }
 
   /**
+   * Adds the {@link HttpServiceTunnel#ID_SIGNATURE_HTTP_HEADER} if the current run context has the property {@link ServiceTunnelOptions#ID_SIGNATURE_PROP} set.
+   */
+  protected void addIdSignatureHeader(final HttpRequest httpRequest) {
+    if (Optional.ofNullable(RunContext.CURRENT.get())
+        .map(rc -> rc.getPropertyOrDefault(ServiceTunnelOptions.ID_SIGNATURE_PROP, false))
+        .orElse(false)) {
+      httpRequest.getHeaders().put(ID_SIGNATURE_HTTP_HEADER, Boolean.TRUE.toString());
+    }
+  }
+
+  /**
    * @return msgEncoder used to encode and decode a request / response to and from the binary stream. Default is the
    * {@link BinaryServiceTunnelContentHandler} which handles binary messages
    */
@@ -215,8 +230,8 @@ public class HttpServiceTunnel extends AbstractServiceTunnel {
 
   /**
    * @param e
-   *          content handler that can encode and decode a request / response to and from the binary stream. Default is
-   *          the {@link BinaryServiceTunnelContentHandler} which handles binary messages
+   *     content handler that can encode and decode a request / response to and from the binary stream. Default is
+   *     the {@link BinaryServiceTunnelContentHandler} which handles binary messages
    */
   public void setContentHandler(IServiceTunnelContentHandler e) {
     m_contentHandler = e;


### PR DESCRIPTION
DOs might only be known on the backend server and are sent to the UI server and then to the browser where they are used in rest calls again. In this case the id needs to be signed on the backend server as the UI server has no idea which parts of the DO are ids and which are not. Therefore, introduce ServiceTunnelOptions that can be used to parametrize service tunnel proxies.
If the idSignature flag of the ServiceTunnelOptions is set serializing and deserializing the request and response on both sides of the tunnel is running in a run context that has a specific property set. If this property is set, the data object wrappers created by the ServiceTunnelObjectReplacer are using a signature object mapper. The TunnelToServer annotation does support the idSignature flag as well. If set the proxy created for the interface is initialized with the flag accordingly.

413664