### PR TITLE
Spec improvements

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -3911,7 +3911,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
         parentRow.childRows.push(row);
       } else {
         // do not allow unresolvable parent rows.
-        throw new Error('Parent row of ' + row + ' can not be resolved.');
+        throw new Error('Parent row ' + row.parentRow + ' of row ' + row.id + ' cannot be resolved.');
       }
     });
 

--- a/eclipse-scout-core/src/uinotification/UiNotificationPoller.ts
+++ b/eclipse-scout-core/src/uinotification/UiNotificationPoller.ts
@@ -237,7 +237,7 @@ export class UiNotificationPoller extends PropertyEventEmitter {
     this.trigger('error', {error});
 
     App.get().errorHandler.analyzeError(error).then(errorInfo => {
-      scout.getSession().sendLogRequest(`UI notification poller failed, call will be retried in ${UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL} ms.\nError message:\n${errorInfo.log}\n()`, LogLevel.INFO);
+      scout.getSession()?.sendLogRequest(`UI notification poller failed, call will be retried in ${UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL} ms.\nError message:\n${errorInfo.log}\n()`, LogLevel.INFO);
     });
 
     this._schedulePoll(UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL);

--- a/eclipse-scout-core/test/ObjectFactorySpec.ts
+++ b/eclipse-scout-core/test/ObjectFactorySpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -60,7 +60,7 @@ describe('ObjectFactory', () => {
     expect(object.objectType).toBe('StringField');
   });
 
-  it('puts the object type to the resulting object', () => {
+  it('puts the object type to the resulting object, ignoring the existing object type', () => {
     let model = {
       parent: session.desktop,
       objectType: 'NumberField' // this objectType will be ignored

--- a/eclipse-scout-core/test/desktop/hybrid/HybridManagerSpec.ts
+++ b/eclipse-scout-core/test/desktop/hybrid/HybridManagerSpec.ts
@@ -166,6 +166,7 @@ describe('HybridManager', () => {
 
   describe('callActionAndWait', () => {
     it('calls a HybridAction and waits for its completion', done => {
+      expect().nothing(); // suppress warning "spec has no expectations"
       const id = '42';
       UuidPool.get(session).uuids.push(id);
       HybridManager.get(session).callActionAndWait('Ping').then(() => done());
@@ -184,6 +185,7 @@ describe('HybridManager', () => {
 
   describe('openForm', () => {
     it('waits for a form to be opened and listens for form events', done => {
+      expect().nothing(); // suppress warning "spec has no expectations"
       const id = '42';
       UuidPool.get(session).uuids.push(id);
       HybridManager.get(session).openForm('Dummy').then(form => {

--- a/eclipse-scout-core/test/form/fields/listbox/ListBoxSpec.ts
+++ b/eclipse-scout-core/test/form/fields/listbox/ListBoxSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -464,6 +464,10 @@ describe('ListBox', () => {
 
     it('has rows with aria role option', () => {
       let listBox = createFieldWithLookupCall();
+      expect(listBox.loading).toBe(true);
+      jasmine.clock().tick(500);
+      expect(listBox.loading).toBe(false);
+      expect(listBox.table.rows.length).toBeGreaterThan(0);
       listBox.table.rows.forEach(row => {
         expect(row.$row).toHaveAttr('role', 'option');
       });

--- a/eclipse-scout-core/test/table/organizer/TableOrganizerSpec.ts
+++ b/eclipse-scout-core/test/table/organizer/TableOrganizerSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -288,35 +288,6 @@ describe('TableOrganizer', () => {
   });
 
   describe('getInvisibleColumns', () => {
-
-    it('returns all invisible columns if no insertAfterColumn is provided', () => {
-      let tableModel = helper.createModelFixture(5);
-      let table = helper.createTable(tableModel);
-      let column0 = table.columns[0];
-      let column1 = table.columns[1];
-      let column2 = table.columns[2];
-      let column3 = table.columns[3];
-      let column4 = table.columns[4];
-      let organizer = table.organizer;
-      column2.setDisplayable(false);
-
-      expect(organizer.getInvisibleColumns()).toEqual([]);
-      column1.setVisible(false);
-      expect(organizer.getInvisibleColumns()).toEqual([column1]);
-      column0.setVisible(false);
-      expect(organizer.getInvisibleColumns()).toEqual([column0, column1]);
-      column4.setVisible(false);
-      expect(organizer.getInvisibleColumns()).toEqual([column0, column1, column4]);
-      column2.setVisible(false);
-      column3.setVisible(false);
-      expect(organizer.getInvisibleColumns()).toEqual([column0, column1, column3, column4]);
-      column2.setVisible(true);
-      expect(organizer.getInvisibleColumns()).toEqual([column0, column1, column3, column4]);
-      column3.setVisible(true);
-      expect(organizer.getInvisibleColumns()).toEqual([column0, column1, column4]);
-
-      expect(organizer.getInvisibleColumns(column3)).toEqual([column0, column1, column4]);
-    });
 
     it('returns all invisible columns if no insertAfterColumn is provided', () => {
       let tableModel = helper.createModelFixture(5);

--- a/eclipse-scout-core/test/tree/TreeAdapterSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeAdapterSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -287,7 +287,7 @@ describe('TreeAdapter', () => {
       expect(nodeIds).toEqual(jasmine.arrayWithExactContents([node.id, childNode1.id, childNode2.id]));
     });
 
-    it('sends checked event of checked node and its children if triggered by server', () => {
+    it('sends checked event of checked node and some of its children if triggered by server', () => {
       let model = helper.createModelFixture(2, 1);
       let adapter = helper.createTreeAdapter(model);
       let tree = adapter.createWidget(model, session.desktop) as Tree;

--- a/eclipse-scout-core/test/uinotification/uiNotificationsSpec.ts
+++ b/eclipse-scout-core/test/uinotification/uiNotificationsSpec.ts
@@ -347,6 +347,8 @@ describe('uiNotifications', () => {
     });
 
     it('rejects if server does not allow it', done => {
+      expect().nothing(); // suppress warning "spec has no expectations"
+
       let errors = [];
       uiNotifications.subscribe('aaa', () => undefined).catch(error => {
         errors.push(error);

--- a/eclipse-scout-core/test/util/objectsSpec.ts
+++ b/eclipse-scout-core/test/util/objectsSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,7 @@ describe('objects', () => {
       }
     }
 
-    it('', () => {
+    it('creates a singleton proxy', () => {
       expect(ObjectFactory.get().initialized).toBeTrue();
       let proxy = objects.createSingletonProxy(ProxyTestClass);
       expect(proxy.prop).toBe('test');
@@ -42,7 +42,7 @@ describe('objects', () => {
       expect(proxy['notExisting']).toBeUndefined();
       expect(proxy['prop']).toBe('test');
     });
-    it('', () => {
+    it('throws errors of the object factory is not initialized', () => {
       ObjectFactory.get().initialized = false;
       let proxy = objects.createSingletonProxy(ProxyTestClass);
       expect(proxy['prototype']).toBeUndefined(); // prototype access does not create the lazy instance
@@ -867,6 +867,7 @@ describe('objects', () => {
 
     it('uses a type predicate to narrow the type', () => {
       // compile time test, ifs are always false
+      expect().nothing(); // suppress warning "spec has no expectations"
 
       let menuClass: new() => Menu;
       if (objects.isSameOrExtendsClass(menuClass, Action)) {


### PR DESCRIPTION
- Prevent warning "spec has no expectations" by adding a dummy expectation.
- Use unique spec names.