### PR TITLE
Property for partitioned session-cookie

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
@@ -70,6 +70,7 @@ import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationKeyStorePa
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationPortProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationPrivateKeyPasswordProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCookieConfigHttpOnlyProperty;
+import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCookieConfigPartitionedProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCookieConfigSameSiteProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCookieConfigSecureProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionTimeoutProperty;
@@ -360,14 +361,16 @@ public class Application {
       boolean httpOnly = CONFIG.getPropertyValue(ScoutApplicationSessionCookieConfigHttpOnlyProperty.class);
       boolean secure = CONFIG.getPropertyValue(ScoutApplicationSessionCookieConfigSecureProperty.class);
       SameSite sameSite = CONFIG.getPropertyValue(ScoutApplicationSessionCookieConfigSameSiteProperty.class);
+      boolean partitioned = CONFIG.getPropertyValue(ScoutApplicationSessionCookieConfigPartitionedProperty.class);
 
-      LOG.info("[Session config] timeout: {} s, HTTP only: {}, secure: {}, same site: {}", sessionTimeoutInSeconds, httpOnly, secure, sameSite.getAttributeValue());
+      LOG.info("[Session config] timeout: {} s, HTTP only: {}, secure: {}, same site: {}, partitioned: {}", sessionTimeoutInSeconds, httpOnly, secure, sameSite.getAttributeValue(), partitioned);
 
       SessionHandler sessionHandler = handler.getSessionHandler();
       sessionHandler.setMaxInactiveInterval(sessionTimeoutInSeconds);
       sessionHandler.getSessionCookieConfig().setHttpOnly(httpOnly);
       sessionHandler.getSessionCookieConfig().setSecure(secure);
       sessionHandler.setSameSite(sameSite);
+      sessionHandler.setPartitioned(partitioned);
     }
 
     handler.setDisplayName(CONFIG.getPropertyValue(ApplicationNameProperty.class));

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
@@ -172,9 +172,9 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Specifies whether any session tracking cookies created by the web application will be marked as secure. "
-          + "If true, the session tracking cookie will be marked as secure even if the request initiated the corresponding session using plain HTTP instead of HTTPS (e.g. Scout application behind reverse proxy terminating SSL). "
-          + "If false, the session tracking cookie will only be marked as secure if the request initiated the corresponding session is secure (using HTTPS). "
+      return "Specifies whether the HTTP session cookie created by the web application will be marked as secure. "
+          + "If true, the HTTP session cookie will be marked as secure even if the request initiated the corresponding session using plain HTTP instead of HTTPS (e.g. Scout application behind reverse proxy terminating SSL). "
+          + "If false, the HTTP session cookie will only be marked as secure if the request initiated the corresponding session is secure (using HTTPS). "
           + "The default value is true for non-development mode.";
     }
   }
@@ -206,6 +206,25 @@ public final class ApplicationProperties {
           .filter(e -> value.equals(e.getAttributeValue()))
           .findFirst()
           .orElseThrow();
+    }
+  }
+
+  public static class ScoutApplicationSessionCookieConfigPartitionedProperty extends AbstractBooleanConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.app.sessionCookieConfigPartitioned";
+    }
+
+    @Override
+    public Boolean getDefaultValue() {
+      return false;
+    }
+
+    @Override
+    public String description() {
+      return "Specifies whether the HTTP session cookie created by the web application will be marked as partitioned. "
+          + "The default value is false.";
     }
   }
 


### PR DESCRIPTION
Add new config property 'scout.app.sessionCookieConfigPartitioned' which controls the partitioned-flag on the session-cookie.

326352