### PR TITLE
JsFormAdapter: Prefer jsFormModel data over undefined input data

### DIFF
--- a/eclipse-scout-core/src/dataobject/dataObjects.ts
+++ b/eclipse-scout-core/src/dataobject/dataObjects.ts
@@ -38,11 +38,7 @@ export const dataObjects = {
    * @returns the JSON string.
    */
   stringify(dataObject: any): string {
-    const serialized = dataObjects.serialize(dataObject);
-    if (!serialized) {
-      return null;
-    }
-    return JSON.stringify(serialized);
+    return JSON.stringify(dataObjects.serialize(dataObject));
   },
 
   /**
@@ -55,11 +51,11 @@ export const dataObjects = {
    * * Properties with value 'undefined' are not part of the result (skipped).
    *
    * @param dataObject The value to serialize. Can be primitives, arrays or objects/classes. Typically, a pojo or data object class extending {@link BaseDoEntity}.
-   * @returns the input serialized. Typically, a pojo.
+   * @returns the input serialized. Typically, a pojo. Returns the unaltered input if the input is falsy.
    */
   serialize(dataObject: any): any {
     if (!dataObject) {
-      return null;
+      return dataObject;
     }
     return scout.create(DataObjectSerializer).serialize(dataObject);
   },
@@ -72,9 +68,13 @@ export const dataObjects = {
    * @param json The JSON string to parse.
    * @param objectType The expected resulting data object.
    * @param deserializerModel Optional configuration object for the DataObjectDeserializer.
-   * @returns The deserialized data object instance.
+   * @returns The deserialized data object instance, if json is defined. Returns undefined if json is undefined. Returns null if json is null or the empty string.
    */
   parse: ((json: string, objectType?: ObjectType<BaseDoEntity | BaseDoEntity[]>, deserializerModel?: DataObjectDeserializerModel) => {
+    if (objects.isNullOrUndefined(json)) {
+      return json;
+    }
+    // check empty string
     if (!json) {
       return null;
     }
@@ -91,9 +91,13 @@ export const dataObjects = {
    * @param obj The pojo to deserialize.
    * @param objectType The expected resulting data object.
    * @param deserializerModel Optional configuration object for the DataObjectDeserializer.
-   * @returns The deserialized data object instance.
+   * @returns The deserialized data object instance. Returns undefined if obj is undefined. Returns null if obj is null or falsy.
    */
   deserialize: ((obj: any, objectType?: ObjectType<BaseDoEntity | BaseDoEntity[]>, deserializerModel?: DataObjectDeserializerModel) => {
+    if (objects.isNullOrUndefined(obj)) {
+      return obj;
+    }
+    // falsy values can't be deserialized
     if (!obj) {
       return null;
     }

--- a/eclipse-scout-core/test/dataobject/dataObjectsSpec.ts
+++ b/eclipse-scout-core/test/dataobject/dataObjectsSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {dataObjects, DoEntity} from '../../src/index';
+import {BaseDoEntity, dataObjects, DoEntity} from '../../src/index';
 
 describe('dataObjects', () => {
 
@@ -161,6 +161,81 @@ describe('dataObjects', () => {
 
       dataObjects.removeContribution(contrib2._type, doEntity);
       expect(doEntity._contributions).toBeUndefined();
+    });
+  });
+
+  describe('stringify', () => {
+    it('booleans', () => {
+      expect(dataObjects.stringify(true)).toBe('true');
+      expect(dataObjects.stringify(false)).toBe('false');
+    });
+    it('numbers', () => {
+      expect(dataObjects.stringify(-1)).toBe('-1');
+      expect(dataObjects.stringify(0)).toBe('0');
+      expect(dataObjects.stringify(NaN)).toBe('null');
+      expect(dataObjects.stringify(Infinity)).toBe('null');
+    });
+    it('strings', () => {
+      expect(dataObjects.stringify('truthy')).toBe('"truthy"');
+      expect(dataObjects.stringify('')).toBe('""');
+    });
+    it('null and undefined', () => {
+      expect(dataObjects.stringify(null)).toBe('null');
+      expect(dataObjects.stringify(undefined)).toBe(undefined);
+    });
+  });
+
+  describe('serialize', () => {
+    it('booleans', () => {
+      expect(dataObjects.serialize(true)).toBe(true);
+      expect(dataObjects.serialize(false)).toBe(false);
+    });
+    it('numbers', () => {
+      expect(dataObjects.serialize(-1)).toBe(-1);
+      expect(dataObjects.serialize(0)).toBe(0);
+      let serializedNan = dataObjects.serialize(NaN);
+      // self-comparison to assert NaN as NaN === NaN is always false
+      // eslint-disable-next-line no-self-compare
+      expect(serializedNan !== undefined && serializedNan !== serializedNan && isNaN(serializedNan)).toBeTrue();
+      expect(dataObjects.serialize(Infinity)).toBe(Infinity);
+    });
+    it('strings', () => {
+      expect(dataObjects.serialize('truthy')).toBe('truthy');
+      expect(dataObjects.serialize('')).toBe('');
+    });
+    it('null and undefined', () => {
+      expect(dataObjects.serialize(null)).toBe(null);
+      expect(dataObjects.serialize(undefined)).toBe(undefined);
+    });
+  });
+
+  describe('parse', () => {
+    it('strings', () => {
+      const parsedObject = dataObjects.parse('{' +
+        '  "value": 13' +
+        '}') as any;
+      expect(parsedObject).toBeInstanceOf(BaseDoEntity);
+      expect(parsedObject.value).toBe(13);
+      expect(dataObjects.parse('')).toBe(null);
+    });
+    it('null and undefined', () => {
+      expect(dataObjects.parse(null)).toBe(null);
+      expect(dataObjects.parse(undefined)).toBe(undefined);
+    });
+  });
+
+  describe('deserialize', () => {
+    it('strings', () => {
+      let deserializedObject = dataObjects.deserialize({
+        value: 13
+      }) as any;
+      expect(deserializedObject).toBeInstanceOf(BaseDoEntity);
+      expect(deserializedObject.value).toBe(13);
+      expect(dataObjects.deserialize('')).toEqual(null);
+    });
+    it('null and undefined', () => {
+      expect(dataObjects.deserialize(null)).toBe(null);
+      expect(dataObjects.deserialize(undefined)).toBe(undefined);
     });
   });
 });

--- a/eclipse-scout-core/test/form/js/JsFormAdapterSpec.ts
+++ b/eclipse-scout-core/test/form/js/JsFormAdapterSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -64,12 +64,13 @@ describe('JsFormAdapter', () => {
     };
   }
 
-  function createAdapterData(id: string, jsFormObjectType: string, jsFormModel?: FormModel) {
+  function createAdapterData(id: string, jsFormObjectType: string, jsFormModel?: FormModel, inputData?: any) {
     return {
       objectType: 'JsForm',
       id: id,
       jsFormObjectType: jsFormObjectType,
-      jsFormModel: jsFormModel
+      jsFormModel: jsFormModel,
+      inputData: inputData
     };
   }
 
@@ -183,5 +184,57 @@ describe('JsFormAdapter', () => {
     expect(desktop.getShownForms()[0]).toBe(localJsForm);
     expect(desktop.getShownForms()[1].id).toBe(js2Form.id);
     expect(desktop.getShownForms()[2].id).toBe(js3Form.id);
+  });
+
+  describe('handles input data and form model correctly', () => {
+
+    it('prefers input data over form model', () => {
+      registerAdapterData([createAdapterData('10', 'jsformspec.LoadingJsForm', {
+        data: {
+          attr: 'jsFormModelAttr'
+        }
+      }, {
+        attr: 'jsInputAttr'
+      })], session);
+      let formShowEvent = new RemoteEvent(desktopAdapter.id, 'formShow', {
+        form: '10',
+        displayParent: desktopAdapter.id
+      });
+      desktopAdapter.onModelAction(formShowEvent);
+      let form = session.getModelAdapter('10').widget as LoadingJsForm;
+      expect(form.data?.attr).toBe('jsInputAttr');
+    });
+
+    it('ignores input data if undefined', () => {
+      registerAdapterData([createAdapterData('10', 'jsformspec.LoadingJsForm', {
+        data: {
+          attr: 'jsFormModelAttr'
+        }
+      })], session);
+      let formShowEvent = new RemoteEvent(desktopAdapter.id, 'formShow', {
+        form: '10',
+        displayParent: desktopAdapter.id
+      });
+      desktopAdapter.onModelAction(formShowEvent);
+      let form = session.getModelAdapter('10').widget as LoadingJsForm;
+      expect(form.data?.attr).toBe('jsFormModelAttr');
+    });
+
+    it('accept null values', () => {
+      registerAdapterData([createAdapterData('10', 'jsformspec.LoadingJsForm', {
+        data: {
+          attr: 'jsFormModelAttr'
+        }
+      }, {
+        attr: null
+      })], session);
+      let formShowEvent = new RemoteEvent(desktopAdapter.id, 'formShow', {
+        form: '10',
+        displayParent: desktopAdapter.id
+      });
+      desktopAdapter.onModelAction(formShowEvent);
+      let form = session.getModelAdapter('10').widget as LoadingJsForm;
+      expect(form.data?.attr).toEqual(null);
+    });
   });
 });


### PR DESCRIPTION
Adjust handling of falsy parameters in data object utility
- Adjusts serialize such that it returns the unaltered given data object
parameter if it is falsy.
- Adjusts stringify to return the data objects string  representation
even if the data object is falsy.
- Adjusts parse such that it returns null/undefined if the given json is
null or undefined. If the given json is an empty string, null is
returned.
- Adjusts deserialize to return the unaltered given object if it is
falsy.

389583