### PR TITLE
IMimeMagic Change JPG/JPEG magic byte to 'ffd8ff'

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/resource/MimeTypesTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/resource/MimeTypesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.resource;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.scout.rt.platform.util.HexUtility;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test cases for {@link MimeTypes} and {@link IMimeMagic}.
+ */
+@RunWith(PlatformTestRunner.class)
+public class MimeTypesTest {
+
+  @Test
+  public void testJpgJpeg() {
+    // without markers
+    runJpegTest("ffd8ff");
+    runJpegTest("FFD8FF");
+
+    // with some markers
+    runJpegTest("ffd8ffdb");
+    runJpegTest("ffd8ffe0");
+    runJpegTest("ffd8ffe1");
+    runJpegTest("ffd8ffe2");
+    runJpegTest("ffd8ffee");
+  }
+
+  protected void runJpegTest(String content) {
+    BinaryResource binRes = BinaryResources.create().withContent(HexUtility.decode(content)).build();
+    assertTrue(MimeType.JPG.getMagic().matches(binRes));
+    assertTrue(MimeType.JPEG.getMagic().matches(binRes));
+    assertTrue(MimeTypes.verifyMagic(binRes));
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/IMimeMagic.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/IMimeMagic.java
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.platform.util.HexUtility;
 /**
  * Typically used in combination with {@link MalwareScanner}
  * <p>
- * see {@link MimeTypes#verifyMagic(BinaryResource)} and https://en.wikipedia.org/wiki/List_of_file_signatures
+ * see {@link MimeTypes#verifyMagic(BinaryResource)} and <a href="https://en.wikipedia.org/wiki/List_of_file_signatures">List of file signatures</a>
  *
  * @since 10.x
  */
@@ -28,7 +28,7 @@ public interface IMimeMagic {
   IMimeMagic GIF = createMagic(0, "474946383761", "474946383961");
   IMimeMagic GZ = createMagic(0, "1f8b");
   IMimeMagic ICO = createMagic(0, "00000100");
-  IMimeMagic JPEG_JPG = createMagic(0, "ffd8ffdb", "ffd8ffe0", "ffd8ffe1", "ffd8ffe2", "ffd8ffee");
+  IMimeMagic JPEG_JPG = createMagic(0, "ffd8ff");
   IMimeMagic MKV = createMagic(0, "1a45dfa3");
   IMimeMagic MP3 = createMagic(0, "494433", "fff2", "fff3", "fffb");
   IMimeMagic MP4 = createMagic(4, "6674797069736f6d", "667479706D703432");


### PR DESCRIPTION
Explanation:
- JPG/JPEG files start with "Start Of Image" (SOI) "FF D8"
- Then a JPEG image consists of a sequence of segments, each beginning with a marker, each of which begins with a 0xFF byte, followed by a byte indicating what kind of marker it is.
- Kind of marker is defined by JPEG guideline T.81 See https://www.w3.org/Graphics/JPEG/itu-t81.pdf  page 32
- Since there are a lot of different marker, reduce the Scout IMimeMagic pattern for JPEG/JPG to ffd8ff without any marker.

414361