### PR TITLE
REST HTTP Client Keep Alive and socket/connect timeout NOK

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
@@ -69,9 +69,11 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.impl.io.DefaultHttpRequestWriterFactory;
 import org.apache.hc.core5.http.io.HttpConnectionFactory;
+import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.io.entity.AbstractHttpEntity;
 import org.apache.hc.core5.http.io.entity.BufferedHttpEntity;
 import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.config.AbstractIntegerConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractLongConfigProperty;
@@ -172,15 +174,22 @@ public class ScoutApacheConnector implements Connector {
           .build();
     }
 
+    Timeout connectTimeout = getConnectTimeoutMillis(config);
+    Timeout socketTimeout = getReadTimeoutMillis(config);
+    TimeValue connectionTimeToLive = TimeValue.ofMilliseconds(getConnectionTimeToLiveMillis(config));
+
     final PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(
         RegistryBuilder.<ConnectionSocketFactory> create()
             .register("http", PlainConnectionSocketFactory.getSocketFactory())
             .register("https", sslConnectionSocketFactory)
             .build(),
-        null, null, TimeValue.ofMilliseconds(getKeepAliveTimeoutMillis(config)), connFactory);
+        null, null, connectionTimeToLive, connFactory);
 
     Builder connectionConfigBuilder = ConnectionConfig.custom()
-        .setTimeToLive(TimeValue.ofMilliseconds(getKeepAliveTimeoutMillis(config)));
+        .setConnectTimeout(connectTimeout)
+        // Note: The socket timeout in ConnectionConfig specifically applies to the connection phase, affecting how long the client will wait for a response after establishing a connection.
+        .setSocketTimeout(socketTimeout)
+        .setTimeToLive(connectionTimeToLive);
 
     final int validateAfterInactivityMillis = getValidateAfterInactivityMillis(config);
     if (validateAfterInactivityMillis > 0) {
@@ -197,9 +206,30 @@ public class ScoutApacheConnector implements Connector {
       connectionManager.setDefaultMaxPerRoute(defaultMaxPerRoute);
     }
 
+    SocketConfig.Builder socketConfigBuilder = SocketConfig.custom()
+        // Note: The socket timeout in SocketConfig applies more broadly to all socket operations, including connection establishment, reading from, and writing to the socket.
+        .setSoTimeout(socketTimeout);
+
     connectionManager.setDefaultConnectionConfig(connectionConfigBuilder.build());
+    connectionManager.setDefaultSocketConfig(socketConfigBuilder.build());
     initMetrics(config, connectionManager);
     return connectionManager;
+  }
+
+  protected Timeout getConnectTimeoutMillis(Configuration config) {
+    Long timeout = TypeCastUtility.castValue(config.getProperty(RestClientProperties.CONNECT_TIMEOUT), Long.class);
+    if (timeout != null) {
+      return Timeout.of(timeout, TimeUnit.MILLISECONDS);
+    }
+    return Timeout.DISABLED;
+  }
+
+  protected Timeout getReadTimeoutMillis(Configuration config) {
+    Long timeout = TypeCastUtility.castValue(config.getProperty(RestClientProperties.READ_TIMEOUT), Long.class);
+    if (timeout != null) {
+      return Timeout.of(timeout, TimeUnit.MILLISECONDS);
+    }
+    return Timeout.DISABLED;
   }
 
   /**
@@ -230,12 +260,13 @@ public class ScoutApacheConnector implements Connector {
   }
 
   /**
-   * Max timeout in ms connections are kept open when idle (requires keep-alive support).
+   * Specifies the total span of time in milliseconds connections can be kept alive or execute requests. May be zero
+   * if the connection does not have an expiry deadline.
    */
-  protected long getKeepAliveTimeoutMillis(Configuration config) {
+  protected long getConnectionTimeToLiveMillis(Configuration config) {
     return ObjectUtility.nvl(
-        TypeCastUtility.castValue(config.getProperty(RestClientProperties.CONNECTION_KEEP_ALIVE), Long.class),
-        CONFIG.getPropertyValue(RestHttpTransportConnectionKeepAliveProperty.class));
+        TypeCastUtility.castValue(config.getProperty(RestClientProperties.CONNECTION_TIME_TO_LIVE), Long.class),
+        CONFIG.getPropertyValue(RestHttpTransportConnectionTimeToLiveProperty.class));
   }
 
   /**
@@ -414,6 +445,7 @@ public class ScoutApacheConnector implements Connector {
 
     initConnectTimeout(clientRequest, requestConfigBuilder);
     initSocketTimeout(clientRequest, requestConfigBuilder);
+    initKeepAliveTimeout(clientRequest, requestConfigBuilder);
 
     boolean redirectsEnabled = BooleanUtility.nvl(clientRequest.resolveProperty(RestClientProperties.FOLLOW_REDIRECTS, m_requestConfig.isRedirectsEnabled()));
     requestConfigBuilder.setRedirectsEnabled(redirectsEnabled);
@@ -456,6 +488,18 @@ public class ScoutApacheConnector implements Connector {
     Integer jerseySocketTimeout = clientRequest.resolveProperty(ClientProperties.READ_TIMEOUT, -1);
     if (jerseySocketTimeout != null && jerseySocketTimeout >= 0) {
       requestConfigBuilder.setResponseTimeout(Math.toIntExact(jerseySocketTimeout), TimeUnit.MILLISECONDS);
+    }
+  }
+
+  protected void initKeepAliveTimeout(ClientRequest clientRequest, RequestConfig.Builder requestConfigBuilder) {
+    // check if keep alive timeout was set by Scout RestClientProperties on request
+    Long keepAliveTimeout = clientRequest.resolveProperty(RestClientProperties.CONNECTION_KEEP_ALIVE, -1L);
+    if (keepAliveTimeout != null && keepAliveTimeout >= 0) {
+      requestConfigBuilder.setDefaultKeepAlive(keepAliveTimeout, TimeUnit.MILLISECONDS);
+    }
+    else {
+      // use config property value as fallback
+      requestConfigBuilder.setDefaultKeepAlive(CONFIG.getPropertyValue(RestHttpTransportConnectionKeepAliveProperty.class), TimeUnit.MILLISECONDS);
     }
   }
 
@@ -758,6 +802,24 @@ public class ScoutApacheConnector implements Connector {
     @Override
     public String getKey() {
       return "scout.rest.client.http.validateAfterInactivity";
+    }
+  }
+
+  public static class RestHttpTransportConnectionTimeToLiveProperty extends AbstractLongConfigProperty {
+
+    @Override
+    public Long getDefaultValue() {
+      return TimeUnit.MINUTES.toMillis(30);
+    }
+
+    @Override
+    public String description() {
+      return "Specifies the maximum time to live of a HTTP connection within the HTTP connection pool. May be zero if the connection does not have an expiry deadline. The default value is 30 minutes.";
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.connectionTimeToLive";
     }
   }
 }

--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnectorTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnectorTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -45,6 +46,7 @@ import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.pool.PoolStats;
+import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
 import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
@@ -64,6 +66,7 @@ import org.eclipse.scout.rt.rest.jersey.RestClientHttpProxyServlet;
 import org.eclipse.scout.rt.rest.jersey.RestClientTestEchoResponse;
 import org.eclipse.scout.rt.rest.jersey.RestClientTestEchoServlet;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportConnectionKeepAliveProperty;
+import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportConnectionTimeToLiveProperty;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportMaxConnectionsPerRouteProperty;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportMaxConnectionsTotalProperty;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportValidateAfterInactivityProperty;
@@ -478,22 +481,22 @@ public class ScoutApacheConnectorTest {
   }
 
   @Test
-  public void testHttpConnectionKeepAlive_defaultValue() {
+  public void testHttpConnectionTimeToLive_defaultValue() {
     Client client = Mockito.mock(Client.class);
     Configuration config = Mockito.mock(Configuration.class);
     ScoutApacheConnector connector = new ScoutApacheConnector(client, config);
-    assertEquals(30 * 60 * 1000, connector.getKeepAliveTimeoutMillis(config));
+    assertEquals(30 * 60 * 1000, connector.getConnectionTimeToLiveMillis(config));
   }
 
   @Test
-  public void testHttpConnectionKeepAlive_byConfigProperty() {
+  public void testHttpConnectionTimeToLive_byConfigProperty() {
     List<IBean<?>> beans = new ArrayList<>();
     try {
-      beans.add(BEANS.get(BeanTestingHelper.class).mockConfigProperty(RestHttpTransportConnectionKeepAliveProperty.class, 100L));
+      beans.add(BEANS.get(BeanTestingHelper.class).mockConfigProperty(RestHttpTransportConnectionTimeToLiveProperty.class, 100L));
       Client client = Mockito.mock(Client.class);
       Configuration config = Mockito.mock(Configuration.class);
       ScoutApacheConnector connector = new ScoutApacheConnector(client, config);
-      assertEquals(100L, connector.getKeepAliveTimeoutMillis(config));
+      assertEquals(100L, connector.getConnectionTimeToLiveMillis(config));
     }
     finally {
       beans.forEach(BeanTestingHelper.get()::unregisterBean);
@@ -501,12 +504,12 @@ public class ScoutApacheConnectorTest {
   }
 
   @Test
-  public void testHttpConnectionKeepAlive_byClientProperty() {
+  public void testHttpConnectionTimeToLive_byClientProperty() {
     Client client = Mockito.mock(Client.class);
     Configuration config = Mockito.mock(Configuration.class);
-    when(config.getProperty(RestClientProperties.CONNECTION_KEEP_ALIVE)).thenReturn(200L);
+    when(config.getProperty(RestClientProperties.CONNECTION_TIME_TO_LIVE)).thenReturn(200L);
     ScoutApacheConnector connector = new ScoutApacheConnector(client, config);
-    assertEquals(200L, connector.getKeepAliveTimeoutMillis(config));
+    assertEquals(200L, connector.getConnectionTimeToLiveMillis(config));
   }
 
   @Test
@@ -721,5 +724,51 @@ public class ScoutApacheConnectorTest {
     clientRequestConsumer.accept(clientRequest);
     connector.initSocketTimeout(clientRequest, requestConfigBuilder);
     assertEquals(expectedTimeout >= 0 ? Timeout.ofMilliseconds(expectedTimeout) : null, requestConfigBuilder.build().getResponseTimeout());
+  }
+
+  @Test
+  public void testConnectionKeepAlive_default() {
+    RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+    assertEquals(TimeValue.of(3, TimeUnit.MINUTES), requestConfigBuilder.build().getConnectionKeepAlive());
+    runTestConnectionKeepAlive(c -> {
+    }, -1);
+  }
+
+  @Test
+  public void testConnectionKeepAlive_null() {
+    // null value as property set
+    //noinspection CodeBlock2Expr
+    runTestConnectionKeepAlive(clientRequest -> {
+      when(clientRequest.resolveProperty(eq(RestClientProperties.CONNECTION_KEEP_ALIVE), any(Long.class))).thenReturn(null);
+    }, -1);
+  }
+
+  @Test
+  public void testConnectionKeepAlive_scoutPropertyValue() {
+    // value set by Scout property
+    //noinspection CodeBlock2Expr
+    runTestConnectionKeepAlive(clientRequest -> {
+      when(clientRequest.resolveProperty(eq(RestClientProperties.CONNECTION_KEEP_ALIVE), any(Long.class))).thenReturn(100L);
+    }, 100);
+  }
+
+  @Test
+  public void testConnectionKeepAlive_invalidScoutPropertyValue() {
+    // invalid value set by Scout property
+    //noinspection CodeBlock2Expr
+    runTestConnectionKeepAlive(clientRequest -> {
+      when(clientRequest.resolveProperty(eq(RestClientProperties.CONNECTION_CLOSE), any(Long.class))).thenReturn(-42L);
+    }, -1);
+  }
+
+  protected void runTestConnectionKeepAlive(Consumer<ClientRequest> clientRequestConsumer, int expected) {
+    RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+    Client client = Mockito.mock(Client.class);
+    Configuration configuration = Mockito.mock(Configuration.class);
+    ScoutApacheConnector connector = new ScoutApacheConnector(client, configuration);
+    ClientRequest clientRequest = Mockito.mock(ClientRequest.class);
+    clientRequestConsumer.accept(clientRequest);
+    connector.initKeepAliveTimeout(clientRequest, requestConfigBuilder);
+    assertEquals(expected >= 0 ? Timeout.ofMilliseconds(expected) : Timeout.of(BEANS.get(RestHttpTransportConnectionKeepAliveProperty.class).getDefaultValue(), TimeUnit.MILLISECONDS), requestConfigBuilder.build().getConnectionKeepAlive());
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/RestClientProperties.java
@@ -29,8 +29,8 @@ public final class RestClientProperties {
   public static final String ENABLE_COOKIES = "scout.rest.client.enableCookies";
 
   /**
-   * Standard cookie specification used by underlying http client. See {@code org.apache.hc.client5.http.cookie.StandardCookieSpec}
-   * for details.
+   * Standard cookie specification used by underlying http client. See
+   * {@code org.apache.hc.client5.http.cookie.StandardCookieSpec} for details.
    * <p>
    * The value MUST be an instance convertible to {@link java.lang.String}.
    * </p>
@@ -220,7 +220,8 @@ public final class RestClientProperties {
   public static final String SUPPRESS_DEFAULT_USER_AGENT = "scout.rest.client.suppressDefaultUserAgent";
 
   /**
-   * Specifies the maximum lifetime in milliseconds for kept alive connections of the REST HTTP client.
+   * Specifies the maximum lifetime in milliseconds for kept alive connections of the REST HTTP client when not explicitly
+   * communicated by the origin server with a Keep-Alive response header.
    * <p>
    * The value MUST be an instance convertible to {@link java.lang.Long}.
    * </p>
@@ -264,6 +265,19 @@ public final class RestClientProperties {
    * </p>
    */
   public static final String VALIDATE_CONNECTION_AFTER_INACTIVITY = "scout.rest.client.http.validateAfterInactivity";
+
+  /**
+   * Specifies the total span of time in milliseconds connections can be kept alive or execute requests. May be zero if the
+   * connection does not have an expiry deadline.
+   * <p>
+   * The value MUST be an instance convertible to {@link java.lang.Long}.
+   * </p>
+   * <p>
+   * The default value is defined by {@link org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportConnectionTimeToLiveProperty}
+   * having 30 * 60 * 1000 milliseconds (30 minutes) as default value.
+   * </p>
+   */
+  public static final String CONNECTION_TIME_TO_LIVE = "scout.rest.client.http.connectionTimeToLive";
 
   /**
    * Activates OpenTelemetry metrics for HTTP client connection pool using property value as HTTP client name.


### PR DESCRIPTION
Setup connection keep alive and socket/connect timeout overriding various 3 minutes default values of Jersey client and Apache http client

See
org.apache.hc.client5.http.config.RequestConfig#DEFAULT_CONN_KEEP_ALIVE (3 Min) org.apache.hc.client5.http.config.RequestConfig#DEFAULT_CONNECTION_REQUEST_TIMEOUT (3 Min) org.apache.hc.client5.http.config.ConnectionConfig#DEFAULT_CONNECT_TIMEOUT (3 Min)

397411