### PR TITLE
DoEntityBuilder: improve predicate type

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoEntityBuilderTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoEntityBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@ import java.util.Objects;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.junit.Test;
 
 public class DoEntityBuilderTest {
@@ -27,6 +28,7 @@ public class DoEntityBuilderTest {
     expected.put("attribute1", "foo");
     expected.put("attribute2", 42);
     expected.put("attribute3", "bar");
+    expected.put("attribute5", "bar");
     expected.putList("listAttribute1", CollectionUtility.arrayList(1, 2, 3));
     expected.putList("listAttribute2", CollectionUtility.arrayList(4, 5, 6));
 
@@ -35,6 +37,9 @@ public class DoEntityBuilderTest {
         .put("attribute2", 42)
         .putIf("attribute3", "bar", Objects::nonNull)
         .putIf("attribute4", null, Objects::nonNull)
+        .putIf("attribute5", "bar", StringUtility::hasText)
+        .putIf("attribute6", " ", StringUtility::hasText)
+        .putIf("attribute7", null, StringUtility::hasText)
         .putList("listAttribute1", 1, 2, 3)
         .putList("listAttribute2", Arrays.asList(4, 5, 6))
         .putListIf("listAttribute3", CollectionUtility.emptyArrayList(), v -> !v.isEmpty())

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoEntityTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,6 +35,7 @@ import org.eclipse.scout.rt.dataobject.fixture.SecondSimpleContributionFixtureDo
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.date.DateUtility;
 import org.junit.Test;
 
@@ -673,9 +674,9 @@ public class DoEntityTest {
     DoEntity entity2 = BEANS.get(DoEntity.class);
 
     assertNotEquals(null, entity1);
-    assertNotEquals(entity1, new Object());
+    assertNotEquals(new Object(), entity1);
 
-    assertEquals(entity1, entity1);
+    assertNotSame(entity1, entity2);
     assertEquals(entity1, entity2);
     assertEquals(entity2, entity1);
     assertEquals(entity1.hashCode(), entity2.hashCode());
@@ -778,11 +779,16 @@ public class DoEntityTest {
     DoEntity expected = BEANS.get(DoEntity.class);
     expected.put("foo1", "value1");
     expected.put("foo3", "value3");
+    expected.put("foo4", "value4");
 
     DoEntity actual = BEANS.get(DoEntity.class);
     actual.putIf("foo1", "value1", Objects::nonNull);
     actual.putIf("foo2", null, Objects::nonNull);
     actual.putIf("foo3", "value3", Objects::nonNull);
+
+    actual.putIf("foo4", "value4", StringUtility::hasText);
+    actual.putIf("foo5", " ", StringUtility::hasText);
+    actual.putIf("foo6", null, StringUtility::hasText);
 
     assertEqualsWithComparisonFailure(expected, actual);
   }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoEntityBuilder.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoEntityBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,7 +42,7 @@ public class DoEntityBuilder {
   /**
    * Adds new value to attribute map of entity if the value satisfies the given {@code predicate}.
    */
-  public DoEntityBuilder putIf(String attributeName, Object value, Predicate<? super Object> predicate) {
+  public <V> DoEntityBuilder putIf(String attributeName, V value, Predicate<V> predicate) {
     m_entity.putIf(attributeName, value, predicate);
     return this;
   }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/IDoEntity.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/IDoEntity.java
@@ -62,7 +62,7 @@ public interface IDoEntity extends IDataObject {
   /**
    * Adds new value to attribute map of entity if the value satisfies the given {@code predicate}.
    */
-  default void putIf(String attributeName, Object value, Predicate<? super Object> predicate) {
+  default <V> void putIf(String attributeName, V value, Predicate<V> predicate) {
     if (predicate.test(value)) {
       put(attributeName, value);
     }


### PR DESCRIPTION
Use generic type to set type of predicate argument to same type as the value to put. This allows using method references as predicate.

Example: result.putIf("name", myName, StringUtility::hasText)