### PR TITLE
Improve displayParent handling for HybridManager and JsForm

### DIFF
--- a/eclipse-scout-core/src/desktop/Desktop.ts
+++ b/eclipse-scout-core/src/desktop/Desktop.ts
@@ -1333,20 +1333,8 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
    * Only one form can be active at once. The currently active form is reflected by {@link activeForm}.
    */
   activateForm(form: Form) {
-    if (!form) {
-      this._setFormActivated(null);
-      return;
-    }
-    let displayParent = form.displayParent || this;
+    let displayParent = form?.displayParent || this;
     displayParent.formController.activateForm(form);
-    this._setFormActivated(form);
-
-    // If the form has a modal child dialog, this dialog needs to be activated as well.
-    form.dialogs.forEach(dialog => {
-      if (dialog.modal) {
-        this.activateForm(dialog);
-      }
-    });
   }
 
   /** @internal */

--- a/eclipse-scout-core/src/desktop/DesktopAdapter.ts
+++ b/eclipse-scout-core/src/desktop/DesktopAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,7 @@ export class DesktopAdapter extends ModelAdapter {
   }
 
   protected _onWidgetFormActivate(event: DesktopFormActivateEvent) {
-    if (event.form && !event.form.modelAdapter) {
+    if (event.form && !ModelAdapter.getModelAdapterForWidget(event.form, true)) {
       return; // Ignore ScoutJS forms
     }
     this._sendFormActivate(event.form);
@@ -48,7 +48,7 @@ export class DesktopAdapter extends ModelAdapter {
 
   protected _sendFormActivate(form: Form) {
     let eventData = {
-      formId: form ? form.modelAdapter.id : null
+      formId: ModelAdapter.getModelAdapterForWidget(form, true)?.id
     };
 
     this._send('formActivate', eventData, {
@@ -56,7 +56,7 @@ export class DesktopAdapter extends ModelAdapter {
         // Do not coalesce if formId was set to null by the previous event,
         // this is the only way the server knows that the desktop was brought to front
         return this.target === previous.target && this.type === previous.type &&
-          !(previous.formId === null && this.formId !== null);
+          !(!previous.formId && this.formId);
       }
     });
   }
@@ -261,6 +261,10 @@ export class DesktopAdapter extends ModelAdapter {
       this._initThemeOrig();
     }
   }
+}
+
+export interface FormWithModelAdapterId extends Form {
+  __modelAdapterId?: string;
 }
 
 App.addListener('bootstrap', DesktopAdapter.modifyDesktopPrototype);

--- a/eclipse-scout-core/src/desktop/DisplayChildController.ts
+++ b/eclipse-scout-core/src/desktop/DisplayChildController.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -103,10 +103,12 @@ export class DisplayChildController implements DisplayChildControllerModel, Obje
     // use _unregisterChild in subclass
   }
 
-  protected _registerChild(child: DisplayChild, children: DisplayChild[], propertyName: string, position?: number) {
+  protected _registerChild(child: DisplayChild, propertyName: string, position?: number) {
+    const children: DisplayChild[] = arrays.ensure(this.displayParent[propertyName]);
     if (children.includes(child)) {
       return;
     }
+    child.one('destroy', e => this._unregisterChild(child, propertyName));
     let newChildren;
     if (position !== undefined) {
       newChildren = [...children];
@@ -118,7 +120,11 @@ export class DisplayChildController implements DisplayChildControllerModel, Obje
     this.displayParent._setProperty(propertyName, newChildren);
   }
 
-  protected _unregisterChild(child: DisplayChild, children: DisplayChild[], propertyName: string) {
+  protected _unregisterChild(child: DisplayChild, propertyName: string) {
+    const children: DisplayChild[] = this.displayParent[propertyName];
+    if (!children?.length) {
+      return;
+    }
     let newChildren = children.filter(f => f !== child);
     if (arrays.equals(children, newChildren)) {
       return;

--- a/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
@@ -121,7 +121,7 @@ export class HybridManager extends Widget {
     widget.trigger(eventType, {data});
   }
 
-  protected _onHybridFormEvent(form: HybridForm, eventType: string, data: AnyDoEntity) {
+  protected _onHybridFormEvent(form: HybridManagerForm, eventType: string, data: AnyDoEntity) {
     if (eventType === 'reset') {
       form.setData(data);
       form.trigger('reset');
@@ -209,7 +209,7 @@ export class HybridManager extends Widget {
     return this.when(`widgetAdd:${id}`).then(event => this._onFormAdd(event.widget as Form));
   }
 
-  protected _onFormAdd(form: HybridForm) {
+  protected _onFormAdd(form: HybridManagerForm) {
     form.one('close', () => {
       form.__closeTriggered = true;
     });
@@ -240,7 +240,7 @@ export interface HybridManagerActionEndEventResult {
   contextElements?: HybridActionContextElements;
 }
 
-interface HybridForm extends Form {
+interface HybridManagerForm extends Form {
   /**
    * @returns true if {@link FormEventMap.close} event was triggered at least once for this form.
    */

--- a/eclipse-scout-core/src/desktop/hybrid/hybridUtil.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/hybridUtil.ts
@@ -87,7 +87,7 @@ export class HybridUtil {
     if (!contextElement) {
       return null;
     }
-    let adapter = scout.assertInstance(contextElement.widget.modelAdapter, ModelAdapter, 'Widget does not have a model adapter');
+    let adapter = scout.assertInstance(ModelAdapter.getModelAdapterForWidget(contextElement.widget, true), ModelAdapter, 'Widget does not have a model adapter');
     let jsonElement = this._modelElementToJson(adapter, contextElement.element);
 
     return {

--- a/eclipse-scout-core/src/filechooser/FileChooserController.ts
+++ b/eclipse-scout-core/src/filechooser/FileChooserController.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,10 +53,10 @@ export class FileChooserController extends DisplayChildController {
   }
 
   protected override _register(fileChooser: FileChooser) {
-    this._registerChild(fileChooser, this.displayParent.fileChoosers, 'fileChoosers');
+    this._registerChild(fileChooser, 'fileChoosers');
   }
 
   protected override _unregister(fileChooser: FileChooser) {
-    this._unregisterChild(fileChooser, this.displayParent.fileChoosers, 'fileChoosers');
+    this._unregisterChild(fileChooser, 'fileChoosers');
   }
 }

--- a/eclipse-scout-core/src/form/FormController.ts
+++ b/eclipse-scout-core/src/form/FormController.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -102,6 +102,25 @@ export class FormController extends DisplayChildController {
    * Activates the given view or dialog.
    */
   activateForm(form: Form) {
+    if (!form) {
+      this.session.desktop._setFormActivated(null);
+      return;
+    }
+
+    // If the form has a modal child dialog, this dialog needs to be activated as well.
+    let activatedModalDialog = false;
+    form.dialogs.forEach(dialog => {
+      if (dialog.modal) {
+        this.activateForm(dialog);
+        activatedModalDialog = true;
+      }
+    });
+
+    // As this._activateForm activates all display parents for a dialog the current form was already activated as it is the display parent of its modal child dialogs.
+    if (activatedModalDialog) {
+      return;
+    }
+
     let displayParent: DisplayParent = this.displayParent;
     while (displayParent) {
       if (displayParent instanceof Outline) {
@@ -111,11 +130,16 @@ export class FormController extends DisplayChildController {
       displayParent = displayParent instanceof Form ? displayParent.displayParent : null;
     }
 
+    this._activateForm(form);
+  }
+
+  protected _activateForm(form: Form) {
     if (form.displayHint === Form.DisplayHint.VIEW) {
       this._activateView(form);
     } else {
       this._activateDialog(form);
     }
+    this.session.desktop._setFormActivated(form);
   }
 
   protected _renderView(view: Form, register: boolean, position?: number, selectView?: boolean) {
@@ -256,7 +280,7 @@ export class FormController extends DisplayChildController {
     if (dialog.displayParent instanceof Form &&
       (dialog.displayParent.displayHint === Form.DisplayHint.VIEW ||
         (dialog.displayParent.displayHint === Form.DisplayHint.DIALOG && dialog.modal))) {
-      this.activateForm(dialog.displayParent);
+      this._activateForm(dialog.displayParent);
     }
 
     if (!dialog.rendered) {
@@ -335,18 +359,18 @@ export class FormController extends DisplayChildController {
   }
 
   protected _registerDialog(dialog: Form) {
-    this._registerChild(dialog, this.displayParent.dialogs, 'dialogs');
+    this._registerChild(dialog, 'dialogs');
   }
 
   protected _unregisterDialog(dialog: Form) {
-    this._unregisterChild(dialog, this.displayParent.dialogs, 'dialogs');
+    this._unregisterChild(dialog, 'dialogs');
   }
 
   protected _registerView(view: Form, position: number) {
-    this._registerChild(view, this.displayParent.views, 'views', position);
+    this._registerChild(view, 'views', position);
   }
 
   protected _unregisterView(view: Form) {
-    this._unregisterChild(view, this.displayParent.views, 'views');
+    this._unregisterChild(view, 'views');
   }
 }

--- a/eclipse-scout-core/src/form/js/JsFormAdapter.ts
+++ b/eclipse-scout-core/src/form/js/JsFormAdapter.ts
@@ -24,7 +24,8 @@ export class JsFormAdapter extends FormAdapter {
       objectType: model.jsFormObjectType,
       displayParent: model.displayParent,
       displayHint: model.displayHint,
-      data: dataObjects.deserialize(model.inputData, null, {createPojoIfDoIsUnknown: true})
+      data: dataObjects.deserialize(model.inputData, null, {createPojoIfDoIsUnknown: true}),
+      __hybridModelAdapter: this
     };
 
     if (model.jsFormModel) {
@@ -45,6 +46,7 @@ export class JsFormAdapter extends FormAdapter {
       if (!widget.exclusiveAdapterKey) {
         // Link the form with this adapter. The form may be an existing form created by JS code or created now by Java.
         widget.exclusiveAdapterKey = this.id;
+        widget.__hybridModelAdapter = this;
       } else if (widget.exclusiveAdapterKey !== this.id) {
         // If the found form belongs to this adapter, it can be opened exclusively.
         // Otherwise, it needs to be opened separately because the server may send events for that form (formHide etc.).

--- a/eclipse-scout-core/src/messagebox/MessageBoxController.ts
+++ b/eclipse-scout-core/src/messagebox/MessageBoxController.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -54,10 +54,10 @@ export class MessageBoxController extends DisplayChildController {
   }
 
   protected override _register(messageBox: MessageBox) {
-    this._registerChild(messageBox, this.displayParent.messageBoxes, 'messageBoxes');
+    this._registerChild(messageBox, 'messageBoxes');
   }
 
   protected override _unregister(messageBox: MessageBox) {
-    this._unregisterChild(messageBox, this.displayParent.messageBoxes, 'messageBoxes');
+    this._unregisterChild(messageBox, 'messageBoxes');
   }
 }

--- a/eclipse-scout-core/src/session/ModelAdapter.ts
+++ b/eclipse-scout-core/src/session/ModelAdapter.ts
@@ -469,6 +469,18 @@ export class ModelAdapter extends EventEmitter implements ModelAdapterModel, Mod
   }
 
   /**
+   * Gets the {@link ModelAdapter} for the given {@link Widget}. The method checks for classic {@link ModelAdapter}s and if the flag `includeHybridModelAdapter` is set to `true` also for hybrid {@link ModelAdapter}s.
+   */
+  static getModelAdapterForWidget(widget: Widget, includeHybridModelAdapter?: boolean): ModelAdapter {
+    if (widget?.modelAdapter) {
+      return widget.modelAdapter;
+    }
+    if (includeHybridModelAdapter) {
+      return (widget as HybridWidget)?.__hybridModelAdapter;
+    }
+  }
+
+  /**
    * Static method to modify the prototype of Widget.
    */
   static modifyWidgetPrototype(event: Event) {
@@ -508,6 +520,13 @@ export interface ModelAdapterLike {
   destroy(): void;
 
   exportAdapterData(adapterData: AdapterData): AdapterData;
+}
+
+/**
+ * A hybrid widget, i.e. a widget implemented in Scout JS with a wrapper in Scout Classic, is not marked with the property modelAdapter but with __hybridModelAdapter.
+ */
+export interface HybridWidget extends Widget {
+  __hybridModelAdapter?: ModelAdapter;
 }
 
 export interface ModelAdapterSendOptions<Data> {

--- a/eclipse-scout-core/test/desktop/DesktopAdapterSpec.ts
+++ b/eclipse-scout-core/test/desktop/DesktopAdapterSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {FormSpecHelper, OutlineSpecHelper} from '../../src/testing/index';
-import {Desktop, DesktopAdapter, Form, FormModel, GroupBox, GroupBoxModel, RemoteEvent} from '../../src/index';
+import {Desktop, DesktopAdapter, Form, FormModel, GroupBox, GroupBoxModel, HybridWidget, RemoteEvent, scout} from '../../src/index';
 
 describe('DesktopAdapter', () => {
   let session: SandboxSession, desktop: Desktop, outlineHelper: OutlineSpecHelper, formHelper: FormSpecHelper, desktopAdapter: DesktopAdapter;
@@ -72,6 +72,29 @@ describe('DesktopAdapter', () => {
         formId: form2.modelAdapter.id
       });
       expect(mostRecentJsonRequest()).toContainEvents(event);
+
+      const jsFormModel = {objectType: 'JsForm', id: '42', jsFormObjectType: 'Form'};
+      registerAdapterData(jsFormModel, session);
+      const jsForm = session.getOrCreateWidget('42', desktop) as Form & HybridWidget;
+
+      desktop.activateForm(jsForm);
+      expect(desktop.activeForm).toBe(jsForm);
+
+      sendQueuedAjaxCalls();
+      event = new RemoteEvent(desktopAdapter.id, 'formActivate', {
+        formId: jsForm.__hybridModelAdapter.id
+      });
+      expect(mostRecentJsonRequest()).toContainEvents(event);
+
+      const remoteEvents = [...mostRecentJsonRequest().events];
+      const jsOnlyForm = scout.create(Form, {parent: session.desktop});
+
+      desktop.activateForm(jsOnlyForm);
+      expect(desktop.activeForm).toBe(jsOnlyForm);
+
+      // nothing was sent to the server, the most recent request is unchanged and therefore contains the same events
+      sendQueuedAjaxCalls();
+      expect(mostRecentJsonRequest()).toContainEventsExactly(remoteEvents);
     });
 
     it('can close and open new form in the same response', () => {
@@ -128,9 +151,7 @@ describe('DesktopAdapter', () => {
       sendQueuedAjaxCalls();
 
       let expectedEvents = [
-        new RemoteEvent(desktopAdapter.id, 'formActivate', {
-          formId: null
-        }),
+        new RemoteEvent(desktopAdapter.id, 'formActivate', {}),
         new RemoteEvent(desktopAdapter.id, 'formActivate', {
           formId: '400'
         })

--- a/eclipse-scout-core/test/desktop/DesktopSpec.ts
+++ b/eclipse-scout-core/test/desktop/DesktopSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -878,40 +878,65 @@ describe('Desktop', () => {
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([dialog0, dialog1, parentDialog, modalChildDialogLevel1, modalChildDialogLevel2]));
       expect(desktop.activeForm).toBe(modalChildDialogLevel2);
 
+      const activatedForms = [];
+      const storeActivatedForm = e => activatedForms.push(e.form);
+      desktop.on('formActivate', storeActivatedForm);
+
       desktop.activateForm(dialog0);
       // expect dialog0 to be on top (= last in the DOM)
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([dialog1, parentDialog, modalChildDialogLevel1, modalChildDialogLevel2, dialog0]));
       expect(desktop.activeForm).toBe(dialog0);
+      expect(activatedForms).toEqual([dialog0]);
+
+      activatedForms.splice(0, activatedForms.length);
 
       desktop.activateForm(dialog1);
       // expect dialog1 to be on top (= last in the DOM)
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([parentDialog, modalChildDialogLevel1, modalChildDialogLevel2, dialog0, dialog1]));
       expect(desktop.activeForm).toBe(dialog1);
+      expect(activatedForms).toEqual([dialog1]);
+
+      activatedForms.splice(0, activatedForms.length);
 
       desktop.activateForm(parentDialog);
       // expect complete hierarchy beginning with parentDialog to be on top (= last in the DOM)
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([dialog0, dialog1, parentDialog, modalChildDialogLevel1, modalChildDialogLevel2]));
       expect(desktop.activeForm).toBe(modalChildDialogLevel2);
+      expect(activatedForms).toEqual([parentDialog, modalChildDialogLevel1, modalChildDialogLevel2]);
+
+      activatedForms.splice(0, activatedForms.length);
 
       desktop.activateForm(dialog0);
       // expect dialog0 to be on top (= last in the DOM)
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([dialog1, parentDialog, modalChildDialogLevel1, modalChildDialogLevel2, dialog0]));
       expect(desktop.activeForm).toBe(dialog0);
+      expect(activatedForms).toEqual([dialog0]);
+
+      activatedForms.splice(0, activatedForms.length);
 
       desktop.activateForm(modalChildDialogLevel1);
       // expect complete hierarchy beginning with parentDialog to be on top (= last in the DOM)
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([dialog1, dialog0, parentDialog, modalChildDialogLevel1, modalChildDialogLevel2]));
       expect(desktop.activeForm).toBe(modalChildDialogLevel2);
+      expect(activatedForms).toEqual([parentDialog, modalChildDialogLevel1, modalChildDialogLevel2]);
+
+      activatedForms.splice(0, activatedForms.length);
 
       desktop.activateForm(dialog0);
       // expect dialog0 to be on top (= last in the DOM)
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([dialog1, parentDialog, modalChildDialogLevel1, modalChildDialogLevel2, dialog0]));
       expect(desktop.activeForm).toBe(dialog0);
+      expect(activatedForms).toEqual([dialog0]);
+
+      activatedForms.splice(0, activatedForms.length);
 
       desktop.activateForm(modalChildDialogLevel2);
       // expect complete hierarchy beginning with parentDialog to be on top (= last in the DOM)
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([dialog1, dialog0, parentDialog, modalChildDialogLevel1, modalChildDialogLevel2]));
       expect(desktop.activeForm).toBe(modalChildDialogLevel2);
+      expect(activatedForms).toEqual([parentDialog, modalChildDialogLevel1, modalChildDialogLevel2]);
+
+      desktop.off('formActivate', storeActivatedForm);
     });
 
     it('keeps position of dialog\'s messagebox relative to it\'s parent dialog while reordering dialogs', () => {

--- a/eclipse-scout-core/test/desktop/DisplayChildControllerSpec.ts
+++ b/eclipse-scout-core/test/desktop/DisplayChildControllerSpec.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {DisplayChild, DisplayChildController, DisplayParent, InitModelOf, scout, Widget} from '../../src/index';
+import {FormSpecHelper} from '../../src/testing';
+
+describe('DisplayChildController', () => {
+  let session: SandboxSession;
+  let displayParent: SpecDisplayParent;
+  let displayChildController: SpecDisplayChildController;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    displayParent = new FormSpecHelper(session).createFormWithOneField();
+    displayChildController = scout.create(SpecDisplayChildController, {displayParent, session});
+  });
+
+  describe('_registerChild', () => {
+
+    it('adds element to child list', () => {
+      expect(displayParent.displayChildren).toBeUndefined();
+
+      const displayChild1 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      displayChildController._registerChild(displayChild1, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild1]);
+
+      const displayChild3 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      displayChildController._registerChild(displayChild3, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild1, displayChild3]);
+
+      const displayChild0 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      displayChildController._registerChild(displayChild0, 'displayChildren', 0);
+      expect(displayParent.displayChildren).toEqual([displayChild0, displayChild1, displayChild3]);
+
+      const displayChild2 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      displayChildController._registerChild(displayChild2, 'displayChildren', 2);
+      expect(displayParent.displayChildren).toEqual([displayChild0, displayChild1, displayChild2, displayChild3]);
+    });
+
+    it('does not add element to child list twice', () => {
+      expect(displayParent.displayChildren).toBeUndefined();
+
+      const displayChild = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      displayChildController._registerChild(displayChild, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild]);
+
+      displayChildController._registerChild(displayChild, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild]);
+    });
+  });
+
+  describe('_unregisterChild', () => {
+
+    it('removes element from child list', () => {
+      expect(displayParent.displayChildren).toBeUndefined();
+
+      const displayChild0 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      const displayChild1 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      const displayChild2 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+
+      displayChildController._registerChild(displayChild0, 'displayChildren');
+      displayChildController._registerChild(displayChild1, 'displayChildren');
+      displayChildController._registerChild(displayChild2, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild0, displayChild1, displayChild2]);
+
+      displayChildController._unregisterChild(displayChild1, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild0, displayChild2]);
+
+      displayChildController._unregisterChild(displayChild2, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild0]);
+
+      displayChildController._unregisterChild(displayChild0, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([]);
+    });
+
+    it('does nothing if element is not a child', () => {
+      expect(displayParent.displayChildren).toBeUndefined();
+
+      const displayChild0 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      const displayChild1 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+
+      displayChildController._unregisterChild(displayChild0, 'displayChildren');
+      expect(displayParent.displayChildren).toBeUndefined();
+
+      displayChildController._registerChild(displayChild0, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild0]);
+
+      displayChildController._unregisterChild(displayChild1, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild0]);
+    });
+
+    it('is called automatically if child is destroyed', () => {
+      expect(displayParent.displayChildren).toBeUndefined();
+
+      const displayChild0 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      const displayChild1 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+      const displayChild2 = scout.create(SpecDisplayChild, {parent: session.desktop, displayParent});
+
+      displayChildController._registerChild(displayChild0, 'displayChildren');
+      displayChildController._registerChild(displayChild1, 'displayChildren');
+      displayChildController._registerChild(displayChild2, 'displayChildren');
+      expect(displayParent.displayChildren).toEqual([displayChild0, displayChild1, displayChild2]);
+
+      displayChild1.destroy();
+      expect(displayParent.displayChildren).toEqual([displayChild0, displayChild2]);
+
+      displayChild2.destroy();
+      expect(displayParent.displayChildren).toEqual([displayChild0]);
+
+      displayChild0.destroy();
+      expect(displayParent.displayChildren).toEqual([]);
+    });
+  });
+
+  interface SpecDisplayParent extends DisplayParent {
+    displayChildren?: SpecDisplayChild[];
+  }
+
+  class SpecDisplayChild extends Widget implements DisplayChild {
+    displayParent: SpecDisplayParent;
+
+    protected override _init(model: InitModelOf<this>) {
+      scout.assertValue(model.displayParent);
+      super._init(model);
+    }
+  }
+
+  class SpecDisplayChildController extends DisplayChildController {
+
+    override _registerChild(child: DisplayChild, propertyName: string, position?: number) {
+      super._registerChild(child, propertyName, position);
+    }
+
+    override _unregisterChild(child: DisplayChild, propertyName: string) {
+      super._unregisterChild(child, propertyName);
+    }
+  }
+});

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/AssertRunContextHybridAction.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/AssertRunContextHybridAction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.desktop.hybrid;
+
+import org.eclipse.scout.rt.client.context.ClientRunContext;
+import org.eclipse.scout.rt.platform.util.Assertions;
+
+public class AssertRunContextHybridAction extends AbstractHybridAction<AssertRunContextHybridActionDo> {
+
+  @Override
+  public void execute(AssertRunContextHybridActionDo data) {
+    var runContext = Assertions.assertInstance(ClientRunContext.CURRENT.get(), ClientRunContext.class);
+    Assertions.assertEquals(runContext.getDesktop(), data.getDesktop());
+    Assertions.assertEquals(runContext.getOutline(), data.getOutline());
+    Assertions.assertEquals(runContext.getForm(), data.getForm());
+  }
+}

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/AssertRunContextHybridActionDo.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/AssertRunContextHybridActionDo.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.desktop.hybrid;
+
+import jakarta.annotation.Generated;
+
+import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
+import org.eclipse.scout.rt.client.ui.desktop.outline.IOutline;
+import org.eclipse.scout.rt.client.ui.form.IForm;
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+
+@TypeName("scout.AssertRunContextHybridAction")
+public class AssertRunContextHybridActionDo extends DoEntity {
+
+  public DoValue<IDesktop> desktop() {
+    return doValue("desktop");
+  }
+
+  public DoValue<IOutline> outline() {
+    return doValue("outline");
+  }
+
+  public DoValue<IForm> form() {
+    return doValue("form");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public AssertRunContextHybridActionDo withDesktop(IDesktop desktop) {
+    desktop().set(desktop);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IDesktop getDesktop() {
+    return desktop().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public AssertRunContextHybridActionDo withOutline(IOutline outline) {
+    outline().set(outline);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IOutline getOutline() {
+    return outline().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public AssertRunContextHybridActionDo withForm(IForm form) {
+    form().set(form);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IForm getForm() {
+    return form().get();
+  }
+}

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/HybridActionRunContextTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/HybridActionRunContextTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.desktop.hybrid;
+
+import org.eclipse.scout.rt.client.context.ClientRunContexts;
+import org.eclipse.scout.rt.client.ui.desktop.AbstractDesktop;
+import org.eclipse.scout.rt.client.ui.desktop.outline.AbstractOutline;
+import org.eclipse.scout.rt.client.ui.desktop.outline.IOutline;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
+import org.eclipse.scout.rt.client.ui.form.AbstractForm;
+import org.eclipse.scout.rt.client.ui.form.IForm;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PlatformTestRunner.class)
+public class HybridActionRunContextTest {
+
+  @Test
+  public void testEmpty() {
+    ClientRunContexts.empty()
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class),
+                BEANS.get(HybridActionContextElements.class)));
+  }
+
+  @Test
+  public void testFromDesktop() {
+    var desktop = new MyDesktop();
+    var outline = new MyOutline();
+    var form = new MyForm();
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop),
+                BEANS.get(HybridActionContextElements.class)));
+
+    desktop.setOutline(outline);
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop)
+                    .withOutline(outline),
+                BEANS.get(HybridActionContextElements.class)));
+
+    desktop.setOutline((IOutline) null);
+    desktop.setActiveForm(form);
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop)
+                    .withForm(form),
+                BEANS.get(HybridActionContextElements.class)));
+
+    desktop.setOutline(outline);
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop)
+                    .withOutline(outline)
+                    .withForm(form),
+                BEANS.get(HybridActionContextElements.class)));
+  }
+
+  @Test
+  public void testFromContextElements() {
+    var desktop = new MyDesktop();
+    var desktopOutline = new MyOutline();
+    var desktopForm = new MyForm();
+
+    desktop.setOutline(desktopOutline);
+    desktop.setActiveForm(desktopForm);
+
+    var outline = new MyOutline();
+    var form = new MyForm();
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop)
+                    .withOutline(desktopOutline)
+                    .withForm(desktopForm),
+                BEANS.get(HybridActionContextElements.class)));
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop)
+                    .withOutline(outline)
+                    .withForm(desktopForm),
+                BEANS.get(HybridActionContextElements.class)
+                    .withElement("runcontext.outline", outline)));
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop)
+                    .withOutline(desktopOutline)
+                    .withForm(form),
+                BEANS.get(HybridActionContextElements.class)
+                    .withElement("runcontext.form", form)));
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop)
+                    .withOutline(outline)
+                    .withForm(form),
+                BEANS.get(HybridActionContextElements.class)
+                    .withElement("runcontext.outline", outline)
+                    .withElement("runcontext.form", form)));
+
+    ClientRunContexts.empty()
+        .withDesktop(desktop)
+        .run(() -> BEANS.get(AssertRunContextHybridAction.class)
+            .execute(
+                "42",
+                BEANS.get(AssertRunContextHybridActionDo.class)
+                    .withDesktop(desktop)
+                    .withOutline(desktopOutline)
+                    .withForm(desktopForm),
+                BEANS.get(HybridActionContextElements.class)
+                    .withElement("runcontext.outline", form)
+                    .withElement("runcontext.form", outline)));
+  }
+
+  protected static class MyDesktop extends AbstractDesktop {
+
+    private IOutline m_outline;
+    private IForm m_activeForm;
+
+    public MyDesktop() {
+      super(false);
+    }
+
+    public void setOutline(IOutline outline) {
+      m_outline = outline;
+    }
+
+    @Override
+    public IOutline getOutline() {
+      return m_outline;
+    }
+
+    @Override
+    public void setActiveForm(IForm form) {
+      m_activeForm = form;
+    }
+
+    @Override
+    public IForm getActiveForm() {
+      return m_activeForm;
+    }
+  }
+
+  protected static class MyOutline extends AbstractOutline {
+
+    @Override
+    protected IPage<?> execCreateRootPage() {
+      return null;
+    }
+  }
+
+  protected static class MyForm extends AbstractForm {
+
+    public MyForm() {
+      // do not initialize form as it tries to access the current desktop of the client session, but this test does not run inside a client session
+      super(false);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/AbstractHybridAction.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/AbstractHybridAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,12 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.eclipse.scout.rt.client.context.ClientRunContext;
+import org.eclipse.scout.rt.client.context.ClientRunContexts;
 import org.eclipse.scout.rt.client.ui.IWidget;
+import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
+import org.eclipse.scout.rt.client.ui.desktop.outline.IOutline;
+import org.eclipse.scout.rt.client.ui.form.IForm;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
@@ -51,6 +56,37 @@ public abstract class AbstractHybridAction<DO_ENTITY extends IDoEntity> implemen
     m_id = id;
     m_contextElements = contextElements;
     m_initialized = true;
+  }
+
+  @Override
+  public ClientRunContext createRunContext() {
+    ClientRunContext runContext = ClientRunContexts.copyCurrent();
+    prepareRunContext(runContext);
+    return runContext;
+  }
+
+  protected void prepareRunContext(ClientRunContext runContext) {
+    // get outline from context elements
+    Optional.ofNullable(optContextElement("runcontext.outline"))
+        .map(HybridActionContextElement::getWidget)
+        .filter(IOutline.class::isInstance)
+        .map(IOutline.class::cast)
+        // use current outline of desktop as fallback
+        .or(() -> Optional.of(runContext)
+            .map(ClientRunContext::getDesktop)
+            .map(IDesktop::getOutline))
+        .ifPresent(outline -> runContext.withOutline(outline, false));
+
+    // get form from context elements
+    Optional.ofNullable(optContextElement("runcontext.form"))
+        .map(HybridActionContextElement::getWidget)
+        .filter(IForm.class::isInstance)
+        .map(IForm.class::cast)
+        // use active form of desktop as fallback
+        .or(() -> Optional.of(runContext)
+            .map(ClientRunContext::getDesktop)
+            .map(IDesktop::getActiveForm))
+        .ifPresent(runContext::withForm);
   }
 
   protected String getId() {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/IHybridAction.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/IHybridAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  */
 package org.eclipse.scout.rt.client.ui.desktop.hybrid;
 
+import org.eclipse.scout.rt.client.context.ClientRunContext;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.platform.Bean;
 
@@ -33,6 +34,8 @@ public interface IHybridAction<DO_ENTITY extends IDoEntity> {
       throw new IllegalArgumentException("data must be of type '" + getDoEntityClass() + "' but is '" + data.getClass() + "'.");
     }
     init(id, contextElements);
-    execute(getDoEntityClass().cast(data));
+    createRunContext().run(() -> execute(getDoEntityClass().cast(data)));
   }
+
+  ClientRunContext createRunContext();
 }


### PR DESCRIPTION
The HybridManager and all of its actions were running inside a run context that has no information about the current outline or active form. This leads e.g. to modal form being opened modal to the desktop and not e.g. to their parent form. In order to improve the displayParent handling of the HybridManager every action creates an own client run context and uses the current outline and active form of the desktop. If a hybrid action needs to run with a different outline or form the caller of the action can pass an outline or form as context element, and it is automatically used for the run context of the hybrid action. If a hybrid action wants to run inside a run context without outline or form it can simply override the method AbstractHybridAction#prepareRunContext and prevent the run context from being initialized with outline and form.
As the active form of the desktop may be a JsForm the browser needs to update the active form on the ui server every time the active form changes. As JsForms do not contain a modelAdapter property they are enhanced with a __hybridModelAdapter property in order to send events for these forms to the server. The DesktopAdapter checks the modelAdapter and the __hybridModelAdapter in order to send formActivate events to the server for all forms that have a pendant on the server. In addition, the hybrid manager now allows JsForms as context elements if one wants to use a JsForm as the run contexts active form. As the hybrid action uses the active form set on the desktop on the ui server, this property needs to be as exact as possible. Consider a JsForm that opens a js only form which then opens a classic form using the hybrid manager. In this case the active form on the ui server is the classic form. If now this classic form is closed the active form in the browser will be the js only form which has no pendant on the ui server. The best estimate for the active form on the ui server is the first parent of the js only form that is known to the server, i.e. the JsForm. To achieve this, the desktop in the browser will always activate the complete stack of parent forms and send formActivate events to the server when a form is activated.
Forms created using HybridManager.createForm are never shown on the desktop on the ui server, so hiding them when they are disposed will do nothing on the server as the desktop does not know these forms. But if a classic form that was only shown on the desktop in the browser is never hidden it may not be unregistered from its displayParent which results in a memory leak. Therefore, add a listener for all elements registered to the DisplayChildController that unregisters the element again if it is destroyed.

389342