### PR TITLE
JsonTagField: retain order of tags

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/tagfield/AbstractTagField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/tagfield/AbstractTagField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -198,7 +198,7 @@ public abstract class AbstractTagField extends AbstractValueField<Set<String>> i
       }
       Set<String> ensuredValue = value.stream()
           .map(this::ensureMaxLength)
-          .collect(Collectors.toSet());
+          .collect(Collectors.toCollection(LinkedHashSet::new));
       setValue(ensuredValue);
     }
 

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/form/fields/tagfield/JsonTagFieldTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/form/fields/tagfield/JsonTagFieldTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html.json.form.fields.tagfield;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.scout.rt.client.ui.form.fields.tagfield.ITagField;
+import org.eclipse.scout.rt.ui.html.json.fixtures.UiSessionMock;
+import org.json.JSONArray;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class JsonTagFieldTest {
+
+  /**
+   * Verifies the jsonToValue returns a sorted set (retain order of values in JSON array).
+   */
+  @Test
+  public void testJsonToValue_Sorted() {
+    JSONArray jsonArray = new JSONArray();
+    jsonArray.put("000");
+    jsonArray.put("bar");
+    jsonArray.put("foo");
+    jsonArray.put("baz");
+    jsonArray.put("999");
+    var jsonTagField = new JsonTagField(Mockito.mock(ITagField.class), new UiSessionMock(), null, null);
+    Set<String> valueSet = jsonTagField.jsonToValue(jsonArray);
+    List<String> valueList = new ArrayList<>(valueSet);
+    for (int i = 0; i < valueList.size(); i++) {
+      assertEquals(jsonArray.get(i), valueList.get(i));
+    }
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/tagfield/JsonTagField.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/form/fields/tagfield/JsonTagField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,7 +9,7 @@
  */
 package org.eclipse.scout.rt.ui.html.json.form.fields.tagfield;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.eclipse.scout.rt.client.services.lookup.ILookupCallResult;
@@ -39,7 +39,7 @@ public class JsonTagField extends JsonValueField<ITagField> {
   @Override
   protected void initJsonProperties(ITagField model) {
     super.initJsonProperties(model);
-    putJsonProperty(new JsonProperty<ITagField>(IValueField.PROP_VALUE, model) {
+    putJsonProperty(new JsonProperty<>(IValueField.PROP_VALUE, model) {
       @Override
       protected Set<String> modelValue() {
         return getModel().getValue();
@@ -54,7 +54,7 @@ public class JsonTagField extends JsonValueField<ITagField> {
         return new JSONArray((Set<String>) value);
       }
     });
-    putJsonProperty(new JsonProperty<ITagField>(ITagField.PROP_RESULT, model) {
+    putJsonProperty(new JsonProperty<>(ITagField.PROP_RESULT, model) {
       @Override
       protected ILookupCallResult<String> modelValue() {
         return getModel().getResult();
@@ -66,7 +66,7 @@ public class JsonTagField extends JsonValueField<ITagField> {
         return JsonLookupCallResult.toJson((ILookupCallResult<String>) value);
       }
     });
-    putJsonProperty(new JsonProperty<ITagField>(ITagField.PROP_MAX_LENGTH, model) {
+    putJsonProperty(new JsonProperty<>(ITagField.PROP_MAX_LENGTH, model) {
       @Override
       protected Integer modelValue() {
         return getModel().getMaxLength();
@@ -110,7 +110,7 @@ public class JsonTagField extends JsonValueField<ITagField> {
   protected Set<String> jsonToValue(Object jsonValue0) {
     JSONArray jsonValue = (JSONArray) jsonValue0;
     int numTags = jsonValue.length();
-    Set<String> tags = new HashSet<>(numTags);
+    Set<String> tags = new LinkedHashSet<>(numTags);
     for (int i = 0; i < numTags; i++) {
       tags.add(jsonValue.getString(i));
     }


### PR DESCRIPTION
Use a LinkedHashSet to retain the order of tags in the value. Otherwise, the same (ordered) list of tags appears in random order in the UI.