### PR TITLE
MenuBox: prevent endless layout

### DIFF
--- a/eclipse-scout-core/src/menu/menubox/MenuBoxLayout.ts
+++ b/eclipse-scout-core/src/menu/menubox/MenuBoxLayout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -250,7 +250,10 @@ export class MenuBoxLayout extends AbstractLayout {
     let menusWidth = this._menusWidth(menus);
     let prefSize = graphics.prefSize(this.menuBox.$container);
     prefSize.width = menusWidth + this.menuBox.htmlComp.insets().horizontal();
-    return prefSize;
+    // If the value is fractional (e.g. 310.00000762939453) and the browser rounds it down when the size is set to the menu box,
+    // the prefSize (menusWidth in layout()) will always be bigger than the containerSize
+    // -> round up pref size to prevent this
+    return prefSize.ceil();
   }
 
   /**


### PR DESCRIPTION
When using the newest open sans font, the menu box may be layouted forever when the screen is small and one menu item contains an image.

Reason:
If the pref width of the menu box value is fractional (e.g. 310.00000762939453) and the browser rounds it down when the size is set to the menu box, the prefSize (menusWidth in layout()) will be bigger than the containerSize -> menu box collapses even though it should only be shrinked.

When the menu box is layouted by the desktop header, the header tries to figure out which mode is necessary for the menu box (compact, shrinked or collapsed).
The desktop header and the menu box need to agree on the mode but if the desktop header tries set the menu box in shrink mode and the menu box will instead collapse itself, the layout won't be deterministic. And because one menu has an image and invalidateLayoutTree() is called when the image loads, the layout loops forever.

414936