### PR TITLE
DataObjects: add support for do type resolvers

### DIFF
--- a/eclipse-scout-core/src/dataobject/dataObjects.ts
+++ b/eclipse-scout-core/src/dataobject/dataObjects.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AnyDoEntity, ArrayDoNodeSerializer, arrays, BaseDoEntity, Constructor, DataObjectDeserializer, DataObjectDeserializerModel, DataObjectSerializer, DateDoNodeSerializer, DoEntity, DoNodeSerializer, doValueMetaData, MapDoNodeSerializer,
-  NumberDoNodeSerializer, objects, ObjectType, scout, SetDoNodeSerializer
+  AnyDoEntity, ArrayDoNodeSerializer, arrays, BaseDoEntity, Constructor, DataObjectDeserializer, DataObjectDeserializerModel, DataObjectSerializer, DateDoNodeSerializer, DefaultDoTypeResolver, DoEntity, DoNodeSerializer, DoTypeResolver,
+  doValueMetaData, MapDoNodeSerializer, NumberDoNodeSerializer, objects, ObjectType, scout, SetDoNodeSerializer
 } from '../index';
 
 /**
@@ -28,6 +28,17 @@ export const dataObjects = {
     new NumberDoNodeSerializer(),
     new ArrayDoNodeSerializer() // must be after Set
   ] as DoNodeSerializer<any>[],
+
+  /**
+   * Editable array of {@link DoTypeResolver} instances.
+   *
+   * By default, the list only contains an instance of {@link DefaultDoTypeResolver}.
+   *
+   * The list may be modified to add a custom resolver. This may be useful for example in the following scenario:
+   * Normally, a {@link BaseDoEntity} is created if the data object class cannot be resolved, unless {@link DataObjectDeserializerModel.createPojoIfDoIsUnknown} is set to true.
+   * To use a specific {@link BaseDoEntity} class for unknown {@link DoEntity._type} values, a custom resolver can be added.
+   */
+  doTypeResolvers: [new DefaultDoTypeResolver()] as DoTypeResolver[],
 
   /**
    * Serializes the given value and converts it to a JSON string using {@link JSON.stringify}.

--- a/eclipse-scout-core/src/dataobject/serialize/DataObjectDeserializer.ts
+++ b/eclipse-scout-core/src/dataobject/serialize/DataObjectDeserializer.ts
@@ -38,7 +38,7 @@ export class DataObjectDeserializer implements DataObjectDeserializerModel, Obje
   }
 
   protected _deserializeObject<T extends object>(rawObj: Record<string, any>, metaData?: DoValueMetaData<T>): T {
-    const constructor = (doValueMetaData.chooseDataObjectType(rawObj, metaData) || BaseDoEntity) as Constructor<T>;
+    const constructor = this._resolveDataObjectType(rawObj, metaData) as Constructor<T>;
     const resultObj = this._createResultObject(constructor);
     const proto = Object.getPrototypeOf(constructor).prototype;
     Object.keys(rawObj)
@@ -47,6 +47,16 @@ export class DataObjectDeserializer implements DataObjectDeserializerModel, Obje
         resultObj[key] = this._convertFieldValue(proto, rawObj, key, rawObj[key]);
       });
     return resultObj;
+  }
+
+  protected _resolveDataObjectType(rawObj: Record<string, any>, metaData: DoValueMetaData): Constructor {
+    for (const resolver of dataObjects.doTypeResolvers) {
+      const constructor = resolver.resolve(rawObj, metaData);
+      if (constructor) {
+        return constructor;
+      }
+    }
+    return BaseDoEntity;
   }
 
   protected _createResultObject<T extends object>(constructor: Constructor<T>): T {

--- a/eclipse-scout-core/src/dataobject/serialize/DoTypeResolver.ts
+++ b/eclipse-scout-core/src/dataobject/serialize/DoTypeResolver.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {Constructor, DoValueMetaData, doValueMetaData} from '../../index';
+
+export interface DoTypeResolver {
+  resolve(rawObj: Record<string, any>, metaData: DoValueMetaData): Constructor;
+}
+
+export class DefaultDoTypeResolver implements DoTypeResolver {
+  resolve(rawObj: Record<string, any>, metaData: DoValueMetaData): Constructor {
+    return doValueMetaData.chooseDataObjectType(rawObj, metaData);
+  }
+}

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -122,6 +122,7 @@ export * from './dataobject/serialize/NumberDoNodeSerializer';
 export * from './dataobject/serialize/SetDoNodeSerializer';
 export * from './dataobject/serialize/DataObjectDeserializer';
 export * from './dataobject/serialize/DataObjectSerializer';
+export * from './dataobject/serialize/DoTypeResolver';
 export * from './dataobject/dataObjects';
 export * from './dataobject/BaseDoEntity';
 export * from './dataobject/ValueDo';

--- a/eclipse-scout-core/test/dataobject/DataObjectDeserializerSpec.ts
+++ b/eclipse-scout-core/test/dataobject/DataObjectDeserializerSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {BaseDoEntity, DataObjectDeserializer, DataObjectInventory, dataObjects, dates, ObjectFactory, objects, scout, typeName} from '../../src/index';
+import {arrays, BaseDoEntity, Constructor, DataObjectDeserializer, DataObjectInventory, dataObjects, dates, DefaultDoTypeResolver, DoValueMetaData, ObjectFactory, objects, scout, typeName} from '../../src/index';
 
 describe('DataObjectDeserializer', () => {
 
@@ -215,7 +215,7 @@ describe('DataObjectDeserializer', () => {
     expect(fixture03Sub.nestedNestedDateSub).toEqual(dates.parseJsonDate('2024-12-12 08:03:39.708Z'));
   });
 
-  it('Uses pojo for unknown DOs if requested', () => {
+  it('uses pojo for unknown DOs if requested', () => {
     const json = `{
       "_type": "scout.Fixture02",
       "nestedObjUnknown": {
@@ -236,6 +236,31 @@ describe('DataObjectDeserializer', () => {
     const topLevelPojo = dataObjects.parse('{"_type": "not_known"}', null, {createPojoIfDoIsUnknown: true}) as any;
     expect(objects.isPojo(topLevelPojo)).toBeTrue();
     expect(topLevelPojo._type).toBe('not_known');
+  });
+
+  it('considers custom type resolvers when resolving the data object type', () => {
+    class DoTypeResolver implements DefaultDoTypeResolver {
+      resolve(rawObj: Record<string, any>, metaData: DoValueMetaData): Constructor {
+        if (rawObj?._type === 'SpecialOne') {
+          return Fixture01Do;
+        }
+        return null;
+      }
+    }
+
+    let dataObject = dataObjects.parse('{"_type": "SpecialOne"}');
+    expect(dataObject).toBeInstanceOf(BaseDoEntity);
+
+    // Custom resolver always resolves to Fixture01Do
+    const resolver = new DoTypeResolver();
+    dataObjects.doTypeResolvers.push(resolver);
+    dataObject = dataObjects.parse('{"_type": "SpecialOne"}');
+    expect(dataObject).toBeInstanceOf(Fixture01Do);
+
+    // Default behavior applies if resolver is removed again
+    arrays.remove(dataObjects.doTypeResolvers, resolver);
+    dataObject = dataObjects.parse('{"_type": "SpecialOne"}');
+    expect(dataObject).toBeInstanceOf(BaseDoEntity);
   });
 });
 


### PR DESCRIPTION
Sometimes it is desired to use a specific BaseDoEntity class if the data object _type cannot be resolved rather than the generic BaseDoEntity. In that case a custom do type resolver can be added.