### PR TITLE
Improve logging in HttpProxy, reduce usage of logging proxy

### DIFF
--- a/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxyTest.java
+++ b/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxyTest.java
@@ -15,8 +15,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,8 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -38,13 +35,20 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ConnectionClosedException;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.AsyncResponseConsumer;
+import org.apache.hc.core5.http.nio.support.classic.AbstractClassicEntityConsumer;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.support.BasicRequestBuilder;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpHeader;
@@ -59,10 +63,11 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.context.CorrelationId;
-import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.platform.context.RunContexts;
+import org.eclipse.scout.rt.platform.exception.ExceptionHandler;
 import org.eclipse.scout.rt.platform.internal.BeanInstanceUtil;
 import org.eclipse.scout.rt.platform.util.EnumerationUtility;
 import org.eclipse.scout.rt.platform.util.ImmutablePair;
@@ -76,6 +81,7 @@ import org.eclipse.scout.rt.shared.http.async.AbstractAsyncHttpClientManager;
 import org.eclipse.scout.rt.shared.http.async.DefaultAsyncHttpClientManager;
 import org.eclipse.scout.rt.shared.http.async.ForceHttp2DefaultAsyncHttpClientManager;
 import org.eclipse.scout.rt.shared.http.async.H2AsyncHttpClientManager;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.mock.RegisterBeanTestRule;
 import org.eclipse.scout.rt.testing.platform.runner.JUnitExceptionHandler;
 import org.eclipse.scout.rt.testing.platform.runner.parameterized.IScoutTestParameter;
@@ -89,7 +95,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
+import org.slf4j.event.Level;
 
 @RunWith(ParameterizedPlatformTestRunner.class)
 public class HttpProxyTest {
@@ -360,7 +366,7 @@ public class HttpProxyTest {
     receivedHeaders.forEach((k, v) -> httpResponse.addHeader(k, v));
 
     // perform actual operation
-    BEANS.get(HttpProxy.class).writeResponseHeaders(res, httpResponse);
+    BEANS.get(HttpProxy.class).writeResponseHeaders("mockCorrelationId", res, httpResponse);
 
     assertEquals(expectedHeaders, collectedHeaders);
     verify(res, atLeast(0)).setHeader(anyString(), anyString());
@@ -457,48 +463,92 @@ public class HttpProxyTest {
   }
 
   @Test
-  public void testProxyRequestRunContextAndCorrelationId() {
-    AtomicInteger hasBeenCalledCount = new AtomicInteger();
-    RunContexts.copyCurrent().withCorrelationId("foo").run(() -> {
-      doAnswer(invocation -> createProxyForTestRunContextAndCorrelationId(hasBeenCalledCount, invocation)).when(m_proxy).createAsyncResponseConsumer(any());
-      doAnswer(invocation -> createProxyForTestRunContextAndCorrelationId(hasBeenCalledCount, invocation)).when(m_proxy).createEntityConsumer(any());
-      doAnswer(invocation -> createProxyForTestRunContextAndCorrelationId(hasBeenCalledCount, invocation)).when(m_proxy).createEntityProducer(any());
-      doAnswer(invocation -> createProxyForTestRunContextAndCorrelationId(hasBeenCalledCount, invocation)).when(m_proxy).createExecuteCallback(any(), any());
+  public void testCreateEntityConsumerCorrelationId() throws Exception {
+    AsyncEntityConsumer<Boolean> entityConsumer = null;
+    try {
+      CorrelationId.CURRENT.set("mockCorrelationId");
+      entityConsumer = m_proxy.createEntityConsumer(mock(HttpServletResponse.class));
+    }
+    finally {
+      CorrelationId.CURRENT.remove();
+    }
+    assertNull(CorrelationId.CURRENT.get());
 
-      testProxyRequest_postRequest();
-    });
-    assertEquals(4, hasBeenCalledCount.get()); // 4: see above, four classes are instrumented, expect for all at least one method call (which itself verified further assertions)
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    doNothing().when(m_proxy).log(any(Level.class), captor.capture(), any(String.class), any(Object[].class));
+    ContentType contentType = mock(ContentType.class);
+    InputStream inputStream = mock(InputStream.class);
+
+    // (1) test invoking consumeData
+    java.lang.reflect.Method method = AbstractClassicEntityConsumer.class.getDeclaredMethod("consumeData", ContentType.class, InputStream.class);
+    method.setAccessible(true);
+    method.invoke(entityConsumer, contentType, inputStream);
+
+    assertFalse(captor.getAllValues().isEmpty());
+    captor.getAllValues().forEach(v -> assertEquals("mockCorrelationId", v));
   }
 
-  protected Object createProxyForTestRunContextAndCorrelationId(AtomicInteger hasBeenCalledCount, InvocationOnMock invocation) throws Throwable {
-    AtomicBoolean hasBeenCalled = new AtomicBoolean(false);
-    Object actualObject = invocation.callRealMethod();
-
-    boolean checkCorrelationId = true;
-    if (Proxy.isProxyClass(actualObject.getClass())) {
-      InvocationHandler invocationHandler = Proxy.getInvocationHandler(actualObject);
-      if (invocationHandler instanceof AbstractAsyncHttpClientManager.AsyncHttpInvocationHandler) {
-        AbstractAsyncHttpClientManager.AsyncHttpInvocationHandler asyncHttpInvocationHandler = (AbstractAsyncHttpClientManager.AsyncHttpInvocationHandler) invocationHandler;
-        RunContext runContext = asyncHttpInvocationHandler.getRunContext();
-        assertEquals("foo", runContext.getCorrelationId());
-        checkCorrelationId = false;
-      }
+  @Test
+  public void testCreateAsyncResponseConsumerCorrelationId() throws Exception {
+    AsyncResponseConsumer<Boolean> responseConsumer = null;
+    try {
+      CorrelationId.CURRENT.set("mockCorrelationId");
+      responseConsumer = m_proxy.createAsyncResponseConsumer(mock(HttpServletResponse.class));
+    }
+    finally {
+      CorrelationId.CURRENT.remove();
     }
 
-    boolean f_checkCorrelationId = checkCorrelationId;
-    return Proxy.newProxyInstance(
-        HttpProxy.class.getClassLoader(),
-        new Class[]{invocation.getMethod().getReturnType()},
-        (proxy, method, args) -> {
-          if (hasBeenCalled.compareAndSet(false, true)) {
-            hasBeenCalledCount.incrementAndGet();
-          }
-          if (f_checkCorrelationId) {
-            assertEquals("foo", CorrelationId.CURRENT.get());
-          }
-          return method.invoke(actualObject, args);
-        }
-    );
+    assertNull(CorrelationId.CURRENT.get());
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getHeaders()).thenReturn(new Header[0]);
+    EntityDetails entityDetails = mock(EntityDetails.class);
+    HttpContext context = mock(HttpContext.class);
+    @SuppressWarnings("unchecked") FutureCallback<Boolean> resultCallback = mock(FutureCallback.class);
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    doNothing().when(m_proxy).log(any(Level.class), captor.capture(), any(String.class), any(Object[].class));
+
+    // (1) test invoking consumeResponse
+    responseConsumer.consumeResponse(response, entityDetails, context, resultCallback);
+
+    // (2) test invoking failed
+    AsyncResponseConsumer<Boolean> finalResponseConsumer = responseConsumer;
+    BEANS.get(JUnitExceptionHandler.class).ignoreExceptionOnce(Exception.class, () -> finalResponseConsumer.failed(new Exception("foo")));
+
+    assertFalse(captor.getAllValues().isEmpty());
+    captor.getAllValues().forEach(v -> assertEquals("mockCorrelationId", v));
+  }
+
+  @Test
+  public void testFutureCallbackCorrelationId() throws Exception {
+    FutureCallback<Boolean> futureCallback = null;
+    try {
+      CorrelationId.CURRENT.set("mockCorrelationId");
+      futureCallback = m_proxy.createExecuteCallback(mock(HttpServletResponse.class), mock(AsyncContext.class));
+    }
+    finally {
+      CorrelationId.CURRENT.remove();
+    }
+
+    BeanTestingHelper.get().registerBean(new BeanMetaData(ExceptionHandler.class).withInitialInstance(mock(ExceptionHandler.class)));
+
+    assertNull(CorrelationId.CURRENT.get());
+
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    doNothing().when(m_proxy).log(any(Level.class), captor.capture(), any(String.class), any(Object[].class));
+
+    // (1) test invoking completed
+    futureCallback.completed(true);
+
+    // (2) test invoking failed
+    FutureCallback<Boolean> finalFutureCallback = futureCallback;
+    BEANS.get(JUnitExceptionHandler.class).ignoreExceptionOnce(Exception.class, () -> finalFutureCallback.failed(new Exception("foo")));
+
+    // (3) test invoking cancelled
+    futureCallback.cancelled();
+
+    assertFalse(captor.getAllValues().isEmpty());
+    captor.getAllValues().forEach(v -> assertEquals("mockCorrelationId", v));
   }
 
   protected void testProxyRequestWithStatusCodeAndContent_Internal(int statusCode, byte[] content, boolean specifyContentLength) throws IOException {

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxy.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxy.java
@@ -70,6 +70,8 @@ import org.apache.hc.core5.http.support.AbstractRequestBuilder;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.config.CONFIG;
+import org.eclipse.scout.rt.platform.context.CorrelationId;
+import org.eclipse.scout.rt.platform.context.CorrelationIdContextValueProvider;
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.exception.ExceptionHandler;
 import org.eclipse.scout.rt.platform.job.internal.JobManager;
@@ -87,6 +89,9 @@ import org.eclipse.scout.rt.shared.http.async.AbstractAsyncHttpClientManager;
 import org.eclipse.scout.rt.shared.http.async.DefaultAsyncHttpClientManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.slf4j.MDC.MDCCloseable;
+import org.slf4j.event.Level;
 
 /**
  * Forwards HTTP requests to the given remote URL.
@@ -408,13 +413,13 @@ public class HttpProxy {
     }
   }
 
-  protected void writeResponseHeaders(HttpServletResponse resp, HttpResponse httpResp) {
+  protected void writeResponseHeaders(String correlationId, HttpServletResponse resp, HttpResponse httpResp) {
     final Set<String> hopByHopHeaderNames = getConnectionHeaderValues(httpResp);
     for (Header header : httpResp.getHeaders()) {
       String name = header.getName();
       String value = header.getValue();
       if (name != null && hopByHopHeaderNames.contains(name.toLowerCase(Locale.US))) {
-        LOG.trace("Removed hop-by-hop response header: {} (original value: {})", name, value);
+        log(Level.TRACE, correlationId, "Removed hop-by-hop response header: {} (original value: {})", name, value);
         continue;
       }
       String originalValue = value;
@@ -423,10 +428,10 @@ public class HttpProxy {
       }
       if (value != null) {
         resp.setHeader(name, value);
-        LOG.trace("Added response header: {}: {}", name, value);
+        log(Level.TRACE, correlationId, "Added response header: {}: {}", name, value);
       }
       else {
-        LOG.trace("Removed response header: {} (original value: {})", name, originalValue);
+        log(Level.TRACE, correlationId, "Removed response header: {} (original value: {})", name, originalValue);
       }
     }
   }
@@ -630,18 +635,17 @@ public class HttpProxy {
    */
   protected AsyncEntityConsumer<Boolean> createEntityConsumer(HttpServletResponse resp) {
     AsyncEntityConsumer<Boolean> entityConsumer = new AbstractClassicEntityConsumer<>(getInitialBufferSize(resp), getBlockingOperationExecutor()) {
+
+      private final String m_correlationId = CorrelationId.CURRENT.get();
+
       @Override
       protected Boolean consumeData(ContentType contentType, InputStream inputStream) throws IOException {
-        LOG.trace("Consuming data with contentType {}", contentType);
+        log(Level.TRACE, m_correlationId, "Consuming data with contentType {}", contentType);
         writeResponsePayload(resp, inputStream);
         return true;
       }
     };
-
-    // consumer is run async: wrap the consumer to retain context information (e.g. for logging purposes)
-    @SuppressWarnings("unchecked")
-    AsyncEntityConsumer<Boolean> wrappedConsumer = (AsyncEntityConsumer<Boolean>) m_httpClientManager.createAsyncInvocationHandler(AsyncEntityConsumer.class, entityConsumer);
-    return wrappedConsumer;
+    return entityConsumer;
   }
 
   /**
@@ -651,7 +655,7 @@ public class HttpProxy {
    * </p>
    * <p>
    * Before the actual response payload is consumed the methods
-   * {@link #writeResponseHeaders(HttpServletResponse, HttpResponse)} and
+   * {@link #writeResponseHeaders(String, HttpServletResponse, HttpResponse)} and
    * {@link #writeResponseStatus(HttpServletResponse, HttpResponse)} are called (in this order) to forward header and
    * status.
    * </p>
@@ -659,20 +663,21 @@ public class HttpProxy {
   protected AsyncResponseConsumer<Boolean> createAsyncResponseConsumer(HttpServletResponse resp) {
     AsyncResponseConsumer<Boolean> consumer = new AsyncResponseConsumer<>() {
 
+      private final String m_correlationId = CorrelationId.CURRENT.get();
       private volatile AsyncEntityConsumer<Boolean> m_dataConsumer = createEntityConsumer(resp);
 
       @Override
       public void consumeResponse(HttpResponse response, EntityDetails entityDetails, HttpContext context, FutureCallback<Boolean> resultCallback) throws HttpException, IOException {
-        LOG.trace("Consuming response (protocol version: {})", context.getProtocolVersion());
-        writeResponseHeaders(resp, response);
+        log(Level.TRACE, m_correlationId, "Consuming response (protocol version: {})", context.getProtocolVersion());
+        writeResponseHeaders(m_correlationId, resp, response);
         writeResponseStatus(resp, response);
 
         if (entityDetails != null) {
-          LOG.trace("Starting stream for entity (content-type: {})", entityDetails.getContentType());
+          log(Level.TRACE, m_correlationId, "Starting stream for entity (content-type: {})", entityDetails.getContentType());
           m_dataConsumer.streamStart(entityDetails, resultCallback);
         }
         else {
-          LOG.trace("No entity data for response");
+          log(Level.TRACE, m_correlationId, "No entity data for response");
           resultCallback.completed(true);
         }
       }
@@ -684,9 +689,11 @@ public class HttpProxy {
 
       @Override
       public void failed(Exception cause) {
-        LOG.trace("Response consumer failed: ", cause);
+        log(Level.TRACE, m_correlationId, "Response consumer failed: ", cause);
         if (!m_connectionErrorDetector.get().isConnectionError(cause)) {
-          BEANS.get(ExceptionHandler.class).handle(cause);
+          try (MDCCloseable ignored = MDC.putCloseable(CorrelationIdContextValueProvider.KEY, m_correlationId)) {
+            BEANS.get(ExceptionHandler.class).handle(cause);
+          }
         }
         releaseResources();
       }
@@ -715,10 +722,7 @@ public class HttpProxy {
       }
     };
 
-    // consumer is run async: wrap the consumer to retain context information (e.g. for logging purposes)
-    @SuppressWarnings("unchecked")
-    AsyncResponseConsumer<Boolean> wrappedConsumer = (AsyncResponseConsumer<Boolean>) m_httpClientManager.createAsyncInvocationHandler(AsyncResponseConsumer.class, consumer);
-    return wrappedConsumer;
+    return consumer;
   }
 
   /**
@@ -727,18 +731,22 @@ public class HttpProxy {
    */
   protected FutureCallback<Boolean> createExecuteCallback(HttpServletResponse resp, AsyncContext asyncContext) {
     FutureCallback<Boolean> callback = new FutureCallback<>() {
+      private final String m_correlationId = CorrelationId.CURRENT.get();
+
       @Override
       public void completed(Boolean result) {
-        LOG.trace("Request execution completed with result: {}", result);
+        log(Level.TRACE, m_correlationId, "Request execution completed with result: {}", result);
         assertTrue(result);
         asyncContext.complete();
       }
 
       @Override
       public void failed(Exception ex) {
-        LOG.trace("Request execution failed", ex);
+        log(Level.TRACE, m_correlationId, "Request execution failed", ex);
         if (!m_connectionErrorDetector.get().isConnectionError(ex)) {
-          BEANS.get(ExceptionHandler.class).handle(ex);
+          try (MDCCloseable ignored = MDC.putCloseable(CorrelationIdContextValueProvider.KEY, m_correlationId)) {
+            BEANS.get(ExceptionHandler.class).handle(ex);
+          }
         }
         try {
           boolean alreadyCommitted = resp.isCommitted();
@@ -747,7 +755,7 @@ public class HttpProxy {
           }
         }
         catch (AlreadyInvalidatedException e) {
-          LOG.trace("Response is invalidated", e);
+          log(Level.TRACE, m_correlationId, "Response is invalidated", e);
         }
         try {
           // this method is already called to handle an exception from within a http-client catch block
@@ -755,21 +763,18 @@ public class HttpProxy {
           asyncContext.complete();
         }
         catch (Exception e) {
-          LOG.warn("Unable to complete async context, assuming already completed", e);
+          log(Level.WARN, m_correlationId, "Unable to complete async context, assuming already completed", e);
         }
       }
 
       @Override
       public void cancelled() {
-        LOG.trace("Request execution cancelled");
+        log(Level.TRACE, m_correlationId, "Request execution cancelled");
         asyncContext.complete();
       }
     };
 
-    // callback is run async: wrap the callback to retain context information (e.g. for logging purposes)
-    @SuppressWarnings("unchecked")
-    FutureCallback<Boolean> wrappedCallback = (FutureCallback<Boolean>) m_httpClientManager.createAsyncInvocationHandler(FutureCallback.class, callback);
-    return wrappedCallback;
+    return callback;
   }
 
   protected int computeStatusCodeForFailure(Exception e) {
@@ -788,6 +793,18 @@ public class HttpProxy {
       return HttpStatus.SC_GATEWAY_TIMEOUT;
     }
     return HttpStatus.SC_INTERNAL_SERVER_ERROR;
+  }
+
+  /**
+   * Logs given message {@code msg} at given {@code level} setting up {@link MDC} context for correlation id.<br>
+   * Note: This is necessary since caller are handling asynchronous responses using separate worker threads without relation to the origin invoking thread.
+   */
+  protected void log(Level level, String correlationId, String msg, Object... args) {
+    if (LOG.isEnabledForLevel(level)) {
+      try (MDCCloseable ignored = MDC.putCloseable(CorrelationIdContextValueProvider.KEY, correlationId)) {
+        LOG.atLevel(level).log(msg, args);
+      }
+    }
   }
 
   /**

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/AbstractAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/AbstractAsyncHttpClientManager.java
@@ -159,7 +159,7 @@ public abstract class AbstractAsyncHttpClientManager<BUILDER> implements IPlatfo
    * calls on the proxy are wrapped with the specific {@link RunContext} (which contains additional context information
    * e.g. for logging).
    */
-  public <T> T createAsyncInvocationHandler(Class<T> clazz, T actualObject) {
+  protected <T> T createAsyncInvocationHandler(Class<T> clazz, T actualObject) {
     if (actualObject == null) {
       return null;
     }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
@@ -42,6 +42,8 @@ import org.eclipse.scout.rt.shared.http.HttpConfigurationProperties.ApacheHttpTr
 import org.eclipse.scout.rt.shared.http.HttpConfigurationProperties.ApacheHttpTransportRetryOnSocketExceptionByConnectionResetProperty;
 import org.eclipse.scout.rt.shared.http.proxy.ConfigurableProxySelector;
 import org.eclipse.scout.rt.shared.http.retry.CustomHttpRequestRetryStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
@@ -62,6 +64,8 @@ import io.opentelemetry.api.metrics.Meter;
  * @see ConfigurableProxySelector
  */
 public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManager<HttpAsyncClientBuilder> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultAsyncHttpClientManager.class);
 
   /**
    * @return Technical transport manager name used for metrics.
@@ -87,9 +91,9 @@ public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManage
 
     // adding execution interceptor allowing access to entityProducer and asyncExecCallback to add context information e.g. for logging purposes
     builder.addExecInterceptorFirst(AsyncHttpInvocationHandler.class.getSimpleName(), (request, entityProducer, scope, chain, asyncExecCallback) -> chain.proceed(request,
-        createAsyncInvocationHandler(AsyncEntityProducer.class, entityProducer),
+        LOG.isDebugEnabled() ? createAsyncInvocationHandler(AsyncEntityProducer.class, entityProducer) : entityProducer,
         scope,
-        createAsyncInvocationHandler(AsyncExecCallback.class, asyncExecCallback)));
+        LOG.isDebugEnabled() ? createAsyncInvocationHandler(AsyncExecCallback.class, asyncExecCallback) : asyncExecCallback));
   }
 
   protected void installConfigurableProxySelector(HttpAsyncClientBuilder builder) {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/H2AsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/H2AsyncHttpClientManager.java
@@ -18,6 +18,8 @@ import org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.apache.hc.core5.http.nio.AsyncEntityProducer;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.opentelemetry.api.OpenTelemetry;
 
@@ -39,6 +41,8 @@ import io.opentelemetry.api.OpenTelemetry;
 @ApplicationScoped
 public class H2AsyncHttpClientManager extends AbstractAsyncHttpClientManager<H2AsyncClientBuilder> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(H2AsyncHttpClientManager.class);
+
   @Override
   protected H2AsyncClientBuilder createBuilder() {
     return HttpAsyncClients.customHttp2();
@@ -50,9 +54,9 @@ public class H2AsyncHttpClientManager extends AbstractAsyncHttpClientManager<H2A
 
     // adding execution interceptor allowing access to entityProducer and asyncExecCallback to add context information e.g. for logging purposes
     builder.addExecInterceptorFirst(AsyncHttpInvocationHandler.class.getSimpleName(), (request, entityProducer, scope, chain, asyncExecCallback) -> chain.proceed(request,
-        createAsyncInvocationHandler(AsyncEntityProducer.class, entityProducer),
+        LOG.isDebugEnabled() ? createAsyncInvocationHandler(AsyncEntityProducer.class, entityProducer) : entityProducer,
         scope,
-        createAsyncInvocationHandler(AsyncExecCallback.class, asyncExecCallback)));
+        LOG.isDebugEnabled() ? createAsyncInvocationHandler(AsyncExecCallback.class, asyncExecCallback) : asyncExecCallback));
   }
 
   @Override


### PR DESCRIPTION
Using logging proxy for all invoked methods causes a large overhead especially for methods which are invoked many times while handling large requests, e.g.
- org.apache.hc.core5.http.nio.AsyncDataConsumer.consume
- org.apache.hc.core5.http.nio.AsyncDataConsumer.updateCapacity

This change removes the logging proxy for all classes which are directly implemented in HttpProxy class and changes all log statements into a log method which dynamically adds correlation id to the MDC before emiting the log statement.

The proxied handler attached in DefaultAsyncHttpClientManager and H2AsyncHttpClientManager are newly guarded by a check statement and just added if log level is <= DEBUG.

416950