### PR TITLE
TableMaxResultsHelper: remove MaxRowCountContributionDo if not used

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -176,7 +176,7 @@ export class PageWithTable extends Page implements PageWithTableModel {
    * @returns the resulting request with the added contribution.
    */
   protected _withMaxRowCountContribution<T>(dataObject: T): T {
-    return scout.create(TableMaxResultsHelper).addMaxRowCountContribution(dataObject, this.detailTable);
+    return scout.create(TableMaxResultsHelper).withMaxRowCountContribution(dataObject, this.detailTable);
   }
 
   /**

--- a/eclipse-scout-core/src/table/TableMaxResultsHelper.ts
+++ b/eclipse-scout-core/src/table/TableMaxResultsHelper.ts
@@ -23,16 +23,18 @@ export class TableMaxResultsHelper {
   }
 
   /**
-   * Adds a DataObject contribution of type {@link MaxRowCountContributionDo} to the given dataObject.
+   * Adds a DataObject contribution of type {@link MaxRowCountContributionDo} to the given dataObject if necessary, removes an existing contribution otherwise.
    * @param dataObject The DataObject to which the contribution should be added.
    * @param table The table to read the maxRowCount property that should be used in the contribution.
    */
-  addMaxRowCountContribution<T extends { _contributions?: DoEntity[] }>(dataObject: T, table: Table): T {
+  withMaxRowCountContribution<T extends { _contributions?: DoEntity[] }>(dataObject: T, table: Table): T {
     const maxRowCountContribution = this.buildMaxRowCountContribution(table);
     if (maxRowCountContribution) {
       dataObject = dataObject || {} as T;
       // see ScoutDataObjectModule.DEFAULT_CONTRIBUTIONS_ATTRIBUTE_NAME
       dataObjects.addContribution(maxRowCountContribution, dataObject);
+    } else {
+      dataObjects.removeContribution(MaxRowCountContributionDo, dataObject);
     }
     return dataObject;
   }

--- a/eclipse-scout-core/test/table/TableMaxResultsHelperSpec.ts
+++ b/eclipse-scout-core/test/table/TableMaxResultsHelperSpec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {TableSpecHelper} from '../../src/testing';
+import {dataObjects, DoEntityWithContributions, MaxRowCountContributionDo, scout, Table, TableMaxResultsHelper} from '../../src';
+
+describe('TableMaxResultsHelper', () => {
+  let table: Table;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    const session = sandboxSession();
+    const helper = new TableSpecHelper(session);
+    table = helper.createTable(helper.createModel([], []));
+  });
+
+  describe('withMaxRowCountContribution', () => {
+
+    it('adds no MaxRowCountContributionDo if maxRowCount is not set', () => {
+      const dataObject: DoEntityWithContributions = {};
+
+      scout.create(TableMaxResultsHelper).withMaxRowCountContribution(dataObject, table);
+      expect(dataObjects.getContribution(MaxRowCountContributionDo, dataObject)).toBeNull();
+    });
+
+    it('adds a MaxRowCountContributionDo if maxRowCount is set', () => {
+      const dataObject: DoEntityWithContributions = {};
+      table.setMaxRowCount(42);
+
+      scout.create(TableMaxResultsHelper).withMaxRowCountContribution(dataObject, table);
+      expect(dataObjects.getContribution(MaxRowCountContributionDo, dataObject)).toEqual(scout.create(MaxRowCountContributionDo, {hint: 42}));
+    });
+
+    it('updates the MaxRowCountContributionDo if maxRowCount has changed', () => {
+      const dataObject: DoEntityWithContributions = {_contributions: [scout.create(MaxRowCountContributionDo, {hint: 13})]};
+      table.setMaxRowCount(42);
+
+      scout.create(TableMaxResultsHelper).withMaxRowCountContribution(dataObject, table);
+      expect(dataObjects.getContribution(MaxRowCountContributionDo, dataObject)).toEqual(scout.create(MaxRowCountContributionDo, {hint: 42}));
+    });
+
+    it('removes the MaxRowCountContributionDo if maxRowCount is no longer set', () => {
+      const dataObject: DoEntityWithContributions = {_contributions: [scout.create(MaxRowCountContributionDo, {hint: 13})]};
+
+      scout.create(TableMaxResultsHelper).withMaxRowCountContribution(dataObject, table);
+      expect(dataObjects.getContribution(MaxRowCountContributionDo, dataObject)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
The data object the MaxRowCountContributionDo is added to may contain an old version of the contribution. If no contribution is necessary because max row count is 0 or undefined this old contribution needs to be removed.