### PR TITLE
Fix NullPointerException in BinaryResource

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/BinaryResource.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/BinaryResource.java
@@ -158,7 +158,7 @@ public final class BinaryResource implements Serializable {
     if (getCharset() != null) {
       charset = Charset.forName(getCharset());
     }
-    return new String(m_content, charset);
+    return m_content != null ? new String(m_content, charset) : null;
   }
 
   /**


### PR DESCRIPTION
java.lang.String.String(byte[], Charset) expects not null arguments, fix this call in BinaryResource.java

363702