### PR TITLE
CSP: set default-src to 'none'

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/ContentSecurityPolicy.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/ContentSecurityPolicy.java
@@ -89,6 +89,7 @@ public class ContentSecurityPolicy {
   public static final String DIRECTIVE_FONT_SRC = "font-src";
   public static final String DIRECTIVE_FORM_ACTION = "form-action";
   public static final String DIRECTIVE_FRAME_ANCESTORS = "frame-ancestors";
+  public static final String DIRECTIVE_MANIFEST_SRC = "manifest-src";
   public static final String DIRECTIVE_MEDIA_SRC = "media-src";
   public static final String DIRECTIVE_OBJECT_SRC = "object-src";
   public static final String DIRECTIVE_PLUGIN_TYPES = "plugin-types";
@@ -106,12 +107,13 @@ public class ContentSecurityPolicy {
   /**
    * Default rules for content security policy (CSP):
    * <ul>
-   * <li><b>default-src 'self'</b><br>
-   * Only accept 'self' sources by default.</li>
-   * <li><b>script-src 'self'</b><br>
+   * <li><b>default-src 'none'</b><br>
+   * Disable fallback handling, directives should be set explicitly.</li>
+   * <li><b>script-src 'self'; font-src 'self'; manifest-src 'self'; media-src 'self'; object-src 'self';</b><br>
+   * Only accept resources from the same origin.</li>
    * <li><b>style-src 'self' 'unsafe-inline'</b><br>
    * Without inline styling many widgets would not work as expected.</li>
-   * <li><b>frame-src *; child-src *</b><br>
+   * <li><b>child-src *</b><br>
    * Everything is allowed because the iframes created by the browser field run in the sandbox mode and therefore handle
    * the security policy by their own.</li>
    * <li><b>report-uri {@link HttpServletControl#CSP_REPORT_URL}</b><br>
@@ -123,13 +125,14 @@ public class ContentSecurityPolicy {
     withImgSrc(getConfiguredDefault(DIRECTIVE_IMG_SRC, "'self'"));
     withStyleSrc(getConfiguredDefault(DIRECTIVE_STYLE_SRC, "'self' 'unsafe-inline'"));
     withChildSrc(getConfiguredDefault(DIRECTIVE_CHILD_SRC, "*"));
-    withConnectSrc(getConfiguredDefault(DIRECTIVE_CONNECT_SRC, null));
-    withDefaultSrc(getConfiguredDefault(DIRECTIVE_DEFAULT_SRC, "'self'"));
-    withFontSrc(getConfiguredDefault(DIRECTIVE_FONT_SRC, null));
+    withConnectSrc(getConfiguredDefault(DIRECTIVE_CONNECT_SRC, "'self'"));
+    withDefaultSrc(getConfiguredDefault(DIRECTIVE_DEFAULT_SRC, "'none'"));
+    withFontSrc(getConfiguredDefault(DIRECTIVE_FONT_SRC, "'self'"));
     withFormAction(getConfiguredDefault(DIRECTIVE_FORM_ACTION, null));
     withFrameAncestors(getConfiguredDefault(DIRECTIVE_FRAME_ANCESTORS, null));
-    withMediaSrc(getConfiguredDefault(DIRECTIVE_MEDIA_SRC, null));
-    withObjectSrc(getConfiguredDefault(DIRECTIVE_OBJECT_SRC, null));
+    withManifestSrc(getConfiguredDefault(DIRECTIVE_MANIFEST_SRC, "'self'"));
+    withMediaSrc(getConfiguredDefault(DIRECTIVE_MEDIA_SRC, "'self'"));
+    withObjectSrc(getConfiguredDefault(DIRECTIVE_OBJECT_SRC, "'self'"));
     withPluginTypes(getConfiguredDefault(DIRECTIVE_PLUGIN_TYPES, null));
     withReportUri(getConfiguredDefault(DIRECTIVE_REPORT_URI, HttpServletControl.CSP_REPORT_URL)); // see also ContentSecurityPolicyReportHandler
     withSandbox(getConfiguredDefault(DIRECTIVE_SANDBOX, null));
@@ -318,6 +321,23 @@ public class ContentSecurityPolicy {
    */
   public ContentSecurityPolicy appendImgSrc(String imgSrc) {
     return addOrAppend(DIRECTIVE_IMG_SRC, imgSrc);
+  }
+
+  /**
+   * @see <a href="https://www.w3.org/TR/CSP3/#directive-manifest-src">https://www.w3.org/TR/CSP3/#directive-manifest-src</a>
+   */
+  public ContentSecurityPolicy withManifestSrc(String manifestSrc) {
+    putOrRemove(DIRECTIVE_MANIFEST_SRC, manifestSrc);
+    return this;
+  }
+
+  /**
+   * Appends {@code manifestSrc} to existing manifest source directive or creates new directive if it not already exists.
+   *
+   * @see <a href="https://www.w3.org/TR/CSP3/#directive-manifest-src">https://www.w3.org/TR/CSP3/#directive-manifest-src</a>
+   */
+  public ContentSecurityPolicy appendManifestSrc(String manifestSrc) {
+    return addOrAppend(DIRECTIVE_MANIFEST_SRC, manifestSrc);
   }
 
   /**

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/ContentSecurityPolicy.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/ContentSecurityPolicy.java
@@ -88,6 +88,7 @@ public class ContentSecurityPolicy {
   public static final String DIRECTIVE_DEFAULT_SRC = "default-src";
   public static final String DIRECTIVE_FONT_SRC = "font-src";
   public static final String DIRECTIVE_FORM_ACTION = "form-action";
+  public static final String DIRECTIVE_FRAME_SRC = "frame-src";
   public static final String DIRECTIVE_FRAME_ANCESTORS = "frame-ancestors";
   public static final String DIRECTIVE_MANIFEST_SRC = "manifest-src";
   public static final String DIRECTIVE_MEDIA_SRC = "media-src";
@@ -109,11 +110,11 @@ public class ContentSecurityPolicy {
    * <ul>
    * <li><b>default-src 'none'</b><br>
    * Disable fallback handling, directives should be set explicitly.</li>
-   * <li><b>script-src 'self'; font-src 'self'; manifest-src 'self'; media-src 'self'; object-src 'self';</b><br>
+   * <li><b>base-uri 'self'; child-src 'self'; font-src 'self'; form-action 'self'; manifest-src 'self'; media-src 'self'; object-src 'self'; script-src 'self'; worker-src 'self';</b><br>
    * Only accept resources from the same origin.</li>
    * <li><b>style-src 'self' 'unsafe-inline'</b><br>
    * Without inline styling many widgets would not work as expected.</li>
-   * <li><b>child-src *</b><br>
+   * <li><b>frame-src *;</b><br>
    * Everything is allowed because the iframes created by the browser field run in the sandbox mode and therefore handle
    * the security policy by their own.</li>
    * <li><b>report-uri {@link HttpServletControl#CSP_REPORT_URL}</b><br>
@@ -121,14 +122,15 @@ public class ContentSecurityPolicy {
    * </ul>
    */
   protected void initDirectives() {
-    withBaseUri(getConfiguredDefault(DIRECTIVE_BASE_URI, null));
+    withBaseUri(getConfiguredDefault(DIRECTIVE_BASE_URI, "'self'"));
     withImgSrc(getConfiguredDefault(DIRECTIVE_IMG_SRC, "'self'"));
     withStyleSrc(getConfiguredDefault(DIRECTIVE_STYLE_SRC, "'self' 'unsafe-inline'"));
-    withChildSrc(getConfiguredDefault(DIRECTIVE_CHILD_SRC, "*"));
+    withChildSrc(getConfiguredDefault(DIRECTIVE_CHILD_SRC, "'self"));
     withConnectSrc(getConfiguredDefault(DIRECTIVE_CONNECT_SRC, "'self'"));
     withDefaultSrc(getConfiguredDefault(DIRECTIVE_DEFAULT_SRC, "'none'"));
     withFontSrc(getConfiguredDefault(DIRECTIVE_FONT_SRC, "'self'"));
-    withFormAction(getConfiguredDefault(DIRECTIVE_FORM_ACTION, null));
+    withFormAction(getConfiguredDefault(DIRECTIVE_FORM_ACTION, "'self'"));
+    withFrameSrc(getConfiguredDefault(DIRECTIVE_FRAME_SRC, "*"));
     withFrameAncestors(getConfiguredDefault(DIRECTIVE_FRAME_ANCESTORS, null));
     withManifestSrc(getConfiguredDefault(DIRECTIVE_MANIFEST_SRC, "'self'"));
     withMediaSrc(getConfiguredDefault(DIRECTIVE_MEDIA_SRC, "'self'"));
@@ -137,7 +139,7 @@ public class ContentSecurityPolicy {
     withReportUri(getConfiguredDefault(DIRECTIVE_REPORT_URI, HttpServletControl.CSP_REPORT_URL)); // see also ContentSecurityPolicyReportHandler
     withSandbox(getConfiguredDefault(DIRECTIVE_SANDBOX, null));
     withScriptSrc(getConfiguredDefault(DIRECTIVE_SCRIPT_SRC, "'self'"));
-    withWorkerSrc(getConfiguredDefault(DIRECTIVE_WORKER_SRC, null));
+    withWorkerSrc(getConfiguredDefault(DIRECTIVE_WORKER_SRC, "'self'"));
   }
 
   protected String getConfiguredDefault(String directiveKey, String fallbackValue) {
@@ -285,6 +287,24 @@ public class ContentSecurityPolicy {
   public ContentSecurityPolicy appendFormAction(String formAction) {
     return addOrAppend(DIRECTIVE_FORM_ACTION, formAction);
   }
+
+  /**
+   * @see <a href="https://www.w3.org/TR/CSP3/#directive-frame-src">https://www.w3.org/TR/CSP3/#directive-frame-src</a>
+   */
+  public ContentSecurityPolicy withFrameSrc(String frameSrc) {
+    putOrRemove(DIRECTIVE_FRAME_SRC, frameSrc);
+    return this;
+  }
+
+  /**
+   * Appends {@code frameSrc} to existing frame source directive or creates new directive if it not already exists.
+   *
+   * @see <a href="https://www.w3.org/TR/CSP3/#directive-frame-src">https://www.w3.org/TR/CSP3/#directive-frame-src</a>
+   */
+  public ContentSecurityPolicy appendFrameSrc(String frameSrc) {
+    return addOrAppend(DIRECTIVE_FRAME_SRC, frameSrc);
+  }
+
 
   /**
    * @see <a href=


### PR DESCRIPTION
Loading resources should be blocked by default, unless it is explicitly allowed by the other directives.
There should be no behavior change to the existing rules, except for one directive: Since prefetch-src is not set, it now defaults to 'none' and not to 'self' anymore. But because it is not a standard property, it should not be set by Scout. It is not supported by every browser anyway, so it is probably not used very often.

417492