### PR TITLE
Add possibility to provide a custom Jetty session handler implementation

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/servlet/ScoutServletContextHandler.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/servlet/ScoutServletContextHandler.java
@@ -26,6 +26,8 @@ import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.URLResourceFactory;
 import org.eclipse.scout.rt.app.Application;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 
 public class ScoutServletContextHandler extends ServletContextHandler {
@@ -115,5 +117,20 @@ public class ScoutServletContextHandler extends ServletContextHandler {
     catch (IOException e) {
       throw new ProcessingException("Error during getResourcePaths", e);
     }
+  }
+
+  /**
+   * Optional provider for a custom Jetty {@link SessionHandler} implementation.
+   */
+  @Override
+  protected SessionHandler newSessionHandler() {
+    return BEANS.optional(ISessionHandlerProvider.class)
+        .orElse(super::newSessionHandler)
+        .newSessionHandler();
+  }
+
+  @ApplicationScoped
+  public interface ISessionHandlerProvider {
+    SessionHandler newSessionHandler();
   }
 }


### PR DESCRIPTION
The interface ISessionHandlerProvider has been added that allows to provide a custom implementation for the Jetty session handler

408657