### PR TITLE
Add missing table changing in AbstractTable#checkRows

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -649,10 +649,10 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
    * Subclasses can override this method. Default is {@link TriState#UNDEFINED}
    *
    * @return <ul>
-   *         <li>{@link TriState#TRUE} if the tooltip should always be shown if the cell content is truncated</li>
-   *         <li>{@link TriState#FALSE} if the tooltip should never be shown</li>
-   *         <li>{@link TriState#UNDEFINED} cell tooltip is only shown if it is not possible to resize the column</li>
-   *         </ul>
+   * <li>{@link TriState#TRUE} if the tooltip should always be shown if the cell content is truncated</li>
+   * <li>{@link TriState#FALSE} if the tooltip should never be shown</li>
+   * <li>{@link TriState#UNDEFINED} cell tooltip is only shown if it is not possible to resize the column</li>
+   * </ul>
    */
   @ConfigProperty(ConfigProperty.BOOLEAN)
   @Order(270)
@@ -2700,6 +2700,7 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
   }
 
   public void checkRows(Collection<? extends ITableRow> rows, boolean value, boolean enabledRowsOnly) {
+    setTableChanging(true);
     try {
       rows = resolveRows(rows);
       // check checked-count with multi-check
@@ -2741,6 +2742,9 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
     }
     catch (RuntimeException e) {
       BEANS.get(ExceptionHandler.class).handle(e);
+    }
+    finally {
+      setTableChanging(false);
     }
   }
 


### PR DESCRIPTION
Otherwise, if isMultiCheck is false, AbstractListBox would see and process intermediate states in AbstractListBox#syncTableToValue.