### PR TITLE
Print stack trace for timed-out tests (of timed-out thread)

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/main/java/org/eclipse/scout/rt/testing/client/runner/statement/TimeoutClientRunContextStatement.java
+++ b/org.eclipse.scout.rt.client.test/src/main/java/org/eclipse/scout/rt/testing/client/runner/statement/TimeoutClientRunContextStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,18 +9,13 @@
  */
 package org.eclipse.scout.rt.testing.client.runner.statement;
 
-import java.util.concurrent.TimeUnit;
-
 import org.eclipse.scout.rt.client.context.ClientRunContexts;
 import org.eclipse.scout.rt.client.job.ModelJobs;
 import org.eclipse.scout.rt.platform.job.IFuture;
-import org.eclipse.scout.rt.platform.util.Assertions;
-import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruptedError;
-import org.eclipse.scout.rt.platform.util.concurrent.TimedOutError;
-import org.eclipse.scout.rt.testing.platform.runner.SafeStatementInvoker;
+import org.eclipse.scout.rt.platform.util.concurrent.IRunnable;
+import org.eclipse.scout.rt.testing.platform.runner.statement.AbstractTimeoutRunContextStatement;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
-import org.junit.runners.model.TestTimedOutException;
 
 /**
  * Statement for executing tests with a timeout (i.e. the annotated test method is expected to complete within the
@@ -30,35 +25,14 @@ import org.junit.runners.model.TestTimedOutException;
  * @see Test#timeout()
  * @since 5.1
  */
-public class TimeoutClientRunContextStatement extends Statement {
-
-  protected final Statement m_next;
-  private final long m_timeoutMillis;
+public class TimeoutClientRunContextStatement extends AbstractTimeoutRunContextStatement {
 
   public TimeoutClientRunContextStatement(final Statement next, final long timeoutMillis) {
-    m_timeoutMillis = timeoutMillis;
-    m_next = Assertions.assertNotNull(next, "next statement must not be null");
+    super(next, timeoutMillis);
   }
 
   @Override
-  public void evaluate() throws Throwable {
-    final SafeStatementInvoker invoker = new SafeStatementInvoker(m_next);
-
-    final IFuture<Void> future = ModelJobs.schedule(invoker, ModelJobs.newInput(ClientRunContexts.copyCurrent()).withName("Running test with support for JUnit timeout"));
-
-    try {
-      if (m_timeoutMillis <= 0) {
-        future.awaitDone();
-      }
-      else {
-        future.awaitDone(m_timeoutMillis, TimeUnit.MILLISECONDS);
-      }
-    }
-    catch (ThreadInterruptedError | TimedOutError e) { // NOSONAR
-      future.cancel(true);
-      throw new TestTimedOutException(m_timeoutMillis, TimeUnit.MILLISECONDS); // JUnit timeout exception
-    }
-
-    invoker.throwOnError();
+  protected IFuture<Void> createFuture(IRunnable runnable) {
+    return ModelJobs.schedule(runnable, ModelJobs.newInput(ClientRunContexts.copyCurrent()).withName("Running test with support for JUnit timeout"));
   }
 }

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/statement/AbstractTimeoutRunContextStatement.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/statement/AbstractTimeoutRunContextStatement.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.testing.platform.runner.statement;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.platform.util.concurrent.IRunnable;
+import org.eclipse.scout.rt.platform.util.concurrent.TimedOutError;
+import org.eclipse.scout.rt.testing.platform.runner.SafeStatementInvoker;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestTimedOutException;
+
+public abstract class AbstractTimeoutRunContextStatement extends Statement {
+
+  protected final Statement m_next;
+  protected final long m_timeoutMillis;
+
+  public AbstractTimeoutRunContextStatement(final Statement next, final long timeoutMillis) {
+    m_next = Assertions.assertNotNull(next, "next statement must not be null");
+    m_timeoutMillis = timeoutMillis;
+  }
+
+  protected abstract IFuture<Void> createFuture(IRunnable runnable);
+
+  @Override
+  public void evaluate() throws Throwable {
+    final SafeStatementInvoker invoker = new SafeStatementInvoker(m_next);
+    class TimeoutFutureRunnable implements IRunnable {
+
+      protected Thread m_thread;
+
+      @Override
+      public void run() {
+        try {
+          m_thread = Thread.currentThread();
+          invoker.run();
+        }
+        finally {
+          m_thread = null;
+        }
+      }
+
+      public StackTraceElement[] getStackTrace() {
+        Thread t = m_thread;
+        if (t != null) {
+          return t.getStackTrace();
+        }
+        return new StackTraceElement[0];
+      }
+    }
+    final TimeoutFutureRunnable runnable = new TimeoutFutureRunnable();
+
+    final IFuture<Void> future = createFuture(runnable);
+    try {
+      if (m_timeoutMillis <= 0) {
+        future.awaitDone();
+      }
+      else {
+        future.awaitDone(m_timeoutMillis, TimeUnit.MILLISECONDS);
+      }
+    }
+    catch (TimedOutError e) { // NOSONAR
+      System.err.println("Test has timed out, cancelling future and printing stack trace");
+      StackTraceElement[] stackTrace = runnable.getStackTrace();
+      future.cancel(true);
+      printStackTrace(stackTrace);
+      throw new TestTimedOutException(m_timeoutMillis, TimeUnit.MILLISECONDS); // JUnit timeout exception
+    }
+
+    invoker.throwOnError();
+  }
+
+  protected void printStackTrace(StackTraceElement[] stackTrace) {
+    System.err.println(StringUtility.box("Trace:\n", Arrays.stream(stackTrace)
+        .map(stackTraceElement -> StringUtility.box("\tat ", Objects.toString(stackTraceElement), null))
+        .collect(Collectors.joining("\n")), null));
+  }
+}

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/statement/AssertNoRunningJobsStatement.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/statement/AssertNoRunningJobsStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,12 +12,15 @@ package org.eclipse.scout.rt.testing.platform.runner.statement;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.eclipse.scout.rt.platform.job.IFuture;
 import org.eclipse.scout.rt.platform.job.JobState;
@@ -27,6 +30,7 @@ import org.eclipse.scout.rt.platform.job.listener.JobEvent;
 import org.eclipse.scout.rt.platform.job.listener.JobEventType;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.IRegistrationHandle;
+import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.concurrent.TimedOutError;
 import org.junit.runners.model.Statement;
 
@@ -83,6 +87,16 @@ public class AssertNoRunningJobsStatement extends Statement {
     catch (final TimedOutError e) { // NOSONAR
       final List<String> runningJobs = findJobNames(jobFilter);
       if (!runningJobs.isEmpty()) {
+        // thread-dump
+        System.err.println("Test will fail because some jobs did not complete yet, creating thread dump for debugging purposes:");
+        System.err.println();
+        System.err.println(Thread.getAllStackTraces().entrySet().stream()
+            .map(entry -> StringUtility.box(entry.getKey() /* Thread */ + "\n", Arrays.stream(entry.getValue() /* StackTraceElement[] */)
+                .map(stackTraceElement -> StringUtility.box("\tat ", Objects.toString(stackTraceElement), null))
+                .collect(Collectors.joining("\n")), "\n"))
+            .filter(StringUtility::hasText)
+            .collect(Collectors.joining("\n")));
+
         fail(String.format("Test failed because some jobs did not complete yet. [context=%s, jobs=%s]", m_context, runningJobs));
       }
     }

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/statement/TimeoutRunContextStatement.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/statement/TimeoutRunContextStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,20 +9,16 @@
  */
 package org.eclipse.scout.rt.testing.platform.runner.statement;
 
-import java.util.concurrent.TimeUnit;
-
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.context.RunContext;
+import org.eclipse.scout.rt.platform.context.RunMonitor;
 import org.eclipse.scout.rt.platform.job.IFuture;
 import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.transaction.TransactionScope;
-import org.eclipse.scout.rt.platform.util.Assertions;
-import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruptedError;
-import org.eclipse.scout.rt.platform.util.concurrent.TimedOutError;
-import org.eclipse.scout.rt.testing.platform.runner.SafeStatementInvoker;
+import org.eclipse.scout.rt.platform.util.concurrent.IRunnable;
 import org.junit.Test;
 import org.junit.internal.runners.statements.FailOnTimeout;
 import org.junit.runners.model.Statement;
-import org.junit.runners.model.TestTimedOutException;
 
 /**
  * JUnit runs tests with a timeout in a separate thread. This statement is a replace for {@link FailOnTimeout}, and
@@ -35,31 +31,20 @@ import org.junit.runners.model.TestTimedOutException;
  * @see FailOnTimeout
  * @since 5.1
  */
-public class TimeoutRunContextStatement extends Statement {
-
-  private final Statement m_next;
-  private final long m_timeoutMillis;
+public class TimeoutRunContextStatement extends AbstractTimeoutRunContextStatement {
 
   public TimeoutRunContextStatement(final Statement next, final long timeoutMillis) {
-    m_next = Assertions.assertNotNull(next, "next statement must not be null");
-    m_timeoutMillis = timeoutMillis;
+    super(next, timeoutMillis);
   }
 
   @Override
-  public void evaluate() throws Throwable {
-    final SafeStatementInvoker invoker = new SafeStatementInvoker(m_next);
-
-    final IFuture<Void> future = Jobs.schedule(invoker, Jobs.newInput()
-        .withRunContext(RunContext.CURRENT.get().copy().withTransactionScope(TransactionScope.REQUIRES_NEW)) // Run in new TX, because the same TX is not allowed to be used by multiple threads.
+  protected IFuture<Void> createFuture(IRunnable runnable) {
+    RunMonitor newRunMonitor = BEANS.get(RunMonitor.class);
+    return Jobs.schedule(runnable, Jobs.newInput()
+        .withRunContext(RunContext.CURRENT.get().copy()
+            .withRunMonitor(newRunMonitor)
+            .withParentRunMonitor(RunMonitor.CURRENT.get())
+            .withTransactionScope(TransactionScope.REQUIRES_NEW)) // Run in new TX, because the same TX is not allowed to be used by multiple threads.
         .withName("Running test with support for JUnit timeout"));
-    try {
-      future.awaitDone(m_timeoutMillis, TimeUnit.MILLISECONDS);
-    }
-    catch (ThreadInterruptedError | TimedOutError e) { // NOSONAR
-      future.cancel(true);
-      throw new TestTimedOutException(m_timeoutMillis, TimeUnit.MILLISECONDS); // JUnit timeout exception
-    }
-
-    invoker.throwOnError();
   }
 }


### PR DESCRIPTION
Also: Create thread dump in case of AssertNoRunningJobsStatement failure

Cherry-pick of 4111b08233f4e078e85d5f44b53893030b1c0ac8