### PR TITLE
BaseDoEntity: don't copy the extra model deeply

### DIFF
--- a/eclipse-scout-core/src/dataobject/BaseDoEntity.ts
+++ b/eclipse-scout-core/src/dataobject/BaseDoEntity.ts
@@ -72,13 +72,14 @@ export class BaseDoEntity {
    * See {@link dataObjects.serialize} for details.
    *
    * @param model An optional model to apply to the clone.
-   * Note: this extra model is applied to the pojo representation of this data object before a new instance is created. So to modify properties, the structure and types of the properties in their pojo form must be used.
+   * * The values of the model are copied by reference and nested objects are _not_ merged (shallow-copy).
+   * * The model is applied to the pojo representation of this data object before a new instance is created. So to modify properties, the structure and types of the properties in their pojo form must be used.
    * @returns A deep clone of this data object instance (compare {@link toPojo}).
    */
   clone(model?: InitModelOf<this> | BaseDoEntity): this {
     const addModel = model instanceof BaseDoEntity ? model.toPojo() : model;
     const thisModel = this.toPojo();
-    return dataObjects.deserialize($.extend(true, thisModel, addModel)) as this;
+    return dataObjects.deserialize($.extend(thisModel, addModel)) as this;
   }
 
   /**

--- a/eclipse-scout-core/test/dataobject/BaseDoEntitySpec.ts
+++ b/eclipse-scout-core/test/dataobject/BaseDoEntitySpec.ts
@@ -51,21 +51,27 @@ describe('BaseDoEntity', () => {
 
     it('accepts extra model', () => {
       const fixture = scout.create(BaseDoEntityFixture01Do, {
+        arr: [1, 2],
         propObj: {
           dateProp: dates.parseJsonDate('2025-01-14 11:04:40.708Z')
         }
       });
       const extra = {
-        dateProp: dates.parseJsonDate('2025-01-14 12:04:40.708Z'),
+        arr: [3],
+        dateProp: dates.parseJsonDate('2028-01-14 12:04:40.708Z'),
         propObj: {
-          shouldBeMerged: true
+          dateProp: dates.parseJsonDate('2030-01-14 11:04:40.708Z'),
+          newProperty: true
         }
       } as any;
       const copy = fixture.clone(extra) as any;
+      expect(copy.arr).toEqual([3]); // Arrays won't be merged, this would be confusing and not expected
+      expect(copy.propObj.newProperty).toBeTrue();
+
       fixture.propObj.dateProp.setFullYear(2020);
+      expect(copy.propObj.dateProp.getFullYear()).toBe(2030); // change in fixture has no effect to copy
+
       extra.dateProp.setFullYear(2021);
-      expect(copy.propObj.dateProp.getFullYear()).toBe(2025); // change in fixture has no effect to copy
-      expect(copy.propObj.shouldBeMerged).toBeTrue();
       expect(copy.dateProp.getFullYear()).toBe(2021); // change in extra has effect to copy as Date is copied by reference
     });
 
@@ -79,9 +85,11 @@ describe('BaseDoEntity', () => {
         dateProp: dates.parseJsonDate('2025-01-14 12:04:40.708Z')
       });
       const copy = fixture.clone(extra) as any;
+
       fixture.propObj.dateProp.setFullYear(2020);
-      extra.dateProp.setFullYear(2021);
       expect(copy.propObj.dateProp.getFullYear()).toBe(2025); // change in fixture has no effect to copy
+
+      extra.dateProp.setFullYear(2021);
       expect(copy.dateProp.getFullYear()).toBe(2025); // change in extra has no effect to copy
     });
   });
@@ -89,6 +97,7 @@ describe('BaseDoEntity', () => {
 
 @typeName('scout.BaseDoEntityFixture01')
 export class BaseDoEntityFixture01Do extends BaseDoEntity {
+  arr: number[];
   propObj: BaseDoEntityFixture02Do;
 }
 


### PR DESCRIPTION
Using $.extend(true, {}) not only deep copies objects but also merges arrays. This is quite unexpected. I don't think a deep merge is required very often, so shallow copy is fine. If a deep merge is required, the extra model needs to be enriched first.

Example:
obj.clone({
  settings: {
    ...obj.settings,
    notes: 'hi'
  }
})

Or if a complete deep merge is needed:
obj.clone($.extend(true, obj.toPojo(), {settings: {notes: 'hi'}}))

416864