### PR TITLE
Mobile: don't make main box of detail forms scrollable

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/transformation/MobileDeviceTransformer.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/transformation/MobileDeviceTransformer.java
@@ -368,16 +368,21 @@ public class MobileDeviceTransformer extends AbstractDeviceTransformer {
   }
 
   protected void makeGroupBoxScrollable(IGroupBox groupBox) {
-    if (!groupBox.isScrollable().isTrue()) {
-      groupBox.setScrollable(true);
+    if (groupBox.isScrollable().isTrue()) {
+      return;
+    }
+    if (groupBox.getForm() != null && getDesktop().getPageDetailForm() == groupBox.getForm()) {
+      // Ignore main boxes of detail forms, see notifyPageDetailFormChanged
+      return;
+    }
+    groupBox.setScrollable(true);
 
-      // GridDataHints have been modified by setScrollable. Update the actual gridData with those hints.
-      if (groupBox.isMainBox()) {
-        FormUtility.initRootBoxGridData(groupBox);
-      }
-      else {
-        rebuildParentGrid(groupBox);
-      }
+    // GridDataHints have been modified by setScrollable. Update the actual gridData with those hints.
+    if (groupBox.isMainBox()) {
+      FormUtility.initRootBoxGridData(groupBox);
+    }
+    else {
+      rebuildParentGrid(groupBox);
     }
   }
 


### PR DESCRIPTION
Normally, makeGroupBoxScrollable is called first
and then notifyPageDetailFormChanged because pageChanging is true while a page is being selected which delays the PROP_DETAIL_FORM changed event.

But if the page is already selected and the detail form changes dynamically, it is the other way round. In that case, makeGroupBoxScrollable must not revert the changes done by notifyPageDetailFormChanged.

413994