### PR TITLE
GroupBoxSpec: make it more robust

### DIFF
--- a/eclipse-scout-core/test/form/fields/groupbox/GroupBoxSpec.ts
+++ b/eclipse-scout-core/test/form/fields/groupbox/GroupBoxSpec.ts
@@ -659,9 +659,16 @@ describe('GroupBox', () => {
   describe('expandable', () => {
 
     beforeEach(() => {
-      $('<style>' +
-        '.group-box.collapsed > .group-box-body { display: none; }' +
-        '</style>').appendTo($('#sandbox'));
+      $(`<style>
+        .label-field {
+          display: flex;
+          width: 20px;
+          height: 20px;
+        }
+        .group-box.collapsed > .group-box-body {
+           display: none;
+        }
+      </style>`).appendTo($('#sandbox'));
     });
 
     it('removes status when collapsed', () => {
@@ -719,7 +726,7 @@ describe('GroupBox', () => {
               expandable: true,
               fields: [
                 {
-                  objectType: StringField
+                  objectType: LabelField
                 }
               ]
             },
@@ -728,7 +735,7 @@ describe('GroupBox', () => {
               expandable: true,
               fields: [
                 {
-                  objectType: StringField,
+                  objectType: LabelField,
                   errorStatus: {
                     message: 'I am an error!!!'
                   }


### PR DESCRIPTION
Depending on zoom level, the spec may fail (e.g. it fails with Windows zoom set to 125%).

Setting a layout width a fixed width and height fixes the issue.