### PR TITLE
clipboard: use desktop as parent for desktop notification

### DIFF
--- a/eclipse-scout-core/src/util/clipboard.ts
+++ b/eclipse-scout-core/src/util/clipboard.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -138,11 +138,12 @@ export const clipboard = {
    */
   showNotification(parent: Widget, status?: Status) {
     scout.assertParameter('parent', parent);
+    status = status || clipboard._successStatus(parent.session);
     let notification = scout.create(DesktopNotification, {
-      parent: parent,
+      parent: parent.findDesktop(), // use desktop as parent in case the given parent widget is destroyed before the notification duration has elapsed
       closable: false,
-      duration: 1234,
-      status: status || clipboard._successStatus(parent.session)
+      duration: status.isValid() ? 1234 : 3456, // use longer duration for errors because error message is longer
+      status: status
     });
     notification.show();
   }

--- a/eclipse-scout-core/test/util/clipboardSpec.ts
+++ b/eclipse-scout-core/test/util/clipboardSpec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {clipboard, scout, StringField} from '../../src/index';
+
+describe('clipboard', () => {
+  let session: SandboxSession, $sandbox: JQuery;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    $sandbox = session.$entryPoint;
+    jasmine.clock().install();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  describe('showNotification', () => {
+
+    it('shows a desktop notification', () => {
+      let parent = scout.create(StringField, {
+        parent: session.desktop
+      });
+      parent.render();
+      expect(session.desktop.notifications.length).toBe(0);
+
+      clipboard.showNotification(parent);
+      expect(session.desktop.notifications.length).toBe(1);
+
+      // Destroy parent widget -> should not destroy notification
+      parent.destroy();
+      expect(session.desktop.notifications.length).toBe(1);
+
+      // Wait for notification to be removed
+      jasmine.clock().tick(5000);
+      expect(session.desktop.notifications.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
clipboard.showNotification() displays a desktop notification with a duration. When the parent widget is destroyed before that duration has elapsed, an error occurs. It happens because the notification is destroyed twice:
First, it is destroyed by its parent widget. This triggers a 'remove' event on the desktop and causes fadeOut() to be called. This then destroys the notification a second time, because it is no longer rendered but not completely destroyed yet (only 'destroying').

We could fix this in the Desktop or the DesktopNotification, but we don't want the clipboard notification to be removed immediately anyway when the parent widget is destroyed. This could happen if the notification was triggered from inside a popup and then that popup is closed while the notification is still showing. If we use the desktop as parent widget, the notification will be preserved until the specified duration has elapsed.

397563