### PR TITLE
Improve resolution of textKeys and iconIds

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -9,8 +9,8 @@
  */
 import {
   arrays, BaseDoEntity, BookmarkSupport, BookmarkTableRowIdentifierDo, ButtonTile, ChildModelOf, Constructor, dataObjects, DoTypeResolver, EnumObject, Event, EventHandler, EventListener, EventMapOf, EventModel, EventSupport, Form,
-  HtmlComponent, icons, InitModelOf, inspector, Menu, MenuBar, ObjectIdProvider, ObjectOrChildModel, ObjectOrType, ObjectWithUuid, Outline, PageDetailMenuContributor, PageEventMap, PageModel, ParentTablePageMenuContributor,
-  PropertyChangeEvent, RequiredUnlessNotSubclass, scout, SomeRequired, strings, Table, TableRow, TableRowClickEvent, TileOutlineOverview, TileOverviewForm, TreeNode, typeName, UuidPathOptions, Widget
+  HtmlComponent, InitModelOf, inspector, Menu, MenuBar, ObjectIdProvider, ObjectOrChildModel, ObjectOrType, ObjectWithUuid, Outline, PageDetailMenuContributor, PageEventMap, PageModel, ParentTablePageMenuContributor, PropertyChangeEvent,
+  RequiredUnlessNotSubclass, scout, SomeRequired, strings, Table, TableRow, TableRowClickEvent, TileOutlineOverview, TileOverviewForm, TreeNode, typeName, UuidPathOptions, Widget
 } from '../../../index';
 import $ from 'jquery';
 
@@ -120,7 +120,7 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
       this._detailFormModel = Page._removePropertyIfLazyLoading(model, 'detailForm') as ChildModelOf<Form>;
 
       super._init(model);
-      icons.resolveIconProperty(this, 'overviewIconId');
+      this._resolveIconIds(['overviewIconId']);
       this._setPageParam(this.pageParam);
 
       let detailMenuContributors = this._createDetailMenuContributors();

--- a/eclipse-scout-core/src/notification/Notification.ts
+++ b/eclipse-scout-core/src/notification/Notification.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {aria, HtmlComponent, Icon, InitModelOf, NotificationEventMap, NotificationModel, scout, Status, StatusOrModel, strings, texts, Widget} from '../index';
+import {aria, HtmlComponent, Icon, icons, InitModelOf, NotificationEventMap, NotificationModel, scout, Status, StatusOrModel, strings, texts, Widget} from '../index';
 import $ from 'jquery';
 
 export class Notification extends Widget implements NotificationModel {
@@ -45,8 +45,17 @@ export class Notification extends Widget implements NotificationModel {
         iconId: scout.nvl(model.iconId, this.status.iconId)
       });
     }
-    texts.resolveTextProperty(this.status, 'message', this.session);
+    this._resolveStatusTextKeys(['message']);
+    this._resolveStatusIconIds(['iconId']);
     this._setStatus(this.status);
+  }
+
+  protected _resolveStatusTextKeys(properties: string[]) {
+    texts.resolveTextProperties(this.status, properties, this.session);
+  }
+
+  protected _resolveStatusIconIds(properties: string[]) {
+    icons.resolveIconProperties(this.status, properties);
   }
 
   protected override _render() {

--- a/eclipse-scout-core/src/table/columns/Column.ts
+++ b/eclipse-scout-core/src/table/columns/Column.ts
@@ -172,9 +172,8 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
       this.initialWidth = scout.nvl(this.width, 0);
     }
 
-    texts.resolveTextProperty(this, 'text');
-    texts.resolveTextProperty(this, 'headerTooltipText');
-    icons.resolveIconProperty(this, 'headerIconId');
+    this._resolveTextKeys(['text', 'headerTooltipText']);
+    this._resolveIconIds(['headerIconId']);
 
     this._setAutoOptimizeWidth(this.autoOptimizeWidth);
     this.sortActive = scout.nvl(this.sortActive, this.sortIndex >= 0);
@@ -223,6 +222,14 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
 
   get table(): Table {
     return this.parent;
+  }
+
+  protected _resolveTextKeys(properties: string[]) {
+    texts.resolveTextProperties(this, properties);
+  }
+
+  protected _resolveIconIds(properties: string[]) {
+    icons.resolveIconProperties(this, properties);
   }
 
   /**

--- a/eclipse-scout-core/src/text/TextMap.ts
+++ b/eclipse-scout-core/src/text/TextMap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,6 @@ export class TextMap {
   constructor(textMap?: Record<string, string>) {
     this.map = textMap || {};
   }
-
-  static TEXT_KEY_REGEX = /\${textKey:([a-zA-Z0-9.]*)}/;
 
   /**
    * Returns the text for the given key.

--- a/eclipse-scout-core/src/text/texts.ts
+++ b/eclipse-scout-core/src/text/texts.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ export const texts = {
    */
   defaultLanguage: 'en',
 
-  TEXT_KEY_REGEX: /\${textKey:([^}]*)}/,
+  TEXT_KEY_REGEX: /^\${textKey:([^}]+)}$/,
 
   textsByLocale: {} as TextMapType,
 
@@ -47,8 +47,10 @@ export const texts = {
   },
 
   init(model: Record<string, Record<string, string>>) {
-    Object.keys(model)
-      .forEach(languageTag => texts.get(languageTag).addAll(model[languageTag]), this);
+    Object.keys(model).forEach(languageTag => {
+      let textMap = model[languageTag];
+      texts.get(languageTag).addAll(textMap);
+    });
   },
 
   /**
@@ -73,18 +75,16 @@ export const texts = {
 
   /**
    * Creates an array containing all relevant tags.
-   * <p>
-   * Examples:<br>
+   *
+   * Examples:
    * - 'de-CH' generates the array: ['de-CH', 'de', 'default']
    * - 'de' generates the array: ['de', 'default']
    * - 'default' generates the array: ['default']
    */
   createOrderedLanguageTags(languageTag: string): string[] {
-    let tags = [],
-      i = languageTag.lastIndexOf('-');
+    let tags = [languageTag];
 
-    tags.push(languageTag);
-
+    let i = languageTag.lastIndexOf('-');
     while (i >= 0) {
       languageTag = languageTag.substring(0, i);
       tags.push(languageTag);
@@ -103,7 +103,7 @@ export const texts = {
    * @returns the TextMap for the given languageTag. Never returns null or undefined.
    */
   get(languageTag: string): TextMap {
-    let textMap: TextMap = texts._get(languageTag);
+    let textMap = texts._get(languageTag);
     if (textMap) {
       return textMap;
     }
@@ -133,7 +133,7 @@ export const texts = {
   /**
    * Extracts NLS texts from the DOM tree. Texts are expected in the following format:
    *
-   *   <scout-text data-key="..." data-value="..." />
+   *   `<scout-text data-key="..." data-value="..." />`
    *
    * This method returns a map with all found texts. It must be called before scout.prepareDOM()
    * is called, as that method removes all <scout-text> tags.
@@ -151,28 +151,35 @@ export const texts = {
   },
 
   /**
-   * Converts a key to the form '${textKey:AKey}'.
-   * @param key to convert (e.g. 'AKey')
-   * @returns text containing the text key like '${textKey:AKey}'.
+   * Returns the given text key in the form `'${textKey:AKey}'`.
+   *
+   * @param key the text key to convert (e.g. `'AKey'`)
+   * @returns the given text key in the form `'${textKey:AKey}'`
    */
   buildKey(key: string): string {
     return '${textKey:' + key + '}';
   },
 
   /**
-   * @param value text which contains a text key like '${textKey:AKey}'.
-   * @returns the resolved key or the unchanged value if the text key could not be extracted.
+   * Returns the text key (e.g. `'AKey'`) if the given text has the form `'${textKey:AKey}'`. Otherwise,
+   * the input is returned unchanged.
+   *
+   * @param value either an arbitrary text or a special string of the form `'${textKey:AKey}'`
+   * @returns the resolved text key or the unchanged value if the text key could not be extracted.
    */
   resolveKey(value: string): string {
-    let result = texts.TEXT_KEY_REGEX.exec(value);
-    if (result && result.length === 2) {
-      return result[1];
+    let match = texts.TEXT_KEY_REGEX.exec(value);
+    if (match) {
+      return match[1];
     }
     return value;
   },
 
   /**
-   * @param value text which contains a text key like '${textKey:AKey}'.
+   * If the given text has the form `'${textKey:AKey}'`, the key is extracted and the text for this
+   * key in the given languages is resolved and returned. Otherwise, the input is returned unchanged.
+   *
+   * @param value either an arbitrary text or a special string of the form `'${textKey:AKey}'`
    * @param languageTag the languageTag to use for the text lookup with the resolved key.
    * @returns the resolved text in the given language or the unchanged text if the text key could not be extracted.
    */
@@ -185,11 +192,12 @@ export const texts = {
   },
 
   /**
-   * Utility function to easily replace an object property which contains a text key like '${textKey:AKey}'.
+   * Converts the value of the specified property from the form `'${textKey:...}'` into a resolved text.
+   * The value remains unchanged if it does not match the {@linkplain texts#resolveText supported format}.
    *
-   * @param object object having a text property which contains a text-key
-   * @param [textProperty] name of the property where a text-key should be replaced by a text. By default, 'text' is used as property name.
-   * @param [session] can be undefined when given 'object' has a session property, otherwise mandatory
+   * @param object non-null object having a text property which may contain a text key (must not be null)
+   * @param textProperty name of the property on the given object which may contain a text key. By default, 'text' is used as property name.
+   * @param session session defining the locale to be used when resolving a text. Can be undefined when the given `object` has a session property, otherwise mandatory.
    */
   resolveTextProperty(object: any, textProperty?: string, session?: Session) {
     textProperty = textProperty || 'text';
@@ -199,6 +207,20 @@ export const texts = {
     if (text !== value) {
       object[textProperty] = text;
     }
+  },
+
+  /**
+   * Converts the values of the specified properties from the form `'${textKey:...}'` into a resolved text.
+   * A value remains unchanged if it does not match the {@linkplain texts#resolveText supported format}.
+   *
+   * @param object non-null object having a text property which may contain a text key (must not be null)
+   * @param textProperties names of the properties on the given object which may contain a text key.
+   * @param session session defining the locale to be used when resolving a text. Can be undefined when the given `object` has a session property, otherwise mandatory.
+   */
+  resolveTextProperties(object: any, textProperties: string[], session?: Session) {
+    arrays.ensure(textProperties).forEach(property => {
+      texts.resolveTextProperty(object, property, session);
+    });
   },
 
   /**

--- a/eclipse-scout-core/src/tree/TreeNode.ts
+++ b/eclipse-scout-core/src/tree/TreeNode.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -136,13 +136,21 @@ export class TreeNode implements TreeNodeModel, ObjectWithType, FilterElement {
 
     $.extend(this, model);
 
-    texts.resolveTextProperty(this, 'text');
-    icons.resolveIconProperty(this, 'iconId');
+    this._resolveTextKeys(['text']);
+    this._resolveIconIds(['iconId']);
 
     // make sure all child nodes are TreeNodes too
     if (this.hasChildNodes()) {
       this.tree.ensureTreeNodes(this.childNodes, this);
     }
+  }
+
+  protected _resolveTextKeys(properties: string[]) {
+    texts.resolveTextProperties(this, properties);
+  }
+
+  protected _resolveIconIds(properties: string[]) {
+    icons.resolveIconProperties(this, properties);
   }
 
   protected _jsonModel(): TreeNodeModel {

--- a/eclipse-scout-core/src/util/icons.ts
+++ b/eclipse-scout-core/src/util/icons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {IconDesc, strings} from '../index';
+import {arrays, IconDesc, strings} from '../index';
 import $ from 'jquery';
 
 export const icons = {
@@ -105,7 +105,7 @@ export const icons = {
   LONG_ARROW_LEFT_BOLD: 'font:\uF177',
   LONG_ARROW_RIGHT_BOLD: 'font:\uF178',
 
-  ICON_ID_REGEX: /\${iconId:([a-zA-Z0-9_.]*)}/,
+  ICON_ID_REGEX: /^\${iconId:([^}]+)}$/,
 
   /**
    * Returns an {@link IconDesc} object with structured info contained in the iconId string.
@@ -115,7 +115,7 @@ export const icons = {
 
     if (strings.startsWith(iconId, 'font:')) {
       icon.iconType = IconDesc.IconType.FONT_ICON;
-      iconId = iconId.substr(5);
+      iconId = iconId.substring(5); // remove 'font:' prefix
       if (strings.countCodePoints(iconId) === 1) {
         // default icon-font scoutIcons
         icon.font = IconDesc.DEFAULT_FONT;
@@ -134,26 +134,25 @@ export const icons = {
   },
 
   /**
-   * Resolves the value of an iconId property, where the value can contain a reference to
+   * Resolves the value of an iconId property, where the value can be a reference to
    * an icon constant in these formats:
-   * <ul>
-   *   <li><code>${iconId:ANGLE_UP}</code> references constant ANGLE_UP</li>
-   *   <li><code>${iconId:foo.BAR}</code> references constant foo.icons.BAR, this is used for custom objects with icon constants</li>
-   * </ul>
+   *
+   * - `${iconId:ANGLE_UP}` references the constant `scout.icons.ANGLE_UP`
+   * - `${iconId:foo.BAR}` references the constant `foo.icons.BAR`
+   *
+   * If the specified namespace does not have an `icons` object, an error will be thrown.
    */
   resolveIconId(value: string): string {
-    let iconId, tmp,
-      result = icons.ICON_ID_REGEX.exec(value);
-    if (result && result.length === 2) {
-      iconId = result[1];
-      tmp = iconId.split('.');
-      if (tmp.length === 1) {
-        // look for icon in [0]
-        value = icons[tmp];
-      } else if (tmp.length === 2) {
+    let match = icons.ICON_ID_REGEX.exec(value);
+    if (match) {
+      let iconId = match[1];
+      let parts = iconId.split('.');
+      if (parts.length === 1) {
+        // look for icon in global object scout.icons.[0]
+        value = window['scout']['icons'][parts[0]];
+      } else if (parts.length === 2) {
         // look for icon in global object [0].icons.[1]
-        // @ts-expect-error
-        value = window[tmp[0]].icons[tmp[1]];
+        value = window[parts[0]]['icons'][parts[1]];
       } else {
         $.log.warn('Invalid iconId: ' + value);
       }
@@ -162,14 +161,11 @@ export const icons = {
   },
 
   /**
-   * Resolves the value of an iconId property, where the value can contain a reference to
-   * an icon constant in these formats:
-   * <ul>
-   *   <li><code>${iconId:ANGLE_UP}</code> references constant ANGLE_UP</li>
-   *   <li><code>${iconId:foo.BAR}</code> references constant foo.icons.BAR, this is used for custom objects with icon constants</li>
-   * </ul>
-   * @param object object having an icon property which contains a iconId
-   * @param iconProperty name of the property where an iconId placeholder should be replaced by the actual iconId. By default, 'iconId' is used as property name.
+   * Converts the value of the specified property from the form `'${iconId:...}'` into a resolved iconId.
+   * The value remains unchanged if it does not match the {@linkplain icons#resolveIconId supported format}.
+   *
+   * @param object non-null object having an icon property which may contain an iconId
+   * @param iconProperty name of the property on the given object which may contain an iconId. By default, `'iconId'` is used as property name.
    */
   resolveIconProperty(object: object, iconProperty?: string) {
     iconProperty = iconProperty || 'iconId';
@@ -178,5 +174,18 @@ export const icons = {
     if (newValue !== value) {
       object[iconProperty] = newValue;
     }
+  },
+
+  /**
+   * Converts the values of the specified properties from the form `'${iconId:...}'` into a resolved iconId.
+   * a value remains unchanged if it does not match the {@linkplain icons#resolveIconId supported format}.
+   *
+   * @param object non-null object having an icon property which may contain an iconId
+   * @param iconProperties names of the properties on the given object which may contain an iconId.
+   */
+  resolveIconProperties(object: object, iconProperties: string[]) {
+    arrays.ensure(iconProperties).forEach(property => {
+      icons.resolveIconProperty(object, property);
+    });
   }
 };

--- a/eclipse-scout-core/src/util/objects.ts
+++ b/eclipse-scout-core/src/util/objects.ts
@@ -681,6 +681,12 @@ export const objects = {
     }
   },
 
+  resolveConstProperties(object: object, configs: { property: string; constType: any }[]) {
+    arrays.ensure(configs).forEach(config => {
+      objects.resolveConstProperty(object, config);
+    });
+  },
+
   /**
    * Cleans the given object, i.e. removes all top-level properties with values that are null, undefined or
    * consist of an empty array or an empty object. This is useful to have a minimal data object.

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -1730,19 +1730,15 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
   }
 
   resolveTextKeys(properties: string[]) {
-    properties.forEach(property => {
-      texts.resolveTextProperty(this, property);
-    });
+    texts.resolveTextProperties(this, properties);
   }
 
   resolveIconIds(properties: string[]) {
-    properties.forEach(property => {
-      icons.resolveIconProperty(this, property);
-    });
+    icons.resolveIconProperties(this, properties);
   }
 
   resolveConsts(configs: { property: string; constType: any }[]) {
-    configs.forEach(config => objects.resolveConstProperty(this, config));
+    objects.resolveConstProperties(this, configs);
   }
 
   /**

--- a/eclipse-scout-core/test/text/textsSpec.ts
+++ b/eclipse-scout-core/test/text/textsSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -82,7 +82,6 @@ describe('texts', () => {
       // Texts which were registered but are part of the new model too are replaced
       expect(texts.get('de').get('theKey')).toBe('de');
     });
-
   });
 
   describe('get', () => {
@@ -121,7 +120,158 @@ describe('texts', () => {
       expect(Object.keys(textMap.map).length).toBe(0);
       expect(textMap.parent).toEqual(texts._get('de'));
     });
-
   });
 
+  describe('resolve', () => {
+
+    it('resolves text', () => {
+      texts.init(model);
+      expect(texts.resolveText('${textKey:theKey}', 'de')).toBe('de');
+      expect(texts.resolveText('${textKey:_DoesNotExist}', 'de')).toBe('[undefined text: _DoesNotExist]');
+      expect(texts.resolveText('foo ${textKey:theKey}', 'de')).toBe('foo ${textKey:theKey}');
+      expect(texts.resolveText('bar', 'de')).toBe('bar');
+    });
+
+    it('resolves text property', () => {
+      texts.init(model);
+
+      setFixtures(sandbox());
+      let session = sandboxSession();
+
+      // With session on object
+
+      let obj = {
+        session: session,
+        text: '${textKey:theKey}',
+        xyz: '${textKey:theKey}',
+        foo: 'bar'
+      };
+
+      texts.resolveTextProperty(obj);
+      expect(obj.text).toBe('deCH');
+      expect(obj.xyz).toBe('${textKey:theKey}');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj, 'xyz');
+      expect(obj.text).toBe('deCH');
+      expect(obj.xyz).toBe('deCH');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj, 'foo');
+      expect(obj.text).toBe('deCH');
+      expect(obj.xyz).toBe('deCH');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj, 'doesNotExist');
+      expect(obj.text).toBe('deCH');
+      expect(obj.xyz).toBe('deCH');
+      expect(obj.foo).toBe('bar');
+
+      // Without session on object
+
+      let obj2 = {
+        text: '${textKey:theKey}',
+        xyz: '${textKey:theKey}',
+        foo: 'bar'
+      };
+
+      expect(() => texts.resolveTextProperty(obj2, 'abc')).toThrow(); // missing session
+
+      texts.resolveTextProperty(obj2, null, session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.xyz).toBe('${textKey:theKey}');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj2, 'xyz', session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.xyz).toBe('deCH');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj2, 'foo', session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.xyz).toBe('deCH');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperty(obj2, 'doesNotExist', session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.xyz).toBe('deCH');
+      expect(obj2.foo).toBe('bar');
+    });
+
+    it('resolves text properties', () => {
+      texts.init(model);
+
+      setFixtures(sandbox());
+      let session = sandboxSession();
+
+      // With session on object
+
+      let obj = {
+        session: session,
+        text: '${textKey:theKey}',
+        text2: '${textKey:theKey}',
+        xyz: '${textKey:theKey}',
+        foo: 'bar'
+      };
+
+      texts.resolveTextProperties(obj, null);
+      expect(obj.text).toBe('${textKey:theKey}');
+      expect(obj.text2).toBe('${textKey:theKey}');
+      expect(obj.xyz).toBe('${textKey:theKey}');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperties(obj, []);
+      expect(obj.text).toBe('${textKey:theKey}');
+      expect(obj.text2).toBe('${textKey:theKey}');
+      expect(obj.xyz).toBe('${textKey:theKey}');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperties(obj, ['xyz', 'doesNotExist', 'foo', 'text']);
+      expect(obj.text).toBe('deCH');
+      expect(obj.text2).toBe('${textKey:theKey}');
+      expect(obj.xyz).toBe('deCH');
+      expect(obj.foo).toBe('bar');
+
+      texts.resolveTextProperties(obj, ['text2']);
+      expect(obj.text).toBe('deCH');
+      expect(obj.text2).toBe('deCH');
+      expect(obj.xyz).toBe('deCH');
+      expect(obj.foo).toBe('bar');
+
+      // Without session on object
+
+      let obj2 = {
+        text: '${textKey:theKey}',
+        text2: '${textKey:theKey}',
+        xyz: '${textKey:theKey}',
+        foo: 'bar'
+      };
+
+      expect(() => texts.resolveTextProperties(obj2, ['abc'])).toThrow(); // missing session
+
+      texts.resolveTextProperties(obj2, null, session);
+      expect(obj2.text).toBe('${textKey:theKey}');
+      expect(obj2.text2).toBe('${textKey:theKey}');
+      expect(obj2.xyz).toBe('${textKey:theKey}');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperties(obj2, [], session);
+      expect(obj2.text).toBe('${textKey:theKey}');
+      expect(obj2.text2).toBe('${textKey:theKey}');
+      expect(obj2.xyz).toBe('${textKey:theKey}');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperties(obj2, ['xyz', 'doesNotExist', 'foo', 'text'], session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.text2).toBe('${textKey:theKey}');
+      expect(obj2.xyz).toBe('deCH');
+      expect(obj2.foo).toBe('bar');
+
+      texts.resolveTextProperties(obj2, ['text2'], session);
+      expect(obj2.text).toBe('deCH');
+      expect(obj2.text2).toBe('deCH');
+      expect(obj2.xyz).toBe('deCH');
+      expect(obj2.foo).toBe('bar');
+    });
+  });
 });

--- a/eclipse-scout-core/test/util/iconsSpec.ts
+++ b/eclipse-scout-core/test/util/iconsSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -51,4 +51,92 @@ describe('icons', () => {
     expect(icon.appendCssClass('font-icon')).toBe('font-icon font-widgetIcons');
   });
 
+  it('resolves iconId', () => {
+    expect(icons.resolveIconId('${iconId:ANGLE_UP}')).toBe(icons.ANGLE_UP);
+    expect(icons.resolveIconId('${iconId:_DOES_NOT_EXIST_}')).toBe(undefined);
+    expect(icons.resolveIconId('foo ${iconId:ANGLE_UP}')).toBe('foo ${iconId:ANGLE_UP}');
+    expect(icons.resolveIconId('bar')).toBe('bar');
+    expect(icons.resolveIconId(icons.INFO)).toBe(icons.INFO);
+
+    window['testIconsSpec'] = {icons: {FOO: 'bar'}}; // dummy namespace
+    expect(icons.resolveIconId('${iconId:testIconsSpec.FOO}')).toBe('bar');
+    delete window['testIconsSpec'];
+  });
+
+  it('resolves iconId property', () => {
+    let obj = {
+      iconId: '${iconId:ANGLE_UP}',
+      name: 'xyz',
+      foo: '${iconId:ANGLE_UP}',
+      bar: icons.ANGLE_UP
+    };
+
+    icons.resolveIconProperty(obj);
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe('${iconId:ANGLE_UP}');
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperty(obj, 'name');
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe('${iconId:ANGLE_UP}');
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperty(obj, 'foo');
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe(icons.ANGLE_UP);
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperty(obj, 'bar');
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe(icons.ANGLE_UP);
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperty(obj, 'doesNotExist');
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe(icons.ANGLE_UP);
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+  });
+
+  it('resolves iconId properties', () => {
+    let obj = {
+      iconId: '${iconId:ANGLE_UP}',
+      iconId2: '${iconId:ANGLE_UP}',
+      name: 'xyz',
+      foo: '${iconId:ANGLE_UP}',
+      bar: icons.ANGLE_UP
+    };
+
+    icons.resolveIconProperties(obj, null);
+    expect(obj.iconId).toBe('${iconId:ANGLE_UP}');
+    expect(obj.iconId2).toBe('${iconId:ANGLE_UP}');
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe('${iconId:ANGLE_UP}');
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperties(obj, []);
+    expect(obj.iconId).toBe('${iconId:ANGLE_UP}');
+    expect(obj.iconId2).toBe('${iconId:ANGLE_UP}');
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe('${iconId:ANGLE_UP}');
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperties(obj, ['foo', 'doesNotExist', 'name', 'iconId']);
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.iconId2).toBe('${iconId:ANGLE_UP}');
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe(icons.ANGLE_UP);
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+
+    icons.resolveIconProperties(obj, ['iconId2']);
+    expect(obj.iconId).toBe(icons.ANGLE_UP);
+    expect(obj.iconId2).toBe(icons.ANGLE_UP);
+    expect(obj.name).toBe('xyz');
+    expect(obj.foo).toBe(icons.ANGLE_UP);
+    expect(obj.bar).toBe(icons.ANGLE_UP);
+  });
 });

--- a/eclipse-scout-core/test/util/objectsSpec.ts
+++ b/eclipse-scout-core/test/util/objectsSpec.ts
@@ -934,6 +934,42 @@ describe('objects', () => {
       expect(model.labelPosition).toBe(FormField.LabelPosition.RIGHT);
     });
 
+    it('resolveConstProperties', () => {
+      let model = {
+        labelPosition: '${const:RIGHT}',
+        labelPosition2: '${const:TOP}',
+        foo: '${const:ON_FIELD}'
+      } as any;
+
+      objects.resolveConstProperties(model, null);
+      expect(model.labelPosition).toBe('${const:RIGHT}');
+      expect(model.labelPosition2).toBe('${const:TOP}');
+      expect(model.foo).toBe('${const:ON_FIELD}');
+      expect(model.bar).toBe(undefined);
+
+      objects.resolveConstProperties(model, [{
+        property: 'labelPosition',
+        constType: FormField.LabelPosition
+      }, {
+        property: 'labelPosition2',
+        constType: FormField.LabelPosition
+      }, {
+        property: 'bar',
+        constType: FormField.LabelPosition
+      }]);
+      expect(model.labelPosition).toBe(FormField.LabelPosition.RIGHT);
+      expect(model.labelPosition2).toBe(FormField.LabelPosition.TOP);
+      expect(model.foo).toBe('${const:ON_FIELD}');
+      expect(model.bar).toBe(undefined);
+      objects.resolveConstProperties(model, [{
+        property: 'foo',
+        constType: FormField.LabelPosition
+      }]);
+      expect(model.labelPosition).toBe(FormField.LabelPosition.RIGHT);
+      expect(model.labelPosition2).toBe(FormField.LabelPosition.TOP);
+      expect(model.foo).toBe(FormField.LabelPosition.ON_FIELD);
+      expect(model.bar).toBe(undefined);
+    });
   });
 
   describe('optProperty', () => {


### PR DESCRIPTION
- Match entire string instead of substrings (that was most likely not intentional)
- The default namespace for iconIds is 'scout'. This now also works if the 'scout.icons' object is replaced.
- Extract resolution to dedicated methods to allow overriding.
- Cleanup code
- Cleanup JsDoc
- Add specs

411068