### PR TITLE
Menu: show text as tooltip for shrunken menus

### DIFF
--- a/eclipse-scout-core/src/action/Action.ts
+++ b/eclipse-scout-core/src/action/Action.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,6 @@ export class Action extends Widget implements ActionModel {
 
   actionStyle: ActionStyle;
   compact: boolean;
-  compactOrig: boolean;
   iconId: string;
   horizontalAlignment: Alignment;
   keyStroke: string;
@@ -41,7 +40,6 @@ export class Action extends Widget implements ActionModel {
    */
   overflown: boolean;
   textVisible: boolean;
-  textVisibleOrig: boolean;
   toggleAction: boolean;
   tooltipText: string;
   showTooltipWhenSelected: boolean;
@@ -50,6 +48,8 @@ export class Action extends Widget implements ActionModel {
   $text: JQuery;
 
   protected _doubleClickSupport: DoubleClickSupport;
+  protected _compactOrig: boolean;
+  protected _textVisibleOrig: boolean;
 
   constructor() {
     super();
@@ -278,6 +278,17 @@ export class Action extends Widget implements ActionModel {
   }
 
   /**
+   * Returns the text to show as a tooltip, which might be different from the `tooltipText` property.
+   * If this value is falsy, the tooltip is not installed.
+   *
+   * @see _configureTooltip
+   * @see _shouldInstallTooltip
+   */
+  protected _computeTooltipText(): string {
+    return this.tooltipText;
+  }
+
+  /**
    * Installs or uninstalls tooltip based on tooltipText, selected and enabledComputed.
    */
   protected _updateTooltip() {
@@ -293,7 +304,8 @@ export class Action extends Widget implements ActionModel {
     if (this.selected && !this.showTooltipWhenSelected) {
       return false;
     }
-    return !!this.tooltipText;
+    let tooltipText = this._computeTooltipText();
+    return !!tooltipText;
   }
 
   /** @see ActionModel.tabbable */
@@ -333,7 +345,7 @@ export class Action extends Widget implements ActionModel {
   protected _configureTooltip(): InitModelOf<TooltipSupport> {
     return {
       parent: this,
-      text: this.tooltipText,
+      text: this._computeTooltipText(),
       $anchor: this.$container,
       arrowPosition: 50,
       arrowPositionUnit: '%',
@@ -422,13 +434,11 @@ export class Action extends Widget implements ActionModel {
 
   /** @see ActionModel.textVisible */
   setTextVisible(textVisible: boolean) {
-    if (this.textVisible === textVisible) {
-      return;
-    }
-    this._setProperty('textVisible', textVisible);
-    if (this.rendered) {
-      this._renderText();
-    }
+    this.setProperty('textVisible', textVisible);
+  }
+
+  protected _renderTextVisible() {
+    this._renderText();
   }
 
   /** @see ActionModel.horizontalAlignment */
@@ -482,5 +492,56 @@ export class Action extends Widget implements ActionModel {
     tooltips.cancel(this.$container);
 
     this.doAction();
+  }
+
+  /**
+   * Sets the action into compact mode. Can be reversed by calling {@link #undoMakeCompact}.
+   * @see ActionModel.compact
+   */
+  makeCompact() {
+    if (this._compactOrig !== undefined) {
+      return; // already done
+    }
+    this._compactOrig = this.compact;
+    this.setCompact(true);
+  }
+
+  /**
+   * Undoes the effect of {@link #makeCompact}, i.e. restores the previous compact state.
+   * If {@link #makeCompact} was not called previously, nothing happens.
+   */
+  undoMakeCompact() {
+    if (this._compactOrig === undefined) {
+      return; // nothing to undo
+    }
+    this.setCompact(this._compactOrig);
+    this._compactOrig = undefined;
+  }
+
+  /**
+   * If the action has an icon, the text is made invisible. Otherwise, nothing happens.
+   * Can be reversed by calling {@link #undoShrink}.
+   */
+  shrink() {
+    if (!this.iconId) {
+      return; // not shrinkable
+    }
+    if (this._textVisibleOrig !== undefined) {
+      return; // already done
+    }
+    this._textVisibleOrig = this.textVisible;
+    this.setTextVisible(false);
+  }
+
+  /**
+   * Undoes the effect of {@link #shrink}, i.e. restores the text visibility to the previous state.
+   * If {@link #shrink} was not called previously, nothing happens.
+   */
+  undoShrink() {
+    if (this._textVisibleOrig === undefined) {
+      return; // nothing to undo
+    }
+    this.setTextVisible(this._textVisibleOrig);
+    this._textVisibleOrig = undefined;
   }
 }

--- a/eclipse-scout-core/src/desktop/toolbox/DesktopToolBox.ts
+++ b/eclipse-scout-core/src/desktop/toolbox/DesktopToolBox.ts
@@ -19,6 +19,7 @@ export class DesktopToolBox extends MenuBox {
   protected override _initMenu(menu: Menu) {
     super._initMenu(menu);
     menu.popupHorizontalAlignment = Popup.Alignment.CENTER;
+    menu.setShrinkable(true); // all menus in the DesktopToolBox should always be shrinkable
   }
 
   protected override _render() {

--- a/eclipse-scout-core/src/menu/Menu.ts
+++ b/eclipse-scout-core/src/menu/Menu.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -358,6 +358,7 @@ export class Menu extends Action implements MenuModel {
     this.$container.toggleClass('has-text', strings.hasText(this.text) && this.textVisible);
     if (!this.rendering) {
       this._renderSubMenuIcon();
+      this._updateTooltip(); // tooltip shows text when menu is shrunk (see _showTextAsTooltip)
     }
     this.invalidateLayoutTree();
   }
@@ -691,6 +692,13 @@ export class Menu extends Action implements MenuModel {
     this.invalidateLayoutTree();
   }
 
+  override shrink() {
+    if (!this.shrinkable) {
+      return;
+    }
+    super.shrink();
+  }
+
   protected override _renderOverflown() {
     super._renderOverflown();
     this._renderActionStyle();
@@ -730,5 +738,24 @@ export class Menu extends Action implements MenuModel {
       return super.focus();
     }
     return false;
+  }
+
+  protected override _computeTooltipText(): string {
+    if (this._showTextAsTooltip()) {
+      return strings.join('\n\n', this.text, this.tooltipText);
+    }
+    return super._computeTooltipText();
+  }
+
+  /**
+   * Specifies whether the value of the `text` property should be included in the tooltip. This is the case if the menu has a text
+   * that is currently invisible because the menus has been shrunken. Note that this does not change the value of the `tooltipText`
+   * property or the aria attributes. Only the _computed_ tooltip text is affected.
+   *
+   * @see shrink
+   * @see _computeTooltipText
+   */
+  protected _showTextAsTooltip(): boolean {
+    return this.text && !this.textVisible && this._textVisibleOrig;
   }
 }

--- a/eclipse-scout-core/src/menu/menubar/MenuBarLayout.ts
+++ b/eclipse-scout-core/src/menu/menubar/MenuBarLayout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -206,29 +206,17 @@ export class MenuBarLayout extends AbstractLayout {
    */
   shrink(menus: Menu[]) {
     menus.forEach(menu => {
-      if (menu.textVisibleOrig !== undefined) {
-        // already done
-        return;
-      }
-      if (menu.shrinkable && menu.icon) {
-        menu.textVisibleOrig = menu.textVisible;
-        menu.htmlComp.suppressInvalidate = true;
-        menu.setTextVisible(false);
-        menu.htmlComp.suppressInvalidate = false;
-      }
+      menu.htmlComp.suppressInvalidate = true;
+      menu.shrink();
+      menu.htmlComp.suppressInvalidate = false;
     });
   }
 
   undoShrink(menus: Menu[]) {
     menus.forEach(menu => {
-      if (menu.textVisibleOrig === undefined) {
-        return;
-      }
-      // Restore old text visible state
       menu.htmlComp.suppressInvalidate = true;
-      menu.setTextVisible(menu.textVisibleOrig);
+      menu.undoShrink();
       menu.htmlComp.suppressInvalidate = false;
-      menu.textVisibleOrig = undefined;
     });
   }
 

--- a/eclipse-scout-core/src/menu/menubox/MenuBox.ts
+++ b/eclipse-scout-core/src/menu/menubox/MenuBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,9 +15,10 @@ export class MenuBox extends Widget implements MenuBoxModel {
   declare self: MenuBox;
 
   compact: boolean;
-  compactOrig: boolean;
   menus: Menu[];
   uiMenuCssClass: string;
+
+  protected _compactOrig: boolean;
 
   constructor() {
     super();
@@ -75,5 +76,28 @@ export class MenuBox extends Widget implements MenuBoxModel {
   protected _renderCompact() {
     this.$container.toggleClass('compact', this.compact);
     this.invalidateLayoutTree();
+  }
+
+  /**
+   * Sets the menu box into compact mode. Can be reversed by calling {@link #undoMakeCompact}.
+   */
+  makeCompact() {
+    if (this._compactOrig !== undefined) {
+      return; // already done
+    }
+    this._compactOrig = this.compact;
+    this.setCompact(true);
+  }
+
+  /**
+   * Undoes the effect of {@link #makeCompact}, i.e. restores the previous compact state.
+   * If {@link #makeCompact} was not called previously, nothing happens.
+   */
+  undoMakeCompact() {
+    if (this._compactOrig === undefined) {
+      return; // nothing to undo
+    }
+    this.setCompact(this._compactOrig);
+    this._compactOrig = undefined;
   }
 }

--- a/eclipse-scout-core/src/menu/menubox/MenuBoxLayout.ts
+++ b/eclipse-scout-core/src/menu/menubox/MenuBoxLayout.ts
@@ -82,23 +82,17 @@ export class MenuBoxLayout extends AbstractLayout {
   }
 
   compact(menus?: Menu[]) {
-    if (this.menuBox.compactOrig === undefined) {
-      this.menuBox.compactOrig = this.menuBox.compact;
-      this.menuBox.htmlComp.suppressInvalidate = true;
-      this.menuBox.setCompact(true);
-      this.menuBox.htmlComp.suppressInvalidate = false;
-    }
+    this.menuBox.htmlComp.suppressInvalidate = true;
+    this.menuBox.makeCompact();
+    this.menuBox.htmlComp.suppressInvalidate = false;
 
     this.compactMenus(menus);
   }
 
   undoCompact(menus?: Menu[]) {
-    if (this.menuBox.compactOrig !== undefined) {
-      this.menuBox.htmlComp.suppressInvalidate = true;
-      this.menuBox.setCompact(this.menuBox.compactOrig);
-      this.menuBox.htmlComp.suppressInvalidate = false;
-      this.menuBox.compactOrig = undefined;
-    }
+    this.menuBox.htmlComp.suppressInvalidate = true;
+    this.menuBox.undoMakeCompact();
+    this.menuBox.htmlComp.suppressInvalidate = false;
 
     this.undoCompactMenus(menus);
   }
@@ -109,13 +103,8 @@ export class MenuBoxLayout extends AbstractLayout {
   compactMenus(menus?: Menu[]) {
     menus = menus || this.visibleMenus();
     menus.forEach(menu => {
-      if (menu.compactOrig !== undefined) {
-        // already done
-        return;
-      }
-      menu.compactOrig = menu.compact;
       menu.htmlComp.suppressInvalidate = true;
-      menu.setCompact(true);
+      menu.makeCompact();
       menu.htmlComp.suppressInvalidate = false;
     });
 
@@ -130,14 +119,9 @@ export class MenuBoxLayout extends AbstractLayout {
   undoCompactMenus(menus?: Menu[]) {
     menus = menus || this.visibleMenus();
     menus.forEach(menu => {
-      if (menu.compactOrig === undefined) {
-        return;
-      }
-      // Restore old compact state
       menu.htmlComp.suppressInvalidate = true;
-      menu.setCompact(menu.compactOrig);
+      menu.undoMakeCompact();
       menu.htmlComp.suppressInvalidate = false;
-      menu.compactOrig = undefined;
     });
 
     if (this._ellipsis) {
@@ -155,16 +139,9 @@ export class MenuBoxLayout extends AbstractLayout {
   shrinkMenus(menus?: Menu[]) {
     menus = menus || this.visibleMenus();
     menus.forEach(menu => {
-      if (menu.textVisibleOrig !== undefined) {
-        // already done
-        return;
-      }
-      if (menu.iconId) {
-        menu.textVisibleOrig = menu.textVisible;
-        menu.htmlComp.suppressInvalidate = true;
-        menu.setTextVisible(false);
-        menu.htmlComp.suppressInvalidate = false;
-      }
+      menu.htmlComp.suppressInvalidate = true;
+      menu.shrink();
+      menu.htmlComp.suppressInvalidate = false;
     });
   }
 
@@ -175,14 +152,9 @@ export class MenuBoxLayout extends AbstractLayout {
   undoShrinkMenus(menus?: Menu[]) {
     menus = menus || this.visibleMenus();
     menus.forEach(menu => {
-      if (menu.textVisibleOrig === undefined) {
-        return;
-      }
-      // Restore old text visible state
       menu.htmlComp.suppressInvalidate = true;
-      menu.setTextVisible(menu.textVisibleOrig);
+      menu.undoShrink();
       menu.htmlComp.suppressInvalidate = false;
-      menu.textVisibleOrig = undefined;
     });
   }
 
@@ -193,7 +165,7 @@ export class MenuBoxLayout extends AbstractLayout {
   }
 
   /**
-   * Undoes the collapsing by removing ellipsis and rendering non rendered menus.
+   * Undoes the collapsing by removing ellipsis and rendering non-rendered menus.
    */
   undoCollapse(menus?: Menu[]) {
     menus = menus || this.visibleMenus();

--- a/eclipse-scout-core/test/action/ActionSpec.ts
+++ b/eclipse-scout-core/test/action/ActionSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Action, keys, scout, Tooltip, tooltips} from '../../src/index';
+import {Action, icons, keys, scout, Tooltip, tooltips} from '../../src/index';
 import {JQueryTesting} from '../../src/testing';
 
 describe('Action', () => {
@@ -230,6 +230,108 @@ describe('Action', () => {
       expect(action.$container).toHaveAttr('aria-pressed', 'true');
       action.setToggleAction(false);
       expect(action.$container.attr('aria-pressed')).toBeFalsy();
+    });
+  });
+
+  describe('compact', () => {
+
+    it('makeCompact() makes the action compact', () => {
+      let action = scout.create(Action, {
+        parent: session.desktop
+      }) as Action & {_compactOrig};
+      expect(action.compact).toBe(false);
+      expect(action._compactOrig).toBe(undefined);
+
+      action.makeCompact();
+      expect(action.compact).toBe(true);
+      expect(action._compactOrig).toBe(false);
+      action.makeCompact(); // no effect
+      expect(action.compact).toBe(true);
+      expect(action._compactOrig).toBe(false);
+
+      action.undoMakeCompact();
+      expect(action.compact).toBe(false);
+      expect(action._compactOrig).toBe(undefined);
+      action.undoMakeCompact(); // no effect
+      expect(action.compact).toBe(false);
+      expect(action._compactOrig).toBe(undefined);
+    });
+
+    it('makeCompact() does nothing if action is already compact', () => {
+      let action = scout.create(Action, {
+        parent: session.desktop,
+        compact: true
+      }) as Action & {_compactOrig};
+      expect(action.compact).toBe(true);
+      expect(action._compactOrig).toBe(undefined);
+
+      action.makeCompact();
+      expect(action.compact).toBe(true);
+      expect(action._compactOrig).toBe(true);
+
+      action.undoMakeCompact();
+      expect(action.compact).toBe(true);
+      expect(action._compactOrig).toBe(undefined);
+    });
+  });
+
+  describe('shrink', () => {
+
+    it('shrink() hides the text if the action has an icon', () => {
+      let action = scout.create(Action, {
+        parent: session.desktop,
+        iconId: icons.WORLD
+      }) as Action & {_textVisibleOrig};
+      expect(action.textVisible).toBe(true);
+      expect(action._textVisibleOrig).toBe(undefined);
+
+      action.shrink();
+      expect(action.textVisible).toBe(false);
+      expect(action._textVisibleOrig).toBe(true);
+      action.shrink(); // no effect
+      expect(action.textVisible).toBe(false);
+      expect(action._textVisibleOrig).toBe(true);
+
+      action.undoShrink();
+      expect(action.textVisible).toBe(true);
+      expect(action._textVisibleOrig).toBe(undefined);
+      action.undoShrink(); // no effect
+      expect(action.textVisible).toBe(true);
+      expect(action._textVisibleOrig).toBe(undefined);
+    });
+
+    it('shrink() does nothing if the action does not have an icon', () => {
+      let action = scout.create(Action, {
+        parent: session.desktop
+      }) as Action & {_textVisibleOrig};
+      expect(action.textVisible).toBe(true);
+      expect(action._textVisibleOrig).toBe(undefined);
+
+      action.shrink();
+      expect(action.textVisible).toBe(true);
+      expect(action._textVisibleOrig).toBe(undefined);
+
+      action.undoShrink();
+      expect(action.textVisible).toBe(true);
+      expect(action._textVisibleOrig).toBe(undefined);
+    });
+
+    it('shrink() has no effect if the action is already shrunk', () => {
+      let action = scout.create(Action, {
+        parent: session.desktop,
+        iconId: icons.WORLD,
+        textVisible: false
+      }) as Action & {_textVisibleOrig};
+      expect(action.textVisible).toBe(false);
+      expect(action._textVisibleOrig).toBe(undefined);
+
+      action.shrink();
+      expect(action.textVisible).toBe(false);
+      expect(action._textVisibleOrig).toBe(false);
+
+      action.undoShrink();
+      expect(action.textVisible).toBe(false);
+      expect(action._textVisibleOrig).toBe(undefined);
     });
   });
 });

--- a/eclipse-scout-core/test/menu/MenuSpec.ts
+++ b/eclipse-scout-core/test/menu/MenuSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Action, ContextMenuPopup, EllipsisMenu, Menu, scout, tooltips} from '../../src/index';
+import {Action, ContextMenuPopup, EllipsisMenu, icons, Menu, scout, tooltips} from '../../src/index';
 import {JQueryTesting, MenuSpecHelper} from '../../src/testing/index';
 
 describe('Menu', () => {
@@ -715,6 +715,165 @@ describe('Menu', () => {
       expect(ellipsis.$container).toHaveAttr('aria-expanded', 'false');
       ellipsis.setSelected(true);
       expect(ellipsis.$container).toHaveAttr('aria-expanded', 'true');
+    });
+  });
+
+  describe('shrink', () => {
+
+    function find$Tooltips() {
+      return $('body').find('.tooltip');
+    }
+
+    function expectTooltip($element: JQuery, tooltipText: string) {
+      // No tooltip initially
+      let $tooltips = find$Tooltips();
+      expect($tooltips.length).toBe(0);
+
+      // Enter mouse cursor and check tooltip
+      JQueryTesting.triggerMouseEnter($element);
+      jasmine.clock().tick(1000);
+      $tooltips = find$Tooltips();
+      if (tooltipText) {
+        expect($tooltips.length).toBe(1);
+        expect($tooltips.get(0).innerText).toBe(tooltipText); // text() does not return line breaks
+      } else {
+        expect($tooltips.length).toBe(0);
+      }
+
+      // Exit mouse cursor, tooltip should be gone
+      JQueryTesting.triggerMouseLeave($element);
+      jasmine.clock().tick(1000);
+      $tooltips = find$Tooltips();
+      expect($tooltips.length).toBe(0);
+    }
+
+    it('does not shrink the menu if it is not shrinkable', () => {
+      let menu = helper.createMenu({
+        text: 'Foo',
+        iconId: icons.PENCIL
+        // 'shrinkable' is false by default
+      });
+      menu.render();
+
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, null);
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe(undefined);
+
+      menu.shrink();
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, null);
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe(undefined);
+
+      menu.undoShrink();
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, null);
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe(undefined);
+    });
+
+    it('always shows the text as label if the action has no icon and is shrunk', () => {
+      let menu = helper.createMenu({
+        text: 'Foo',
+        tooltipText: 'Bar',
+        shrinkable: true
+      });
+      menu.render();
+
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, 'Bar');
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe('Bar');
+
+      menu.shrink();
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, 'Bar');
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe('Bar');
+
+      menu.undoShrink();
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, 'Bar');
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe('Bar');
+    });
+
+    it('shows the text as tooltip if the action has an icon and is shrunk', () => {
+      let menu = helper.createMenu({
+        text: 'Foo',
+        iconId: icons.PENCIL,
+        shrinkable: true
+      });
+      menu.render();
+
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, null);
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe(undefined);
+
+      menu.shrink();
+      expect(menu.textVisible).toBe(false);
+      expect(menu.$text).toBeFalsy();
+      expectTooltip(menu.$container, 'Foo');
+      expect(menu.$container.attr('aria-label')).toBe('Foo');
+      expect(menu.$container.attr('aria-description')).toBe(undefined);
+
+      menu.undoShrink();
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, null);
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe(undefined);
+    });
+
+    it('shows both the text and the tooltip as tooltip if the action has an icon and is shrunk', () => {
+      let menu = helper.createMenu({
+        text: 'Foo',
+        tooltipText: 'Bar',
+        iconId: icons.PENCIL,
+        shrinkable: true
+      });
+      menu.render();
+
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, 'Bar');
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe('Bar');
+
+      menu.shrink();
+      expect(menu.textVisible).toBe(false);
+      expect(menu.$text).toBeFalsy();
+      // Visible tooltip texts are combined
+      expectTooltip(menu.$container, 'Foo\n\nBar');
+      // Aria attributes are still separate
+      expect(menu.$container.attr('aria-label')).toBe('Foo');
+      expect(menu.$container.attr('aria-description')).toBe('Bar');
+
+      menu.undoShrink();
+      expect(menu.textVisible).toBe(true);
+      expect(menu.$text).toBeTruthy();
+      expect(menu.$text.text()).toBe('Foo');
+      expectTooltip(menu.$container, 'Bar');
+      expect(menu.$container.attr('aria-label')).toBe(undefined);
+      expect(menu.$container.attr('aria-description')).toBe('Bar');
     });
   });
 });


### PR DESCRIPTION
MenuBarLayout (used for menu bars) and MenuBoxLayout (used for the desktop tool box) both reduce the size of menu items before moving them to the ellipsis menu. One of these transformation is called "shrinking". It only has an effect for menus with both an icon and a text. When shrunk, the text is hidden and only the icon remains visible, taking up much less space. However, this makes it less obvious for the user what the menu does.

To improve this, the hidden text is now automatically shown as the menu's tooltip. When the menu is un-shrunk, the tooltip is removed again. If the menu already has a tooltip, both values are combined.

In the MenuBox (desktop tool box), we explicitly set all menus to be shrinkable. This is a convenience to avoid having tp set all desktop menus to shrinkable=true manually. It is only relevant on small screens (e.g. mobile) and is therefore easily forgettable.

400639