### PR TITLE
Table: add insertColumns, deleteColumns, setColumns

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -423,28 +423,12 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   protected _initColumns() {
     let cols = this.columns as ObjectOrChildModel<Column<any>>[];
     this.columns = cols.map((colModel, index) => {
-      let column: Column<any>;
-      let columnOrModel = colModel as FullModelOf<Column<any>>;
-      if (columnOrModel instanceof Column) {
-        column = columnOrModel;
-        column._setParent(this);
-      } else {
-        columnOrModel.parent = this;
-        column = scout.create(columnOrModel);
-      }
-
+      const column = this._ensureColumn(colModel);
       if (column.index < 0) {
         column.index = index;
       }
-      if (column.checkable) {
-        // set checkable column if this column is the checkable one
-        this.checkableColumn = column as BooleanColumn;
-      }
       return column;
     });
-
-    // Add gui only checkbox column at the beginning
-    this._setCheckable(this.checkable);
 
     // Add gui only row icon column at the beginning
     if (this.rowIconVisible) {
@@ -452,11 +436,27 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     }
 
     this._setCompact(this.compact);
+
+    // update checkable column, table node column and sort columns
+    this._calculateCheckableTableNodeAndSortColumns();
+
+    this.columnLayoutDirty = true;
+  }
+
+  /**
+   * Calculates the {@link Table.checkableColumn} (see {@link Table._calculateCheckableColumn}), the {@link Table.tableNodeColumn} (see {@link Table._calculateTableNodeColumn})
+   * and the {@link Table._permanentHeadSortColumns} and {@link Table._permanentTailSortColumns} (see {@link Table._setHeadAndTailSortColumns}).
+   */
+  protected _calculateCheckableTableNodeAndSortColumns() {
+    // update checkable column
+    this._calculateCheckableColumn();
+    this._setCheckable(this.checkable);
+
+    // update table node column
     this._calculateTableNodeColumn();
 
-    // Sync head and tail sort columns
+    // update sort columns
     this._setHeadAndTailSortColumns();
-    this.columnLayoutDirty = true;
   }
 
   protected override _destroy() {
@@ -912,7 +912,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   onColumnVisibilityChanged() {
     this.columnLayoutDirty = true;
     this._calculateTableNodeColumn();
-    this.trigger('columnStructureChanged');
+    this._triggerColumnStructureChanged(this.columns, this.columns);
 
     // Rebuild aggregate rows. This computes missing aggregate values for previously hidden columns. It is also a convenient
     // way to fix the column indices. The aggregate table control was already updated via 'columnStructureChanged' event.
@@ -4985,16 +4985,17 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   protected _setRowIconVisible(rowIconVisible: boolean) {
     this._setProperty('rowIconVisible', rowIconVisible);
     let column = this.rowIconColumn;
+    const columns = [...this.columns];
     if (this.rowIconVisible && !column) {
       this._insertRowIconColumn();
       this._calculateTableNodeColumn();
-      this.trigger('columnStructureChanged');
+      this._triggerColumnStructureChanged(columns, this.columns);
     } else if (!this.rowIconVisible && column) {
       column.destroy();
       arrays.remove(this.columns, column);
       this.rowIconColumn = null;
       this._calculateTableNodeColumn();
-      this.trigger('columnStructureChanged');
+      this._triggerColumnStructureChanged(columns, this.columns);
     }
   }
 
@@ -5283,19 +5284,34 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     this._updateCheckableColumn();
   }
 
+  /**
+   * Calculates the {@link Table.checkableColumn}. It is the last column in {@link Table.columns} that is {@link Column.checkable}.
+   */
+  protected _calculateCheckableColumn() {
+    const oldCheckableColumn = this.checkableColumn;
+    this.checkableColumn = [...this.columns].reverse().find(c => c.checkable) as BooleanColumn;
+
+    // remove old checkable column if it was a guiOnly column
+    if (this.checkableColumn !== oldCheckableColumn && oldCheckableColumn?.guiOnly) {
+      oldCheckableColumn.destroy();
+      arrays.remove(this.columns, oldCheckableColumn);
+    }
+  }
+
   protected _updateCheckableColumn() {
     let column = this.checkableColumn;
     let showCheckBoxes = this.checkable && scout.isOneOf(this.checkableStyle, Table.CheckableStyle.CHECKBOX, Table.CheckableStyle.CHECKBOX_TABLE_ROW);
+    const columns = [...this.columns];
     if (showCheckBoxes && !column) {
       this._insertBooleanColumn();
       this._calculateTableNodeColumn();
-      this.trigger('columnStructureChanged');
+      this._triggerColumnStructureChanged(columns, this.columns);
     } else if (!showCheckBoxes && column && column.guiOnly) {
       column.destroy();
       arrays.remove(this.columns, column);
       this.checkableColumn = null;
       this._calculateTableNodeColumn();
-      this.trigger('columnStructureChanged');
+      this._triggerColumnStructureChanged(columns, this.columns);
     }
   }
 
@@ -5885,14 +5901,241 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   }
 
   /**
+   * Sets the given {@link Column}s. All columns that are removed will also be removed from {@link TableRow.cells}. All new columns are initialized with the given initValue.
+   * Column properties, e.g. {@link Column.sortIndex}, {@link Column.grouped} and {@link NumberColumn.backgroundEffect}, and {@link Table.filters} are re-applied.
+   */
+  setColumns(columnOrModels: ObjectOrChildModel<Column<any>>[], initValue?: any | ((Column, TableRow) => any)) {
+    // do not check equality of columns, this gives the possibility to only apply new column settings like sorting, grouping, etc.
+    if (this.columns === columnOrModels) {
+      return;
+    }
+    this._setColumns(columnOrModels, initValue);
+    if (this.rendered) {
+      this._renderColumns();
+    }
+  }
+
+  /**
+   * @see setColumns
+   */
+  protected _setColumns(columnOrModels: ObjectOrChildModel<Column<any>>[], initValue?: any | ((Column, TableRow) => any)) {
+    // ensure this.columns are initialized, otherwise models contained in this.columns are considered deleted and therefore corresponding cells are deleted as well
+    for (const column of this.columns) {
+      scout.assertInstance(column, Column, 'Table.columns are not initialized yet.');
+    }
+
+    // ensure initValue function
+    if (initValue === undefined) {
+      initValue = null;
+    }
+    if (!objects.isFunction(initValue)) {
+      const value = initValue;
+      initValue = (column: Column, row: TableRow) => value;
+    }
+
+    // ensure guiOnly columns are part of columnsOrModels and are the first elements
+    const guiOnlyColumns = this.filterColumns(c => c.guiOnly);
+    arrays.removeAll(columnOrModels, guiOnlyColumns);
+    columnOrModels = [...guiOnlyColumns, ...columnOrModels];
+
+    // ensure columns
+    const columns = columnOrModels
+      .map(column => this._ensureColumn(column))
+      .filter(column => !!column);
+
+    const oldColumns = [...this.columns];
+    const deletedColumns = arrays.diff(this.columns, columns);
+    const insertedColumns = arrays.diff(columns, this.columns);
+    const currentColumns = [...this.columns];
+
+    let buffering: JQuery.Deferred<void>;
+
+    // deleted columns
+    for (const column of deletedColumns) {
+      // update index of other columns and handle cells if removed column has an index set
+      if (column.index >= 0) {
+        // update index of all columns whose index is greater than the index of the removed column
+        for (const c of currentColumns) {
+          if (c.index > column.index) {
+            c.index--;
+          }
+        }
+
+        // remove cells for all rows at the correct position (column.index)
+        this.rows.forEach(row => row.cells.splice(column.index, 1));
+      }
+
+      // remove column filters, do not apply filters here as they will be applied in batch later
+      this.removeFilterByKey(column.id, false);
+
+      // destroy column and remove from current columns
+      column.destroy();
+      arrays.remove(currentColumns, column);
+    }
+
+    // inserted columns
+    for (const column of insertedColumns) {
+      // set index to max index + 1 if no index is provided
+      if (column.index < 0) {
+        column.index = Math.max(-1, ...currentColumns.map(column => column.index)) + 1;
+      }
+
+      // update index of all columns whose index is greater or equal to the index of the new column
+      for (const c of currentColumns) {
+        if (c.index >= column.index) {
+          c.index++;
+        }
+      }
+
+      // set updateBuffer buffering until all columns are added, otherwise column.initCell triggers updateRow before the rows cell array is modified
+      if (!buffering) {
+        buffering = $.Deferred();
+        this.updateBuffer.pushPromise(buffering.promise());
+      }
+
+      // insert new cell for all rows at the correct position (column.index)
+      this.rows.forEach(row => {
+        if (column.index > row.cells.length + 1) {
+          // if index is larger than length, arrays.insert will insert it at the end which is not correct if index is larger than length + 1
+          // in this case there is no need to shift other elements -> simply add the cell at the right index
+          row.cells[column.index] = column.initCell(initValue(column, row), row);
+        } else {
+          arrays.insert(row.cells, column.initCell(initValue(column, row), row), column.index);
+        }
+      });
+
+      // add to current columns
+      currentColumns.push(column);
+    }
+
+    this._setProperty('columns', columns);
+
+    // update checkable column, table node column and sort columns
+    this._calculateCheckableTableNodeAndSortColumns();
+
+    // apply sorting and grouping
+    this._sort();
+
+    // only calculate values for background effect, rendering is done in _renderColumns
+    this._calculateValuesForBackgroundEffect();
+
+    // re-apply filters
+    this._updateRowStructure({filteredRows: true});
+
+    // resolve buffering and trigger events
+    buffering?.resolve();
+    this._triggerColumnStructureChanged(oldColumns, this.columns);
+  }
+
+  protected _renderColumns() {
+    this.columnLayoutDirty = true;
+    this._updateRowWidth();
+    this.redraw();
+  }
+
+  /**
+   * Triggers {@link TableColumnStructureChangedEvent}.
+   */
+  protected _triggerColumnStructureChanged(oldColumns: Column<any>[], newColumns: Column<any>[]) {
+    // create new arrays to prevent unexpected behaviour if listeners modify the arrays
+    oldColumns = [...oldColumns];
+    newColumns = [...newColumns];
+    this.trigger('columnStructureChanged', {oldColumns, newColumns});
+  }
+
+  /**
+   * Inserts the given {@link Column}.
+   * The column will be inserted into {@link Table.columns} at the specified position or after the given anchor {@link Column}.
+   * The inserted column is initialized with the given initValue.
+   */
+  insertColumn(columnOrModel: ObjectOrChildModel<Column<any>>, positionOrInsertAfterColumn?: number | Column<any>, initValue?: any | ((Column, TableRow) => any)) {
+    this.insertColumns([columnOrModel], positionOrInsertAfterColumn, initValue);
+  }
+
+  /**
+   * Inserts the given {@link Column}s.
+   * The columns will be inserted into {@link Table.columns} at the specified position or after the given anchor {@link Column}.
+   * The inserted columns are initialized with the given initValue.
+   */
+  insertColumns(columnOrModels: ObjectOrChildModel<Column<any>>[], positionOrInsertAfterColumn?: number | Column<any>, initValue?: any | ((Column, TableRow) => any)) {
+    if (!columnOrModels?.length) {
+      return;
+    }
+
+    // determine position
+    let position: number;
+    if (objects.isNumber(positionOrInsertAfterColumn)) {
+      position = positionOrInsertAfterColumn;
+    } else if (positionOrInsertAfterColumn instanceof Column) {
+      // insert directly after anchor column if it is part of this.columns
+      const positionCandidate = this.columns.indexOf(positionOrInsertAfterColumn);
+      if (positionCandidate > -1) {
+        position = positionCandidate + 1;
+      }
+    }
+
+    // add columns last if no position has been determined
+    if (!objects.isNumber(position)) {
+      position = this.columns.length;
+    }
+
+    // remove columns from columnOrModels that are already part of this.columns
+    arrays.removeAll(columnOrModels, this.columns);
+
+    // create new columns
+    const newColumns = [...this.columns];
+    arrays.insertAll(newColumns, columnOrModels, position);
+
+    this.setColumns(newColumns, initValue);
+  }
+
+  /**
+   * Deletes the given {@link Column} from {@link Table.columns}.
+   */
+  deleteColumn(column: Column) {
+    this.deleteColumns([column]);
+  }
+
+  /**
+   * Deletes the given {@link Column}s from {@link Table.columns}.
+   */
+  deleteColumns(columns: Column[]) {
+    if (!columns?.length) {
+      return;
+    }
+
+    // create new columns
+    const newColumns = [...this.columns];
+    arrays.removeAll(newColumns, columns);
+
+    this.setColumns(newColumns);
+  }
+
+  /**
+   * Ensures the given {@link ObjectOrChildModel} to be a {@link Column} and sets its parent to this {@link Table}.
+   */
+  protected _ensureColumn<T extends Column<any> = Column>(columnOrModel: ObjectOrChildModel<T>): T {
+    if (columnOrModel instanceof Column) {
+      columnOrModel._setParent(this);
+      return columnOrModel;
+    }
+
+    return scout.create({
+      ...columnOrModel,
+      parent: this
+    }) as T;
+  }
+
+  /**
    * Rebuilds the header.<br>
    * Does not modify the rows, it expects a deleteAll and insert operation to follow which will do the job.
    */
   updateColumnStructure(columns: Column<any>[]) {
     this._destroyColumns();
+    const oldColumns = [...this.columns];
     this.columns = columns;
     this._initColumns();
-    this.trigger('columnStructureChanged');
+    this._triggerColumnStructureChanged(oldColumns, this.columns);
     if (this._isDataRendered()) {
       this._updateRowWidth();
       this.$rows(true).css('width', this.rowWidth);

--- a/eclipse-scout-core/src/table/TableEventMap.ts
+++ b/eclipse-scout-core/src/table/TableEventMap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,6 +49,14 @@ export interface TableColumnResizedEvent<TValue = any, T = Table> extends Event<
 
 export interface TableColumnResizedToFitEvent<TValue = any, T = Table> extends Event<T> {
   column: Column<TValue>;
+}
+
+/**
+ * Event containing the old and new list of {@link Column}s after {@link Table.columns} changed.
+ */
+export interface TableColumnStructureChangedEvent<T = Table> extends Event<T> {
+  oldColumns: Column<any>[];
+  newColumns: Column<any>[];
 }
 
 export interface TableCompleteCellEditEvent<TValue = any, T = Table> extends Event<T> {
@@ -160,7 +168,7 @@ export interface TableEventMap extends WidgetEventMap {
   'columnMoved': TableColumnMovedEvent;
   'columnResized': TableColumnResizedEvent;
   'columnResizedToFit': TableColumnResizedToFitEvent;
-  'columnStructureChanged': Event;
+  'columnStructureChanged': TableColumnStructureChangedEvent;
   'completeCellEdit': TableCompleteCellEditEvent;
   'drop': TableDropEvent;
   'filter': Event;
@@ -195,6 +203,7 @@ export interface TableEventMap extends WidgetEventMap {
   'propertyChange:autoResizeColumns': PropertyChangeEvent<boolean>;
   'propertyChange:checkable': PropertyChangeEvent<boolean>;
   'propertyChange:checkableStyle': PropertyChangeEvent<TableCheckableStyle>;
+  'propertyChange:columns': PropertyChangeEvent<Column<any>[]>;
   'propertyChange:compact': PropertyChangeEvent<boolean>;
   'propertyChange:contextColumn': PropertyChangeEvent<Column<any>>;
   'propertyChange:dropMaximumSize': PropertyChangeEvent<number>;

--- a/eclipse-scout-core/src/testing/table/SpecTable.ts
+++ b/eclipse-scout-core/src/testing/table/SpecTable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,8 @@ export class SpecTable extends Table {
   declare events: EventSupport & { _eventListeners: EventListener[] };
   declare footer: TableFooter & { _$infoTableStatus: JQuery; _$infoTableStatusIcon: JQuery };
   declare _doubleClickSupport: DoubleClickSupport & { _lastTimestamp: number };
+  declare _permanentHeadSortColumns: Column<any>[];
+  declare _permanentTailSortColumns: Column<any>[];
 
   override _resizeToFit(column: Column<any>, maxWidth?: number, calculatedSize?: number) {
     super._resizeToFit(column, maxWidth, calculatedSize);

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  Action, BeanColumn, Cell, Column, ColumnModel, Device, graphics, IconColumn, icons, Menu, MenuDestinations, NumberColumn, ObjectFactory, Point, Range, RemoteEvent, scout, scrollbars, SmartColumn, Status, Table, TableField, TableRow,
-  TableRowModel, Tooltip
+  Action, BeanColumn, BooleanColumn, Cell, Column, ColumnModel, Device, graphics, IconColumn, icons, Menu, MenuDestinations, NumberColumn, ObjectFactory, Point, Range, RemoteEvent, scout, scrollbars, SmartColumn, Status, strings, Table,
+  TableField, TableRow, TableRowModel, Tooltip
 } from '../../src/index';
 import {JQueryTesting, LocaleSpecHelper, SpecTable, TableSpecHelper} from '../../src/testing/index';
 import $ from 'jquery';
@@ -4262,6 +4262,585 @@ describe('Table', () => {
       expect(table._columnAtX(119 + offset)).toBe(column1);
       // right of last column -> returns last column
       expect(table._columnAtX(130 + offset)).toBe(column1);
+    });
+  });
+
+  describe('insert columns', () => {
+    let table: SpecTable;
+
+    beforeEach(() => {
+      const model = helper.createModelFixture(3, 5);
+      table = helper.createTable(model);
+      table.render();
+    });
+
+    it('does nothing if no column is given', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.insertColumns([]);
+
+      expect(table.columns.length).toBe(3);
+    });
+
+    it('does nothing if column is already part of table', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.insertColumns([table.columns[0]]);
+
+      expect(table.columns.length).toBe(3);
+    });
+
+    it('inserts a column at the end with no value if position and initValue are not specified', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.insertColumns([helper.createModelColumn('foo')]);
+
+      expect(table.columns.length).toBe(4);
+
+      const column = table.columns[3];
+      expect(column.text).toBe('foo');
+      expect(column.index).toBe(3);
+      table.rows.forEach(row => expect(table.cellValue(column, row)).toBeNull());
+    });
+
+    it('inserts a column at the specified position', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.insertColumns([helper.createModelColumn('foo')], 1);
+
+      expect(table.columns.length).toBe(4);
+
+      const column = table.columns[1];
+      expect(column.text).toBe('foo');
+      expect(column.index).toBe(3);
+    });
+
+    it('inserts the columns at the specified position', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.insertColumns([helper.createModelColumn('foo'), helper.createModelColumn('number', NumberColumn)], 1);
+
+      expect(table.columns.length).toBe(5);
+
+      const column = table.columns[1];
+      expect(column.text).toBe('foo');
+      expect(column.index).toBe(3);
+
+      const numberColumn = table.columns[2];
+      expect(numberColumn.text).toBe('number');
+      expect(numberColumn.index).toBe(4);
+    });
+
+    it('inserts the columns after the specified column', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.insertColumns([helper.createModelColumn('foo'), helper.createModelColumn('number', NumberColumn)], table.columns[1]);
+
+      expect(table.columns.length).toBe(5);
+
+      const column = table.columns[2];
+      expect(column.text).toBe('foo');
+      expect(column.index).toBe(3);
+
+      const numberColumn = table.columns[3];
+      expect(numberColumn.text).toBe('number');
+      expect(numberColumn.index).toBe(4);
+    });
+
+    it('inserts the columns at the end if the specified column is not part of the table', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.insertColumns([helper.createModelColumn('foo'), helper.createModelColumn('number', NumberColumn)], scout.create(Column, {
+        parent: table,
+        ...helper.createModelColumn('anchor')
+      }));
+
+      expect(table.columns.length).toBe(5);
+
+      const column = table.columns[3];
+      expect(column.text).toBe('foo');
+      expect(column.index).toBe(3);
+
+      const numberColumn = table.columns[4];
+      expect(numberColumn.text).toBe('number');
+      expect(numberColumn.index).toBe(4);
+    });
+
+    it('initializes the inserted column with the specified value', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.insertColumns([helper.createModelColumn('foo')], null, 'bar');
+
+      expect(table.columns.length).toBe(4);
+
+      const column = table.columns[3];
+      table.rows.forEach(row => expect(table.cellValue(column, row)).toBe('bar'));
+
+      table.insertColumns([helper.createModelColumn('number', NumberColumn)], null, (column, row) => table.rows.indexOf(row));
+
+      expect(table.columns.length).toBe(5);
+
+      const numberColumn = table.columns[4];
+      table.rows.forEach((row, index) => expect(table.cellValue(numberColumn, row)).toBe(index));
+    });
+
+    it('calculates the correct index', () => {
+      table.setColumns([]);
+      expect(table.columns.length).toBe(0);
+
+      table.insertColumns([{...helper.createModelColumn('foo'), index: 42}]);
+
+      expect(table.columns.length).toBe(1);
+
+      const column = table.columns[0];
+      expect(column.text).toBe('foo');
+      expect(column.index).toBe(42);
+
+      table.insertColumns([helper.createModelColumn('number', NumberColumn)]);
+
+      expect(table.columns.length).toBe(2);
+
+      const numberColumn = table.columns[1];
+      expect(numberColumn.text).toBe('number');
+      expect(numberColumn.index).toBe(43);
+    });
+
+    it('shifts index of existing columns if necessary', () => {
+      expect(table.columns.length).toBe(3);
+      expect(table.columns.map(c => c.index)).toEqual([0, 1, 2]);
+
+      table.insertColumns([
+        {
+          ...helper.createModelColumn('foo'),
+          index: 1
+        },
+        helper.createModelColumn('number', NumberColumn)
+      ]);
+
+      expect(table.columns.length).toBe(5);
+
+      const column = table.columns[3];
+      expect(column.text).toBe('foo');
+      expect(column.index).toBe(1);
+
+      const numberColumn = table.columns[4];
+      expect(numberColumn.text).toBe('number');
+      expect(numberColumn.index).toBe(4);
+
+      expect(table.columns.map(c => c.index)).toEqual([0, 2, 3, 1, 4]);
+    });
+
+    it('triggers columnStructureChanged event', async () => {
+      jasmine.clock().uninstall();
+
+      expect(table.columns.length).toBe(3);
+
+      const columnStructureChangedPromise = table.when('columnStructureChanged');
+
+      const [column0, column1, column2] = table.columns;
+      table.insertColumns([helper.createModelColumn('foo'), helper.createModelColumn('number', NumberColumn)]);
+
+      expect(table.columns.length).toBe(5);
+
+      const columnStructureChangedEvent = await columnStructureChangedPromise;
+      expect(columnStructureChangedEvent.oldColumns).toEqual([column0, column1, column2]);
+      expect(columnStructureChangedEvent.newColumns.map(c => c.text)).toEqual([column0.text, column1.text, column2.text, 'foo', 'number']);
+    });
+  });
+
+  describe('delete columns', () => {
+    let table: SpecTable;
+
+    beforeEach(() => {
+      const model = helper.createModelFixture(3, 5);
+      table = helper.createTable(model);
+      table.render();
+    });
+
+    it('does nothing if no column is given', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.deleteColumns([]);
+
+      expect(table.columns.length).toBe(3);
+    });
+
+    it('does nothing if column is not part of table', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.deleteColumns([scout.create(Column, {
+        parent: table,
+        ...helper.createModelColumn('foo')
+      })]);
+
+      expect(table.columns.length).toBe(3);
+    });
+
+    it('deletes and destroys columns', () => {
+      expect(table.columns.length).toBe(3);
+
+      const [column0, column1, column2] = table.columns;
+
+      table.deleteColumns([column0, column2]);
+
+      expect(table.columns.length).toBe(1);
+      expect(table.columns[0]).toBe(column1);
+
+      expect(column0.table).toBeNull();
+      expect(column2.table).toBeNull();
+    });
+
+    it('shifts index of remaining columns if necessary', () => {
+      expect(table.columns.length).toBe(3);
+
+      const [column0, column1, column2] = table.columns;
+      expect(column0.index).toBe(0);
+      expect(column1.index).toBe(1);
+      expect(column2.index).toBe(2);
+
+      table.deleteColumns([column1]);
+
+      expect(table.columns.length).toBe(2);
+      expect(column0.index).toBe(0);
+      expect(column2.index).toBe(1);
+    });
+
+    it('triggers columnStructureChanged event', async () => {
+      jasmine.clock().uninstall();
+
+      expect(table.columns.length).toBe(3);
+
+      const columnStructureChangedPromise = table.when('columnStructureChanged');
+
+      const [column0, column1, column2] = table.columns;
+      table.deleteColumns([column0, column1]);
+
+      expect(table.columns.length).toBe(1);
+
+      const columnStructureChangedEvent = await columnStructureChangedPromise;
+      expect(columnStructureChangedEvent.oldColumns).toEqual([column0, column1, column2]);
+      expect(columnStructureChangedEvent.newColumns).toEqual([column2]);
+    });
+  });
+
+  describe('setColumns', () => {
+    let table: SpecTable;
+
+    beforeEach(() => {
+      const model = helper.createModelFixture(3, 5);
+      table = helper.createTable(model);
+      table.render();
+    });
+
+    it('does nothing if column arrays are identical', () => {
+      const columns = table.columns;
+      table.setColumns(columns);
+      expect(table.columns).toBe(columns);
+    });
+
+    it('sets columns if columns are identical but arrays are not', () => {
+      const columns = table.columns;
+      table.setColumns([...columns]);
+      expect(table.columns).not.toBe(columns);
+      expect(table.columns).toEqual(columns);
+    });
+
+    it('initializes inserted columns with the specified value', () => {
+      expect(table.columns.length).toBe(3);
+
+      table.setColumns([...table.columns, helper.createModelColumn('foo')], 'bar');
+
+      expect(table.columns.length).toBe(4);
+
+      const column = table.columns[3];
+      table.rows.forEach(row => expect(table.cellValue(column, row)).toBe('bar'));
+
+      table.setColumns([...table.columns, helper.createModelColumn('number', NumberColumn)], (column, row) => table.rows.indexOf(row));
+
+      expect(table.columns.length).toBe(5);
+
+      const numberColumn = table.columns[4];
+      table.rows.forEach((row, index) => expect(table.cellValue(numberColumn, row)).toBe(index));
+    });
+
+    it('inserts and deletes columns', () => {
+      expect(table.columns.length).toBe(3);
+
+      const [column0, column1, column2] = table.columns;
+
+      table.setColumns([column1, helper.createModelColumn('foo')]);
+
+      expect(table.columns.length).toBe(2);
+
+      expect(table.columns[0]).toBe(column1);
+      expect(column1.index).toBe(0);
+
+      const column = table.columns[1];
+      expect(column.text).toBe('foo');
+      expect(column.index).toBe(1);
+
+      expect(column0.table).toBeNull();
+      expect(column2.table).toBeNull();
+    });
+
+    it('ensures guiOnly columns are not deleted', () => {
+      table.setCheckable(true);
+      table.setRowIconVisible(true);
+
+      expect(table.columns.length).toBe(5);
+      expect(table.checkableColumn).toBe(table.columns[0] as BooleanColumn);
+      expect(table.rowIconColumn).toBe(table.columns[1]);
+
+      table.setColumns([helper.createModelColumn('foo')]);
+
+      expect(table.columns.length).toBe(3);
+      expect(table.checkableColumn).toBe(table.columns[0] as BooleanColumn);
+      expect(table.rowIconColumn).toBe(table.columns[1]);
+    });
+
+    it('updates checkable column', () => {
+      table.setCheckable(true);
+
+      expect(table.columns.length).toBe(4);
+
+      table.setColumns([...table.columns, {...helper.createModelColumn('MyCheckableColumn', BooleanColumn), checkable: true}]);
+
+      expect(table.columns.length).toBe(4);
+      expect(table.checkableColumn).toBe(table.columns[3] as BooleanColumn);
+      expect(table.checkableColumn.text).toBe('MyCheckableColumn');
+    });
+
+    it('updates table node column', () => {
+      expect(table.columns.length).toBe(3);
+      expect(table.tableNodeColumn).toBe(table.columns[0]);
+
+      table.setColumns(helper.createModelColumns(3).map(model => ({...model, nodeColumnCandidate: false})));
+      expect(table.tableNodeColumn).toBeUndefined();
+
+      table.setColumns([...table.columns, helper.createModelColumn('MyTableNodeColumn')]);
+
+      expect(table.columns.length).toBe(4);
+      expect(table.tableNodeColumn).toBe(table.columns[3]);
+      expect(table.tableNodeColumn.text).toBe('MyTableNodeColumn');
+    });
+
+    it('updates permanent sort columns', () => {
+      expect(table.columns.length).toBe(3);
+
+      expect(table._permanentHeadSortColumns.length).toBe(0);
+      expect(table._permanentTailSortColumns.length).toBe(0);
+
+      table.setColumns([
+        ...table.columns,
+        {...helper.createModelColumn('sort-begin-1'), sortIndex: 1, initialAlwaysIncludeSortAtBegin: true}
+      ]);
+
+      expect(table._permanentHeadSortColumns.length).toBe(1);
+      expect(table._permanentHeadSortColumns.map(c => c.text)).toEqual(['sort-begin-1']);
+      expect(table._permanentTailSortColumns.length).toBe(0);
+
+      table.setColumns([
+        {...helper.createModelColumn('sort-end-1'), sortIndex: 1, initialAlwaysIncludeSortAtEnd: true},
+        {...helper.createModelColumn('sort-begin-0'), sortIndex: 0, initialAlwaysIncludeSortAtBegin: true},
+        ...table.columns,
+        {...helper.createModelColumn('sort-end-0'), sortIndex: 0, initialAlwaysIncludeSortAtEnd: true}
+      ]);
+
+      expect(table._permanentHeadSortColumns.length).toBe(2);
+      expect(table._permanentHeadSortColumns.map(c => c.text)).toEqual(['sort-begin-0', 'sort-begin-1']);
+      expect(table._permanentTailSortColumns.length).toBe(2);
+      expect(table._permanentTailSortColumns.map(c => c.text)).toEqual(['sort-end-0', 'sort-end-1']);
+    });
+
+    it('sorts the table rows', () => {
+      for (let i = 0; i < table.rows.length; i++) {
+        (table.rows[i] as { __foo?: string }).__foo = `foo-${i}`;
+        (table.rows[i] as { __bar?: string }).__bar = `bar-${i}`;
+      }
+      table.setColumns([helper.createModelColumn('foo'), helper.createModelColumn('bar')], (column, row) => row[`__${column.text}`]);
+
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0', 'bar-0'],
+        ['foo-1', 'bar-1'],
+        ['foo-2', 'bar-2'],
+        ['foo-3', 'bar-3'],
+        ['foo-4', 'bar-4']
+      ]);
+
+      table.columns[1].sortIndex = 0;
+      table.columns[1].sortActive = true;
+      table.columns[1].sortAscending = false;
+
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0', 'bar-0'],
+        ['foo-1', 'bar-1'],
+        ['foo-2', 'bar-2'],
+        ['foo-3', 'bar-3'],
+        ['foo-4', 'bar-4']
+      ]);
+
+      table.setColumns([...table.columns]);
+
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-4', 'bar-4'],
+        ['foo-3', 'bar-3'],
+        ['foo-2', 'bar-2'],
+        ['foo-1', 'bar-1'],
+        ['foo-0', 'bar-0']
+      ]);
+    });
+
+    it('groups the table rows', () => {
+      for (let i = 0; i < table.rows.length; i++) {
+        (table.rows[i] as { __foo?: string }).__foo = `foo-${i % 2}`;
+        (table.rows[i] as { __bar?: string }).__bar = `bar-${i}`;
+      }
+      table.setColumns([helper.createModelColumn('foo'), helper.createModelColumn('bar')], (column, row) => row[`__${column.text}`]);
+
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0', 'bar-0'],
+        ['foo-1', 'bar-1'],
+        ['foo-0', 'bar-2'],
+        ['foo-1', 'bar-3'],
+        ['foo-0', 'bar-4']
+      ]);
+
+      table.columns[0].grouped = true;
+      table.columns[0].sortIndex = 0;
+      table.columns[0].sortActive = true;
+
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0', 'bar-0'],
+        ['foo-1', 'bar-1'],
+        ['foo-0', 'bar-2'],
+        ['foo-1', 'bar-3'],
+        ['foo-0', 'bar-4']
+      ]);
+
+      table.setColumns([...table.columns]);
+
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0', 'bar-0'],
+        ['foo-0', 'bar-2'],
+        ['foo-0', 'bar-4'],
+        ['foo-1', 'bar-1'],
+        ['foo-1', 'bar-3']
+      ]);
+    });
+
+    it('calculates values for background effect', () => {
+      table.setColumns([...table.columns, {...helper.createModelColumn('MyColumnWithBackgroundEffect', NumberColumn), backgroundEffect: 'barChart'}], (column, row) => table.rows.indexOf(row));
+
+      expect(table.columns.length).toBe(4);
+      expect(table.columns[3]).toBeInstanceOf(NumberColumn);
+      expect((table.columns[3] as NumberColumn).calcMinValue).toBe(0);
+      expect((table.columns[3] as NumberColumn).calcMaxValue).toBe(4);
+    });
+
+    it('applies filters', () => {
+      for (let i = 0; i < table.rows.length; i++) {
+        (table.rows[i] as { __foo?: string }).__foo = `foo-${i}`;
+        (table.rows[i] as { __bar?: string }).__bar = `bar-${i % 2}`;
+      }
+
+      table.setColumns([helper.createModelColumn('foo')], (column, row) => row[`__${column.text}`]);
+
+      expect(table.rows.length).toBe(5);
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0'],
+        ['foo-1'],
+        ['foo-2'],
+        ['foo-3'],
+        ['foo-4']
+      ]);
+      expect(table.filteredRows().length).toBe(5);
+
+      table.addFilter(row => strings.contains(row.cells.reduce((acc, cell) => acc + cell.text, ''), '0'));
+      expect(table.rows.length).toBe(5);
+      expect(table.filteredRows().length).toBe(1);
+      expect(table.filteredRows().map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0']
+      ]);
+
+      table.setColumns([...table.columns, helper.createModelColumn('bar')], (column, row) => row[`__${column.text}`]);
+
+      expect(table.rows.length).toBe(5);
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0', 'bar-0'],
+        ['foo-1', 'bar-1'],
+        ['foo-2', 'bar-0'],
+        ['foo-3', 'bar-1'],
+        ['foo-4', 'bar-0']
+      ]);
+      expect(table.filteredRows().length).toBe(3);
+      expect(table.filteredRows().map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0', 'bar-0'],
+        ['foo-2', 'bar-0'],
+        ['foo-4', 'bar-0']
+      ]);
+    });
+
+    it('removes column filters', () => {
+      for (let i = 0; i < table.rows.length; i++) {
+        (table.rows[i] as { __foo?: string }).__foo = `foo-${i}`;
+        (table.rows[i] as { __bar?: string }).__bar = `bar-${i}`;
+      }
+      table.setColumns([helper.createModelColumn('foo'), helper.createModelColumn('bar')], (column, row) => row[`__${column.text}`]);
+
+      const [fooColumn, barColumn] = table.columns;
+
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0', 'bar-0'],
+        ['foo-1', 'bar-1'],
+        ['foo-2', 'bar-2'],
+        ['foo-3', 'bar-3'],
+        ['foo-4', 'bar-4']
+      ]);
+      expect(table.filteredRows().length).toBe(5);
+
+      helper.createAndRegisterColumnFilter({
+        session: session,
+        table: table,
+        column: barColumn,
+        selectedValues: ['bar-2', 'bar-3']
+      });
+
+      expect(table.rows.length).toBe(5);
+      expect(table.filteredRows().length).toBe(2);
+      expect(table.filteredRows().map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-2', 'bar-2'],
+        ['foo-3', 'bar-3']
+      ]);
+
+      table.setColumns([fooColumn]);
+
+      expect(table.rows.length).toBe(5);
+      expect(table.rows.map(row => row.cells.map(cell => cell.value))).toEqual([
+        ['foo-0'],
+        ['foo-1'],
+        ['foo-2'],
+        ['foo-3'],
+        ['foo-4']
+      ]);
+      expect(table.filteredRows().length).toBe(5);
+    });
+
+    it('triggers columnStructureChanged event', async () => {
+      jasmine.clock().uninstall();
+
+      expect(table.columns.length).toBe(3);
+
+      const [column0, column1, column2] = table.columns;
+
+      const columnStructureChangedPromise = table.when('columnStructureChanged');
+
+      table.setColumns([column2, helper.createModelColumn('foo'), helper.createModelColumn('number', NumberColumn)]);
+
+      expect(table.columns.length).toBe(3);
+
+      const columnStructureChangedEvent = await columnStructureChangedPromise;
+      expect(columnStructureChangedEvent.oldColumns).toEqual([column0, column1, column2]);
+      expect(columnStructureChangedEvent.newColumns.map(c => c.text)).toEqual([column2.text, 'foo', 'number']);
     });
   });
 });


### PR DESCRIPTION
Adds the utility functions to insert, delete or set columns on a Table. For insertColumns and setColumns an initial value (value or callback) can be passed. The index of each column is handled automatically and the cells array of each row is updated accordingly.
After the modification a columnStructureChanged event is triggered containing the old and new columns.

378974