### PR TITLE
Improve AutoLeafPageWithNodes

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/AutoLeafPageWithNodes.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/AutoLeafPageWithNodes.ts
@@ -20,6 +20,6 @@ export class AutoLeafPageWithNodes extends Page implements AutoLeafPageWithNodes
   protected override _init(model: InitModelOf<this>) {
     scout.assertParameter('row', model.row, TableRow);
     super._init(model);
-    this.text = this.row.cells[0].text;
+    this.text = this.computeTextForRow(this.row);
   }
 }

--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -517,15 +517,23 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
       page.htmlEnabled = row.cells[0].htmlEnabled;
       page.cssClass = row.cells[0].cssClass;
     }
+    if (row.getTable().compact) {
+      page.htmlEnabled = true;
+    }
     return page;
   }
 
   /**
-   * This function creates the text property of this page. The default implementation returns the texts of the summary columns of the table or
-   * from the first cell of the given row. It's allowed to ignore the given row entirely, when you override this function.
+   * This function creates the text property of this page. The default implementation returns the compactValue of the row if the table is compact,
+   * the texts of the summary columns of the table or from the first cell of the given row. It's allowed to ignore the given row entirely, when
+   * you override this function.
    */
   computeTextForRow(row: TableRow): string {
-    const summaryColumns = row.table.summaryColumns();
+    const table = row.table;
+    if (table.compact) {
+      return row.compactValue;
+    }
+    const summaryColumns = table.summaryColumns();
     if (summaryColumns.length) {
       return strings.join(' ', ...summaryColumns.map(summaryColumn => summaryColumn.cellText(row)));
     }


### PR DESCRIPTION
The AutoLeafPageWithNodes must not use the text of the first cell of the corresponding row as this cell holds e.g. a primary key and is not displayable. Therefore, use the result of computeTextForRow as this combines the values of all summary columns.
If the Table is compact computeTextForRow now returns the compactValue of the row.

378974