### PR TITLE
OutlineMediator: prevent drill-down if Table has a defaultRowAction

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/OutlineMediator.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineMediator.ts
@@ -53,6 +53,10 @@ export class OutlineMediator {
       return;
     }
 
+    if (event.source.defaultRowAction) {
+      return;
+    }
+
     let drillNode = event.row.page;
     page.outline.drillDown(drillNode);
   }

--- a/eclipse-scout-core/test/desktop/outline/OutlineMediatorSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineMediatorSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Device, Outline, PageWithNodes, PageWithTable, scout, Table, TableModel, TableTextUserFilter} from '../../../src/index';
+import {Action, Device, Outline, PageWithNodes, PageWithTable, scout, Table, TableModel, TableTextUserFilter} from '../../../src/index';
 import {OutlineSpecHelper, TableSpecHelper} from '../../../src/testing/index';
 
 describe('OutlineMediator', () => {
@@ -75,6 +75,18 @@ describe('OutlineMediator', () => {
 
     expect(page.expanded).toBe(false);
     expect(outline.selectedNode()).toBe(null);
+
+    // no drill down on row action if defaultRowAction is set
+    detailTable.setDefaultRowAction(scout.create(Action, {parent: detailTable}));
+
+    detailTable.selectRows([firstRow]);
+    detailTable.doRowAction(firstRow, firstColumn);
+
+    expect(page.expanded).toBe(false);
+    expect(outline.selectedNode()).toBe(null);
+
+    // drill down on row action if defaultRowAction is not set
+    detailTable.setDefaultRowAction(null);
 
     detailTable.selectRows([firstRow]);
     detailTable.doRowAction(firstRow, firstColumn);


### PR DESCRIPTION
The Table has a defaultRowAction that is executed when a row is double-clicked. If this property is present and e.g. opens a Form a drill-down is unexpected. Therefore, the OutlineMediator executes the drill-down on tableRowAction only if no defaultRowAction is present on the Table.

416422