### PR TITLE
Column: add ensureId objectFactoryHint

### DIFF
--- a/eclipse-scout-core/src/lookup/LookupCall.ts
+++ b/eclipse-scout-core/src/lookup/LookupCall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,6 @@ export class LookupCall<TKey> implements LookupCallModel<TKey>, ObjectWithType {
   declare model: LookupCallModel<TKey>;
   declare initModel: SomeRequired<this['model'], 'session'>;
 
-  id: string;
   objectType: string;
   session: Session;
   hierarchical: boolean;

--- a/eclipse-scout-core/src/system/System.ts
+++ b/eclipse-scout-core/src/system/System.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,6 @@ export class System implements SystemModel, ObjectWithType {
   declare initModel: SomeRequired<this['model'], 'name'>;
   declare self: System;
 
-  id: string;
   objectType: string;
   name: string;
   baseUrl: string;

--- a/eclipse-scout-core/src/table/columns/Column.ts
+++ b/eclipse-scout-core/src/table/columns/Column.ts
@@ -8,11 +8,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AggregateTableRow, Alignment, Cell, CellEditorPopup, ColumnComparator, ColumnEventMap, ColumnModel, ColumnOptimalWidthMeasurer, ColumnUserFilter, comparators, Event, EventHandler, FormField, GridData, icons, InitModelOf, ObjectIdProvider,
-  objects, ObjectWithType, ObjectWithUuid, PropertyEventEmitter, scout, Session, SomeRequired, Status, StringField, strings, styles, Table, TableColumnMovedEvent, TableHeader, TableHeaderMenu, TableRow, texts, UuidPathOptions, ValueField
+  AggregateTableRow, Alignment, Cell, CellEditorPopup, ColumnComparator, ColumnEventMap, ColumnModel, ColumnOptimalWidthMeasurer, ColumnUserFilter, comparators, Event, EventHandler, FormField, GridData, icons, InitModelOf,
+  objectFactoryHints, ObjectIdProvider, objects, ObjectWithType, ObjectWithUuid, PropertyEventEmitter, scout, Session, SomeRequired, Status, StringField, strings, styles, Table, TableColumnMovedEvent, TableHeader, TableHeaderMenu, TableRow,
+  texts, UuidPathOptions, ValueField
 } from '../../index';
 import $ from 'jquery';
 
+@objectFactoryHints({ensureId: true})
 export class Column<TValue = string> extends PropertyEventEmitter implements ColumnModel<TValue>, ObjectWithType, ObjectWithUuid {
   declare model: ColumnModel<TValue>;
   declare initModel: SomeRequired<this['model'], 'session'>;

--- a/eclipse-scout-core/src/table/columns/ColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/ColumnModel.ts
@@ -7,9 +7,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Alignment, Column, ColumnComparator, ObjectModelWithUuid, Session, Table} from '../../index';
+import {Alignment, Column, ColumnComparator, ObjectModelWithId, ObjectModelWithUuid, Session, Table} from '../../index';
 
-export interface ColumnModel<TValue = string> extends ObjectModelWithUuid<Column<TValue>> {
+export interface ColumnModel<TValue = string> extends ObjectModelWithUuid<Column<TValue>>, ObjectModelWithId {
   session?: Session;
   /**
    * Configures whether the column width is auto optimized.

--- a/eclipse-scout-core/test/form/fields/listbox/ListBoxSpec.ts
+++ b/eclipse-scout-core/test/form/fields/listbox/ListBoxSpec.ts
@@ -290,7 +290,7 @@ describe('ListBox', () => {
       });
       field.on('prepareLookupCall', event => {
         expect(event.lookupCall['customProperty']).toBe(templatePropertyValue);
-        expect(event.lookupCall.id).not.toBe(field.lookupCall.id);
+        expect(event.lookupCall).not.toBe(field.lookupCall);
         expect(event.type).toBe('prepareLookupCall');
         expect(event.source).toBe(field);
 

--- a/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -569,7 +569,7 @@ describe('SmartField', () => {
       });
       field.on('prepareLookupCall', event => {
         expect(event.lookupCall['customProperty']).toBe(templatePropertyValue);
-        expect(event.lookupCall.id).not.toBe(field.lookupCall.id);
+        expect(event.lookupCall).not.toBe(field.lookupCall);
         expect(event.type).toBe('prepareLookupCall');
         expect(event.source).toBe(field);
 

--- a/eclipse-scout-core/test/form/fields/tagfield/TagFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/tagfield/TagFieldSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -148,7 +148,7 @@ describe('TagField', () => {
       });
       field.on('prepareLookupCall', event => {
         expect(event.lookupCall['customProperty']).toBe(templatePropertyValue);
-        expect(event.lookupCall.id).not.toBe(field.lookupCall.id);
+        expect(event.lookupCall).not.toBe(field.lookupCall);
         expect(event.type).toBe('prepareLookupCall');
         expect(event.source).toBe(field);
 

--- a/eclipse-scout-core/test/form/fields/treebox/TreeBoxSpec.ts
+++ b/eclipse-scout-core/test/form/fields/treebox/TreeBoxSpec.ts
@@ -270,7 +270,7 @@ describe('TreeBox', () => {
       });
       field.on('prepareLookupCall', event => {
         expect(event.lookupCall['customProperty']).toBe(templatePropertyValue);
-        expect(event.lookupCall.id).not.toBe(field.lookupCall.id);
+        expect(event.lookupCall).not.toBe(field.lookupCall);
         expect(event.type).toBe('prepareLookupCall');
         expect(event.source).toBe(field);
 


### PR DESCRIPTION
People may have used the id to store columns in POJOs. Also, the column gets an ID when used with Scout Classic, so it is consistent if Scout JS columns get one as well.

Also remove obsolete id on LookupCall and System.

389577