### PR TITLE
Table: improve moveColumn

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -4507,12 +4507,26 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     return spaceAvailableForText + (newIsIconVisible ? -iconWidth : iconWidth);
   }
 
-  moveColumn(column: Column<any>, visibleOldPos: number, visibleNewPos: number, dragged?: boolean) {
+  /**
+   * Moves the column to the new position. The position must be an index of {@link visibleColumns}.
+   *
+   * @returns true, if the column was moved, false if not.
+   */
+  moveColumn(column: Column<any>, visibleNewPos: number): boolean {
+    let visibleColumns = this.visibleColumns();
+    let visibleOldPos = visibleColumns.indexOf(column);
+    let range = new Range(0, visibleColumns.length);
+    if (!range.contains(visibleOldPos) || !range.contains(visibleNewPos)) {
+      return false;
+    }
+
     // If there are fixed columns, don't allow moving the column onto the other side of the fixed columns
-    visibleNewPos = this._considerFixedPositionColumns(visibleOldPos, visibleNewPos);
+    visibleNewPos = this.considerFixedPositionColumns(visibleOldPos, visibleNewPos);
+    if (visibleNewPos === visibleOldPos) {
+      return false;
+    }
 
     // Translate position of 'visible columns' array to position in 'all columns' array
-    let visibleColumns = this.visibleColumns();
     let newColumn = visibleColumns[visibleNewPos];
     let newPos = this.columns.indexOf(newColumn);
 
@@ -4523,7 +4537,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     visibleNewPos = visibleColumns.indexOf(column); // we must re-evaluate visible columns
 
     this._calculateTableNodeColumn();
-    this._triggerColumnMoved(column, visibleOldPos, visibleNewPos, dragged);
+    this._triggerColumnMoved(column, visibleOldPos, visibleNewPos);
 
     // move aggregated rows
     this._aggregateRows.forEach(aggregateRow => arrays.move(aggregateRow.contents, visibleOldPos, visibleNewPos));
@@ -4532,12 +4546,18 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     if (this._isDataRendered()) {
       this._rerenderViewport();
     }
+    return true;
   }
 
   /**
-   * Ensures the given newPos does not pass a fixed column boundary (necessary when moving columns)
+   * Ensures the given visibleNewPos does not pass a fixed column boundary (necessary when moving columns)
+   *
+   * @returns the adjusted visibleNewPos if the position passes a fixed column boundary, otherwise the unmodified visibleNewPos
    */
-  protected _considerFixedPositionColumns(visibleOldPos: number, visibleNewPos: number): number {
+  considerFixedPositionColumns(visibleOldPos: number, visibleNewPos: number): number {
+    if (visibleNewPos === visibleOldPos) {
+      return visibleNewPos;
+    }
     let fixedColumnIndex = -1;
     if (visibleNewPos > visibleOldPos) {
       // move to right
@@ -4677,12 +4697,11 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     this.trigger('columnResizedToFit', event);
   }
 
-  protected _triggerColumnMoved(column: Column<any>, oldPos: number, newPos: number, dragged?: boolean) {
+  protected _triggerColumnMoved(column: Column<any>, oldPos: number, newPos: number) {
     let event = {
       column: column,
       oldPos: oldPos,
-      newPos: newPos,
-      dragged: dragged
+      newPos: newPos
     };
     this.trigger('columnMoved', event);
   }

--- a/eclipse-scout-core/src/table/TableEventMap.ts
+++ b/eclipse-scout-core/src/table/TableEventMap.ts
@@ -41,7 +41,6 @@ export interface TableColumnMovedEvent<TValue = any, T = Table> extends Event<T>
   column: Column<TValue>;
   oldPos: number;
   newPos: number;
-  dragged: boolean;
 }
 
 export interface TableColumnResizedEvent<TValue = any, T = Table> extends Event<T> {

--- a/eclipse-scout-core/src/table/TableHeader.ts
+++ b/eclipse-scout-core/src/table/TableHeader.ts
@@ -258,24 +258,23 @@ export class TableHeader extends Widget implements TableHeaderModel {
     let that = this;
     $headers.each(function() {
       // move to old position and then animate
-      $(this).css('left', $(this).data('old-pos') - $(this).offset().left)
-        .animate({
-          left: 0
-        }, {
-          progress: function(animation, progress, remainingMs) {
-            let $headerItem = $(this);
-            if (!$headerItem.isSelected()) {
-              return;
-            }
-            // make sure selected header item is visible
-            scrollbars.scrollHorizontalTo(that.table.$data, $headerItem);
-
-            // move menu
-            if (that.tableHeaderMenu && that.tableHeaderMenu.rendered) {
-              that.tableHeaderMenu.position();
-            }
+      const $headerItem = $(this);
+      const oldLeft = $headerItem.data('old-left') - $headerItem.offset().left;
+      $headerItem.cssLeftAnimated(oldLeft, 0, {
+        progress: function(animation, progress, remainingMs) {
+          const $headerItem = $(this);
+          if (!$headerItem.isSelected()) {
+            return;
           }
-        });
+          // make sure selected header item is visible
+          scrollbars.scrollHorizontalTo(that.table.$data, $headerItem);
+
+          // move menu
+          if (that.tableHeaderMenu && that.tableHeaderMenu.rendered) {
+            that.tableHeaderMenu.position();
+          }
+        }
+      });
     });
   }
 
@@ -560,31 +559,26 @@ export class TableHeader extends Widget implements TableHeaderModel {
   }
 
   protected _onTableColumnMoved(event: TableColumnMovedEvent) {
-    let
-      column = event.column,
-      oldPos = event.oldPos,
-      newPos = event.newPos,
-      $header = column.$header,
-      $headers = this.findHeaderItems(),
-      $moveHeader = $headers.eq(oldPos),
-      $moveResize = $moveHeader.next('.table-header-resize'),
-      visibleColumns = this._visibleColumns(),
-      lastColumnPos = visibleColumns.length - 1;
-
     // store old position of header
+    const $headers = this.findHeaderItems();
     $headers.each(function() {
-      $(this).data('old-pos', $(this).offset().left);
+      $(this).data('old-left', $(this).offset().left);
     });
 
     // change order in dom of header
+    const oldPos = event.oldPos;
+    const newPos = event.newPos;
+    const $movedHeader = $headers.eq(oldPos);
+    const $targetHeader = $headers.eq(newPos);
     if (newPos < oldPos) {
-      $headers.eq(newPos).before($moveHeader);
+      $targetHeader.before($movedHeader);
     } else {
-      $headers.eq(newPos).after($moveHeader);
-      $moveHeader.before($moveHeader.next('.table-header-resize'));
+      $targetHeader.after($movedHeader);
+      $movedHeader.before($movedHeader.next('.table-header-resize'));
     }
-    // The resizer belongs to a column which is especially relevant for fixed width columns where resizer is disabled -> ensure it is always positioned after the header
-    $moveHeader.after($moveResize);
+    // The separator belongs to a column which is especially relevant for fixed width columns where resizing is disabled -> ensure it is always positioned after the header
+    const $separator = $movedHeader.next('.table-header-resize');
+    $movedHeader.after($separator);
 
     // Update first/last markers
     if ($headers.length > 0) {
@@ -592,6 +586,8 @@ export class TableHeader extends Widget implements TableHeaderModel {
       $headers.eq($headers.length - 1).removeClass('last');
     }
 
+    const visibleColumns = this._visibleColumns();
+    const lastColumnPos = visibleColumns.length - 1;
     if (visibleColumns.length > 0) {
       visibleColumns[0].$header.addClass('first');
       visibleColumns[lastColumnPos].$header.addClass('last');
@@ -602,13 +598,9 @@ export class TableHeader extends Widget implements TableHeaderModel {
       visibleColumns.forEach(column => this.resizeHeaderItem(column));
     }
 
-    // move to old position and then animate
-    if (event.dragged) {
-      $header.css('left', parseInt($header.css('left'), 0) + $header.data('old-pos') - $header.offset().left)
-        .addClass('releasing')
-        .animateAVCSD('left', 0, () => $header.removeClass('releasing'));
-    } else {
-      this._arrangeHeaderItems($headers);
+    // move to old position and then animate unless it was dragged and being released
+    if (!this.dragging) {
+      this._arrangeHeaderItems($([$movedHeader[0], $targetHeader[0]]));
     }
   }
 
@@ -625,7 +617,7 @@ export class TableHeader extends Widget implements TableHeaderModel {
 
     // store old position of headers
     $headers.each(function() {
-      $(this).data('old-pos', $(this).offset().left);
+      $(this).data('old-left', $(this).offset().left);
     });
 
     // change order in dom of header
@@ -773,8 +765,13 @@ export class TableHeader extends Widget implements TableHeaderModel {
       });
 
       // move column
-      if (newPos > -1 && oldPos !== newPos) {
-        that.table.moveColumn($header.data('column'), oldPos, newPos, true);
+      const oldLeft = $header.offset().left;
+      const moved = that.table.moveColumn($header.data('column'), newPos);
+      if (moved) {
+        const left = $header.cssLeft() + oldLeft - $header.offset().left;
+        $header.css('left', left)
+          .addClass('releasing')
+          .animateAVCSD('left', 0, () => $header.removeClass('releasing'));
         that.dragging = false;
         that.columnMoved = true;
       } else {

--- a/eclipse-scout-core/src/table/TableHeaderMenu.ts
+++ b/eclipse-scout-core/src/table/TableHeaderMenu.ts
@@ -318,9 +318,8 @@ export class TableHeaderMenu extends Popup implements TableHeaderMenuModel {
   }
 
   protected _renderMovingGroup(): TableHeaderMenuGroup {
-    let table = this.table,
-      column = this.column,
-      pos = table.visibleColumns().indexOf(column);
+    let table = this.table;
+    let column = this.column;
 
     this.moveGroup = scout.create(TableHeaderMenuGroup, {
       parent: this,
@@ -333,8 +332,7 @@ export class TableHeaderMenu extends Popup implements TableHeaderMenuModel {
       cssClass: 'move move-top'
     });
     this.toBeginButton.on('action', () => {
-      table.moveColumn(column, pos, 0);
-      pos = table.visibleColumns().indexOf(column);
+      table.moveColumn(column, 0);
     });
 
     this.forwardButton = scout.create(TableHeaderMenuButton, {
@@ -343,8 +341,8 @@ export class TableHeaderMenu extends Popup implements TableHeaderMenuModel {
       cssClass: 'move move-up'
     });
     this.forwardButton.on('action', () => {
-      table.moveColumn(column, pos, Math.max(pos - 1, 0));
-      pos = table.visibleColumns().indexOf(column);
+      let pos = table.visibleColumns().indexOf(column);
+      table.moveColumn(column, Math.max(pos - 1, 0));
     });
 
     this.backwardButton = scout.create(TableHeaderMenuButton, {
@@ -353,8 +351,8 @@ export class TableHeaderMenu extends Popup implements TableHeaderMenuModel {
       cssClass: 'move move-down'
     });
     this.backwardButton.on('action', () => {
-      table.moveColumn(column, pos, Math.min(pos + 1, table.header.findHeaderItems().length - 1));
-      pos = table.visibleColumns().indexOf(column);
+      let pos = table.visibleColumns().indexOf(column);
+      table.moveColumn(column, Math.min(pos + 1, table.header.findHeaderItems().length - 1));
     });
 
     this.toEndButton = scout.create(TableHeaderMenuButton, {
@@ -363,8 +361,7 @@ export class TableHeaderMenu extends Popup implements TableHeaderMenuModel {
       cssClass: 'move move-bottom'
     });
     this.toEndButton.on('action', () => {
-      table.moveColumn(column, pos, table.header.findHeaderItems().length - 1);
-      pos = table.visibleColumns().indexOf(column);
+      table.moveColumn(column, table.header.findHeaderItems().length - 1);
     });
 
     this.moveGroup.render(this.$columnActions);

--- a/eclipse-scout-core/test/table/TableGroupingSpec.ts
+++ b/eclipse-scout-core/test/table/TableGroupingSpec.ts
@@ -214,7 +214,7 @@ describe('Table Grouping', () => {
     expect(tableControl.aggregateRow[4]).toBeDefined();
 
     // Move last column between first and second column
-    table.moveColumn(table.columns[4], 4, 1);
+    table.moveColumn(table.columns[4], 1);
     // 0: col0<String> [G] | 1: col4<Number> | 2: col1<String> | 3: col2<String> | 4: col3<Number>
     expect(table._aggregateRows.length).toBe(2);
     expect(table._aggregateRows[0].contents.length).toBe(5);

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -2598,13 +2598,13 @@ describe('Table', () => {
       expect(table.columns.indexOf($header1.data('column'))).toBe(1);
       expect(table.columns.indexOf($header2.data('column'))).toBe(2);
 
-      table.moveColumn($header0.data('column'), 0, 2);
+      table.moveColumn($header0.data('column'), 2);
 
       expect(table.columns.indexOf($header1.data('column'))).toBe(0);
       expect(table.columns.indexOf($header2.data('column'))).toBe(1);
       expect(table.columns.indexOf($header0.data('column'))).toBe(2);
 
-      table.moveColumn($header2.data('column'), 1, 0);
+      table.moveColumn($header2.data('column'), 0);
 
       expect(table.columns.indexOf($header2.data('column'))).toBe(0);
       expect(table.columns.indexOf($header1.data('column'))).toBe(1);
@@ -2624,7 +2624,7 @@ describe('Table', () => {
       expect($cells0.eq(1).text()).toBe('0_1');
       expect($cells0.eq(2).text()).toBe('0_2');
 
-      table.moveColumn(table.columns[0], 0, 2);
+      table.moveColumn(table.columns[0], 2);
       $rows = table.$rows();
       expect(table.viewRangeRendered).toEqual(new Range(0, 1));
       expect($rows.length).toBe(1);
@@ -3168,11 +3168,11 @@ describe('Table', () => {
       colB.setVisible(false); // column in the middle is invisible
       expect(table.visibleColumns().length).toBe(2);
 
-      table.moveColumn(colC, 1, 0); // move C to be the first column
+      table.moveColumn(colC, 0); // move C to be the first column
       expect(table.visibleColumns()).toEqual([colC, colA]);
       expect(table.columns).toEqual([colC, colA, colB]);
 
-      table.moveColumn(colC, 0, 1); // move C to be the last column
+      table.moveColumn(colC, 1); // move C to be the last column
       expect(table.visibleColumns()).toEqual([colA, colC]);
       expect(table.columns).toEqual([colA, colC, colB]);
     });


### PR DESCRIPTION
- moveColumn now does nothing if column is already at the correct position or is not allowed to be moved to a new position. This ensures header item animation does not break when calling moveColumn for such columns.
- Removed oldPos and dragging parameter to simplify api
- Moving back to original position if user tries to move passed a fixed position column now works the same way as releasing without changing to a new position.