### PR TITLE
Table: improve rowOrderChanged event

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -100,9 +100,6 @@ export class PageWithTable extends Page implements PageWithTableModel {
   }
 
   protected _onTableRowOrderChanged(event: TableRowOrderChangedEvent) {
-    if (event.animating) { // do nothing while row order animation is in progress
-      return;
-    }
     this.outline.mediator.onTableRowOrderChanged(event, this);
   }
 

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -1346,10 +1346,10 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
           $row.css('top', oldTop - $row.offset().top).animate({
             top: 0
           }, {
-            progress: function() {
-              this._triggerRowOrderChanged(row, true);
+            progress: () => {
+              this._triggerRowOrderChangeAnimation(row);
               this.updateScrollbars();
-            }.bind(this)
+            }
           });
         }
       });
@@ -3308,10 +3308,10 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
       visibleRows: true
     });
     this.clearAggregateRows(this._animateAggregateRows);
+    this._triggerRowOrderChanged();
     if (this._isDataRendered()) {
       this._renderRowOrderChanges();
     }
-    this._triggerRowOrderChanged();
 
     this._group(this._animateAggregateRows);
     this._animateAggregateRows = false;
@@ -4655,12 +4655,15 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     }
   }
 
-  protected _triggerRowOrderChanged(row?: TableRow, animating?: boolean) {
+  protected _triggerRowOrderChanged() {
+    this.trigger('rowOrderChanged');
+  }
+
+  protected _triggerRowOrderChangeAnimation(row?: TableRow) {
     let event = {
-      row: row,
-      animating: animating
+      row: row
     };
-    this.trigger('rowOrderChanged', event);
+    this.trigger('rowOrderChangeAnimation', event);
   }
 
   protected _triggerColumnResized(column: Column<any>) {

--- a/eclipse-scout-core/src/table/TableEventMap.ts
+++ b/eclipse-scout-core/src/table/TableEventMap.ts
@@ -108,8 +108,10 @@ export interface TableRowInitEvent<T = Table> extends Event<T> {
 }
 
 export interface TableRowOrderChangedEvent<T = Table> extends Event<T> {
+}
+
+export interface TableRowOrderChangeAnimationEvent<T = Table> extends Event<T> {
   row: TableRow;
-  animating: boolean;
 }
 
 export interface TableRowsCheckedEvent<T = Table> extends Event<T> {
@@ -178,7 +180,14 @@ export interface TableEventMap extends WidgetEventMap {
   'rowAction': TableRowActionEvent;
   'rowClick': TableRowClickEvent;
   'rowInit': TableRowInitEvent;
+  /**
+   * Will be triggered when the row order has changed but before the new order is rendered.
+   */
   'rowOrderChanged': TableRowOrderChangedEvent;
+  /**
+   * Will be triggered during the row order change animation for each animation step.
+   */
+  'rowOrderChangeAnimation': TableRowOrderChangeAnimationEvent;
   'rowsChecked': TableRowsCheckedEvent;
   'rowsDeleted': TableRowsDeletedEvent;
   'rowsExpanded': TableRowsExpandedEvent;

--- a/eclipse-scout-core/src/table/TableTooltip.ts
+++ b/eclipse-scout-core/src/table/TableTooltip.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {EventHandler, InitModelOf, SomeRequired, Table, TableRow, TableRowOrderChangedEvent, TableTooltipModel, Tooltip} from '../index';
+import {EventHandler, InitModelOf, SomeRequired, Table, TableRow, TableRowOrderChangeAnimationEvent, TableRowOrderChangedEvent, TableTooltipModel, Tooltip} from '../index';
 
 export class TableTooltip extends Tooltip implements TableTooltipModel {
   declare model: TableTooltipModel;
@@ -16,7 +16,7 @@ export class TableTooltip extends Tooltip implements TableTooltipModel {
   table: Table;
   row: TableRow;
 
-  protected _rowOrderChangedFunc: EventHandler<TableRowOrderChangedEvent>;
+  protected _rowOrderChangedHandler: EventHandler<TableRowOrderChangedEvent>;
 
   protected override _init(options: InitModelOf<this>) {
     super._init(options);
@@ -27,21 +27,21 @@ export class TableTooltip extends Tooltip implements TableTooltipModel {
   protected override _render() {
     super._render();
 
-    this._rowOrderChangedFunc = (event: TableRowOrderChangedEvent) => {
-      if (event.animating) {
+    this._rowOrderChangedHandler = (event: TableRowOrderChangedEvent | TableRowOrderChangeAnimationEvent) => {
+      if (event.type === 'rowOrderChangeAnimation') {
         // row is only set while animating
-        if (event.row === this.row) {
+        if ((event as TableRowOrderChangeAnimationEvent).row === this.row) {
           this.position();
         }
       } else {
         this.position();
       }
     };
-    this.table.on('rowOrderChanged', this._rowOrderChangedFunc);
+    this.table.on('rowOrderChanged rowOrderChangeAnimation', this._rowOrderChangedHandler);
   }
 
   protected override _remove() {
     super._remove();
-    this.table.off('rowOrderChanged', this._rowOrderChangedFunc);
+    this.table.off('rowOrderChanged rowOrderChangeAnimation', this._rowOrderChangedHandler);
   }
 }

--- a/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
+++ b/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
@@ -9,7 +9,7 @@
  */
 import {
   AbstractLayout, Cell, CellEditorCancelEditKeyStroke, CellEditorCompleteEditKeyStroke, CellEditorPopupLayout, CellEditorPopupModel, CellEditorTabKeyStroke, Column, EventHandler, events, graphics, InitModelOf, KeyStroke,
-  KeyStrokeManagerKeyStrokeEvent, Point, Popup, Rectangle, scout, SomeRequired, Table, TableRow, TableRowOrderChangedEvent, ValueField, widgets
+  KeyStrokeManagerKeyStrokeEvent, Point, Popup, Rectangle, scout, SomeRequired, Table, TableRow, TableRowOrderChangeAnimationEvent, TableRowOrderChangedEvent, ValueField, widgets
 } from '../../index';
 import $ from 'jquery';
 
@@ -21,8 +21,8 @@ export class CellEditorPopup<TValue> extends Popup implements CellEditorPopupMod
   column: Column<TValue>;
   row: TableRow;
   cell: Cell<TValue>;
-  protected _rowOrderChangedFunc: EventHandler<TableRowOrderChangedEvent>;
   protected _pendingCompleteCellEdit: JQuery.Promise<void>;
+  protected _rowOrderChangedHandler: EventHandler<TableRowOrderChangedEvent>;
   protected _keyStrokeHandler: EventHandler<KeyStrokeManagerKeyStrokeEvent>;
 
   constructor() {
@@ -96,17 +96,17 @@ export class CellEditorPopup<TValue> extends Popup implements CellEditorPopupMod
     // Make sure cell content is not visible while the editor is open (especially necessary for transparent editors like checkboxes)
     this.$anchor.css('visibility', 'hidden');
 
-    this._rowOrderChangedFunc = event => {
-      if (event.animating) {
+    this._rowOrderChangedHandler = event => {
+      if (event.type === 'rowOrderChangeAnimation') {
         // row is only set while animating
-        if (event.row === this.row) {
+        if ((event as TableRowOrderChangeAnimationEvent).row === this.row) {
           this.position();
         }
       } else {
         this.position();
       }
     };
-    this.table.on('rowOrderChanged', this._rowOrderChangedFunc);
+    this.table.on('rowOrderChanged rowOrderChangeAnimation', this._rowOrderChangedHandler);
     // Set table style to focused, so that it looks as it still has the focus.
     // This prevents flickering if the cell editor gets opened, especially when tabbing to the next cell editor.
     if (this.table.enabled) {
@@ -157,7 +157,7 @@ export class CellEditorPopup<TValue> extends Popup implements CellEditorPopupMod
     super._remove(); // uninstalls the focus context for this popup
 
     this.session.keyStrokeManager.off('keyStroke', this._keyStrokeHandler);
-    this.table.off('rowOrderChanged', this._rowOrderChangedFunc);
+    this.table.off('rowOrderChanged rowOrderChangeAnimation', this._rowOrderChangedHandler);
     // table may have been removed in the meantime
     if (this.table.rendered) {
       this.table.$container.removeClass('focused');

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -627,6 +627,18 @@ describe('Table', () => {
       expect(table.$rows().length).toBe(2);
       expect(table.rows.length).toBe(3);
     });
+
+    it('triggers row order changed event', () => {
+      table.render();
+      table.on('rowOrderChanged', event => {
+        // New order has been applied to model
+        expect(table.rows).toEqual([row2, row1, row0]);
+
+        // New order has not been rendered yet
+        expect(table.$rows().toArray().map(elem => $(elem).data('row').id)).toEqual([row0.id, row1.id, row2.id]);
+      });
+      table.updateRowOrder([row2, row1, row0]);
+    });
   });
 
   describe('checkRow', () => {
@@ -1743,6 +1755,22 @@ describe('Table', () => {
       expect([$row0, $row1, $row2, $row4]).not.anyToHaveClass('select-middle');
       expect([$row0, $row1, $row2, $row3]).not.anyToHaveClass('select-bottom');
       expect([$row0, $row1, $row2, $row3, $row4]).not.anyToHaveClass('select-single');
+    });
+
+    it('triggers rowOrderChanged event', () => {
+      prepareTable();
+      table.render();
+      let row0 = table.rows[0];
+      let row1 = table.rows[1];
+      let row2 = table.rows[2];
+      table.on('rowOrderChanged', event => {
+        // New order has been applied to model
+        expect(table.rows).toEqual([row2, row1, row0]);
+
+        // New order has not been rendered yet
+        expect(table.$rows().toArray().map(elem => $(elem).data('row').id)).toEqual([row0.id, row1.id, row2.id]);
+      });
+      table.sort(column0, 'desc');
     });
 
     describe('sorting', () => {


### PR DESCRIPTION
- Event should be triggered before new order is rendered. This makes it possible to update the row (e.g. by setting a new cell text) before the animation starts, otherwise the animation would be aborted because the row will be replaced. This is the pattern we use for other events as well: change model, trigger event, render.
- Don't trigger rowOrderChanged for each animation step. Normally, a consumer only needs to know if the order has changed and doesn't need to be informed about every animation step. If the property 'animating' on the event is not checked explicitly, the handler is called too many times which may slow down the execution -> add a dedicated animation event.

397703