### PR TITLE
Tree: send correct events if root node changes

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/overview/TileOutlineOverview.ts
+++ b/eclipse-scout-core/src/desktop/outline/overview/TileOutlineOverview.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {aria, Desktop, EventHandler, HtmlComponent, InitModelOf, OutlineOverview, Page, PageTileGrid, PropertyChangeEvent, RowLayout, scout, TileOutlineOverviewEventMap, TileOutlineOverviewModel} from '../../../index';
+import {
+  aria, Desktop, EventHandler, HtmlComponent, InitModelOf, OutlineOverview, Page, PageTileGrid, PropertyChangeEvent, RowLayout, scout, TileOutlineOverviewEventMap, TileOutlineOverviewModel, TreeNodesDeletedEvent, TreeNodesInsertedEvent
+} from '../../../index';
 
 export class TileOutlineOverview extends OutlineOverview implements TileOutlineOverviewModel {
   declare model: TileOutlineOverviewModel;
@@ -20,6 +22,8 @@ export class TileOutlineOverview extends OutlineOverview implements TileOutlineO
   contentHtmlComp: HtmlComponent;
   $title: JQuery;
   protected _desktopNavigationVisibilityChangeHandler: EventHandler<PropertyChangeEvent<boolean, Desktop>>;
+  protected _outlineNodesInsertedHandler: EventHandler<TreeNodesInsertedEvent>;
+  protected _outlineNodesDeletedHandler: EventHandler<TreeNodesDeletedEvent>;
 
   constructor() {
     super();
@@ -28,15 +32,27 @@ export class TileOutlineOverview extends OutlineOverview implements TileOutlineO
     this.titleVisible = true;
     this._addWidgetProperties(['pageTileGrid']);
     this._desktopNavigationVisibilityChangeHandler = this._onDesktopNavigationVisibilityChange.bind(this);
+    this._outlineNodesInsertedHandler = this._onOutlineNodesInserted.bind(this);
+    this._outlineNodesDeletedHandler = this._onOutlineNodesDeleted.bind(this);
   }
 
   protected override _init(model: InitModelOf<this>) {
     super._init(model);
-    if (!this.pageTileGrid) {
-      this.pageTileGrid = this._createPageTileGrid();
+    this.pageTileGrid = this._createPageTileGrid();
+    if (this.outline.compact) {
+      this.outline.on('nodesDeleted', this._outlineNodesDeletedHandler);
+      this.outline.on('nodesInserted', this._outlineNodesInsertedHandler);
     }
     this.scrollable = !this.outline.compact;
     this.addCssClass('dimmed-background');
+  }
+
+  protected override _destroy() {
+    if (this.outline.compact) {
+      this.outline.off('nodesDeleted', this._outlineNodesDeletedHandler);
+      this.outline.off('nodesInserted', this._outlineNodesInsertedHandler);
+    }
+    super._destroy();
   }
 
   protected override _render() {
@@ -62,6 +78,10 @@ export class TileOutlineOverview extends OutlineOverview implements TileOutlineO
     super._renderProperties();
     this._renderPageTileGrid();
     this._renderScrollable();
+  }
+
+  protected setPageTileGrid(pageTileGrid: PageTileGrid) {
+    this.setProperty('pageTileGrid', pageTileGrid);
   }
 
   protected _renderPageTileGrid() {
@@ -112,5 +132,23 @@ export class TileOutlineOverview extends OutlineOverview implements TileOutlineO
 
   protected _onDesktopNavigationVisibilityChange(event: PropertyChangeEvent<boolean, Desktop>) {
     this._updateTitle();
+  }
+
+  protected _onOutlineNodesInserted(event: TreeNodesInsertedEvent) {
+    if (this.pageTileGrid) {
+      // If there is already a page tile grid, it will handle the insertion itself
+      return;
+    }
+    this.setPageTileGrid(this._createPageTileGrid());
+  }
+
+  protected _onOutlineNodesDeleted(event: TreeNodesDeletedEvent) {
+    // If outline is compact, the root page is passed to the page tile grid.
+    // If the root page is deleted, the grid needs to be recreated
+    // If outline is not compact, the grid itself takes care of page removals / insertions
+    const deletedNodes = event.nodes;
+    if (this.pageTileGrid && deletedNodes.length === 1 && this.pageTileGrid.page === deletedNodes[0]) {
+      this.setPageTileGrid(null);
+    }
   }
 }

--- a/eclipse-scout-core/src/desktop/outline/overview/TileOutlineOverviewModel.ts
+++ b/eclipse-scout-core/src/desktop/outline/overview/TileOutlineOverviewModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,9 +7,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ObjectOrChildModel, OutlineOverviewModel, PageTileGrid} from '../../../index';
+import {OutlineOverviewModel} from '../../../index';
 
 export interface TileOutlineOverviewModel extends OutlineOverviewModel {
-  pageTileGrid?: ObjectOrChildModel<PageTileGrid>;
   titleVisible?: boolean;
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/transformation/MobileDeviceTransformer.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/transformation/MobileDeviceTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -153,11 +153,11 @@ public class MobileDeviceTransformer extends AbstractDeviceTransformer {
       return;
     }
     // The root content (default detail form / outline overview) will be embedded into the root node
-    // To make this work the root node needs to be visible. We also have to mark is as compact root so that the UI knows where to embed the root content.
-    // We also need to make sure that deselecting all nodes actually select the root node
-    // The root node will only be visible when it is selected which is done by using CSS, see Outline.less
+    // To make this work the root node needs to be visible.
     outline.setRootNodeVisible(true);
-    outline.getRootPage().setCompactRoot(true);
+
+    // Make sure that deselecting all nodes actually select the root node
+    // The root node will only be visible when it is selected which is done by using CSS, see Outline.less
     // Use _UI_TreeListener to make sure the event buffer in JsonTree contains the event with no selection when we select the root node,
     // otherwise changing the selection during a selection event would not be possible
     outline.addUITreeListener(event -> {
@@ -165,6 +165,22 @@ public class MobileDeviceTransformer extends AbstractDeviceTransformer {
         outline.selectNode(outline.getRootNode());
       }
     }, TreeEvent.TYPE_NODES_SELECTED);
+
+    // If root node changes dynamically, apply the root node transformation for the new root node
+    outline.addUITreeListener(event -> {
+      if (event.getNodeCount() == 1 && event.getNode() == outline.getRootNode()) {
+        transformRootPage(outline.getRootPage());
+      }
+    }, TreeEvent.TYPE_NODES_INSERTED);
+
+    transformRootPage(outline.getRootPage());
+  }
+
+  protected void transformRootPage(IPage page) {
+    // Mark is as compact root so that the UI knows where to embed the root content.
+    page.setCompactRoot(true);
+    page.setExpanded(true);
+    IOutline outline = page.getOutline();
     if (outline.getSelectedNodes().isEmpty()) {
       outline.selectNode(outline.getRootNode());
     }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@ package org.eclipse.scout.rt.client.ui.basic.tree;
 
 import java.security.Permission;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1133,26 +1134,40 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
 
   @Override
   public void setRootNode(ITreeNode root) {
-    if (m_rootNode != null) {
-      m_rootNode.setTreeInternal(null, true);
-      // inform root of remove
-      m_rootNode.nodeRemovedNotify();
-      m_rootNode.dispose();
-    }
-    m_rootNode = root;
-    if (m_rootNode != null) {
-      m_rootNode.setTreeInternal(this, true);
-      // inform root of add
-      m_rootNode.nodeAddedNotify();
-      // expand root if it is not visible
-      if (!isRootNodeVisible()) {
-        try {
-          m_rootNode.ensureChildrenLoaded();
-        }
-        catch (RuntimeException e) {
-          LOG.error("expanding root node of {}", getTitle(), e);
+    this.setTreeChanging(true);
+    try {
+      if (m_rootNode != null) {
+        deselectNode(m_rootNode);
+        setNodeChecked(m_rootNode, false);
+        m_rootNode.setTreeInternal(null, true);
+        // inform root of remove
+        m_rootNode.nodeRemovedNotify();
+        m_rootNode.dispose();
+        if (this.isInitConfigDone()) {
+          fireNodesDeleted(null, Arrays.asList(m_rootNode));
         }
       }
+      m_rootNode = root;
+      if (m_rootNode != null) {
+        if (this.isInitConfigDone()) {
+          fireNodesInserted(null, Arrays.asList(m_rootNode)); // Needs to happen before linking it with the tree, see addChildNodes
+        }
+        m_rootNode.setTreeInternal(this, true);
+        // inform root of add
+        m_rootNode.nodeAddedNotify();
+        // expand root if it is not visible
+        if (!isRootNodeVisible()) {
+          try {
+            m_rootNode.ensureChildrenLoaded();
+          }
+          catch (RuntimeException e) {
+            LOG.error("expanding root node of {}", getTitle(), e);
+          }
+        }
+      }
+    }
+    finally {
+      setTreeChanging(false);
     }
   }
 

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutlineTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutlineTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.transformation.MobileDeviceTransformer;
 import org.eclipse.scout.rt.client.ui.action.menu.AbstractMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenuType;
@@ -28,6 +29,7 @@ import org.eclipse.scout.rt.client.ui.desktop.outline.AbstractOutline;
 import org.eclipse.scout.rt.client.ui.desktop.outline.IOutline;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.AbstractPageWithNodes;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.classid.ClassId;
 import org.eclipse.scout.rt.platform.holders.Holder;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -331,6 +333,34 @@ public class JsonOutlineTest {
     // Only the insert event for the child node of the invisible root page is sent
     assertEquals(1, events.size());
     assertEquals(JsonTree.EVENT_NODES_INSERTED, events.get(0).getType());
+  }
+
+  @Test
+  public void testChangingVisibleRootNodeForMobile() {
+    IOutline outline = new OutlineWithOneNode();
+    outline.setRootNodeVisible(true);
+    BEANS.get(MobileDeviceTransformer.class).transformOutline(outline);
+
+    IPage<?> oldRootNode = outline.getRootPage();
+    JsonOutline<IOutline> jsonOutline = UiSessionTestUtility.newJsonAdapter(m_uiSession, outline);
+    String oldRootNodeId = jsonOutline.getNodeId(oldRootNode);
+
+    NodePage newRootNode = new NodePage();
+    outline.setRootNode(newRootNode);
+
+    JsonTestUtility.processBufferedEvents(m_uiSession);
+
+    assertNull(jsonOutline.optNodeId(oldRootNode));
+    assertNotNull(jsonOutline.optNodeId(newRootNode));
+
+    List<JsonEvent> events = m_uiSession.currentJsonResponse().getEventList();
+
+    String newRootNodeId = jsonOutline.getNodeId(newRootNode);
+    assertEquals(4, events.size());
+    JsonTreeTest.assertEventTypeAndNodeIds(events.get(0), JsonTree.EVENT_NODES_DELETED, oldRootNodeId);
+    assertEquals(JsonTree.EVENT_NODES_INSERTED, events.get(1).getType());
+    assertEquals("pageChanged", events.get(2).getType()); // because selecting the new root node creates the detail table
+    JsonTreeTest.assertEventTypeAndNodeIds(events.get(3), JsonTree.EVENT_NODES_SELECTED, newRootNodeId); // Mobile Device transformer selects the new root node
   }
 
   /**

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/tree/JsonTreeTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/tree/JsonTreeTest.java
@@ -101,48 +101,6 @@ public class JsonTreeTest {
     assertEquals(0, responseEvents.size());
   }
 
-  /*
-   * If the selection event triggers the selection of another node, the selection event must not be ignored.
-   */
-  //TODO [7.0] cgu: Test fails due to scout model bug: selectNode puts first selection event AFTER this new selection event -> gets filtered in processEventBuffers. With table it works though.
-  //  @Test
-  //  public void testIgnorableSelectionEvent2() throws JSONException {
-  //    List<ITreeNode> nodes = new LinkedList<>();
-  //    final TreeNode firstNode = new TreeNode();
-  //    final TreeNode secondNode = new TreeNode();
-  //
-  //    nodes.add(firstNode);
-  //    nodes.add(secondNode);
-  //    ITree tree = new Tree(nodes) {
-  //
-  //      @Override
-  //      protected void execNodesSelected(TreeEvent e) {
-  //        if (e.getNode().equals(secondNode)) {
-  //          selectNode(firstNode);
-  //        }
-  //      }
-  //    };
-  //    tree.initTree();
-  //
-  //    JsonTree<ITree> jsonTree = m_uiSession.createJsonAdapter(tree, new JsonAdapterMock());
-  //    JsonEvent event = createJsonSelectedEvent(jsonTree.getOrCreateNodeId(secondNode));
-  //
-  //    assertFalse(firstNode.isSelectedNode());
-  //    assertFalse(secondNode.isSelectedNode());
-  //
-  //    jsonTree.handleUiEvent(event);
-  //
-  //    assertTrue(firstNode.isSelectedNode());
-  //    assertFalse(secondNode.isSelectedNode());
-  //
-  //    List<JsonEvent> responseEvents = JsonTestUtility.extractEventsFromResponse(
-  //        m_uiSession.currentJsonResponse(), JsonTree.EVENT_NODES_SELECTED);
-  //    assertTrue(responseEvents.size() == 1);
-  //
-  //    List<ITreeNode> treeNodes = jsonTree.extractTreeNodes(responseEvents.get(0).getData());
-  //    assertEquals(firstNode, treeNodes.get(0));
-  //  }
-
   /**
    * Selection must not be cleared if nodeIds cannot be resolved.
    */
@@ -487,44 +445,6 @@ public class JsonTreeTest {
     assertEventTypeAndNodeIds(events.get(0), "nodesDeleted", node0Id);
   }
 
-  //  @Test
-  //  public void testNodeAndUserFilter() throws JSONException {
-  //    TreeNode node0 = new TreeNode();
-  //    TreeNode node1 = new TreeNode();
-  //    TreeNode node2 = new TreeNode();
-  //    List<ITreeNode> nodes = new ArrayList<ITreeNode>();
-  //    nodes.add(node0);
-  //    nodes.add(node1);
-  //    nodes.add(node2);
-  //    ITree tree = createTree(nodes);
-  //    JsonTree<ITree> jsonTree = m_uiSession.createJsonAdapter(tree, new JsonAdapterMock());
-  //    jsonTree.toJson();
-  //
-  //    String node0Id = jsonTree.getOrCreateNodeId(nodes.get(0));
-  //    assertNotNull(node0Id);
-  //    assertNotNull(jsonTree.getNode(node0Id));
-  //
-  //    node0.setEnabled(false);
-  //    tree.addNodeFilter(new ITreeNodeFilter() {
-  //
-  //      @Override
-  //      public boolean accept(ITreeNode node, int level) {
-  //        return node.isEnabled();
-  //      }
-  //    });
-  //
-  //    JsonEvent event = createJsonRowsFilteredEvent(row0Id, row2Id);
-  //    jsonTree.handleUiEvent(event);
-  //
-  //    JsonTestUtility.processBufferedEvents(m_uiSession);
-  //    assertNull(jsonTree.getNodeId(nodes.get(0)));
-  //    assertNull(jsonTree.getNode(node0Id));
-  //
-  //    List<JsonEvent> events = m_uiSession.currentJsonResponse().getEventList();
-  //    assertEquals(1, events.size());
-  //    assertEventTypeAndNodeIds(events.get(0), "nodesDeleted", node0Id);
-  //  }
-
   /**
    * Tests whether the child nodes gets removed from the maps after deletion (m_treeNodes, m_treeNodeIds)
    */
@@ -739,10 +659,10 @@ public class JsonTreeTest {
     assertEquals("nodesInserted", events.get(0).getType());
   }
 
-  protected void assertEventTypeAndNodeIds(JsonEvent event, String expectedType, String... expectedNodeIds) {
+  public static void assertEventTypeAndNodeIds(JsonEvent event, String expectedType, String... expectedNodeIds) {
     assertEquals(expectedType, event.getType());
 
-    JSONArray nodeIds = event.getData().getJSONArray("nodeIds");
+    JSONArray nodeIds = event.getData().optJSONArray("nodeIds");
     assertEquals(nodeIds.length(), expectedNodeIds.length);
     for (int i = 0; i < expectedNodeIds.length; i++) {
       assertEquals(nodeIds.get(i), expectedNodeIds[i]);
@@ -895,6 +815,32 @@ public class JsonTreeTest {
     catch (UiException e) {
       fail("Regression of ticket 210096: Tree does not contain node whose children are to be deleted.");
     }
+  }
+
+  @Test
+  public void testNoEventsSentForOldVisibleRootNode() {
+    ITree tree = createTreeWithOneNode();
+    tree.setRootNodeVisible(true);
+    ITreeNode oldRootNode = tree.getRootNode();
+    tree.selectNode(oldRootNode);
+
+    JsonTree<ITree> jsonTree = UiSessionTestUtility.newJsonAdapter(m_uiSession, tree);
+    String oldRootNodeId = jsonTree.getNodeId(oldRootNode);
+
+    TreeNode newRootNode = new TreeNode();
+    tree.setRootNode(newRootNode);
+
+    JsonTestUtility.processBufferedEvents(m_uiSession);
+
+    assertNull(jsonTree.optNodeId(oldRootNode));
+    assertNotNull(jsonTree.optNodeId(newRootNode));
+
+    List<JsonEvent> events = m_uiSession.currentJsonResponse().getEventList();
+
+    assertEquals(3, events.size());
+    assertEventTypeAndNodeIds(events.get(0), JsonTree.EVENT_NODES_SELECTED);
+    assertEventTypeAndNodeIds(events.get(1), JsonTree.EVENT_NODES_DELETED, oldRootNodeId);
+    assertEquals(JsonTree.EVENT_NODES_INSERTED, events.get(2).getType());
   }
 
   public static JsonEvent createJsonSelectedEvent(String nodeId) throws JSONException {

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutline.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutline.java
@@ -129,11 +129,11 @@ public class JsonOutline<OUTLINE extends IOutline> extends JsonTree<OUTLINE> {
   }
 
   @Override
-  protected void attachNode(ITreeNode node, boolean attachChildren) {
+  protected void attachNodeInternal(ITreeNode node) {
     if (!(node instanceof IPage)) {
       throw new IllegalArgumentException("Expected node to be a page. " + node);
     }
-    super.attachNode(node, attachChildren);
+    super.attachNodeInternal(node);
     IPage<?> page = (IPage<?>) node;
     if (hasDetailForm(page)) {
       attachGlobalAdapter(page.getDetailForm());

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/tree/JsonTree.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/tree/JsonTree.java
@@ -318,6 +318,7 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
   }
 
   protected void attachNodes(Collection<ITreeNode> nodes, boolean attachChildren) {
+    nodes = getChildrenIfInvisibleRootNode(nodes);
     for (ITreeNode node : nodes) {
       attachNode(node, attachChildren);
     }
@@ -618,7 +619,7 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
 
   protected void handleModelNodesInserted(TreeEvent event) {
     Set<ITreeNode> acceptedNodes = new HashSet<>();
-    attachNodes(event.getNodes(), true); // TODO [7.0] cgu: why not inside loop? attaching for rejected nodes?
+    attachNodes(event.getNodes(), true);
     IChildNodeIndexLookup childIndexes = createChildNodeIndexLookup();
     JSONArray jsonNodes = treeNodesToJson(event.getNodes(), childIndexes, acceptedNodes);
     if (jsonNodes.length() == 0) {
@@ -931,6 +932,7 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
   }
 
   protected JSONArray treeNodesToJson(Collection<ITreeNode> nodes, IChildNodeIndexLookup childIndexes, Set<ITreeNode> acceptedNodes) {
+    nodes = getChildrenIfInvisibleRootNode(nodes);
     JSONArray jsonNodes = new JSONArray();
     for (ITreeNode node : nodes) {
       if (isNodeAccepted(node)) {
@@ -939,6 +941,21 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
       }
     }
     return jsonNodes;
+  }
+
+  /**
+   * If the given nodes just consist of the invisible root node, the children of that node are returned instead.
+   * Otherwise, the given nodes are returned as they are.
+   */
+  protected Collection<ITreeNode> getChildrenIfInvisibleRootNode(Collection<ITreeNode> nodes) {
+    if (nodes.size() != 1) {
+      return nodes;
+    }
+    ITreeNode node = nodes.stream().findFirst().get();
+    if (isInvisibleRootNode(node)) {
+      nodes = node.getChildNodes();
+    }
+    return nodes;
   }
 
   protected JSONObject treeNodeToJson(ITreeNode node, IChildNodeIndexLookup childIndexes, Set<ITreeNode> acceptedNodes) {


### PR DESCRIPTION
If root node is visible and changes dynamically, the ui needs to be informed about the new state. Currently, the UI server sends selection and page changed events referring the old root node which creates exceptions in the browser because that root node cannot be found.

422641