### PR TITLE
TableHeader: fix position of separator when moving a column

### DIFF
--- a/eclipse-scout-core/src/table/TableHeader.ts
+++ b/eclipse-scout-core/src/table/TableHeader.ts
@@ -570,14 +570,14 @@ export class TableHeader extends Widget implements TableHeaderModel {
     const newPos = event.newPos;
     const $movedHeader = $headers.eq(oldPos);
     const $targetHeader = $headers.eq(newPos);
+    // The separator always belongs to a column -> remember it before moving the header
+    const $separator = $movedHeader.next('.table-header-resize');
     if (newPos < oldPos) {
       $targetHeader.before($movedHeader);
     } else {
       $targetHeader.after($movedHeader);
       $movedHeader.before($movedHeader.next('.table-header-resize'));
     }
-    // The separator belongs to a column which is especially relevant for fixed width columns where resizing is disabled -> ensure it is always positioned after the header
-    const $separator = $movedHeader.next('.table-header-resize');
     $movedHeader.after($separator);
 
     // Update first/last markers

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -2621,22 +2621,34 @@ describe('Table', () => {
       let $header0 = $colHeaders.eq(0);
       let $header1 = $colHeaders.eq(1);
       let $header2 = $colHeaders.eq(2);
+      let $resizer0 = $header0.next('.table-header-resize');
+      let $resizer1 = $header1.next('.table-header-resize');
+      let $resizer2 = $header2.next('.table-header-resize');
 
       expect(table.columns.indexOf($header0.data('column'))).toBe(0);
       expect(table.columns.indexOf($header1.data('column'))).toBe(1);
       expect(table.columns.indexOf($header2.data('column'))).toBe(2);
+      expect($resizer0.length).toBe(1);
+      expect($resizer1.length).toBe(1);
+      expect($resizer2.length).toBe(1);
 
       table.moveColumn($header0.data('column'), 2);
 
       expect(table.columns.indexOf($header1.data('column'))).toBe(0);
       expect(table.columns.indexOf($header2.data('column'))).toBe(1);
       expect(table.columns.indexOf($header0.data('column'))).toBe(2);
+      expect($header0.next('.table-header-resize')[0]).toBe($resizer0[0]);
+      expect($header1.next('.table-header-resize')[0]).toBe($resizer1[0]);
+      expect($header2.next('.table-header-resize')[0]).toBe($resizer2[0]);
 
       table.moveColumn($header2.data('column'), 0);
 
       expect(table.columns.indexOf($header2.data('column'))).toBe(0);
       expect(table.columns.indexOf($header1.data('column'))).toBe(1);
       expect(table.columns.indexOf($header0.data('column'))).toBe(2);
+      expect($header0.next('.table-header-resize')[0]).toBe($resizer0[0]);
+      expect($header1.next('.table-header-resize')[0]).toBe($resizer1[0]);
+      expect($header2.next('.table-header-resize')[0]).toBe($resizer2[0]);
     });
 
     it('considers view range (does not fail if not all rows are rendered)', () => {


### PR DESCRIPTION
The resize handle always has to be moved in conjunction with the column header -> remember it _before_ moving the header.