### PR TITLE
HybridManager: add initial data for all form hybrid actions

### DIFF
--- a/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
@@ -122,7 +122,9 @@ export class HybridManager extends Widget {
   }
 
   protected _onHybridFormEvent(form: HybridManagerForm, eventType: string, data: AnyDoEntity) {
-    if (eventType === 'reset') {
+    if (eventType === 'data') {
+      form.setData(data);
+    } else if (eventType === 'reset') {
       form.setData(data);
       form.trigger('reset');
     } else if (eventType === 'save') {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/AbstractFormHybridAction.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/AbstractFormHybridAction.java
@@ -47,6 +47,8 @@ public abstract class AbstractFormHybridAction<FORM extends IForm, DO_ENTITY ext
     addFormListeners(form);
     startForm(form);
     addWidget(form);
+
+    fireHybridWidgetEvent("data", exportResultInternal(form));
   }
 
   protected abstract FORM createForm(DO_ENTITY data);


### PR DESCRIPTION
When a form is created using an AbstractFormHybridAction the data set initially is now exported and sent back to the browser in order to make it accessible for Scout JS.