### PR TITLE
Ensure disabled styles override icon color in the toolbox

### DIFF
--- a/eclipse-scout-core/src/desktop/toolbox/DesktopToolBox.less
+++ b/eclipse-scout-core/src/desktop/toolbox/DesktopToolBox.less
@@ -58,6 +58,11 @@
   &.disabled {
     background-color: transparent;
     color: @desktop-header-disabled-color;
+
+    & > .font-icon {
+      background-color: transparent;
+      color: @desktop-header-disabled-color;
+    }
   }
 }
 


### PR DESCRIPTION
Previously, when a color was set on an icon in the toolbox, the disabled style didn’t take effect because the color wasn’t applied directly to the element. This ensures that the disabled style now properly overrides the icon color.