### PR TITLE
Fix incorrect parsing of HEX NCRs

### DIFF
--- a/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.ts
+++ b/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.ts
@@ -137,6 +137,16 @@ describe('PlainTextEncoder', () => {
     );
   });
 
+  it('converts hexadecimal NCRs to unicode character', () => {
+    // Emojis
+    expect(encoder.encode('&#x1f600;')).toBe('\uD83D\uDE00'); // Grinning Face
+    expect(encoder.encode('&#x1f60e;')).toBe('\uD83D\uDE0E'); // Smiling Face with Sunglasses
+
+    // Other characters
+    expect(encoder.encode('&#39;&#x27;&apos;')).toBe('\u0027\u0027\u0027');
+    expect(encoder.encode('&#x68;&#x69;')).toBe('hi');
+  });
+
   it('removes font icons if configured', () => {
     let htmlText = '<span class="table-cell-icon font-icon"></span><span class="text">Text</span>';
     expect(encoder.encode(htmlText)).toBe('Text');

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -197,5 +197,18 @@ public class HtmlHelperTest {
 
     assertEquals("one &amp; two<br>three &amp; four", helper.escapeAndNewLineToBr("one & two\nthree & four"));
     assertEquals("&gt;&lt;script&gt;alert(&#39;hacker<br>attack&#39;);&lt;&#47;script&gt;&lt;", helper.escapeAndNewLineToBr("><script>alert('hacker\r\nattack');</script><"));
+  }
+
+  @Test
+  public void testHexEncodedCharacters() {
+    HtmlHelper helper = BEANS.get(HtmlHelper.class);
+
+    // Emojis
+    assertEquals("\uD83D\uDE00", helper.toPlainText("&#x1f600;")); // Grinning Face
+    assertEquals("\uD83D\uDE0E", helper.toPlainText("&#x1f60e;")); // Smiling Face with Sunglasses
+
+    // Other characters
+    assertEquals("\u0027\u0027\u0027", helper.toPlainText("&#39;&#x27;&apos;"));
+    assertEquals("hi", helper.toPlainText("&#x68;&#x69;"));
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ public class HtmlHelper {
   private static final Pattern MULTIPLE_SPACES = Pattern.compile("[ ]+");
   private static final Pattern SPACES_ADJACENT_LINEBREAKS = Pattern.compile("[ ]+\n[ ]?|[ ]?\n[ ]+");
   private static final Pattern DECIMAL_NCR = Pattern.compile("&#(\\d+);");
+  private static final Pattern HEX_NCR = Pattern.compile("&#x([0-9a-fA-F]+);");
 
   /**
    * Very basic HTML to plain text conversion, without parsing and building a model.
@@ -125,13 +126,29 @@ public class HtmlHelper {
     s = StringUtility.replaceNoCase(s, "&#x9;", "\t");
 
     //decimal numeric character reference
+    StringBuilder sb = new StringBuilder();
     s = StringUtility.replace(s, "&zwj;", Character.toString(0x200D)); //zero width joiner for combined characters
     matcher = DECIMAL_NCR.matcher(s);
-    StringBuilder sb = new StringBuilder();
     while (matcher.find()) {
       String decimalNcr = matcher.group(1);
       try {
         String character = Character.toString(Integer.parseInt(decimalNcr));
+        matcher.appendReplacement(sb, character);
+      }
+      catch (IllegalArgumentException e) {
+        matcher.appendReplacement(sb, decimalNcr);
+      }
+    }
+    matcher.appendTail(sb);
+    s = sb.toString();
+
+    // hexadecimal numeric characters
+    sb = new StringBuilder();
+    matcher = HEX_NCR.matcher(s);
+    while (matcher.find()) {
+      String decimalNcr = matcher.group(1);
+      try {
+        String character = Character.toString(Integer.parseInt(decimalNcr, 16));
         matcher.appendReplacement(sb, character);
       }
       catch (IllegalArgumentException e) {


### PR DESCRIPTION
Characters or emojis encoded as hexadecimal NCRs are not corretly parsed. A new regex matcher was added to parse HEX NCRs to plain text. Also a test case ensures the correct parsing.

370628