### PR TITLE
Mobile: several improvements

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
@@ -306,8 +306,7 @@ export class OutlineAdapter extends TreeAdapter {
       objectType: pageModel.jsPageObjectType,
       pageParam: pageParam,
       classId: pageModel.classId,
-      modelClass: pageModel.modelClass,
-      text: pageModel.text || undefined // because summary column might come from Java parent page
+      modelClass: pageModel.modelClass
     };
   }
 

--- a/eclipse-scout-core/src/desktop/outline/pages/AutoLeafPageWithNodes.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/AutoLeafPageWithNodes.ts
@@ -7,19 +7,27 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AutoLeafPageWithNodesModel, InitModelOf, Page, scout, TableRow} from '../../../index';
+import {AutoLeafPageWithNodesModel, InitModelOf, PageWithNodes, scout, Table, TableRow} from '../../../index';
 
-export class AutoLeafPageWithNodes extends Page implements AutoLeafPageWithNodesModel {
+export class AutoLeafPageWithNodes extends PageWithNodes implements AutoLeafPageWithNodesModel {
   declare model: AutoLeafPageWithNodesModel;
 
   constructor() {
     super();
+    // hide table and form
+    this.detailTableVisible = false;
+    this.detailFormVisible = false;
     this.leaf = true;
+  }
+
+  protected override _createDetailTable(): Table {
+    // do not create a table, AutoLeafPageWithNodes has no own content
+    return null;
   }
 
   protected override _init(model: InitModelOf<this>) {
     scout.assertParameter('row', model.row, TableRow);
     super._init(model);
-    this.text = this.row.cells[0].text;
+    this.text = this.computeTextForRow(this.row);
   }
 }

--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  arrays, BaseDoEntity, BookmarkSupport, BookmarkTableRowIdentifierDo, ButtonTile, ChildModelOf, Constructor, dataObjects, DoTypeResolver, EnumObject, Event, EventHandler, EventListener, EventMapOf, EventModel, EventSupport, Form,
-  HtmlComponent, InitModelOf, inspector, Menu, MenuBar, MenuOwner, ObjectIdProvider, ObjectOrType, ObjectWithUuid, Outline, PageDetailMenuContributor, PageEventMap, PageModel, ParentTablePageMenuContributor, PropertyChangeEvent,
-  RequiredUnlessNotSubclass, scout, SomeRequired, strings, Table, TableRow, TableRowClickEvent, TileOutlineOverview, TileOverviewForm, TreeNode, typeName, UuidPathOptions, Widget
+  arrays, BaseDoEntity, BookmarkSupport, BookmarkTableRowIdentifierDo, ButtonTile, ChildModelOf, Column, comparators, Constructor, dataObjects, DoTypeResolver, EnumObject, Event, EventHandler, EventListener, EventMapOf, EventModel,
+  EventSupport, Form, HtmlComponent, InitModelOf, inspector, Menu, MenuBar, MenuOwner, ObjectIdProvider, ObjectOrType, ObjectWithUuid, Outline, PageDetailMenuContributor, PageEventMap, PageModel, ParentTablePageMenuContributor,
+  PropertyChangeEvent, RequiredUnlessNotSubclass, scout, SomeRequired, strings, Table, TableRow, TableRowClickEvent, TileOutlineOverview, TileOverviewForm, TreeNode, typeName, UuidPathOptions, Widget
 } from '../../../index';
 import $ from 'jquery';
 
@@ -512,27 +512,61 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
   updatePageFromTableRow(row: TableRow): Page {
     let page = row.page;
     page.enabled = row.enabled;
-    page.text = page.computeTextForRow(row);
-    if (row.cells.length) {
-      page.htmlEnabled = row.cells[0].htmlEnabled;
-      page.cssClass = row.cells[0].cssClass;
+
+    const summaryColumns = page._computeSummaryColumns(row);
+    page.text = page.computeTextForRow(row, summaryColumns);
+
+    // get properties from cell of first summary column
+    const firstSummaryColumn = summaryColumns[0];
+    if (firstSummaryColumn) {
+      const cell = firstSummaryColumn.cell(row);
+      page.htmlEnabled = cell.htmlEnabled;
+      page.cssClass = cell.cssClass;
+      page.iconId = cell.iconId || row.iconId;
     }
+
     return page;
   }
 
   /**
-   * This function creates the text property of this page. The default implementation returns the texts of the summary columns of the table or
-   * from the first cell of the given row. It's allowed to ignore the given row entirely, when you override this function.
+   * This function creates the text property of this page. The default implementation returns {@link Column#cellText} of all summary columns.
    */
-  computeTextForRow(row: TableRow): string {
-    const summaryColumns = row.table.summaryColumns();
+  computeTextForRow(row: TableRow, summaryColumns?: Column[]): string {
+    if (!summaryColumns) {
+      summaryColumns = this._computeSummaryColumns(row);
+    }
+    return strings.join(' ', ...summaryColumns.map(summaryColumn => summaryColumn.cellText(row)));
+  }
+
+  /**
+   * Computes the summary columns of the given {@link TableRow}. The summary columns are
+   * <ol>
+   *   <li> the {@link Table#compactColumn} if it exists and the {@link Outline} is compact
+   *   <li> the {@link Table#summaryColumns}
+   *   <li> the first visible column
+   * </ol>
+   */
+  protected _computeSummaryColumns(row: TableRow): Column<any>[] {
+    if (!row) {
+      return [];
+    }
+
+    const table = row.table;
+
+    // use compact column if outline is compact
+    if (this.outline.compact && table.compactColumn) {
+      return [table.compactColumn];
+    }
+
+    const summaryColumns = table.summaryColumns();
     if (summaryColumns.length) {
-      return strings.join(' ', ...summaryColumns.map(summaryColumn => summaryColumn.cellText(row)));
+      return summaryColumns;
     }
-    if (row.cells.length >= 1) {
-      return row.cells[0].text;
-    }
-    return '';
+
+    // find the first visible column considering the originally defined column order (ignoring the column order changes the user did)
+    const columns = table.visibleColumns(false, true);
+    columns.sort((c1, c2) => comparators.NUMERIC.compare(c1.index, c2.index));
+    return columns.slice(0, 1);
   }
 
   /**

--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  arrays, AutoLeafPageWithNodes, BookmarkSupport, BookmarkTableRowIdentifierDo, dataObjects, DoEntity, EventHandler, Form, FormTableControl, LimitedResultInfoContributionDo, ObjectOrModel, Page, PageWithTableEventMap, PageWithTableModel,
-  scout, Status, Table, TableAllRowsDeletedEvent, TableMaxResultsHelper, TableOrganizerMenu, TableReloadEvent, TableReloadReason, TableRow, TableRowActionEvent, TableRowOrderChangedEvent, TableRowsDeletedEvent, TableRowsInsertedEvent,
-  TableRowsUpdatedEvent
+  arrays, AutoLeafPageWithNodes, BookmarkSupport, BookmarkTableRowIdentifierDo, dataObjects, DoEntity, Event, EventHandler, Form, InitModelOf, LimitedResultInfoContributionDo, ObjectOrModel, Page, PageWithTableEventMap, PageWithTableModel,
+  PropertyChangeEvent, scout, SearchFormTableControl, Status, Table, TableAllRowsDeletedEvent, TableControl, TableMaxResultsHelper, TableOrganizerMenu, TableReloadEvent, TableReloadReason, TableRow, TableRowActionEvent,
+  TableRowOrderChangedEvent, TableRowsDeletedEvent, TableRowsInsertedEvent, TableRowsUpdatedEvent
 } from '../../../index';
 import $ from 'jquery';
 
@@ -26,6 +26,9 @@ export class PageWithTable extends Page implements PageWithTableModel {
   protected _tableRowActionHandler: EventHandler<TableRowActionEvent>;
   protected _tableRowOrderChangeHandler: EventHandler<TableRowOrderChangedEvent>;
   protected _tableDataLoadHandler: EventHandler<TableReloadEvent>;
+  protected _tableControlsChangeHandler: EventHandler<PropertyChangeEvent<TableControl[]>> = this._onTableControlsChange.bind(this);
+  protected _searchFormTableControlSearchHandler: EventHandler<Event<SearchFormTableControl>> = this._onSearchFormTableControlSearch.bind(this);
+  protected _searchFormTableControlResetHandler: EventHandler<Event<SearchFormTableControl>> = this._onSearchFormTableControlReset.bind(this);
 
   constructor() {
     super();
@@ -42,8 +45,41 @@ export class PageWithTable extends Page implements PageWithTableModel {
     this._tableDataLoadHandler = (e: TableReloadEvent) => this.loadTableData(e?.reloadReason);
   }
 
+  protected override _init(model: InitModelOf<this>) {
+    super._init(model);
+
+    // display rows as AutoLeafPageWithNodes if outline is compact
+    if (this.outline.compact) {
+      this.setAlwaysCreateChildPage(true);
+      this.setLeaf(false);
+    }
+  }
+
+  setAlwaysCreateChildPage(alwaysCreateChildPage: boolean) {
+    this.alwaysCreateChildPage = alwaysCreateChildPage;
+  }
+
   protected override _initDetailTable(table: Table) {
     super._initDetailTable(table);
+
+    if (this.outline.compact) {
+      // set table compact if outline is compact
+      table.setCompact(true);
+
+      // disable more-link and enable html to plain text on compact handler
+      table.compactHandler.setMoreLinkAvailable(false);
+      table.compactHandler.setLineCustomizer(line => line.textBlock.setHtmlToPlainTextEnabled(true));
+
+      // hide all table controls except search form table control
+      const searchFormTableControl = this._findSearchFormTableControl(table);
+      for (const tableControl of table.tableControls) {
+        if (tableControl === searchFormTableControl) {
+          continue;
+        }
+        tableControl.setVisibleGranted(false);
+      }
+    }
+
     table.on('rowsDeleted allRowsDeleted', this._tableRowDeleteHandler);
     table.on('rowsInserted', this._tableRowInsertHandler);
     table.on('rowsUpdated', this._tableRowUpdateHandler);
@@ -52,6 +88,9 @@ export class PageWithTable extends Page implements PageWithTableModel {
     table.on('reload', this._tableDataLoadHandler);
     table.hasReloadHandler = true;
     table.insertMenus([scout.create(TableOrganizerMenu, {parent: table})]);
+
+    table.on('propertyChange:tableControls', this._tableControlsChangeHandler);
+    this._addSearchFormTableControlListeners(this._findSearchFormTableControl(table));
   }
 
   protected override _destroyDetailTable(table: Table) {
@@ -61,6 +100,10 @@ export class PageWithTable extends Page implements PageWithTableModel {
     table.off('rowAction', this._tableRowActionHandler);
     table.off('rowOrderChanged', this._tableRowOrderChangeHandler);
     table.off('reload', this._tableDataLoadHandler);
+
+    table.off('propertyChange:tableControls', this._tableControlsChangeHandler);
+    this._removeSearchFormTableControlListeners(this._findSearchFormTableControl(table));
+
     super._destroyDetailTable(table);
   }
 
@@ -103,6 +146,45 @@ export class PageWithTable extends Page implements PageWithTableModel {
 
   protected _onTableRowOrderChanged(event: TableRowOrderChangedEvent) {
     this.outline.mediator.onTableRowOrderChanged(event, this);
+  }
+
+  protected _onTableControlsChange(e: PropertyChangeEvent<TableControl[]>) {
+    // disable search/reset listeners on old search form controls
+    arrays.ensure(e.oldValue)
+      .filter(tableControl => tableControl instanceof SearchFormTableControl)
+      .forEach((searchFormTableControl: SearchFormTableControl) => this._removeSearchFormTableControlListeners(searchFormTableControl));
+
+    // enable search/reset listeners on search form control
+    this._addSearchFormTableControlListeners(this.getSearchFormTableControl());
+  }
+
+  /**
+   * Adds search and reset listener to the given {@link SearchFormTableControl}.
+   */
+  protected _addSearchFormTableControlListeners(searchFormTableControl: SearchFormTableControl) {
+    searchFormTableControl?.on('search', this._searchFormTableControlSearchHandler);
+    searchFormTableControl?.on('reset', this._searchFormTableControlResetHandler);
+  }
+
+  /**
+   * Removes search and reset listener from the given {@link SearchFormTableControl}.
+   */
+  protected _removeSearchFormTableControlListeners(searchFormTableControl: SearchFormTableControl) {
+    searchFormTableControl?.off('search', this._searchFormTableControlSearchHandler);
+    searchFormTableControl?.off('reset', this._searchFormTableControlResetHandler);
+  }
+
+  protected _onSearchFormTableControlSearch(e: Event<SearchFormTableControl>) {
+    this.detailTable.reload(Table.ReloadReason.SEARCH);
+
+    // close search table control after search if outline is compact, otherwise the search form covers the table
+    if (this.outline.compact) {
+      this.getSearchFormTableControl().setSelected(false);
+    }
+  }
+
+  protected _onSearchFormTableControlReset(e: Event<SearchFormTableControl>) {
+    this.detailTable.reload(Table.ReloadReason.SEARCH);
   }
 
   protected _createChildPageInternal(row: TableRow): Page {
@@ -164,12 +246,24 @@ export class PageWithTable extends Page implements PageWithTableModel {
   }
 
   /**
+   * Returns the {@link SearchFormTableControl} for the given {@link Table}, or `null` if no {@link SearchFormTableControl} is present.
+   */
+  protected _findSearchFormTableControl(table: Table): SearchFormTableControl {
+    return table?.findTableControl(SearchFormTableControl);
+  }
+
+  /**
+   * Returns the {@link SearchFormTableControl} for this page, or `null` if no {@link SearchFormTableControl} is present.
+   */
+  getSearchFormTableControl(): SearchFormTableControl {
+    return this._findSearchFormTableControl(this.detailTable);
+  }
+
+  /**
    * Returns the search form for this page, or `null` if no search form is present.
    */
   getSearchForm(): Form {
-    // TODO bsh [js-bookmark] Add dedicated SearchTableControl class to find the correct table control more reliably
-    let tableControl = this.detailTable?.findTableControl(FormTableControl, tableControl => !!tableControl.form);
-    return tableControl ? tableControl.form : null;
+    return this.getSearchFormTableControl()?.form || null;
   }
 
   /**

--- a/eclipse-scout-core/src/desktop/outline/pages/ParentTablePageMenuContributor.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/ParentTablePageMenuContributor.ts
@@ -17,7 +17,7 @@ export class ParentTablePageMenuContributor extends PageDetailMenuContributor {
   }
 
   protected _computeParentTablePageMenus(detailContent: Widget): Menu[] {
-    if (!this.page.parentNode) {
+    if (!this.page.parentNode || (this.page.outline.compact && detailContent instanceof Table)) {
       return [];
     }
 

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -587,6 +587,7 @@ export * from './table/controls/FormTableControlModel';
 export * from './table/controls/FormTableControlEventMap';
 export * from './table/controls/FormTableControlAdapter';
 export * from './table/controls/FormTableControlLayout';
+export * from './table/controls/SearchFormTableControl';
 export * from './table/editor/CellEditorPopup';
 export * from './table/editor/CellEditorPopupModel';
 export * from './table/editor/CellEditorPopupLayout';

--- a/eclipse-scout-core/src/table/TableCompactHandler.ts
+++ b/eclipse-scout-core/src/table/TableCompactHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,8 @@ export class TableCompactHandler implements TableCompactHandlerModel, ObjectWith
   table: Table;
   useOnlyVisibleColumns: boolean;
   maxContentLines: number;
+  moreLinkAvailable: boolean;
+  lineCustomizer: (line: CompactLine) => void;
   protected _oldStates: Record<string, any>;
   protected _updateHandler: EventHandler<TableRowsInsertedEvent | TableRowsUpdatedEvent | Event<Table>>;
 
@@ -26,6 +28,8 @@ export class TableCompactHandler implements TableCompactHandlerModel, ObjectWith
     this.table = null;
     this.useOnlyVisibleColumns = true;
     this.maxContentLines = 3;
+    this.moreLinkAvailable = true;
+    this.lineCustomizer = null;
     this._oldStates = objects.createMap();
     this._updateHandler = null;
   }
@@ -40,6 +44,14 @@ export class TableCompactHandler implements TableCompactHandlerModel, ObjectWith
 
   setMaxContentLines(maxContentLines: number) {
     this.maxContentLines = maxContentLines;
+  }
+
+  setMoreLinkAvailable(moreLinkAvailable: boolean) {
+    this.moreLinkAvailable = moreLinkAvailable;
+  }
+
+  setLineCustomizer(lineCustomizer: (line: CompactLine) => void) {
+    this.lineCustomizer = lineCustomizer;
   }
 
   handle(compact: boolean) {
@@ -104,7 +116,7 @@ export class TableCompactHandler implements TableCompactHandlerModel, ObjectWith
     if (rows.length === 0) {
       return;
     }
-    let columns = this._getColumns();
+    let columns = this.getColumns();
     rows.forEach(row => this._updateValue(columns, row));
   }
 
@@ -127,7 +139,7 @@ export class TableCompactHandler implements TableCompactHandlerModel, ObjectWith
     columns.forEach((column, i) => this._processColumn(column, i, row, bean));
   }
 
-  protected _getColumns(): Column<any>[] {
+  getColumns(): Column<any>[] {
     return this.table.filterColumns(column => this._acceptColumn(column));
   }
 
@@ -199,10 +211,14 @@ export class TableCompactHandler implements TableCompactHandlerModel, ObjectWith
       }
       line.textBlock.setText(text);
     }
+    this.lineCustomizer?.(line);
   }
 
   protected _postProcessBean(bean: CompactBean) {
-    bean.transform({maxContentLines: this.maxContentLines});
+    bean.transform({
+      maxContentLines: this.maxContentLines,
+      moreLinkAvailable: this.moreLinkAvailable
+    });
 
     // If only title is set move it to content. A title without content does not look good.
     if (bean.title && !bean.subtitle && !bean.titleSuffix && !bean.content) {
@@ -213,7 +229,7 @@ export class TableCompactHandler implements TableCompactHandlerModel, ObjectWith
 
   protected _buildValue(bean: CompactBean): string {
     let hasHeader = (bean.title + bean.titleSuffix + bean.subtitle) ? ' has-header' : '';
-    let moreLink = bean.moreContent ? `<div class="compact-cell-more"><span class="more-link link">${this.table.session.text('More')}</span></div>` : '';
+    let moreLink = (this.moreLinkAvailable && bean.moreContent) ? `<div class="compact-cell-more"><span class="more-link link">${this.table.session.text('More')}</span></div>` : '';
 
     return `
 <div class="compact-cell-header">

--- a/eclipse-scout-core/src/table/TableRowDetail.ts
+++ b/eclipse-scout-core/src/table/TableRowDetail.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,7 +49,14 @@ export class TableRowDetail extends Widget implements TableRowDetailModel {
   }
 
   protected _renderRow() {
-    this.table.visibleColumns().forEach(this._renderCell.bind(this));
+    let columns: Column<any>[] = [];
+    if (this.table.compactHandler) {
+      // use columns of compact handler if set as compact handler may be customized
+      columns = this.table.compactHandler.getColumns();
+    } else {
+      columns = this.table.visibleColumns(false, true);
+    }
+    columns.forEach(this._renderCell.bind(this));
     this.invalidateLayoutTree();
   }
 

--- a/eclipse-scout-core/src/table/columns/CompactBean.ts
+++ b/eclipse-scout-core/src/table/columns/CompactBean.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -74,10 +74,12 @@ export class CompactBean {
    *
    * @param options.removeEmptyContentLines default true
    * @param options.maxContentLines default 1000
+   * @param options.moreLinkAvailable If <code>true</code>, maxContentLines may be increased by 1 if the more link would reveal only one line. Does not have any effect if it is <code>false</code>. Default is <code>false</code>.
    */
-  transform(options?: { removeEmptyContentLines?: boolean; maxContentLines?: number }) {
+  transform(options?: { removeEmptyContentLines?: boolean; maxContentLines?: number; moreLinkAvailable?: boolean }) {
     let removeEmptyContentLines = scout.nvl(options.removeEmptyContentLines, true);
     let maxContentLines = scout.nvl(options.maxContentLines, 1000);
+    const moreLinkAvailable = options.moreLinkAvailable;
     if (this.titleLine) {
       this.setTitle(this.titleLine.build());
     }
@@ -92,7 +94,7 @@ export class CompactBean {
     if (removeEmptyContentLines) {
       contentLines = this.contentLines.filter(line => !!line.build());
     }
-    if (maxContentLines + 1 === contentLines.length) {
+    if (moreLinkAvailable && maxContentLines + 1 === contentLines.length) {
       // Don't show more link if it would only reveal one element
       maxContentLines++;
     }

--- a/eclipse-scout-core/src/table/controls/SearchFormTableControl.ts
+++ b/eclipse-scout-core/src/table/controls/SearchFormTableControl.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {Event, EventHandler, Form, FormTableControl, FormTableControlEventMap, icons} from '../../index';
+
+export class SearchFormTableControl extends FormTableControl {
+  declare eventMap: SearchFormTableControlEventMap;
+  declare self: SearchFormTableControl;
+
+  protected _formSearchHandler: EventHandler<Event<Form>> = this._onFormSearch.bind(this);
+  protected _formResetHandler: EventHandler<Event<Form>> = this._onFormReset.bind(this);
+
+  constructor() {
+    super();
+
+    this.iconId = icons.SEARCH;
+    this.tooltipText = '${textKey:Search}';
+    this.enabled = false;
+    this.keyStroke = 'ctrl-shift-f';
+  }
+
+  protected _onFormSearch(event: Event<Form>) {
+    this.trigger('search');
+  }
+
+  protected _onFormReset(event: Event<Form>) {
+    this.trigger('reset');
+  }
+
+  protected override _setForm(form: Form) {
+    // disable search/reset listeners on old form
+    this.form?.off('search', this._formSearchHandler);
+    this.form?.off('reset', this._formResetHandler);
+
+    // enable search/reset listeners on new form
+    form?.on('search', this._formSearchHandler);
+    form?.on('reset', this._formResetHandler);
+
+    super._setForm(form);
+
+    // set enabled iff form is set
+    this.setEnabled(!!form);
+  }
+}
+
+export interface SearchFormTableControlEventMap extends FormTableControlEventMap {
+  'search': Event<SearchFormTableControl>;
+  'reset': Event<SearchFormTableControl>;
+}

--- a/eclipse-scout-core/test/bookmark/bookmark-fixtures.ts
+++ b/eclipse-scout-core/test/bookmark/bookmark-fixtures.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  BaseDoEntity, BooleanColumn, Column, Desktop, DesktopModel, Form, FormModel, FormTableControl, GroupBox, icons, NumberColumn, ObjectOrModel, Outline, OutlineViewButton, Page, PageParamDo, PageWithNodes, PageWithTable, ResetMenu, scout,
+  BaseDoEntity, BooleanColumn, Column, Desktop, DesktopModel, Form, FormModel, GroupBox, NumberColumn, ObjectOrModel, Outline, OutlineViewButton, Page, PageParamDo, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl,
   SearchMenu, StringField, strings, Table, TableRow, typeName
 } from '../../src';
 
@@ -244,8 +244,7 @@ export class SpecTablePage2 extends PageWithTable {
       }],
       tableControls: [{
         id: 'SearchFormTableControl',
-        objectType: FormTableControl,
-        iconId: icons.SEARCH,
+        objectType: SearchFormTableControl,
         form: {
           id: 'SearchForm',
           objectType: SpecSearchForm
@@ -322,8 +321,7 @@ export class SpecTablePage3 extends PageWithTable {
       }],
       tableControls: [{
         id: 'SearchFormTableControl',
-        objectType: FormTableControl,
-        iconId: icons.SEARCH,
+        objectType: SearchFormTableControl,
         form: {
           id: 'SearchForm',
           objectType: SpecSearchForm

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/SummaryCellBuilder.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/SummaryCellBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,29 +39,26 @@ public class SummaryCellBuilder implements ISummaryCellBuilder {
     if (summaryColumns.isEmpty()) {
       return new Cell();
     }
-    else if (summaryColumns.size() == 1) {
-      Cell cell = new Cell(getTable().getCell(row, summaryColumns.get(0)));
-      if (cell.getIconId() == null) {
-        // use icon of row
-        cell.setIconId(row.getIconId());
-      }
+
+    Cell cell = new Cell(getTable().getCell(row, summaryColumns.get(0)));
+    if (cell.getIconId() == null) {
+      // use icon of row
+      cell.setIconId(row.getIconId());
+    }
+
+    if (summaryColumns.size() == 1) {
       return cell;
     }
-    else {
-      Cell cell = new Cell(getTable().getCell(row, summaryColumns.get(0)));
-      if (cell.getIconId() == null) {
-        // use icon of row
-        cell.setIconId(row.getIconId());
+
+    StringBuilder b = new StringBuilder();
+    for (IColumn<?> c : summaryColumns) {
+      if (b.length() > 0) {
+        b.append(" ");
       }
-      StringBuilder b = new StringBuilder();
-      for (IColumn<?> c : summaryColumns) {
-        if (b.length() > 0) {
-          b.append(" ");
-        }
-        b.append(getTable().getCell(row, c).toPlainText());
-      }
-      cell.setText(b.toString());
-      return cell;
+      b.append(getTable().getCell(row, c).toPlainText());
     }
+    cell.setText(b.toString());
+
+    return cell;
   }
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutline.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutline.java
@@ -180,12 +180,9 @@ public class JsonOutline<OUTLINE extends IOutline> extends JsonTree<OUTLINE> {
   @Override
   protected void putCellProperties(JSONObject json, ITreeNode node) {
     if (node instanceof IJsPage) {
-      // Send text because it might come from a summary column from a parent PageWithTable
-      json.put("text", node.getCell().getText());
+      return;
     }
-    else {
-      super.putCellProperties(json, node);
-    }
+    super.putCellProperties(json, node);
   }
 
   @Override
@@ -245,6 +242,18 @@ public class JsonOutline<OUTLINE extends IOutline> extends JsonTree<OUTLINE> {
   protected void putJsPageObjectTypeAndModel(JSONObject json, IJsPage jsPage) {
     putProperty(json, IJsPage.PROP_JS_PAGE_OBJECT_TYPE, jsPage.getJsPageObjectType());
     putProperty(json, IJsPage.PROP_JS_PAGE_MODEL, jsonDoHelper().dataObjectToJson(jsPage.getJsPageModel()));
+
+    if (jsPage.getParentNode() instanceof IPageWithTable) {
+      JSONObject jsPageModel = ObjectUtility.nvl(json.optJSONObject(IJsPage.PROP_JS_PAGE_MODEL), new JSONObject());
+
+      // Send the properties which might come from a summary column from a parent PageWithTable
+      jsPageModel.put("text", jsPage.getCell().getText());
+      jsPageModel.put("htmlEnabled", jsPage.getCell().isHtmlEnabled());
+      jsPageModel.put("cssClass", jsPage.getCell().getCssClass());
+      jsPageModel.put("iconId", jsPage.getCell().getIconId());
+
+      putProperty(json, IJsPage.PROP_JS_PAGE_MODEL, jsPageModel);
+    }
   }
 
   @Override

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonSearchForm.ts
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonSearchForm.ts
@@ -1,16 +1,9 @@
 import PersonSearchFormModel, {PersonSearchFormWidgetMap} from './PersonSearchFormModel';
-import {Form, FormModel, FormTableControl, InitModelOf, scout} from '@eclipse-scout/core';
+import {Form, FormModel, scout} from '@eclipse-scout/core';
 import {PersonRestrictionDo} from '../index';
 
 export class PersonSearchForm extends Form {
   declare widgetMap: PersonSearchFormWidgetMap;
-
-  protected override _init(model: InitModelOf<this>) {
-    super._init(model);
-    let parent = this.parent as FormTableControl;
-    let parentTable = parent.table;
-    this.widget('SearchButton').on('action', () => parentTable.reload());
-  }
 
   protected override _jsonModel(): FormModel {
     return PersonSearchFormModel();

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonSearchFormModel.ts
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonSearchFormModel.ts
@@ -1,4 +1,4 @@
-import {Action, FormModel, GroupBox, Menu, ResetMenu, StringField} from '@eclipse-scout/core';
+import {FormModel, GroupBox, ResetMenu, SearchMenu, StringField} from '@eclipse-scout/core';
 
 export default (): FormModel => ({
   rootGroupBox: {
@@ -27,11 +27,8 @@ export default (): FormModel => ({
     ],
     menus: [
       {
-        id: 'SearchButton',
-        objectType: Menu,
-        actionStyle: Action.ActionStyle.BUTTON,
-        text: '${symbol_dollar}{textKey:Search}',
-        keyStroke: 'ENTER'
+        id: 'SearchMenu',
+        objectType: SearchMenu
       },
       {
         id: 'ResetMenu',
@@ -50,6 +47,6 @@ export type PersonSearchFormWidgetMap = {
   'DetailBox': GroupBox;
   'FirstNameField': StringField;
   'LastNameField': StringField;
-  'SearchButton': Menu;
+  'SearchMenu': SearchMenu;
   'ResetMenu': ResetMenu;
 };

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonTablePageModel.ts
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonTablePageModel.ts
@@ -1,4 +1,4 @@
-import {AggregateTableControl, BooleanColumn, Column, FormTableControl, icons, Menu, NumberColumn, PageWithTable, PageWithTableModel, Table} from '@eclipse-scout/core';
+import {AggregateTableControl, BooleanColumn, Column, icons, Menu, NumberColumn, PageWithTable, PageWithTableModel, SearchFormTableControl, Table} from '@eclipse-scout/core';
 import {PersonSearchForm} from '../index';
 import {PersonSearchFormWidgetMap} from './PersonSearchFormModel';
 
@@ -66,8 +66,7 @@ export default (): PageWithTableModel => ({
     tableControls: [
       {
         id: 'SearchFormTableControl',
-        objectType: FormTableControl,
-        iconId: icons.SEARCH,
+        objectType: SearchFormTableControl,
         form: {
           id: 'SearchForm',
           objectType: PersonSearchForm
@@ -94,7 +93,7 @@ export type PersonTablePageTableWidgetMap = {
   'EditPersonMenu': Menu;
   'CreatePersonMenu': Menu;
   'DeletePersonMenu': Menu;
-  'SearchFormTableControl': FormTableControl;
+  'SearchFormTableControl': SearchFormTableControl;
   'SearchForm': PersonSearchForm;
   'AggregateTableControl': AggregateTableControl;
 } & PersonSearchFormWidgetMap;


### PR DESCRIPTION
Mobile: several improvements

AutoLeafPageWithNodes
Extend from PageWithNodes, but remove detailTable and detailForm created by super class. Use computeTextForRow to compute the text for this page instead of the text of the first cell as computeTextForRow correctly handles e.g. compact rows or summary columns.

Page
Improve updatePageFromTable and computeTextForRow. First determine the summary columns in the following order
- the compact column if the outline is compact
- the summary columns of the table
- the first visible column
With these column, build the summary text and use the first of these columns to determine the properties htmlEnabled, cssClass, iconId of the current page.

SearchFormTableControl
Add a table control designed for search forms. It has a default icon and keyStroke and enables/disables itself whether a form is set or not. It re-triggers the 'search' and 'reset' events of its form.

PageWithTable
Use the SearchFormTableControl to build the searchFilter and listen for 'search' and 'reset' of the SearchFormTableControl to reload the table. If the outline is compact, set alwaysCreateChildPage to true and leaf to false. In addition, hide all table controls that are not the SearchFormTableControl and close the SearchFormTableControl after a search is executed.

ParentTablePageMenuContributor
The ParentTablePageMenuContributor does not need to pass menus from a parent page to its children if the outline is compact. This is done by the Outline.

JsPage
A JsPage must not always send its text property to the UI. This was done because the text might come from a summary column from the parent page. The only case the text is from a summary of the parent page is when the parent page is a IPageWithTable. In this case send not just the text but also htmlEnabled, cssClass and iconId as these properties are also set by the SummaryCellBuilder.

TableRowDetail
Improve column selection used to display row detail. Earlier only visible columns where used to build the row detail. But as the TableRowDetail needs to display the same values as the TableCompactHandler use the columns of the compact handler if set on the table. As a fallback use visible columns including the compacted columns because otherwise no column will be used if the table is compacted.

422641