### PR TITLE
Add overflow- and break-styles to calendar popups

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.less
+++ b/eclipse-scout-core/src/calendar/Calendar.less
@@ -323,6 +323,7 @@
 .calendar-component-title {
   font-weight: bold;
   font-size: @font-size-plus;
+  #scout.overflow-ellipsis-nowrap();
 }
 
 .calendar-component-intro {
@@ -361,6 +362,8 @@
   & > .text {
     display: inline-block;
     vertical-align: top;
+    word-wrap: break-word;
+    word-break: break-word;
   }
 
   &:not(.first) {


### PR DESCRIPTION
Set ellipsis and no-wrap for title and break-word for description.