### PR TITLE
423929 added 'dom.iterable' to tsconfig to support usage of NodeList.

### DIFF
--- a/eclipse-scout-tsconfig/tsconfig.json
+++ b/eclipse-scout-tsconfig/tsconfig.json
@@ -19,6 +19,7 @@
     "experimentalDecorators": true,
     "lib": [
       "dom",
+      "dom.iterable",
       "ES2022"
     ],
     "types": []


### PR DESCRIPTION
According to MDN the minimum browser versions required by Scout, all support the iterable NodeList feature.
Thus we can safely activate "dom.iterable". See:

https://developer.mozilla.org/en-US/docs/Web/API/NodeList#browser_compatibility

https://eclipsescout.github.io/scout-docs/25.2/technical-guide/user-interface/browser-support.html

I'd rather not use "es2022.full", as it also includes things like "scripthost", which seems to be an API for the windows script host. See:

https://github.com/microsoft/TypeScript/blob/main/src/lib/es2022.full.d.ts