### PR TITLE
DataObjectInventory: prevent replacements

### DIFF
--- a/eclipse-scout-core/src/dataobject/DataObjectInventory.ts
+++ b/eclipse-scout-core/src/dataobject/DataObjectInventory.ts
@@ -47,6 +47,9 @@ export class DataObjectInventory {
       return false;
     }
 
+    if (this._constructorByTypeName.has(typeName)) {
+      throw new Error(`There is already a constructor registered for type name '${typeName}'.`);
+    }
     this._constructorByTypeName.set(typeName, doClass);
     objectType = objectType || ObjectFactory.get().getObjectType(doClass);
     if (!objectType) {

--- a/eclipse-scout-core/test/dataobject/BaseDoEntitySpec.ts
+++ b/eclipse-scout-core/test/dataobject/BaseDoEntitySpec.ts
@@ -7,23 +7,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {BaseDoEntity, DataObjectInventory, dates, ObjectFactory, scout, typeName} from '../../src/index';
+import {BaseDoEntity, dates, ObjectFactory, scout, typeName} from '../../src/index';
 
 describe('BaseDoEntity', () => {
   beforeAll(() => {
     ObjectFactory.get().registerNamespace('scout', {
       BaseDoEntityFixture01Do, BaseDoEntityFixture02Do
     }, {allowedReplacements: ['scout.BaseDoEntityFixture01Do', 'scout.BaseDoEntityFixture02Do']});
-
-    const doInventory = DataObjectInventory.get();
-    doInventory.add(BaseDoEntityFixture01Do);
-    doInventory.add(BaseDoEntityFixture02Do);
-  });
-
-  afterAll(() => {
-    const doInventory = DataObjectInventory.get();
-    doInventory.remove(BaseDoEntityFixture01Do);
-    doInventory.remove(BaseDoEntityFixture02Do);
   });
 
   describe('clone', () => {

--- a/eclipse-scout-core/test/dataobject/DataObjectDeserializerSpec.ts
+++ b/eclipse-scout-core/test/dataobject/DataObjectDeserializerSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, BaseDoEntity, Constructor, DataObjectDeserializer, DataObjectInventory, dataObjects, dates, DefaultDoTypeResolver, DoValueMetaData, ObjectFactory, objects, scout, typeName} from '../../src/index';
+import {arrays, BaseDoEntity, Constructor, DataObjectDeserializer, dataObjects, dates, DefaultDoTypeResolver, DoValueMetaData, ObjectFactory, objects, scout, typeName} from '../../src/index';
 
 describe('DataObjectDeserializer', () => {
 
@@ -15,20 +15,6 @@ describe('DataObjectDeserializer', () => {
     ObjectFactory.get().registerNamespace('scout', {
       Fixture01Do, Fixture02Do, Fixture03Do, Fixture03SubDo
     }, {allowedReplacements: ['scout.Fixture01Do', 'scout.Fixture02Do', 'scout.Fixture03Do', 'scout.Fixture03SubDo']});
-
-    const doInventory = DataObjectInventory.get();
-    doInventory.add(Fixture01Do);
-    doInventory.add(Fixture02Do);
-    doInventory.add(Fixture03Do);
-    doInventory.add(Fixture03SubDo);
-  });
-
-  afterAll(() => {
-    const doInventory = DataObjectInventory.get();
-    doInventory.remove(Fixture01Do);
-    doInventory.remove(Fixture02Do);
-    doInventory.remove(Fixture03Do);
-    doInventory.remove(Fixture03SubDo);
   });
 
   it('can deserialize based on _type', () => {

--- a/eclipse-scout-core/test/dataobject/DataObjectInventorySpec.ts
+++ b/eclipse-scout-core/test/dataobject/DataObjectInventorySpec.ts
@@ -103,5 +103,14 @@ describe('DataObjectInventory', () => {
     expect(inventory._typeNameByObjectType.size).toBe(0);
     expect(inventory._objectTypeByTypeName.size).toBe(0);
   });
+
+  it('register fails if type name is already present', () => {
+    expectInventorySize(0);
+    expect(inventory.add(SpecDo)).toBeTrue();
+    expectInventorySize(1);
+    expectSpecDoInRegistry();
+
+    expect(() => inventory.add(SpecDo)).toThrowError('There is already a constructor registered for type name \'scout.Spec\'.');
+  });
 });
 

--- a/eclipse-scout-core/test/dataobject/DataObjectSerializerSpec.ts
+++ b/eclipse-scout-core/test/dataobject/DataObjectSerializerSpec.ts
@@ -18,19 +18,17 @@ describe('DataObjectSerializer', () => {
       Fixture01Do, Fixture02Do, Fixture03Do, Fixture04Do, Fixture05Do, Fixture06Do
     }, {allowedReplacements: ['Fixture01Do', 'Fixture02Do', 'Fixture03Do', 'Fixture04Do', 'Fixture05Do', 'Fixture06Do']});
 
+    // remove Fixture04Do and Fixture05Do
     const doInventory = DataObjectInventory.get();
-    doInventory.add(Fixture01Do);
-    doInventory.add(Fixture02Do);
-    doInventory.add(Fixture03Do);
-    // Fixture04Do and Fixture05Do not added here!
-    doInventory.add(Fixture06Do);
+    doInventory.remove(Fixture04Do);
+    doInventory.remove(Fixture05Do);
   });
 
   afterAll(() => {
+    // add Fixture04Do and Fixture05Do again
     const doInventory = DataObjectInventory.get();
-    doInventory.remove(Fixture01Do);
-    doInventory.remove(Fixture02Do);
-    doInventory.remove(Fixture03Do);
+    doInventory.add(Fixture04Do);
+    doInventory.add(Fixture05Do);
   });
 
   it('can serialize arrays', () => {
@@ -166,10 +164,8 @@ describe('DataObjectSerializer', () => {
         "propObj2": {
           "propDate": "2024-07-01 11:51:39.708",
           "_type": "scout.Fixture06"
-        },
-        "_type": "scout.Fixture05"
-      },
-      "_type": "scout.Fixture04"
+        }
+      }
     }
     `));
     const json = dataObjects.stringify({

--- a/eclipse-scout-core/test/dataobject/MapDoNodeSerializerSpec.ts
+++ b/eclipse-scout-core/test/dataobject/MapDoNodeSerializerSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {BaseDoEntity, DataObjectInventory, dataObjects, dates, ObjectFactory, scout, typeName} from '../../src/index';
+import {BaseDoEntity, dataObjects, dates, ObjectFactory, scout, typeName} from '../../src/index';
 
 describe('MapDoNodeSerializer', () => {
 
@@ -92,15 +92,6 @@ describe('MapDoNodeSerializer', () => {
 
   beforeAll(() => {
     ObjectFactory.get().registerNamespace('scout', {MapFixture01Do, MapFixture02Do}, {allowedReplacements: ['scout.MapFixture01Do', 'scout.MapFixture02Do']});
-    const doInventory = DataObjectInventory.get();
-    doInventory.add(MapFixture01Do);
-    doInventory.add(MapFixture02Do);
-  });
-
-  afterAll(() => {
-    const doInventory = DataObjectInventory.get();
-    doInventory.remove(MapFixture02Do);
-    doInventory.remove(MapFixture01Do);
   });
 
   it('can serialize maps', () => {

--- a/eclipse-scout-core/test/dataobject/SetDoNodeSerializerSpec.ts
+++ b/eclipse-scout-core/test/dataobject/SetDoNodeSerializerSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {BaseDoEntity, DataObjectInventory, dataObjects, ObjectFactory, scout, typeName} from '../../src/index';
+import {BaseDoEntity, dataObjects, ObjectFactory, scout, typeName} from '../../src/index';
 
 describe('SetDoNodeSerializer', () => {
 
@@ -23,15 +23,6 @@ describe('SetDoNodeSerializer', () => {
 
   beforeAll(() => {
     ObjectFactory.get().registerNamespace('scout', {SetFixture01Do}, {allowedReplacements: ['scout.SetFixture01Do']});
-    const doInventory = DataObjectInventory.get();
-    doInventory.add(SetFixture01Do);
-    doInventory.add(SetFixture02Do);
-  });
-
-  afterAll(() => {
-    const doInventory = DataObjectInventory.get();
-    doInventory.remove(SetFixture01Do);
-    doInventory.remove(SetFixture02Do);
   });
 
   it('can serialize Sets', () => {


### PR DESCRIPTION
DOs must not be loaded and registered twice. Otherwise, the inventory will always know the last loaded prototype and will use it everywhere during serialization and deserialization. If there are instances of the DOs already created these DOs may no longer be serializable, as e.g. all attributes present are checked against the current DO definition (i.e. the last loaded prototype). Prevent re-registering by throwing an error if the type name is already present.

410638