### PR TITLE
Use jdk source/target version from maven master for hello world apps

### DIFF
--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -12,7 +12,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <jdk.source.version>${javaVersion}</jdk.source.version>
     <org.eclipse.scout.rt.version>25.2-SNAPSHOT</org.eclipse.scout.rt.version>
     <org.jooq.version>3.20.2</org.jooq.version>
     <derby.version>10.17.1.0</derby.version>

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <${groupId}.${rootArtifactId}.version>${project.version}</${groupId}.${rootArtifactId}.version>
-    <jdk.source.version>${javaVersion}</jdk.source.version>
     <org.eclipse.scout.rt.version>25.2-SNAPSHOT</org.eclipse.scout.rt.version>
     <master_npm_release_dependency_mapping>--mapping.0.regex=@eclipse-scout --mapping.0.version=${org.eclipse.scout.rt.version}</master_npm_release_dependency_mapping>
 


### PR DESCRIPTION
The currently used version of Eclipse Compiler for Java (ECJ) does not support target level 24

418636