### PR TITLE
Table: default values for columns are not applied anymore

### DIFF
--- a/eclipse-scout-core/src/table/TableAdapter.ts
+++ b/eclipse-scout-core/src/table/TableAdapter.ts
@@ -727,7 +727,7 @@ export class TableAdapter extends ModelAdapter {
 
     // init
     objects.replacePrototypeFunction(Column, 'init', function(this: Column & { initOrig }, model: ColumnModel<any>) {
-      if (model.table && model.table.modelAdapter && !model.guiOnly) {
+      if (model.parent && model.parent.modelAdapter && !model.guiOnly) {
         // Fill in the missing default values only in remote case, don't do it JS case to not accidentally set undefined properties (e.g. uiSortEnabled)
         model = $.extend({}, model);
         defaultValues.applyTo(model);


### PR DESCRIPTION
This was especially noticeable for the modifiable property. Column.modifiable returned true for remote columns even though they were not modifiable.

The bug was introduced with ff2e585dbcb12d46d836da3188658c0d5e648ee6.

329600