### PR TITLE
Desktop: activate child dialog if view is activated

### DIFF
--- a/eclipse-scout-core/src/desktop/Desktop.ts
+++ b/eclipse-scout-core/src/desktop/Desktop.ts
@@ -8,10 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AbstractLayout, Action, arrays, BenchColumnLayoutData, BusyIndicatorOptions, BusySupport, cookies, DeferredGlassPaneTarget, DesktopBench, DesktopBenchViewActivateEvent, DesktopEventMap, DesktopFormController, DesktopHeader, DesktopLayout,
-  DesktopModel, DesktopNavigation, DesktopNotification, Device, DisableBrowserF5ReloadKeyStroke, DisableBrowserTabSwitchingKeyStroke, DisplayParent, DisplayViewId, EnumObject, Event, EventEmitter, EventHandler, FileChooser,
-  FileChooserController, Form, GlassPaneTarget, HtmlComponent, HtmlEnvironment, InitModelOf, KeyStrokeContext, Menu, MessageBox, MessageBoxController, NativeNotificationVisibility, ObjectIdProvider, ObjectOrChildModel, ObjectOrModel,
-  objects, OfflineDesktopNotification, OpenUriHandler, Outline, OutlineContent, OutlineViewButton, Popup, ReloadPageOptions, ResponsiveHandler, scout, SimpleTabArea, SimpleTabBox, Splitter, SplitterMoveEndEvent, SplitterMoveEvent,
+  AbstractLayout, Action, arrays, BenchColumnLayoutData, BusyIndicatorOptions, BusySupport, cookies, DeferredGlassPaneTarget, DesktopBench, DesktopEventMap, DesktopFormController, DesktopHeader, DesktopLayout, DesktopModel,
+  DesktopNavigation, DesktopNotification, Device, DisableBrowserF5ReloadKeyStroke, DisableBrowserTabSwitchingKeyStroke, DisplayParent, DisplayViewId, EnumObject, Event, EventEmitter, EventHandler, FileChooser, FileChooserController, Form,
+  GlassPaneTarget, HtmlComponent, HtmlEnvironment, InitModelOf, KeyStrokeContext, Menu, MessageBox, MessageBoxController, NativeNotificationVisibility, ObjectIdProvider, ObjectOrChildModel, ObjectOrModel, objects,
+  OfflineDesktopNotification, OpenUriHandler, Outline, OutlineContent, OutlineViewButton, Popup, ReloadPageOptions, ResponsiveHandler, scout, SimpleTabArea, SimpleTabBox, Splitter, SplitterMoveEndEvent, SplitterMoveEvent,
   SplitterPositionChangeEvent, strings, styles, Tooltip, Tree, TreeDisplayStyle, UnsavedFormChangesForm, URL, ViewButton, webstorage, Widget, widgets
 } from '../index';
 import $ from 'jquery';
@@ -78,7 +78,6 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
   protected _glassPaneTargetFilters: GlassPaneTargetFilter[];
   protected _offlineNotification: OfflineDesktopNotification;
   /** event listeners */
-  protected _benchActiveViewChangedHandler: EventHandler<DesktopBenchViewActivateEvent>;
   protected _selectedViewDestroyHandler: EventHandler<Event<Form>>;
   protected _popstateHandler: (event: JQuery.TriggeredEvent) => void;
   protected _repositionTooltipsHandler: () => void;
@@ -136,7 +135,6 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
     this._addPreserveOnPropertyChangeProperties(['focusedElement', 'selectedViewTabs']);
 
     this._glassPaneTargetFilters = [];
-    this._benchActiveViewChangedHandler = this._onBenchActivateViewChanged.bind(this);
     this._selectedViewDestroyHandler = this._onSelectedViewDestroy.bind(this);
     this._repositionTooltipsHandler = null;
   }
@@ -285,17 +283,6 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
   /** @see DesktopModel.nativeNotificationDefaults */
   setNativeNotificationDefaults(defaults: NativeNotificationDefaults) {
     this.setProperty('nativeNotificationDefaults', defaults);
-  }
-
-  protected _onBenchActivateViewChanged(event: DesktopBenchViewActivateEvent) {
-    if (this.initialFormRendering) {
-      return;
-    }
-    let view = event.view;
-    if (view instanceof Form && this.bench.outlineContent !== view && !view.detailForm) {
-      // Notify model that this form is active (only for regular views, not detail forms)
-      this._setFormActivated(view);
-    }
   }
 
   protected override _render() {
@@ -474,7 +461,6 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
       return;
     }
     this.bench = this._createBench();
-    this.bench.on('viewActivate', this._benchActiveViewChangedHandler);
     this.bench.render();
     this.bench.$container.insertBefore(this.$overlaySeparator);
     this.invalidateLayoutTree();
@@ -493,7 +479,6 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
     if (!this.bench) {
       return;
     }
-    this.bench.off('viewActivate', this._benchActiveViewChangedHandler);
     this.bench.on('destroy', () => {
       this.bench = null;
       this.invalidateLayoutTree();

--- a/eclipse-scout-core/test/desktop/DesktopSpec.ts
+++ b/eclipse-scout-core/test/desktop/DesktopSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {DummyLookupCall, FormSpecHelper, OutlineSpecHelper} from '../../src/testing/index';
+import {DummyLookupCall, FormSpecHelper, JQueryTesting, OutlineSpecHelper} from '../../src/testing/index';
 import {
   arrays, BusyIndicator, Button, DateField, DatePickerPopup, Desktop, DesktopNotification, DesktopTab, Event, FileChooser, Form, FormMenu, GroupBox, ListBox, MessageBox, MessageBoxes, ObjectOrChildModel, Outline, OutlineViewButton, Popup,
   scout, SmartField, SmartFieldPopup, Status, StringField, strings, Tooltip, UnsavedFormChangesForm, Widget, WidgetPopup, WrappedFormField
@@ -1395,6 +1395,38 @@ describe('Desktop', () => {
 
       outline.selectNode(page);
       expect(desktop.activeForm).toBe(form);
+    });
+
+    it('will be set to open dialog if view gets activated that owns the dialog', async () => {
+      const outline = outlineHelper.createOutlineWithOneDetailForm();
+      const page = outline.nodes[0];
+      desktop.setOutline(outline);
+      outline.selectNode(page);
+      expect(desktop.activeForm).toBe(null);
+
+      let view = scout.create(Form, {
+        parent: session.desktop,
+        displayHint: 'view',
+        title: 'a'
+      });
+      await view.open();
+      expect(desktop.activeForm).toBe(view);
+
+      let dialog = scout.create(Form, {
+        parent: view,
+        displayParent: view
+      });
+      await dialog.open();
+      expect(desktop.activeForm).toBe(dialog);
+
+      desktop.bringOutlineToFront();
+      expect(desktop.activeForm).toBe(null);
+
+      let desktopTab = desktop.bench.getViewTab(view) as DesktopTab;
+      JQueryTesting.triggerClick(desktopTab.$container);
+      expect(view.rendered).toBe(true);
+      expect(dialog.rendered).toBe(true);
+      expect(desktop.activeForm).toBe(dialog);
     });
   });
 


### PR DESCRIPTION
If desktop is in foreground and a view tab clicked, the view will be activated. If the view has a dialog, the dialog needs to be activated instead of the view.
This is already correctly implemented in form._attach() and form._postAttach(). But the handler on the desktop changes the active form again to the view because it does not consider the child forms.
It looks like that handler on the desktop is not needed anymore and can be removed.

421387