### PR TITLE
Improve abstract DOs in Scout JS

### DIFF
--- a/eclipse-scout-core/src/dataobject/DoEntity.ts
+++ b/eclipse-scout-core/src/dataobject/DoEntity.ts
@@ -29,7 +29,7 @@ export interface AnyDoEntity extends DoEntity {
  * Class decorator function for data objects. It writes the given typeName value to the _type attribute of the data object instance. Is executed before the class constructor.
  * @param typeName The typeName (_type) of the data object.
  */
-export function typeName(typeName: string) {
+export function typeName(typeName?: string) {
   return <T extends Constructor | AbstractConstructor>(BaseClass: T) => class extends BaseClass {
     constructor(...args: any[]) {
       super(...args);

--- a/eclipse-scout-core/test/dataobject/DataObjectDeserializerSpec.ts
+++ b/eclipse-scout-core/test/dataobject/DataObjectDeserializerSpec.ts
@@ -248,10 +248,28 @@ describe('DataObjectDeserializer', () => {
     dataObject = dataObjects.parse('{"_type": "SpecialOne"}');
     expect(dataObject).toBeInstanceOf(BaseDoEntity);
   });
+
+  it('can deserialize properties from abstract DOs', () => {
+    const json = `{
+      "_type": "scout.Fixture01",
+      "abstractPropDate": "2013-05-25 22:30:00.000Z",
+      "propDate": "2013-05-25 22:30:00.000Z"
+    }
+    `;
+    const foo = dataObjects.parse(json) as Fixture01Do;
+    expect(foo).toBeInstanceOf(Fixture01Do);
+    expect(foo.abstractPropDate).toEqual(dates.parseJsonDate('2013-05-25 22:30:00.000Z'));
+    expect(foo.propDate).toEqual(dates.parseJsonDate('2013-05-25 22:30:00.000Z'));
+  });
 });
 
+@typeName()
+export abstract class AbstractFixture01Do extends BaseDoEntity {
+  abstractPropDate?: Date;
+}
+
 @typeName('scout.Fixture01')
-export class Fixture01Do extends BaseDoEntity {
+export class Fixture01Do extends AbstractFixture01Do {
   propBool: boolean;
   propNum: number;
   propStr: string;

--- a/eclipse-scout-core/test/dataobject/DataObjectSerializerSpec.ts
+++ b/eclipse-scout-core/test/dataobject/DataObjectSerializerSpec.ts
@@ -179,6 +179,20 @@ describe('DataObjectSerializer', () => {
     expect(json).toBe(expected);
   });
 
+  it('can serialize properties from abstract DOs', () => {
+    const expected = JSON.stringify(JSON.parse(`{
+      "_type": "scout.Fixture06",
+      "abstractPropDate": "2013-05-25 22:30:00.000",
+      "propDate": "2013-05-25 22:30:00.000"
+    }
+    `));
+    const json = dataObjects.stringify(scout.create(Fixture06Do, {
+      propDate: dates.parseJsonDate('2013-05-25 22:30:00.000'),
+      abstractPropDate: dates.parseJsonDate('2013-05-25 22:30:00.000')
+    }));
+    expect(json).toBe(expected);
+  });
+
   function _createFixture01Do(arr: Fixture02Do[], obj: Fixture03Do): Fixture01Do {
     const model = {
       propBool: true,
@@ -217,7 +231,12 @@ export class Fixture05Do extends BaseDoEntity {
   propObj2: Fixture06Do;
 }
 
+@typeName()
+export abstract class AbstractFixture06Do extends BaseDoEntity {
+  abstractPropDate?: Date;
+}
+
 @typeName('scout.Fixture06')
-export class Fixture06Do extends BaseDoEntity {
+export class Fixture06Do extends AbstractFixture06Do {
   propDate: Date;
 }


### PR DESCRIPTION
Allow _typeName being used without a value. The decorator triggers that the metadata are being written to the runtime code, which needs to be done for abstract DO classes even if they do not have a type name.

410638