### PR TITLE
Tree: ensure node is visible when selected if parent is lazily expanded

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -2130,20 +2130,25 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
     this._nodesSelectedInternal(nodes);
     this._triggerNodesSelected(debounceSend);
 
-    if (this.selectedNodes.length > 0 && !this.visibleNodesMap[this.selectedNodes[0].id]) {
-      this._expandAllParentNodes(this.selectedNodes[0]);
-    }
-
-    if (this.selectedNodes.length === 1) {
-      aria.linkElementWithActiveDescendant(this.$container, this.selectedNodes[0].$node);
+    let selectedNode = this.selectedNode();
+    if (selectedNode) {
+      aria.linkElementWithActiveDescendant(this.$container, selectedNode.$node);
+      if (!this.visibleNodesMap[selectedNode.id]) {
+        this._expandAllParentNodes(selectedNode);
+        if (!this.visibleNodesMap[selectedNode.id] && !this.isBreadcrumbStyleActive()) {
+          // If node is still not visible, the parent was likely already lazily expanded -> trigger LazyNodeFilter to show selected node.
+          // It is not necessary in breadcrumb mode because it will be re-filtered anyway, see below.
+          this.applyFiltersForNode(selectedNode);
+        }
+      }
     }
 
     this._updateItemPath(true);
     if (this.isBreadcrumbStyleActive()) {
       // In breadcrumb mode selected node has to be expanded
-      if (this.selectedNodes.length > 0 && !this.selectedNodes[0].expanded) {
-        this.expandNode(this.selectedNodes[0]);
-        this.selectedNodes[0].filterDirty = true;
+      if (selectedNode && !selectedNode.expanded) {
+        this.expandNode(selectedNode);
+        selectedNode.filterDirty = true;
       }
       this.filter();
     }
@@ -2239,8 +2244,8 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
   }
 
   protected _expandAllParentNodes(node: TreeNode) {
-    let i, currNode = node,
-      parentNodes = [];
+    let currNode = node;
+    let parentNodes = [];
 
     currNode = node;
     let nodesToInsert: TreeNode[] = [];
@@ -2252,7 +2257,7 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
       currNode = currNode.parentNode;
     }
 
-    for (i = parentNodes.length - 1; i >= 0; i--) {
+    for (let i = parentNodes.length - 1; i >= 0; i--) {
       if (nodesToInsert.indexOf(parentNodes[i]) !== -1) {
         this._addToVisibleFlatList(parentNodes[i], false);
       }

--- a/eclipse-scout-core/test/tree/TreeSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1885,6 +1885,45 @@ describe('Tree', () => {
       expect(node0.expanded).toBe(true);
       expect(child0.expanded).toBe(true);
       expect(tree.$selectedNodes().length).toBe(1);
+      expect(grandchild0.$node.isSelected()).toBe(true);
+    });
+
+    it('ensures the selected node is shown even if the parent is lazily expanded', () => {
+      let model = helper.createModelFixture(1, 2, false);
+      model.nodes[0].childNodes[0].lazyExpandingEnabled = true;
+      let tree = helper.createTree(model);
+      let node0 = tree.nodes[0];
+      let child0 = node0.childNodes[0];
+      let grandchild0 = child0.childNodes[0];
+      tree.render();
+
+      tree.expandNode(node0);
+      tree.expandNode(child0);
+      expect(child0.expandedLazy).toBe(true);
+      expect(grandchild0.filterAccepted).toBe(false);
+      expect(grandchild0.rendered).toBe(false);
+
+      tree.selectNode(grandchild0);
+      expect(grandchild0.filterAccepted).toBe(true);
+      expect(grandchild0.rendered).toBe(true);
+      expect(grandchild0.$node.isSelected()).toBe(true);
+    });
+
+    it('ensures the selected node is shown even if the grand-parent is lazily expanded', () => {
+      let model = helper.createModelFixture(1, 2, false);
+      model.nodes[0].lazyExpandingEnabled = true;
+      let tree = helper.createTree(model);
+      let node0 = tree.nodes[0];
+      let child0 = node0.childNodes[0];
+      let grandchild0 = child0.childNodes[0];
+      tree.render();
+
+      tree.expandNode(node0);
+      expect(node0.expandedLazy).toBe(true);
+      expect(grandchild0.rendered).toBe(false);
+
+      tree.selectNode(grandchild0);
+      expect(grandchild0.rendered).toBe(true);
       expect(grandchild0.$node.isSelected()).toBe(true);
     });
 


### PR DESCRIPTION
Use case:
- set lazyExpandingEnabled on parent node
- expand parent nodes
- select child node -> child node is not visible

Reason: when the lazy parent is expanded, there is no selected node yet. Because of the laziness, no child nodes are shown which is correct. When the child node is selected and not visible, it tries to expand all parent nodes, but they are already expanded, so nothing happens. Instead, it needs to trigger the LazyNodeFilter because this filter will now return true for the child node because it is now selected.

424792