### PR TITLE
Table: apply filters when setFilters() is called with empty array

### DIFF
--- a/eclipse-scout-chart/src/table/controls/ChartTableControl.ts
+++ b/eclipse-scout-chart/src/table/controls/ChartTableControl.ts
@@ -44,7 +44,7 @@ export class ChartTableControl extends TableControl implements ChartTableControl
   protected _tableUpdatedHandler: (e: Event<Table>) => void;
   protected _tableColumnStructureChangedHandler: () => void;
   protected _chartValueClickedHandler: () => void;
-  protected _filterResetListener: EventListener;
+  protected _filterRemovedListener: EventListener;
   protected _tableUpdatedTimeOutId: number;
 
   constructor() {
@@ -417,10 +417,11 @@ export class ChartTableControl extends TableControl implements ChartTableControl
     ];
 
     // listeners
-    this._filterResetListener = this.table.on('filterReset', event => {
-      if (this.chart) {
-        this.chart.setCheckedItems([]);
+    this._filterRemovedListener = this.table.on('filterRemoved', event => {
+      if (!(event.filter instanceof ChartTableUserFilter)) {
+        return;
       }
+      this.chart.setCheckedItems([]);
     });
 
     this._addListeners();
@@ -1233,7 +1234,7 @@ export class ChartTableControl extends TableControl implements ChartTableControl
     this._removeScrollbars();
     this.$contentContainer.remove();
     this.chart.remove();
-    this.table.events.removeListener(this._filterResetListener);
+    this.table.events.removeListener(this._filterRemovedListener);
     this._removeListeners();
     this.oldChartType = null;
     this.recomputeEnabled();

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -4383,10 +4383,8 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   }
 
   resetUserFilter(applyFilter = true) {
-    this.filters.filter(filter => filter instanceof TableUserFilter)
-      .forEach(filter => this.removeFilter(filter, applyFilter));
-
-    this._triggerFilterReset();
+    let newFilters = this.filters.filter(filter => !(filter instanceof TableUserFilter));
+    this.setFilters(newFilters, applyFilter);
   }
 
   hasUserFilter(): boolean {
@@ -4491,17 +4489,11 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
    * @see TableModel.filters
    */
   setFilters(filters: (FilterOrFunction<TableRow> | ObjectOrModel<TableUserFilter>)[], applyFilter = true) {
-    this.resetUserFilter(false);
     let tableFilters = filters.map(filter => this._ensureFilter(filter));
     let result = this.filterSupport.setFilters(tableFilters, applyFilter);
-    let filtersAdded = result.filtersAdded;
-    let filtersRemoved = result.filtersRemoved;
-    filtersAdded.forEach(filter => this.trigger('filterAdded', {
-      filter: filter
-    }));
-    filtersRemoved.forEach(filter => this.trigger('filtersRemoved', {
-      filter: filter
-    }));
+
+    result.filtersAdded.forEach(filter => this.trigger('filterAdded', {filter}));
+    result.filtersRemoved.forEach(filter => this.trigger('filterRemoved', {filter}));
   }
 
   protected _ensureFilter<T extends Filter<TableRow>>(filter: TableUserFilterModel | FilterOrFunction<TableRow>): Filter<TableRow> {
@@ -4949,10 +4941,6 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
 
   protected _triggerFilter() {
     this.trigger('filter');
-  }
-
-  protected _triggerFilterReset() {
-    this.trigger('filterReset');
   }
 
   protected _triggerAppLinkAction(column: Column<any>, row: TableRow, ref: string, $appLink: JQuery) {

--- a/eclipse-scout-core/src/table/TableEventMap.ts
+++ b/eclipse-scout-core/src/table/TableEventMap.ts
@@ -77,10 +77,6 @@ export interface TableFilterRemovedEvent<T = Table> extends Event<T> {
   filter: Filter<TableRow>;
 }
 
-export interface TableFiltersRemovedEvent<T = Table> extends Event<T> {
-  filter: Filter<TableRow>;
-}
-
 export interface TableGroupEvent<TValue = any, T = Table> extends Event<T> {
   column: Column<TValue>;
   groupAscending: boolean;
@@ -174,8 +170,6 @@ export interface TableEventMap extends WidgetEventMap {
   'filter': Event;
   'filterAdded': TableFilterAddedEvent;
   'filterRemoved': TableFilterRemovedEvent;
-  'filterReset': Event;
-  'filtersRemoved': TableFiltersRemovedEvent;
   'group': TableGroupEvent;
   'prepareCellEdit': TablePrepareCellEditEvent;
   'reload': TableReloadEvent;

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -9,7 +9,7 @@
  */
 import {
   Action, BeanColumn, BooleanColumn, Cell, Column, ColumnModel, Device, graphics, IconColumn, icons, Menu, MenuDestinations, NumberColumn, ObjectFactory, Point, Range, RemoteEvent, scout, scrollbars, SmartColumn, Status, strings, Table,
-  TableAdapter, TableField, TableRow, TableRowModel, Tooltip
+  TableAdapter, TableField, TableRow, TableRowModel, TableUserFilter, Tooltip
 } from '../../src/index';
 import {JQueryTesting, LocaleSpecHelper, SpecTable, TableModelWithCells, TableSpecHelper} from '../../src/testing/index';
 import $ from 'jquery';
@@ -3967,6 +3967,122 @@ describe('Table', () => {
       table.setFilters([]);
       expect(table.filters.length).toBe(0);
       expect(table.filteredRows().length).toBe(4);
+    });
+  });
+
+  describe('setFilters', () => {
+
+    it('replaces existing filters', () => {
+      class SpecTableUserFilter extends TableUserFilter {
+        key: string;
+        acceptedRows: TableRow[];
+
+        constructor(key: string, acceptedRows: TableRow[]) {
+          super();
+          this.key = key;
+          this.acceptedRows = acceptedRows;
+        }
+
+        override createKey(): string {
+          return this.key;
+        }
+
+        override createLabel(): string {
+          return 'Spec Table User Filter';
+        }
+
+        override accept(row: TableRow): boolean {
+          return scout.isOneOf(row, this.acceptedRows);
+        }
+      }
+
+      let model = helper.createModelFixture(2, 4);
+      let table = helper.createTable(model);
+      let row0 = table.rows[0];
+      let row1 = table.rows[1];
+      let row2 = table.rows[2];
+      let row3 = table.rows[3];
+
+      let eventCollector = [];
+      table.on('filterAdded filterRemoved', event => eventCollector.push(event));
+
+      let filter1 = new SpecTableUserFilter('F1', [row1]);
+      let filter2 = new SpecTableUserFilter('F2', [row3, row0]);
+      let filter3 = new SpecTableUserFilter('F3', [row2]);
+
+      // -----
+
+      table.addFilter(filter1);
+      expect(table.filters.length).toBe(1);
+      expect(table.filteredRows()).toEqual([row1]);
+      expect(eventCollector.length).toBe(1);
+      expect(eventCollector[0].type).toBe('filterAdded');
+      expect(eventCollector[0].filter).toBe(filter1);
+      eventCollector = [];
+
+      table.setFilters([filter2]);
+      expect(table.filters.length).toBe(1);
+      expect(table.filteredRows()).toEqual([row0, row3]);
+      expect(eventCollector.length).toBe(2);
+      expect(eventCollector[0].type).toBe('filterAdded');
+      expect(eventCollector[0].filter).toBe(filter2);
+      expect(eventCollector[1].type).toBe('filterRemoved');
+      expect(eventCollector[1].filter).toBe(filter1);
+      eventCollector = [];
+
+      table.setFilters([filter2, filter1]);
+      expect(table.filters.length).toBe(2);
+      expect(table.filteredRows()).toEqual([]);
+      expect(eventCollector.length).toBe(1);
+      expect(eventCollector[0].type).toBe('filterAdded');
+      expect(eventCollector[0].filter).toBe(filter1);
+      eventCollector = [];
+
+      table.setFilters([]);
+      expect(table.filters.length).toBe(0);
+      expect(table.filteredRows()).toEqual([row0, row1, row2, row3]);
+      expect(eventCollector.length).toBe(2);
+      expect(eventCollector[0].type).toBe('filterRemoved');
+      expect(eventCollector[0].filter).toBe(filter2);
+      expect(eventCollector[1].type).toBe('filterRemoved');
+      expect(eventCollector[1].filter).toBe(filter1);
+      eventCollector = [];
+
+      table.setFilters([filter1, filter2]);
+      expect(table.filters.length).toBe(2);
+      expect(table.filteredRows()).toEqual([]);
+      expect(eventCollector.length).toBe(2);
+      expect(eventCollector[0].type).toBe('filterAdded');
+      expect(eventCollector[0].filter).toBe(filter1);
+      expect(eventCollector[1].type).toBe('filterAdded');
+      expect(eventCollector[1].filter).toBe(filter2);
+      eventCollector = [];
+
+      table.resetUserFilter();
+      expect(table.filters.length).toBe(0);
+      expect(table.filteredRows()).toEqual([row0, row1, row2, row3]);
+      expect(eventCollector.length).toBe(2);
+      expect(eventCollector[0].type).toBe('filterRemoved');
+      expect(eventCollector[0].filter).toBe(filter1);
+      expect(eventCollector[1].type).toBe('filterRemoved');
+      expect(eventCollector[1].filter).toBe(filter2);
+      eventCollector = [];
+
+      table.setFilters([filter1, filter2]);
+      table.removeFilter(filter3);
+      expect(table.filters.length).toBe(2);
+      expect(table.filteredRows()).toEqual([]);
+      table.removeFilter(filter2);
+      expect(table.filters.length).toBe(1);
+      expect(table.filteredRows()).toEqual([row1]);
+      expect(eventCollector.length).toBe(3);
+      expect(eventCollector[0].type).toBe('filterAdded');
+      expect(eventCollector[0].filter).toBe(filter1);
+      expect(eventCollector[1].type).toBe('filterAdded');
+      expect(eventCollector[1].filter).toBe(filter2);
+      expect(eventCollector[2].type).toBe('filterRemoved');
+      expect(eventCollector[2].filter).toBe(filter2);
+      eventCollector = [];
     });
   });
 


### PR DESCRIPTION
When removing all existing user filters from a table by calling setFilters([]), the filtered rows were not updated correctly. Because the old implementation first removed all existing user filters, the filterSupport did not think there was a change and did not do anything. Resetting the user filters is not necessary at all, because they are removed automatically.

Additionally, the unnecessary 'filterReset' event was removed. It was only used to update the table controls. Instead, they now listen for the 'filterRemoved' event. This allows to update a single table control while retaining other

The 'filtersRemoved' event was removed, because it was most likely a typo. Instead, 'filterRemoved' should be used, analog to 'filterAdded'.

426270