### PR TITLE
Bookmarks: don't include compactRoot node in the page path

### DIFF
--- a/eclipse-scout-core/src/bookmark/BookmarkDoBuilder.ts
+++ b/eclipse-scout-core/src/bookmark/BookmarkDoBuilder.ts
@@ -88,7 +88,7 @@ export class BookmarkDoBuilder implements ObjectWithType, BookmarkDoBuilderModel
     if (createOutlineBookmarkDefinition && page) {
       let parentPage = page.parentNode;
       let childPage = page;
-      while (parentPage) {
+      while (parentPage && !parentPage.compactRoot) {
         let pathEntry = await this._pageToBookmarkPage(parentPage, childPage);
         if (!pathEntry) {
           // non-bookmarkable page

--- a/eclipse-scout-core/src/prefs/UiPreferences.ts
+++ b/eclipse-scout-core/src/prefs/UiPreferences.ts
@@ -234,7 +234,7 @@ export class UiPreferences implements ObjectWithType {
         return scout.create(TableColumnClientUiPreferenceDo, {
           columnId: column.buildUuid(),
           viewIndex: index,
-          visible: column.visible,
+          visible: column.visibleIgnoreCompacted, // in compact mode, all columns would be invisible otherwise
           width: column.width,
           sortOrder: column.sortIndex,
           sortAscending: column.sortAscending,

--- a/eclipse-scout-core/test/bookmark/BookmarkSupportSpec.ts
+++ b/eclipse-scout-core/test/bookmark/BookmarkSupportSpec.ts
@@ -15,9 +15,9 @@ import {
 } from '../../src/index';
 import {
   FRUIT_1_KEY, FRUIT_2_KEY, FRUIT_3_KEY, FRUIT_4_KEY, FRUIT_5_KEY, goToOutline, SPEC_NODE_PAGE_1_UUID, SPEC_NODE_PAGE_2_UUID, SPEC_NODE_PAGE_3_UUID, SPEC_NODE_PAGE_4_UUID, SPEC_OUTLINE_1_ID, SPEC_OUTLINE_1_UUID, SPEC_OUTLINE_2_ID,
-  SPEC_OUTLINE_2_UUID, SPEC_TABLE_PAGE_1_UUID, SPEC_TABLE_PAGE_2_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_1_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_2_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_3_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_4_UUID,
-  SPEC_TABLE_PAGE_3_TABLE_COLUMN_5_UUID, SPEC_TABLE_PAGE_3_TABLE_UUID, SPEC_TABLE_PAGE_3_UUID, specDesktopModel, SpecNodePage1, SpecNodePage2, SpecNodePage3, SpecNodePage4, SpecPageParamDo, SpecSearchDo, SpecSearchForm, SpecTablePage1,
-  SpecTablePage2, SpecTablePage3
+  SPEC_OUTLINE_2_UUID, SPEC_OUTLINE_3_ID, SPEC_OUTLINE_3_UUID, SPEC_TABLE_PAGE_1_UUID, SPEC_TABLE_PAGE_2_UUID,  SPEC_TABLE_PAGE_3_TABLE_COLUMN_1_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_2_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_3_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_4_UUID,
+  SPEC_TABLE_PAGE_3_TABLE_COLUMN_5_UUID, SPEC_TABLE_PAGE_3_TABLE_UUID,SPEC_TABLE_PAGE_3_UUID, specDesktopModel, SpecNodePage1, SpecNodePage2, SpecNodePage3, SpecNodePage4, SpecPageParamDo,
+  SpecSearchDo, SpecSearchForm, SpecTablePage1, SpecTablePage2, SpecTablePage3
 } from './bookmark-fixtures';
 
 describe('BookmarkSupport', () => {
@@ -443,6 +443,79 @@ describe('BookmarkSupport', () => {
         expect(error).toBe(BookmarkDoBuilder.ERROR_MISSING_OUTLINE);
       }
       expect(bookmarkSupport.handleCreateBookmarkError).not.toHaveBeenCalled();
+    });
+
+    it('does not include invisible root node in page path', async () => {
+      let outline = goToOutline(desktop, SPEC_OUTLINE_3_ID);
+      expect(outline).toBeInstanceOf(Outline);
+      expect(outline.title).toBe('Outline 3');
+      expect(outline.nodes.length).toBe(1);
+      expect(outline.nodes[0]).toBeInstanceOf(SpecNodePage4);
+      expect(outline.nodes[0].compactRoot).toBe(true); // <--
+      expect(outline.selectedNode()).toBe(null);
+
+      let page1 = outline.nodes[0] as SpecNodePage4;
+      outline.drillDown(page1);
+      await page1.ensureLoadChildren();
+      expect(page1.childNodes.length).toBe(2);
+      expect(page1.childNodes[0]).toBeInstanceOf(SpecNodePage2);
+      expect(page1.childNodes[0].compactRoot).toBe(false);
+      expect(page1.childNodes[1]).toBeInstanceOf(SpecTablePage2);
+      expect(page1.childNodes[1].compactRoot).toBe(false);
+
+      let page2 = page1.childNodes[1] as SpecTablePage2;
+      outline.drillDown(page2);
+      await page2.ensureLoadChildren();
+      expect(page2.detailTable.rows.length).toBe(5);
+      page2.setSearchFilter(scout.create(SpecSearchDo, {text: 'i'})); // Matches 'Pineapple' and 'Kiwi'
+      page2.reloadPage();
+      await page2.ensureLoadChildren();
+      expect(page2.detailTable.rows.length).toBe(2);
+      expect(page2.childNodes.length).toBe(2);
+      expect(page2.childNodes[0]).toBeInstanceOf(SpecNodePage4);
+      expect(page2.childNodes[0].compactRoot).toBe(false);
+      expect(page2.childNodes[0].pageParam).toBeInstanceOf(SpecPageParamDo);
+      expect((page2.childNodes[0].pageParam as SpecPageParamDo).fooId).toBe(FRUIT_3_KEY);
+      expect(page2.childNodes[1]).toBeInstanceOf(SpecNodePage4);
+      expect(page2.childNodes[1].pageParam).toBeInstanceOf(SpecPageParamDo);
+      expect((page2.childNodes[1].pageParam as SpecPageParamDo).fooId).toBe(FRUIT_5_KEY);
+
+      let page3 = page2.childNodes[1] as SpecNodePage4;
+      outline.drillDown(page3);
+      await page3.ensureLoadChildren();
+
+      // -----
+
+      let bookmark = await bookmarkSupport.createBookmark() as BookmarkDo;
+
+      expect(bookmark).toBeInstanceOf(BookmarkDo);
+      expect(bookmark.id).toBeUndefined();
+      expect(bookmark.title).toBe('Outline 3 - Table Page 2 - Kiwi');
+      expect(bookmark.description).toBe('Table Page 2\n  text: "i"\n  Kiwi');
+      expect(bookmark.definition).toBeInstanceOf(OutlineBookmarkDefinitionDo);
+      let bookmarkDefinition = bookmark.definition as OutlineBookmarkDefinitionDo;
+      expect(bookmarkDefinition.outlineId).toBe(SPEC_OUTLINE_3_UUID);
+      expect(bookmarkDefinition.pagePath.length).toBe(1); // <--
+
+      let pagePathElement1 = bookmarkDefinition.pagePath[0] as TableBookmarkPageDo;
+      expect(pagePathElement1).toBeInstanceOf(TableBookmarkPageDo);
+      expect(pagePathElement1.displayText).toBe('Table Page 2');
+      expect(pagePathElement1.pageParam).toBeInstanceOf(PageIdDummyPageParamDo);
+      expect((pagePathElement1.pageParam as PageIdDummyPageParamDo).pageId).toBe(SPEC_TABLE_PAGE_2_UUID);
+      expect(pagePathElement1.searchFilterComplete).toBe(true);
+      expect(pagePathElement1.searchData).toBeInstanceOf(BaseDoEntity);
+      expect((pagePathElement1.searchData as BaseDoEntity).toPojo()).toEqual(scout.create(SpecSearchDo, {text: 'i'}).toPojo());
+      expect(pagePathElement1.expandedChildRow).toBeInstanceOf(BookmarkTableRowIdentifierDo);
+      expect(pagePathElement1.expandedChildRow.toPojo()).toEqual(scout.create(BookmarkTableRowIdentifierDo, {
+        keyComponents: [scout.create(BookmarkTableRowIdentifierStringComponentDo, {key: FRUIT_5_KEY})]
+      }).toPojo());
+      expect(pagePathElement1.selectedChildRows.length).toBe(0); // selected rows are not exported by default
+
+      let bookmarkedPage = bookmarkDefinition.bookmarkedPage as NodeBookmarkPageDo;
+      expect(bookmarkedPage).toBeInstanceOf(NodeBookmarkPageDo);
+      expect(bookmarkedPage.displayText).toBe('Kiwi');
+      expect(bookmarkedPage.pageParam).toBeInstanceOf(SpecPageParamDo);
+      expect((bookmarkedPage.pageParam as SpecPageParamDo).fooId).toBe(FRUIT_5_KEY);
     });
   });
 

--- a/eclipse-scout-core/test/bookmark/bookmark-fixtures.ts
+++ b/eclipse-scout-core/test/bookmark/bookmark-fixtures.ts
@@ -9,7 +9,7 @@
  */
 import {
   BaseDoEntity, BooleanColumn, Column, Desktop, DesktopModel, Form, FormModel, GroupBox, NumberColumn, ObjectOrModel, Outline, OutlineViewButton, Page, PageParamDo, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl,
-  SearchMenu, StringField, strings, Table, TableRow, typeName
+  SearchMenu, StringField, strings, Table, TableRow, Tree, typeName
 } from '../../src';
 
 // ---------------------------------------------------------------
@@ -28,6 +28,11 @@ import {
 //      |     +- SpecNodePage2 [leaf, SpecDetailForm]
 //      |     +- (rec:SpecTablePage2)
 //      +- SpecNodePage2 [leaf, SpecDetailForm]
+//
+//   SpecOutline3 [breadcrumb]
+//   +- SpecNodePage4 [compactRoot]
+//      +- SpecNodePage2 [leaf, SpecDetailForm]
+//      +- (rec:SpecTablePage2)
 //
 // ---------------------------------------------------------------
 
@@ -81,6 +86,25 @@ export function specDesktopModel(): DesktopModel {
         },
         displayStyle: 'MENU',
         text: 'Outline Button 2'
+      },
+      {
+        id: 'SpecOutline3ViewButton',
+        objectType: OutlineViewButton,
+        outline: {
+          id: SPEC_OUTLINE_3_ID,
+          uuid: SPEC_OUTLINE_3_UUID,
+          objectType: Outline,
+          title: 'Outline 3',
+          displayStyle: Tree.DisplayStyle.BREADCRUMB,
+          nodes: [
+            {
+              objectType: SpecNodePage4,
+              compactRoot: true
+            }
+          ]
+        },
+        displayStyle: 'MENU',
+        text: 'Outline Button 3'
       }
     ],
     outline: SPEC_OUTLINE_1_ID
@@ -91,8 +115,10 @@ export function specDesktopModel(): DesktopModel {
 
 export const SPEC_OUTLINE_1_ID = 'SpecOutline1';
 export const SPEC_OUTLINE_2_ID = 'SpecOutline2';
+export const SPEC_OUTLINE_3_ID = 'SpecOutline3';
 export const SPEC_OUTLINE_1_UUID = '8841b967-4801-47bb-87a9-a5f6d54b4014';
 export const SPEC_OUTLINE_2_UUID = 'a6379a66-c844-4ec7-8e7e-1f854dc7e81e';
+export const SPEC_OUTLINE_3_UUID = 'cbe9986e-cbb8-415c-94fc-680a961280a7';
 export const SPEC_NODE_PAGE_1_UUID = '9e4a69e7-73a5-44fd-8d68-ebb6a50f07ba';
 export const SPEC_NODE_PAGE_2_UUID = 'c7f9ad97-d80a-429b-8701-0378cad9307f';
 export const SPEC_NODE_PAGE_3_UUID = '80e022bf-5b00-491d-818e-3c4054d7fcc3';

--- a/eclipse-scout-core/test/table/TableUiPreferencesSpec.ts
+++ b/eclipse-scout-core/test/table/TableUiPreferencesSpec.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  BooleanColumn, Column, DateColumn, NumberColumn, scout, Table, TableClientUiPreferenceProfileDo, TableClientUiPreferencesDo, TableColumnClientUiPreferenceDo, TableRow, TableTextUserFilter, TextColumnUserFilter, Tile, uiPreferences,
-  UiPreferences, UiPreferencesDo, WidgetModel
+  BooleanColumn, Column, DateColumn, NumberColumn, ObjectIdProvider, scout, Table, TableClientUiPreferenceProfileDo, TableClientUiPreferencesDo, TableColumnClientUiPreferenceDo, TableRow, TableTextUserFilter, TextColumnUserFilter, Tile,
+  uiPreferences, UiPreferences, UiPreferencesDo, WidgetModel
 } from '../../src/index';
 import {SpecUiPreferencesStore} from '../../src/testing';
 
@@ -420,6 +420,46 @@ describe('TableUiPreferences', () => {
       expect(table.columns.length).toBe(6 + 2);
       expect(table.columns.map(c => c.guiOnly ? null : c.id)).toEqual([null, null, 'c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
       expect(c2.width).toBe(202);
+    });
+
+    it('ignores compact mode', () => {
+      let table = scout.create(SpecTable, {
+        parent: session.desktop,
+        id: 't1'
+      });
+      table.columnById('c3').setVisible(false);
+
+      const getColumnId = (column: Column) => {
+        if (ObjectIdProvider.get().isUiSeqId(column.id)) {
+          return null;
+        }
+        return column.id;
+      };
+
+      expect(table.columns.length).toBe(6);
+      expect(table.columns.map(c => getColumnId(c))).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
+      expect(table.columns.map(c => c.guiOnly)).toEqual([undefined, undefined, undefined, undefined, undefined, undefined]);
+      expect(table.columns.map(c => c.visible)).toEqual([false, true, false, true, true, true]);
+      expect(table.columns.map(c => c.visibleIgnoreCompacted)).toEqual([false, true, false, true, true, true]);
+      expect(table.columns.map(c => c.compacted)).toEqual([false, false, false, false, false, false]);
+      let profile1 = uiPreferences.createTablePreferenceProfile(table);
+      expect(profile1.columns.length).toBe(6);
+      expect(profile1.columns.map(c => c.columnId)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
+      expect(profile1.columns.map(c => c.visible)).toEqual([false, true, false, true, true, true]);
+      expect(profile1.columns.map(c => c.width)).toEqual([60, 102, 103, 104, 105, 106]);
+
+      table.setCompact(true);
+      expect(table.columns.length).toBe(7);
+      expect(table.columns.map(c => getColumnId(c))).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6', null]);
+      expect(table.columns.map(c => c.guiOnly)).toEqual([undefined, undefined, undefined, undefined, undefined, undefined, true]);
+      expect(table.columns.map(c => c.visible)).toEqual([false, false, false, false, false, false, true]);
+      expect(table.columns.map(c => c.visibleIgnoreCompacted)).toEqual([false, true, false, true, true, true, true]);
+      expect(table.columns.map(c => c.compacted)).toEqual([false, true, true, true, true, true, false]);
+      let profile2 = uiPreferences.createTablePreferenceProfile(table);
+      expect(profile2.columns.length).toBe(6); // <--
+      expect(profile2.columns.map(c => c.columnId)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
+      expect(profile2.columns.map(c => c.visible)).toEqual([false, true, false, true, true, true]);
+      expect(profile2.columns.map(c => c.width)).toEqual([60, 102, 103, 104, 105, 106]);
     });
   });
 


### PR DESCRIPTION
The InvisibleRootNode of an outline is usually not present in the UI. However, in mobile mode, the node exists to display the tile outline overview inside the tree. Because the code that can activate a bookmark at its original location assumes that the bookmark page path does _not_ include this node, it should be filtered accordingly. Otherwise, the bookmark activation will fail.

425717