### PR TITLE
UiPreferences: extract table-specific code to TableUiPreferences

### DIFF
--- a/eclipse-scout-core/src/bookmark/BookmarkDoBuilder.ts
+++ b/eclipse-scout-core/src/bookmark/BookmarkDoBuilder.ts
@@ -9,7 +9,8 @@
  */
 import {
   arrays, BaseDoEntity, BookmarkDo, BookmarkDoBuilderModel, BookmarkSupport, BookmarkTableRowIdentifierDo, ChartTableControlConfigHelper, Desktop, Form, IBookmarkDefinitionDo, IBookmarkDo, IBookmarkPageDo, IChartTableControlConfigDo,
-  InitModelOf, NodeBookmarkPageDo, objects, ObjectWithType, OutlineBookmarkDefinitionDo, Page, PageBookmarkDefinitionDo, PageWithTable, scout, Session, strings, TableBookmarkPageDo, TableClientUiPreferencesDo, UiPreferences, uiPreferences
+  InitModelOf, NodeBookmarkPageDo, objects, ObjectWithType, OutlineBookmarkDefinitionDo, Page, PageBookmarkDefinitionDo, PageWithTable, scout, Session, strings, TableBookmarkPageDo, TableClientUiPreferencesDo, TableUiPreferences,
+  tableUiPreferences
 } from '../index';
 
 export class BookmarkDoBuilder implements ObjectWithType, BookmarkDoBuilderModel {
@@ -214,12 +215,10 @@ export class BookmarkDoBuilder implements ObjectWithType, BookmarkDoBuilderModel
       return null;
     }
     let table = page.detailTable;
-    let prefs = uiPreferences.createTablePreferences(table);
-    let profile = uiPreferences.createTablePreferenceProfile(table, {
-      includeUserFilters: true
-    });
+    let prefs = tableUiPreferences.create(table);
+    let profile = tableUiPreferences.createProfile(table, {includeUserFilters: true});
     prefs.tablePreferenceProfiles = new Map([
-      [UiPreferences.TABLE_PREFERENCE_PROFILE_ID_BOOKMARK, profile]
+      [TableUiPreferences.PROFILE_ID_BOOKMARK, profile]
     ]);
     return prefs;
   }

--- a/eclipse-scout-core/src/bookmark/BookmarkSupport.ts
+++ b/eclipse-scout-core/src/bookmark/BookmarkSupport.ts
@@ -10,7 +10,7 @@
 import {
   App, arrays, BaseDoEntity, BookmarkDo, BookmarkDoBuilder, BookmarkDoBuilderModel, BookmarkSupportModel, BookmarkTableRowIdentifierDo, BookmarkTableRowIdentifierDoFactory, ChartTableControlConfigHelper, Constructor, Desktop, IBookmarkDo,
   IBookmarkPageDo, InitModelOf, MaxRowCountContributionDo, MessageBoxes, NodeBookmarkPageDo, objects, ObjectWithType, Outline, OutlineBookmarkDefinitionDo, Page, PageParamDo, PageWithNodes, PageWithTable, scout, Session, Status,
-  TableBookmarkPageDo, TableRow, UiPreferences, uiPreferences
+  TableBookmarkPageDo, TableRow, TableUiPreferences, tableUiPreferences
 } from '../index';
 import $ from 'jquery';
 
@@ -485,19 +485,17 @@ export class BookmarkSupport implements ObjectWithType, BookmarkSupportModel {
   protected _prepareTablePreferences(page: PageWithTable, bookmarkPage: TableBookmarkPageDo, saveState: boolean) {
     const table = page.detailTable;
     const prefs = bookmarkPage.tablePreferences;
-    const profile = uiPreferences.getTablePreferenceProfile(prefs, UiPreferences.TABLE_PREFERENCE_PROFILE_ID_BOOKMARK);
+    const profile = tableUiPreferences.getProfile(prefs, TableUiPreferences.PROFILE_ID_BOOKMARK);
 
-    uiPreferences.applyTablePreferences(table, prefs);
-    uiPreferences.applyTablePreferenceProfile(table, profile, {
-      applyUserFilters: true
-    });
+    tableUiPreferences.apply(table, prefs);
+    tableUiPreferences.applyProfile(table, profile, {applyUserFilters: true});
 
     if (saveState) {
       // Set bookmarked profile as default preferences (no need to store the GLOBAL setting, but "reset to factory settings" should still be possible)
-      table.setInitialUiPreferences(profile || uiPreferences.createTablePreferenceProfile(table));
+      table.setInitialUiPreferences(profile || tableUiPreferences.createProfile(table));
     } else {
       // Store applied settings as GLOBAL setting
-      uiPreferences.storeGlobalTablePreferenceProfile(table);
+      tableUiPreferences.storeGlobalProfile(table);
     }
   }
 

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -332,6 +332,7 @@ export * from './popup/MobilePopupLayout';
 export * from './prefs/UiPreferences';
 export * from './prefs/UiPreferencesStore';
 export * from './prefs/LocalUiPreferencesStore';
+export * from './prefs/TableUiPreferences';
 export * from './datepicker/DatePicker';
 export * from './datepicker/DatePickerModel';
 export * from './datepicker/DatePickerEventMap';

--- a/eclipse-scout-core/src/prefs/TableUiPreferences.ts
+++ b/eclipse-scout-core/src/prefs/TableUiPreferences.ts
@@ -1,0 +1,510 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {
+  arrays, Column, ErrorHandler, Event, ITableCustomizerDo, IUserFilterStateDo, NumberColumn, NumberColumnAggregationFunction, NumberColumnBackgroundEffect, objects, ObjectWithType, PropertyChangeEvent, scout, strings, Table,
+  TableClientUiPreferenceProfileDo, TableClientUiPreferencesDo, TableColumnClientUiPreferenceDo, TableUserFilter, UiPreferences, uiPreferences, UserFilterStateMappers
+} from '../index';
+
+/**
+ * A singleton that represents all {@link Table}-specific UI preferences of the current user. It is populated during the start of the
+ * application, so the preferences can be accessed synchronously.
+ */
+export class TableUiPreferences implements ObjectWithType {
+
+  /**
+   * Key for the current global preferences of a table, i.e. preferences that are not stored in a specific settings profile.
+   */
+  static PROFILE_ID_GLOBAL = 'global-' + 'a134390b-bfef-4b9e-a14e-425df161e768';
+
+  /**
+   * Special key used to store table settings of a bookmarked table page. The bookmark support will consider this state as
+   * the "factory settings" when the page is displayed in the bookmark outline.
+   */
+  static PROFILE_ID_BOOKMARK = 'bookmark-' + 'aebcacd2-ddb6-4b7f-8673-d1585701d388';
+
+  objectType: string;
+
+  /** Map of all table preferences, indexed by table identifier (see {@link _computeTablePreferencesKey}). */
+  protected _tablePreferencesMap: Map<string, TableClientUiPreferencesDo> = new Map();
+  /** If > 0, table events are ignored. Useful when applying preferences. */
+  protected _ignoreTableEventsCounter = 0;
+  protected _columResizeTimeoutId: number;
+
+  protected _tableColumnListener = this._onTableColumnEvent.bind(this);
+  protected _tableTileModeListener = this._onTableTileModeChange.bind(this);
+
+  // --------------------------------------
+
+  /**
+   * Imports the given data into the internal structures, so individual table preferences can be read and
+   * modified by the various methods on this class. Any existing data is replaced.
+   *
+   * @internal should only be called from the registered {@link UiPreferencesHandler}!
+   */
+  _importTablePreferences(tablePreferences: TableClientUiPreferencesDo[]) {
+    this._tablePreferencesMap.clear();
+    tablePreferences?.forEach(tablePrefs => {
+      let tableId = tablePrefs.tableId;
+      let userPreferenceContext = tablePrefs.userPreferenceContext;
+      let key = this._computeTablePreferencesKey(tableId, userPreferenceContext);
+      this._tablePreferencesMap.set(key, tablePrefs);
+    });
+  }
+
+  /**
+   * Exports the current state of the internal data structures as persistable table preferences.
+   *
+   * @internal should only be called from the registered {@link UiPreferencesHandler}!
+   */
+  _exportTablePreferences(): TableClientUiPreferencesDo[] {
+    return [...this._tablePreferencesMap.values()];
+  }
+
+  /**
+   * Returns the preferences for the given table. If no preferences are registered yet, a new empty
+   * preferences data object is created and stored.
+   */
+  protected _getOrCreateTablePreferences(table: Table): TableClientUiPreferencesDo {
+    scout.assertParameter('table', table, Table);
+    let tableId = table.buildUuidPath();
+    let userPreferenceContext = table.userPreferenceContext;
+    let key = this._computeTablePreferencesKey(tableId, userPreferenceContext);
+
+    let prefs = this._tablePreferencesMap.get(key);
+    if (!prefs) {
+      prefs = this.create(table);
+      this._tablePreferencesMap.set(key, prefs);
+      this._scheduleStore();
+    }
+    return prefs;
+  }
+
+  protected _computeTablePreferencesKey(tableId: string, userPreferenceContext: string): string {
+    return strings.join('#', tableId, userPreferenceContext);
+  }
+
+  protected _scheduleStore() {
+    uiPreferences.scheduleStore(TableUiPreferences);
+  }
+
+  // --------------------------------------
+
+  /**
+   * Installs or uninstalls UI preference support for the given table according to its {@link Table#uiPreferencesEnabled} flag.
+   */
+  updateUiPreferencesEnabled(table: Table) {
+    scout.assertParameter('table', table, Table);
+    if (table.uiPreferencesEnabled) {
+      // Save current state as "factory defaults". User filters are not included.
+      table.setInitialUiPreferences(this.createProfile(table));
+
+      // If there is a stored GLOBAL profile, apply it now
+      let prefs = this.get(table);
+      this.apply(table, prefs, TableUiPreferences.PROFILE_ID_GLOBAL);
+
+      // Install a table listener that stores all changes into the GLOBAL profile.
+      // This is only done _after_ applying the initial state, so that no events were triggered.
+      this._installTableListener(table);
+    } else {
+      // Uninstall listener
+      this._uninstallTableListener(table);
+    }
+  }
+
+  /**
+   * Installs a table listener for all preference-related changes and stores them in the {@link TableUiPreferences#PROFILE_ID_GLOBAL} profile for that table.
+   */
+  protected _installTableListener(table: Table) {
+    this._uninstallTableListener(table);
+    table.on('columnMoved columnResized columnStructureChanged group sort aggregationFunctionChanged columnBackgroundEffectChanged', this._tableColumnListener);
+    table.on('propertyChange:tileMode', this._tableTileModeListener);
+  }
+
+  /**
+   * Uninstalls the listener installed by {@link _installTableListener}.
+   */
+  protected _uninstallTableListener(table: Table) {
+    table.off('columnMoved columnResized columnStructureChanged group sort aggregationFunctionChanged columnBackgroundEffectChanged', this._tableColumnListener);
+    table.off('propertyChange:tileMode', this._tableTileModeListener);
+  }
+
+  protected get _ignoreTableEvents(): boolean {
+    return this._ignoreTableEventsCounter > 0;
+  }
+
+  protected set _ignoreTableEvents(applyingTablePreferences: boolean) {
+    if (applyingTablePreferences) {
+      this._ignoreTableEventsCounter++;
+    } else {
+      this._ignoreTableEventsCounter = Math.max(0, this._ignoreTableEventsCounter - 1);
+    }
+  }
+
+  protected _onTableColumnEvent(event: Event<Table>) {
+    if (this._ignoreTableEvents) {
+      return;
+    }
+
+    // FIXME bsh [js-bookmark] Find a better solution. It would convenient if there was a 'columnResizeEnd' event that is only triggered if the user has finished changing the size.
+    clearTimeout(this._columResizeTimeoutId);
+    if (event.type === 'columnResized') {
+      this._columResizeTimeoutId = setTimeout(() => {
+        this.storeGlobalProfile(event.source);
+      }, 750); // same delay as in TableAdapter#_sendColumnResized
+    } else {
+      this.storeGlobalProfile(event.source);
+    }
+  }
+
+  protected _onTableTileModeChange(event: PropertyChangeEvent<boolean, Table>) {
+    if (this._ignoreTableEvents) {
+      return;
+    }
+    this.store(event.source);
+  }
+
+  // --------------------------------------
+
+  /**
+   * Returns the preferences for the given table, or `null` if no preferences are registered yet.
+   */
+  get(table: Table): TableClientUiPreferencesDo {
+    scout.assertParameter('table', table, Table);
+    let tableId = table.buildUuidPath();
+    let userPreferenceContext = table.userPreferenceContext;
+    let key = this._computeTablePreferencesKey(tableId, userPreferenceContext);
+
+    return this._tablePreferencesMap.get(key);
+  }
+
+  /**
+   * Returns the profile with the given id from the given table preferences. If no such profile exists, `undefined` is returned.
+   */
+  getProfile(prefs: TableClientUiPreferencesDo, profileId: string): TableClientUiPreferenceProfileDo {
+    return prefs?.tablePreferenceProfiles?.get(profileId);
+  }
+
+  /**
+   * Creates a new data object consisting of all profile-independent preferences for the given table, according to its current state.
+   *
+   * Note: the `tablePreferences` map is *not* set automatically.
+   */
+  create(table: Table): TableClientUiPreferencesDo {
+    scout.assertParameter('table', table, Table);
+    return scout.create(TableClientUiPreferencesDo, {
+      tableId: table.buildUuidPath(),
+      userPreferenceContext: table.userPreferenceContext,
+      tileMode: table.tileMode
+    });
+  }
+
+  /**
+   * Creates a new data object consisting of all profile-dependent preferences for the given table, according to its current state.
+   */
+  createProfile(table: Table, options?: CreateTablePreferenceProfileOptions): TableClientUiPreferenceProfileDo {
+    let columnPreferences = this.createColumnPreferences(table);
+    let userFilters = options?.includeUserFilters ? this.createUserFilterStates(table) : null;
+    let customizerData = this.createCustomizerData(table);
+
+    return scout.create(TableClientUiPreferenceProfileDo, {
+      columns: arrays.nullIfEmpty(columnPreferences) || undefined,
+      userFilters: arrays.nullIfEmpty(userFilters) || undefined,
+      tableCustomizerData: customizerData || undefined
+    });
+  }
+
+  /**
+   * Creates a list of new data objects consisting of the preferences for each column of the given table, according to their current state.
+   * The result is never `null`. Invisible columns are included, while `guiOnly` columns are ignored.
+   */
+  createColumnPreferences(table: Table): TableColumnClientUiPreferenceDo[] {
+    scout.assertParameter('table', table, Table);
+    return table.columns
+      .filter(column => !column.guiOnly)
+      .map((column, index) => {
+        return scout.create(TableColumnClientUiPreferenceDo, {
+          columnId: column.buildUuid(),
+          viewIndex: index,
+          visible: column.visibleIgnoreCompacted, // in compact mode, all columns would be invisible otherwise
+          width: column.width,
+          sortOrder: column.sortIndex,
+          sortAscending: column.sortAscending,
+          groupingActive: column.grouped,
+          aggregationFunctionId: column instanceof NumberColumn ? column.aggregationFunction : undefined,
+          backgroundEffectId: column instanceof NumberColumn ? column.backgroundEffect : undefined
+        });
+      });
+  }
+
+  /**
+   * Creates a list of new data objects consisting of the state of each {@link TableUserFilter} of the given table.
+   * The result is never `null`. Only user filters with a registered {@link UserFilterStateMapper} are returned.
+   */
+  createUserFilterStates(table: Table): IUserFilterStateDo[] {
+    scout.assertParameter('table', table, Table);
+    return table.filters
+      .filter(filter => filter instanceof TableUserFilter)
+      .map((filter: TableUserFilter) => {
+        for (let mapper of UserFilterStateMappers.all()) {
+          let filterState = mapper.tryToDo(table, filter);
+          if (filterState) {
+            return filterState;
+          }
+        }
+        scout.create(ErrorHandler, {displayError: false, sendError: true}).handle(`Unable to map filter to data object [table=${table.id}, filterType=${filter?.filterType}, filterLabel=${filter?.createLabel()}`);
+        return null;
+      })
+      .filter(Boolean);
+  }
+
+  /**
+   * If the table is customizable, returns the customizer data. Otherwise, `null` is returned.
+   */
+  createCustomizerData(table: Table): ITableCustomizerDo {
+    scout.assertParameter('table', table, Table);
+    return table.isCustomizable() ? table.customizer.getCustomizerData() : null;
+  }
+
+  // --------------------------------------
+
+  /**
+   * Stores the given profile under the given profileId in the table preferences of the given table.
+   */
+  storeProfile(table: Table, profileId: string, profile: TableClientUiPreferenceProfileDo) {
+    if (!profileId || !profile) {
+      return;
+    }
+
+    let prefs = this._getOrCreateTablePreferences(table);
+
+    // Check if store is necessary
+    let existingProfile = this.getProfile(prefs, profileId);
+    if (existingProfile) {
+      if (profile.equals(existingProfile)) {
+        // The new profile is identical to the already stored profile
+        return;
+      }
+    } else {
+      if (profileId === TableUiPreferences.PROFILE_ID_GLOBAL && profile.equals(table.initialUiPreferences)) {
+        // If the new profile is equal to the default state, it is not necessary to store it as the global profile.
+        // For other profileIds, we always want to store, because they are explicitly created by the user.
+        return;
+      }
+    }
+
+    prefs.tablePreferenceProfiles = prefs.tablePreferenceProfiles || new Map();
+    prefs.tablePreferenceProfiles.set(profileId, profile);
+    this._scheduleStore();
+  }
+
+  /**
+   * Renames a table preference profile and stores it.
+   */
+  renameProfile(table: Table, oldProfileId: string, newProfileId: string) {
+    if (!oldProfileId || !newProfileId || oldProfileId === newProfileId) {
+      return;
+    }
+
+    let prefs = this.get(table);
+    let profile = prefs?.tablePreferenceProfiles?.get(oldProfileId);
+    if (profile) {
+      prefs.tablePreferenceProfiles.set(newProfileId, profile);
+      prefs.tablePreferenceProfiles.delete(oldProfileId);
+      this._scheduleStore();
+    }
+  }
+
+  /**
+   * Removes the specified profile from the table preferences and stores it.
+   */
+  removeProfile(table: Table, profileId: string) {
+    if (!profileId) {
+      return;
+    }
+
+    let prefs = this.get(table);
+    let profile = prefs?.tablePreferenceProfiles?.get(profileId);
+    if (profile) {
+      prefs.tablePreferenceProfiles.delete(profileId);
+      this._scheduleStore();
+    }
+  }
+
+  /**
+   * Updates and stores the profile-independent table preferences to match the current state of the table.
+   */
+  store(table: Table) {
+    let prefs = this._getOrCreateTablePreferences(table);
+
+    if (this._storeTableTileMode(table, prefs)) {
+      this._scheduleStore();
+    }
+  }
+
+  protected _storeTableTileMode(table: Table, prefs: TableClientUiPreferencesDo): boolean {
+    if (prefs.tileMode !== table.tileMode) {
+      prefs.tileMode = table.tileMode;
+      return true;
+    }
+
+    return false; // nothing to do
+  }
+
+  /**
+   * Stores the current profile-dependent preferences of the given table in the {@link TableUiPreferences#PROFILE_ID_GLOBAL} profile.
+   */
+  storeGlobalProfile(table: Table) {
+    this.storeProfile(table, TableUiPreferences.PROFILE_ID_GLOBAL, this.createProfile(table));
+  }
+
+  /**
+   * Removes the {@link TableUiPreferences#PROFILE_ID_GLOBAL} profile for the given table.
+   */
+  clearGlobalProfile(table: Table) {
+    this.removeProfile(table, TableUiPreferences.PROFILE_ID_GLOBAL);
+  }
+
+  // --------------------------------------
+
+  /**
+   * Applies the given preferences to the given table, i.e. changes the table state to match the preferences. If a `profileId` is given
+   * and the table preferences contain a profile with that id, it is applied as well. Otherwise, only profile-independent preferences
+   * are applied.
+   */
+  apply(table: Table, prefs: TableClientUiPreferencesDo, profileId?: string, options?: ApplyTablePreferencesOptions) {
+    if (!prefs) {
+      return; // nothing to apply
+    }
+    scout.assertParameter('table', table, Table);
+
+    this._ignoreTableEvents = true;
+    try {
+      this._applyTablePreferencesInternal(table, prefs, options);
+
+      let profile = this.getProfile(prefs, profileId);
+      if (profile) {
+        this._applyTablePreferenceProfileInternal(table, profile, options);
+      }
+    } finally {
+      this._ignoreTableEvents = false;
+    }
+  }
+
+  /**
+   * Applies the given preference profile to the given table, i.e. changes the table state to match the profile.
+   */
+  applyProfile(table: Table, profile: TableClientUiPreferenceProfileDo, options?: ApplyTablePreferencesOptions) {
+    if (!profile) {
+      return; // nothing to apply
+    }
+    scout.assertParameter('table', table, Table);
+
+    this._ignoreTableEvents = true;
+    try {
+      this._applyTablePreferenceProfileInternal(table, profile, options);
+    } finally {
+      this._ignoreTableEvents = false;
+    }
+  }
+
+  protected _applyTablePreferencesInternal(table: Table, prefs: TableClientUiPreferencesDo, options?: ApplyTablePreferencesOptions) {
+    table.setTileMode(prefs.tileMode);
+  }
+
+  protected _applyTablePreferenceProfileInternal(table: Table, profile: TableClientUiPreferenceProfileDo, options?: ApplyTablePreferencesOptions) {
+    // Order is important! Applying column preferences requires custom columns to be injected first
+    this._applyCustomizerData(table, profile.tableCustomizerData, options);
+    this._applyColumnPreferences(table, profile.columns, options);
+    this._applyUserFilterStates(table, profile.userFilters, options);
+  }
+
+  protected _applyCustomizerData(table: Table, customizerData: ITableCustomizerDo, options?: ApplyTablePreferencesOptions) {
+    if (table.isCustomizable()) {
+      table.customizer.setCustomizerData(customizerData);
+    }
+  }
+
+  protected _applyColumnPreferences(table: Table, columnPreferences: TableColumnClientUiPreferenceDo[], options?: ApplyTablePreferencesOptions) {
+    let columnPreferencesMap = new Map(arrays.ensure(columnPreferences).map(pref => [pref.columnId, pref]));
+
+    // Sort existing columns according to the order specified in the preferences
+    let newColumns = table.columns
+      .filter(c => !c.guiOnly) // will be recreated by _setColumns
+      .sort((c1, c2) => { // reorder
+        let viewIndex1 = columnPreferencesMap.get(c1.buildUuid())?.viewIndex ?? Infinity;
+        let viewIndex2 = columnPreferencesMap.get(c2.buildUuid())?.viewIndex ?? Infinity;
+        return viewIndex1 - viewIndex2;
+      });
+    // Apply preferences to existing columns. Columns without corresponding entry in the preferences are left
+    // untouched, while preference entries without corresponding column are simply ignored.
+    newColumns.forEach(column => this._applyColumnPreferencesToColumn(column, columnPreferencesMap.get(column.buildUuid())));
+
+    table.setColumns(newColumns);
+  }
+
+  protected _applyColumnPreferencesToColumn(column: Column<any>, columnPreferences: TableColumnClientUiPreferenceDo) {
+    if (!columnPreferences) {
+      return; // can happen if preferences are applied before the customizer is installed or if preferences contains obsolete data
+    }
+
+    // Use setter for 'visible' property because it is a multidimensional property
+    column.setVisible(columnPreferences.visible, false); // parameter 'false' skips call of onColumnVisibilityChanged()
+
+    // Don't use setter for 'width' property to prevent unnecessarily redrawing the table (will be done again later in setColumns anyway)
+    column.width = columnPreferences.width;
+
+    // Properties without setter (changes will be applied later by _setColumns)
+    column.sortIndex = columnPreferences.sortOrder;
+    column.sortAscending = columnPreferences.sortAscending;
+    column.sortActive = column.sortIndex >= 0;
+    column.grouped = columnPreferences.groupingActive;
+
+    if (column instanceof NumberColumn) {
+      // Use setters to correctly update internal structures (e.g. aggrStart function)
+      column.setAggregationFunction(columnPreferences.aggregationFunctionId as NumberColumnAggregationFunction);
+      column.setBackgroundEffect(columnPreferences.backgroundEffectId as NumberColumnBackgroundEffect);
+    }
+  }
+
+  protected _applyUserFilterStates(table: Table, userFilterStates: IUserFilterStateDo[], options?: ApplyTablePreferencesOptions) {
+    if (options?.applyUserFilters) { // true when showing a bookmark
+      table.applyUserFilterStates(userFilterStates);
+    }
+  }
+}
+
+// --------------------------------------
+
+export interface CreateTablePreferenceProfileOptions {
+  /**
+   * Specifies whether to include the state of user filters ({@link IUserFilterStateDo}) in the preference profile. Default is `false`.
+   */
+  includeUserFilters: boolean;
+}
+
+export interface ApplyTablePreferencesOptions {
+  /**
+   * Specifies whether to apply user filter states from the preference profile to the table. Default is `false`.
+   */
+  applyUserFilters?: boolean;
+}
+
+// --------------------------------------
+
+export const tableUiPreferences = objects.createSingletonProxy(TableUiPreferences);
+
+UiPreferences.registerHandler(TableUiPreferences, {
+  importPreferences: preferences => {
+    tableUiPreferences._importTablePreferences(preferences.tablePreferences);
+  },
+  exportPreferences: preferences => {
+    preferences.tablePreferences = tableUiPreferences._exportTablePreferences();
+  }
+});

--- a/eclipse-scout-core/src/prefs/UiPreferences.ts
+++ b/eclipse-scout-core/src/prefs/UiPreferences.ts
@@ -7,45 +7,65 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {
-  arrays, ErrorHandler, Event, ITableCustomizerDo, IUserFilterStateDo, NumberColumn, objects, ObjectWithType, PropertyChangeEvent, scout, strings, Table, TableClientUiPreferenceProfileDo, TableClientUiPreferencesDo,
-  TableColumnClientUiPreferenceDo, TableUserFilter, UiPreferencesDo, UiPreferencesStore, UiPreferencesUpdateDo, UserFilterStateMappers
-} from '../index';
+import {ErrorHandler, objects, ObjectWithType, scout, UiPreferencesDo, UiPreferencesStore, UiPreferencesUpdateDo} from '../index';
 import $ from 'jquery';
 
+let handlers = new Map<UiPreferencesHandlerId, UiPreferencesHandler>();
+
 /**
- * A singleton that represents all UI preferences of the current user. It is populated during the start of the application,
- * so the preferences can be accessed synchronously.
+ * A singleton that loads and stores all UI preferences for the current user. It is populated during the start of the
+ * application, so the preferences data can be accessed synchronously. After the data is loaded, it is passed to
+ * all registered {@link UiPreferencesHandler}s to handle component-specific parts the preferences data.
  */
 export class UiPreferences implements ObjectWithType {
 
   /**
-   * Key for the current global preferences of a table, i.e. preferences that are not stored in a specific settings profile.
+   * Registers a new handler to receive and provide parts of the global {@link UiPreferencesDo} object. Any value can
+   * be used as the ID, as long it is the same that is later used to call {@link UiPreferences.scheduleStore}.
+   *
+   * If the given arguments are missing or if there is already a handler registered for the same ID, an error is thrown.
    */
-  static TABLE_PREFERENCE_PROFILE_ID_GLOBAL = 'global-' + 'a134390b-bfef-4b9e-a14e-425df161e768';
+  static registerHandler(handlerId: UiPreferencesHandlerId, handler: UiPreferencesHandler) {
+    scout.assertParameter('handlerId', handlerId);
+    scout.assertParameter('handler', handler);
+    if (handlers.has(handlerId)) {
+      throw new Error('Already registered'); // prevent re-registration
+    }
+    handlers.set(handlerId, handler);
+  }
 
   /**
-   * Special key used to store table settings of a bookmarked table page. The bookmark support will consider this state as
-   * the "factory settings" when the page is displayed in the bookmark outline.
+   * Unregisters the previously registered {@link UiPreferencesHandler}. Normally, this only has to be done to replace
+   * and registered handlers with a different instance for the same ID.
    */
-  static TABLE_PREFERENCE_PROFILE_ID_BOOKMARK = 'bookmark-' + 'aebcacd2-ddb6-4b7f-8673-d1585701d388';
+  static unregisterHandler(handlerId: UiPreferencesHandlerId): boolean {
+    return handlers.delete(handlerId);
+  }
+
+  /**
+   * Returns all registered {@link UiPreferencesHandler}s.
+   */
+  static getHandlers(): UiPreferencesHandler[] {
+    return [...handlers.values()];
+  }
+
+  /**
+   * Returns the {@link UiPreferencesHandler} for the given ID, or `null` if not such handler was registered.
+   */
+  static getHandler(handlerId: UiPreferencesHandlerId): UiPreferencesHandler {
+    return handlers.get(handlerId) ?? null;
+  }
+
+  // --------------------------------------
 
   objectType: string;
 
   protected _store: UiPreferencesStore;
   protected _storeTimeoutId = 0;
-  protected _storeDelay = 0;
+  protected _modifiedHandlers = new Set<UiPreferencesHandler>();
 
-  /** All loaded preferences */
+  /** Loaded preferences data (never `null`) */
   protected _preferences: UiPreferencesDo;
-
-  /** Map of all table preferences in {@link _preferences}, indexed by table identifier (see {@link _computeTablePreferencesKey}). */
-  protected _tablePreferencesMap: Map<string, TableClientUiPreferencesDo>;
-  /** If > 0, table events are ignored. Useful when applying preferences. */
-  protected _ignoreTableEventsCounter = 0;
-
-  protected _tableColumnListener = this._onTableColumnEvent.bind(this);
-  protected _tableTileModeListener = this._onTableTileModeChange.bind(this);
 
   // --------------------------------------
 
@@ -92,14 +112,21 @@ export class UiPreferences implements ObjectWithType {
    * Writes the current state of this singleton object to the {@link UiPreferencesStore}.
    */
   store(): JQuery.Promise<void> {
+    this._processModifiedHandlers();
     return this._store.store(this._preferences);
   }
 
   /**
    * Schedules a task to call {@link store}. This method is to be called whenever a preference has been changed.
    * By scheduling a task rather than storing immediately, we can coalesce multiple store requests into a single one.
+   *
+   * The given argument specifies which {@link UiPreferencesHandler} has been modified. Before the data is actually
+   * stored, all modified handlers will be called back to update the global {@link UiPreferencesDo} object. If this
+   * method is called without argument, _all_ registered handlers are marked as modified.
    */
-  scheduleStore() {
+  scheduleStore(modifiedHandlerId?: UiPreferencesHandlerId) {
+    this._markHandlerAsModified(modifiedHandlerId);
+
     clearTimeout(this._storeTimeoutId);
     this._storeTimeoutId = setTimeout(() => {
       this.store()
@@ -107,7 +134,30 @@ export class UiPreferences implements ObjectWithType {
           // Unable to store UI preferences -> log silently
           scout.create(ErrorHandler, {displayError: false, sendError: true}).handle(error);
         });
-    }, this._storeDelay);
+    });
+  }
+
+  /**
+   * Marks the given handler as modified, i.e. the handler's export method will be called before the preferences
+   * data is stored. If no handler is specified, _all_ handlers are marked as modified.
+   */
+  protected _markHandlerAsModified(handlerId?: UiPreferencesHandlerId) {
+    if (handlerId) {
+      let handler = UiPreferences.getHandler(handlerId);
+      if (handler) {
+        this._modifiedHandlers.add(handler);
+      }
+    } else {
+      UiPreferences.getHandlers().forEach(handler => this._modifiedHandlers.add(handler));
+    }
+  }
+
+  /**
+   * Processes the list of modified handlers, i.e. calls each handler's export method. After that, the list is reset.
+   */
+  protected _processModifiedHandlers() {
+    this._modifiedHandlers.forEach(handler => handler.exportPreferences(this._preferences));
+    this._modifiedHandlers.clear();
   }
 
   protected _subscribeForUpdates(): JQuery.Promise<void> {
@@ -120,371 +170,29 @@ export class UiPreferences implements ObjectWithType {
 
   protected _initPreferences(preferences: UiPreferencesDo) {
     this._preferences = preferences || scout.create(UiPreferencesDo); // never null
-    this._initTablePreferences();
-  }
-
-  protected get _ignoreTableEvents(): boolean {
-    return this._ignoreTableEventsCounter > 0;
-  }
-
-  protected set _ignoreTableEvents(applyingTablePreferences: boolean) {
-    if (applyingTablePreferences) {
-      this._ignoreTableEventsCounter++;
-    } else {
-      this._ignoreTableEventsCounter = Math.max(0, this._ignoreTableEventsCounter - 1);
-    }
-  }
-
-  // --------------------------------------
-
-  protected _initTablePreferences() {
-    this._tablePreferencesMap = new Map();
-    this._preferences?.tablePreferences?.forEach(tablePrefs => {
-      let tableId = tablePrefs.tableId;
-      let userPreferenceContext = tablePrefs.userPreferenceContext;
-      let key = this._computeTablePreferencesKey(tableId, userPreferenceContext);
-      this._tablePreferencesMap.set(key, tablePrefs);
-    });
-  }
-
-  protected _computeTablePreferencesKey(tableId: string, userPreferenceContext: string): string {
-    return strings.join('#', tableId, userPreferenceContext);
-  }
-
-  // --------------------------------------
-
-  /**
-   * Returns the preferences for the given table, or `null` if no preferences are registered yet.
-   */
-  getTablePreferences(table: Table): TableClientUiPreferencesDo {
-    scout.assertParameter('table', table, Table);
-    let tableId = table.buildUuidPath();
-    let userPreferenceContext = table.userPreferenceContext;
-    let key = this._computeTablePreferencesKey(tableId, userPreferenceContext);
-
-    return this._tablePreferencesMap.get(key);
-  }
-
-  /**
-   * Returns the preferences for the given table. If no preferences are registered yet, a new empty
-   * preferences data object is created and stored.
-   */
-  getOrCreateTablePreferences(table: Table): TableClientUiPreferencesDo {
-    scout.assertParameter('table', table, Table);
-    let tableId = table.buildUuidPath();
-    let userPreferenceContext = table.userPreferenceContext;
-    let key = this._computeTablePreferencesKey(tableId, userPreferenceContext);
-
-    let prefs = this._tablePreferencesMap.get(key);
-    if (!prefs) {
-      prefs = this.createTablePreferences(table);
-      this._preferences.tablePreferences = this._preferences.tablePreferences || [];
-      this._preferences.tablePreferences.push(prefs);
-      this._tablePreferencesMap.set(key, prefs);
-      this.scheduleStore();
-    }
-    return prefs;
-  }
-
-  /**
-   * Returns the profile with the given id from the given table preferences. If no such profile exists, `undefined` is returned.
-   */
-  getTablePreferenceProfile(prefs: TableClientUiPreferencesDo, profileId: string): TableClientUiPreferenceProfileDo {
-    return prefs?.tablePreferenceProfiles?.get(profileId);
-  }
-
-  /**
-   * Creates a new data object consisting of all profile-independent preferences for the given table, according to its current state.
-   *
-   * Note: the `tablePreferences` map is *not* set automatically.
-   */
-  createTablePreferences(table: Table): TableClientUiPreferencesDo {
-    scout.assertParameter('table', table, Table);
-    return scout.create(TableClientUiPreferencesDo, {
-      tableId: table.buildUuidPath(),
-      userPreferenceContext: table.userPreferenceContext,
-      tileMode: table.tileMode
-    });
-  }
-
-  /**
-   * Creates a new data object consisting of all profile-dependent preferences for the given table, according to its current state.
-   */
-  createTablePreferenceProfile(table: Table, options?: CreateTablePreferenceProfileOptions): TableClientUiPreferenceProfileDo {
-    let columnPreferences = this.createTableColumnPreferences(table);
-    let userFilters = options?.includeUserFilters ? this.createTableUserFilterStates(table) : null;
-    let customizerData = this.createTableCustomizerData(table);
-
-    return scout.create(TableClientUiPreferenceProfileDo, {
-      columns: arrays.nullIfEmpty(columnPreferences) || undefined,
-      userFilters: arrays.nullIfEmpty(userFilters) || undefined,
-      tableCustomizerData: customizerData || undefined
-    });
-  }
-
-  /**
-   * Creates a list of new data objects consisting of the preferences for each column of the given table, according to their current state.
-   * The result is never `null`. Invisible columns are included, while `guiOnly` columns are ignored.
-   */
-  createTableColumnPreferences(table: Table): TableColumnClientUiPreferenceDo[] {
-    scout.assertParameter('table', table, Table);
-    return table.columns
-      .filter(column => !column.guiOnly)
-      .map((column, index) => {
-        return scout.create(TableColumnClientUiPreferenceDo, {
-          columnId: column.buildUuid(),
-          viewIndex: index,
-          visible: column.visibleIgnoreCompacted, // in compact mode, all columns would be invisible otherwise
-          width: column.width,
-          sortOrder: column.sortIndex,
-          sortAscending: column.sortAscending,
-          groupingActive: column.grouped,
-          aggregationFunctionId: column instanceof NumberColumn ? column.aggregationFunction : undefined,
-          backgroundEffectId: column instanceof NumberColumn ? column.backgroundEffect : undefined
-        });
-      });
-  }
-
-  /**
-   * Creates a list of new data objects consisting of the state of each {@link TableUserFilter} of the given table.
-   * The result is never `null`. Only user filters with a registered {@link UserFilterStateMapper} are returned.
-   */
-  createTableUserFilterStates(table: Table): IUserFilterStateDo[] {
-    scout.assertParameter('table', table, Table);
-    return table.filters
-      .filter(filter => filter instanceof TableUserFilter)
-      .map((filter: TableUserFilter) => {
-        for (let mapper of UserFilterStateMappers.all()) {
-          let filterState = mapper.tryToDo(table, filter);
-          if (filterState) {
-            return filterState;
-          }
-        }
-        scout.create(ErrorHandler, {displayError: false, sendError: true}).handle(`Unable to map filter to data object [table=${table.id}, filterType=${filter?.filterType}, filterLabel=${filter?.createLabel()}`);
-        return null;
-      })
-      .filter(Boolean);
-  }
-
-  /**
-   * If the table is customizable, returns the customizer data. Otherwise, `null` is returned.
-   */
-  createTableCustomizerData(table: Table): ITableCustomizerDo {
-    scout.assertParameter('table', table, Table);
-    return table.isCustomizable() ? table.customizer.getCustomizerData() : null;
-  }
-
-  // --------------------------------------
-
-  /**
-   * Installs a table listener for all preference-related changes and stores them in the {@link UiPreferences#TABLE_PREFERENCE_PROFILE_ID_GLOBAL} profile for that table.
-   */
-  installTableListener(table: Table) {
-    scout.assertParameter('table', table, Table);
-    this.uninstallTableListener(table);
-    table.on('columnMoved columnResized columnStructureChanged group sort aggregationFunctionChanged columnBackgroundEffectChanged', this._tableColumnListener);
-    table.on('propertyChange:tileMode', this._tableTileModeListener);
-  }
-
-  /**
-   * Uninstalls the listener installed by {@link installTableListener}.
-   */
-  uninstallTableListener(table: Table) {
-    scout.assertParameter('table', table, Table);
-    table.off('columnMoved columnResized columnStructureChanged group sort aggregationFunctionChanged columnBackgroundEffectChanged', this._tableColumnListener);
-    table.off('propertyChange:tileMode', this._tableTileModeListener);
-  }
-
-  protected _onTableColumnEvent(event: Event<Table>) {
-    if (this._ignoreTableEvents) {
-      return;
-    }
-    // FIXME bsh [js-bookmark] Find a better solution. It would convenient if there was a 'columnResizeEnd' event that is only triggered if the user has finished changing the size.
-    let oldStoreDelay = this._storeDelay;
-    if (event.type === 'columnResized') {
-      this._storeDelay = 750; // same delay as in TableAdapter#_sendColumnResized
-    }
-    try {
-      this.storeGlobalTablePreferenceProfile(event.source);
-    } finally {
-      this._storeDelay = oldStoreDelay;
-    }
-  }
-
-  protected _onTableTileModeChange(event: PropertyChangeEvent<boolean, Table>) {
-    if (this._ignoreTableEvents) {
-      return;
-    }
-    this.storeTablePreferences(event.source);
-  }
-
-  // --------------------------------------
-
-  /**
-   * Applies the given preferences to the given table, i.e. changes the table state to match the preferences. If a `profileId` is given
-   * and the table preferences contain a profile with that id, it is applied as well. Otherwise, only profile-independent preferences
-   * are applied.
-   */
-  applyTablePreferences(table: Table, prefs: TableClientUiPreferencesDo, profileId?: string, options?: ApplyTablePreferencesOptions) {
-    if (!prefs) {
-      return; // nothing to apply
-    }
-    scout.assertParameter('table', table, Table);
-
-    this._ignoreTableEvents = true;
-    try {
-      this._applyTablePreferencesInternal(table, prefs, options);
-
-      let profile = this.getTablePreferenceProfile(prefs, profileId);
-      if (profile) {
-        this._applyTablePreferenceProfileInternal(table, profile, options);
-      }
-    } finally {
-      this._ignoreTableEvents = false;
-    }
-  }
-
-  /**
-   * Applies the given preference profile to the given table, i.e. changes the table state to match the profile.
-   */
-  applyTablePreferenceProfile(table: Table, profile: TableClientUiPreferenceProfileDo, options?: ApplyTablePreferencesOptions) {
-    if (!profile) {
-      return; // nothing to apply
-    }
-    scout.assertParameter('table', table, Table);
-
-    this._ignoreTableEvents = true;
-    try {
-      this._applyTablePreferenceProfileInternal(table, profile, options);
-    } finally {
-      this._ignoreTableEvents = false;
-    }
-  }
-
-  protected _applyTablePreferencesInternal(table: Table, prefs: TableClientUiPreferencesDo, options?: ApplyTablePreferencesOptions) {
-    table.setTileMode(prefs.tileMode);
-  }
-
-  protected _applyTablePreferenceProfileInternal(table: Table, profile: TableClientUiPreferenceProfileDo, options?: ApplyTablePreferencesOptions) {
-    // Order is important! Applying column preferences requires custom columns to be injected first
-    if (table.isCustomizable()) {
-      table.customizer.setCustomizerData(profile.tableCustomizerData);
-    }
-
-    table.applyColumnPreferences(profile.columns);
-
-    if (options?.applyUserFilters) { // true when showing a bookmark
-      table.applyUserFilterStates(profile.userFilters);
-    }
-  }
-
-  // --------------------------------------
-
-  /**
-   * Stores the given profile under the given profileId in the table preferences of the given table.
-   */
-  storeTablePreferenceProfile(table: Table, profileId: string, profile: TableClientUiPreferenceProfileDo) {
-    if (!profileId || !profile) {
-      return;
-    }
-
-    let prefs = this.getOrCreateTablePreferences(table);
-    let existingProfile = this.getTablePreferenceProfile(prefs, profileId);
-    if (existingProfile) {
-      if (profile.equals(existingProfile)) {
-        return; // nothing to do (the new profile is the same as the already stored profile)
-      }
-    } else {
-      if (profile.equals(table.initialUiPreferences)) {
-        return; // nothing to do (no old profile exists and the new profile is equal to the default state)
-      }
-    }
-
-    prefs.tablePreferenceProfiles = prefs.tablePreferenceProfiles || new Map();
-    prefs.tablePreferenceProfiles.set(profileId, profile);
-    this.scheduleStore();
-  }
-
-  /**
-   * Renames a table preference profile and stores it.
-   */
-  renameTablePreferenceProfile(table: Table, oldProfileId: string, newProfileId: string) {
-    if (!oldProfileId || !newProfileId || oldProfileId === newProfileId) {
-      return;
-    }
-
-    let prefs = this.getTablePreferences(table);
-    let profile = prefs?.tablePreferenceProfiles?.get(oldProfileId);
-    if (profile) {
-      prefs.tablePreferenceProfiles.set(newProfileId, profile);
-      prefs.tablePreferenceProfiles.delete(oldProfileId);
-      this.scheduleStore();
-    }
-  }
-
-  /**
-   * Removes the specified profile from the table preferences and stores it.
-   */
-  removeTablePreferenceProfile(table: Table, profileId: string) {
-    if (!profileId) {
-      return;
-    }
-
-    let prefs = this.getTablePreferences(table);
-    let profile = prefs?.tablePreferenceProfiles?.get(profileId);
-    if (profile) {
-      prefs.tablePreferenceProfiles.delete(profileId);
-      this.scheduleStore();
-    }
-  }
-
-  /**
-   * Stores the profile-independent table preferences to match the current state of the table.
-   */
-  storeTablePreferences(table: Table) {
-    let prefs = this.getOrCreateTablePreferences(table);
-
-    if (this._storeTableTileMode(table, prefs)) {
-      this.scheduleStore();
-    }
-  }
-
-  protected _storeTableTileMode(table: Table, prefs: TableClientUiPreferencesDo): boolean {
-    if (prefs.tileMode !== table.tileMode) {
-      prefs.tileMode = table.tileMode;
-      return true;
-    }
-
-    return false; // nothing to do
-  }
-
-  /**
-   * Stores the current profile-dependent preferences of the given table in the {@link UiPreferences#TABLE_PREFERENCE_PROFILE_ID_GLOBAL} profile.
-   */
-  storeGlobalTablePreferenceProfile(table: Table) {
-    this.storeTablePreferenceProfile(table, UiPreferences.TABLE_PREFERENCE_PROFILE_ID_GLOBAL, this.createTablePreferenceProfile(table));
-  }
-
-  /**
-   * Removes the {@link UiPreferences#TABLE_PREFERENCE_PROFILE_ID_GLOBAL} profile for the given table.
-   */
-  clearGlobalTablePreferenceProfile(table: Table) {
-    this.removeTablePreferenceProfile(table, UiPreferences.TABLE_PREFERENCE_PROFILE_ID_GLOBAL);
+    UiPreferences.getHandlers().forEach(handler => handler.importPreferences(this._preferences));
   }
 }
 
 export const uiPreferences = objects.createSingletonProxy(UiPreferences);
 
-export interface CreateTablePreferenceProfileOptions {
+/**
+ * An ID that identifiers a registered {@link UiPreferencesHandler}. Any value is allowed, as long as it is unique
+ * (no two handlers can share the same ID) and the same value is used when calling {@link UiPreferences.scheduleStore}.
+ */
+export type UiPreferencesHandlerId = any;
+
+/**
+ * A small object that can extract and update parts of the global {@link UiPreferencesDo} object.
+ */
+export interface UiPreferencesHandler {
   /**
-   * Specifies whether to include the state of user filters ({@link IUserFilterStateDo}) in the preference profile. Default is `false`.
+   * Extracts component-specific parts of the global {@link UiPreferencesDo} object into internal data structures.
    */
-  includeUserFilters: boolean;
+  importPreferences: (preferences: UiPreferencesDo) => void;
+  /**
+   * Updates the component-specific parts of the given {@link UiPreferencesDo} object from the internal data structures.
+   */
+  exportPreferences: (preferences: UiPreferencesDo) => void;
 }
 
-export interface ApplyTablePreferencesOptions {
-  /**
-   * Specifies whether to apply user filter states from the preference profile to the table. Default is `false`.
-   */
-  applyUserFilters?: boolean;
-}

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -12,11 +12,11 @@ import {
   ContextMenuPopup, dataObjects, DefaultTableAccessibilityRenderer, Desktop, DesktopPopupOpenEvent, Device, DisplayViewId, DoubleClickSupport, dragAndDrop, DragAndDropHandler, DropType, EnumObject, ErrorHandler, EventHandler, Filter,
   Filterable, FilterOrFunction, FilterResult, FilterSupport, FullModelOf, graphics, HierarchicalTableAccessibilityRenderer, HtmlComponent, IconColumn, InitModelOf, Insets, IUserFilterStateDo, keys, KeyStrokeContext,
   LimitedResultTableStatus, LoadingSupport, Menu, MenuBar, MenuDestinations, MenuItemsOrder, menus as menuUtil, menus, NumberColumn, NumberColumnAggregationFunction, NumberColumnBackgroundEffect, ObjectOrChildModel, ObjectOrModel, objects,
-  Predicate, PropertyChangeEvent, Range, scout, scrollbars, ScrollToOptions, Status, StatusOrModel, strings, styles, TableClientUiPreferenceProfileDo, TableColumnClientUiPreferenceDo, TableCompactHandler, TableControl, TableCopyKeyStroke,
-  TableCustomizer, TableEventMap, TableFooter, TableHeader, TableLayout, TableModel, TableNavigationCollapseKeyStroke, TableNavigationDownKeyStroke, TableNavigationEndKeyStroke, TableNavigationExpandKeyStroke, TableNavigationHomeKeyStroke,
+  Predicate, PropertyChangeEvent, Range, scout, scrollbars, ScrollToOptions, Status, StatusOrModel, strings, styles, TableClientUiPreferenceProfileDo, TableCompactHandler, TableControl, TableCopyKeyStroke, TableCustomizer, TableEventMap,
+  TableFooter, TableHeader, TableLayout, TableModel, TableNavigationCollapseKeyStroke, TableNavigationDownKeyStroke, TableNavigationEndKeyStroke, TableNavigationExpandKeyStroke, TableNavigationHomeKeyStroke,
   TableNavigationPageDownKeyStroke, TableNavigationPageUpKeyStroke, TableNavigationUpKeyStroke, TableOrganizer, TableRefreshKeyStroke, TableRow, TableRowModel, TableSelectAllKeyStroke, TableSelectionHandler, TableStartCellEditKeyStroke,
-  TableTextUserFilter, TableTileGridMediator, TableToggleRowKeyStroke, TableTooltip, TableUpdateBuffer, TableUserFilter, TableUserFilterModel, Tile, TileTableHeaderBox, tooltips, TooltipSupport, UiPreferences, uiPreferences,
-  UpdateFilteredElementsOptions, UserFilterStateMappers, ValueField, Widget
+  TableTextUserFilter, TableTileGridMediator, TableToggleRowKeyStroke, TableTooltip, TableUiPreferences, tableUiPreferences, TableUpdateBuffer, TableUserFilter, TableUserFilterModel, Tile, TileTableHeaderBox, tooltips, TooltipSupport,
+  UiPreferences, UpdateFilteredElementsOptions, UserFilterStateMappers, ValueField, Widget
 } from '../index';
 import $ from 'jquery';
 
@@ -6569,21 +6569,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
 
   protected _setUiPreferencesEnabled(uiPreferencesEnabled: boolean) {
     this._setProperty('uiPreferencesEnabled', uiPreferencesEnabled);
-    if (uiPreferencesEnabled) {
-      // Save current state as "factory defaults". User filters are not included.
-      this.setInitialUiPreferences(uiPreferences.createTablePreferenceProfile(this));
-
-      // If there is a stored GLOBAL profile, apply it now
-      let prefs = uiPreferences.getTablePreferences(this);
-      uiPreferences.applyTablePreferences(this, prefs, UiPreferences.TABLE_PREFERENCE_PROFILE_ID_GLOBAL);
-
-      // Install a table listener that stores all changes into the GLOBAL profile.
-      // This is only done _after_ applying the initial state, so that no events were triggered.
-      uiPreferences.installTableListener(this);
-    } else {
-      // Uninstall listener
-      uiPreferences.uninstallTableListener(this);
-    }
+    tableUiPreferences.updateUiPreferencesEnabled(this);
   }
 
   setInitialUiPreferences(initialUiPreferences: TableClientUiPreferenceProfileDo) {
@@ -6595,60 +6581,16 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   }
 
   /**
-   * Applies the {@link initialUiPreferences} and clears the stored {@link UiPreferences#TABLE_PREFERENCE_PROFILE_ID_GLOBAL} profile.
+   * Applies the {@link initialUiPreferences} and clears the stored {@link TableUiPreferences#PROFILE_ID_GLOBAL} profile.
    * If the initial ui preferences were not previously set, this method has no effect.
    */
   resetToInitialUiPreferences() {
     if (!this._initialUiPreferences) {
       return;
     }
-    uiPreferences.applyTablePreferenceProfile(this, this._initialUiPreferences, {
-      applyUserFilters: true
-    });
+    tableUiPreferences.applyProfile(this, this._initialUiPreferences, {applyUserFilters: true});
     if (this.uiPreferencesEnabled) {
-      uiPreferences.clearGlobalTablePreferenceProfile(this);
-    }
-  }
-
-  applyColumnPreferences(columnPreferences: TableColumnClientUiPreferenceDo[]) {
-    let columnPreferencesMap = new Map(arrays.ensure(columnPreferences).map(pref => [pref.columnId, pref]));
-
-    // Sort existing columns according to the order specified in the preferences
-    let newColumns = this.columns
-      .filter(c => !c.guiOnly) // will be recreated by _setColumns
-      .sort((c1, c2) => { // reorder
-        let viewIndex1 = columnPreferencesMap.get(c1.buildUuid())?.viewIndex ?? Infinity;
-        let viewIndex2 = columnPreferencesMap.get(c2.buildUuid())?.viewIndex ?? Infinity;
-        return viewIndex1 - viewIndex2;
-      });
-    // Apply preferences to existing columns. Columns without corresponding entry in the preferences are left
-    // untouched, while preference entries without corresponding column are simply ignored.
-    newColumns.forEach(column => this._applyColumnPreferencesToColumn(column, columnPreferencesMap.get(column.buildUuid())));
-
-    this.setColumns(newColumns);
-  }
-
-  protected _applyColumnPreferencesToColumn(column: Column<any>, columnPreferences: TableColumnClientUiPreferenceDo) {
-    if (!columnPreferences) {
-      return; // can happen if preferences are applied before the customizer is installed or if preferences contains obsolete data
-    }
-
-    // Use setter for 'visible' property because it is a multidimensional property
-    column.setVisible(columnPreferences.visible, false); // parameter 'false' skips call of onColumnVisibilityChanged()
-
-    // Don't use setter for 'width' property to prevent unnecessarily redrawing the table (will be done again later in setColumns anyway)
-    column.width = columnPreferences.width;
-
-    // Properties without setter (changes will be applied later by _setColumns)
-    column.sortIndex = columnPreferences.sortOrder;
-    column.sortAscending = columnPreferences.sortAscending;
-    column.sortActive = column.sortIndex >= 0;
-    column.grouped = columnPreferences.groupingActive;
-
-    if (column instanceof NumberColumn) {
-      // Use setters to correctly update internal structures (e.g. aggrStart function)
-      column.setAggregationFunction(columnPreferences.aggregationFunctionId as NumberColumnAggregationFunction);
-      column.setBackgroundEffect(columnPreferences.backgroundEffectId as NumberColumnBackgroundEffect);
+      tableUiPreferences.clearGlobalProfile(this);
     }
   }
 

--- a/eclipse-scout-core/src/table/TableModel.ts
+++ b/eclipse-scout-core/src/table/TableModel.ts
@@ -294,7 +294,7 @@ export interface TableModel extends WidgetModel {
    */
   userPreferenceContext?: string;
   /**
-   * Specifies whether some UI changes made by the user (e.g. order or width of columns) are stored and re-applied later.
+   * Specifies whether certain UI changes made by the user (e.g. order or width of columns) are stored and re-applied later.
    * The default is `false`.
    *
    * **Important:** To ensure that the saved preferences are assigned to the correct table again, it is important that

--- a/eclipse-scout-core/src/table/organizer/TableOrganizerForm.ts
+++ b/eclipse-scout-core/src/table/organizer/TableOrganizerForm.ts
@@ -9,7 +9,7 @@
  */
 import {
   Action, arrays, Cell, Column, Event, Form, InitModelOf, MoveTableRowMenuHelper, scout, ShowInvisibleColumnsForm, StringField, strings, Table, TableCompleteCellEditEvent, TableOrganizerFormWidgetMap, TableRow, TableRowModel,
-  TableRowsSelectedEvent, TableStartCellEditEvent, UiPreferences, uiPreferences, WidgetModel
+  TableRowsSelectedEvent, TableStartCellEditEvent, tableUiPreferences, TableUiPreferences, WidgetModel
 } from '../../index';
 import TableOrganizerFormModel, {ColumnsTable0, ProfilesTable} from './TableOrganizerFormModel';
 
@@ -49,7 +49,7 @@ export class TableOrganizerForm extends Form {
     this._installColumnUpDownMenus();
 
     // Pages in a bookmark outline should only have one profile (the one stored in the bookmark) -> disable menu to create new profiles
-    if (strings.startsWith(this.table.userPreferenceContext, `${UiPreferences.TABLE_PREFERENCE_PROFILE_ID_BOOKMARK}:`)) {
+    if (strings.startsWith(this.table.userPreferenceContext, `${TableUiPreferences.PROFILE_ID_BOOKMARK}:`)) {
       this.widget('NewConfigMenu').setEnabled(false);
     }
   }
@@ -65,10 +65,10 @@ export class TableOrganizerForm extends Form {
     const rows: TableRowModel[] = [{cells: [this.session.text('DefaultSettings'), true]}];
 
     // Create a row for each preference profile, except the GLOBAL profile (this represents the current state and cannot be activated explicitly)
-    let prefs = uiPreferences.getTablePreferences(this.table);
-    if (prefs && prefs.tablePreferenceProfiles) {
+    let prefs = tableUiPreferences.get(this.table);
+    if (prefs?.tablePreferenceProfiles) {
       [...prefs.tablePreferenceProfiles.keys()]
-        .filter(key => key !== UiPreferences.TABLE_PREFERENCE_PROFILE_ID_GLOBAL)
+        .filter(key => key !== TableUiPreferences.PROFILE_ID_GLOBAL)
         .forEach(key => rows.push({cells: [key]}));
     }
 
@@ -92,7 +92,7 @@ export class TableOrganizerForm extends Form {
 
     let oldConfigName = this.profilesTable.columnById('ConfigNameColumn').cellValue(event.row);
     let newConfigName = event.field.value;
-    uiPreferences.renameTablePreferenceProfile(this.table, oldConfigName, newConfigName);
+    tableUiPreferences.renameProfile(this.table, oldConfigName, newConfigName);
   }
 
   protected _updateProfileMenus() {
@@ -105,8 +105,8 @@ export class TableOrganizerForm extends Form {
   protected _addNewConfig() {
     let configName = this._newConfigName();
 
-    let profile = uiPreferences.createTablePreferenceProfile(this.table, {includeUserFilters: true});
-    uiPreferences.storeTablePreferenceProfile(this.table, configName, profile);
+    let profile = tableUiPreferences.createProfile(this.table, {includeUserFilters: true});
+    tableUiPreferences.storeProfile(this.table, configName, profile);
 
     let row = scout.create(TableRow, {parent: this.profilesTable});
     this.profilesTable.columnById('ConfigNameColumn').setCellValue(row, configName);
@@ -133,11 +133,11 @@ export class TableOrganizerForm extends Form {
     if (defaultConfig) {
       this.table.resetToInitialUiPreferences();
     } else {
-      let prefs = uiPreferences.getTablePreferences(this.table);
-      let profile = uiPreferences.getTablePreferenceProfile(prefs, configName);
-      uiPreferences.applyTablePreferenceProfile(this.table, profile);
+      let prefs = tableUiPreferences.get(this.table);
+      let profile = tableUiPreferences.getProfile(prefs, configName);
+      tableUiPreferences.applyProfile(this.table, profile);
       // Store activated profile as current state
-      uiPreferences.storeGlobalTablePreferenceProfile(this.table);
+      tableUiPreferences.storeGlobalProfile(this.table);
     }
 
     this._reloadColumnsTable();
@@ -150,8 +150,8 @@ export class TableOrganizerForm extends Form {
       return;
     }
     let configName = this.profilesTable.columnById('ConfigNameColumn').cellValue(row);
-    let profile = uiPreferences.createTablePreferenceProfile(this.table);
-    uiPreferences.storeTablePreferenceProfile(this.table, configName, profile);
+    let profile = tableUiPreferences.createProfile(this.table);
+    tableUiPreferences.storeProfile(this.table, configName, profile);
   }
 
   protected _renameConfig(row?: TableRow) {
@@ -171,7 +171,7 @@ export class TableOrganizerForm extends Form {
     rows = rows.filter(row => !defaultConfigColumn.cellValue(row));
     rows.forEach(row => {
       let configName = configNameColumn.cellValue(row);
-      uiPreferences.removeTablePreferenceProfile(this.table, configName);
+      tableUiPreferences.removeProfile(this.table, configName);
     });
     this.profilesTable.deleteRows(rows);
   }

--- a/eclipse-scout-core/test/bookmark/BookmarkSupportSpec.ts
+++ b/eclipse-scout-core/test/bookmark/BookmarkSupportSpec.ts
@@ -11,12 +11,12 @@
 import {
   ActivateBookmarkPathParam, BaseDoEntity, BookmarkDo, BookmarkDoBuilder, BookmarkSupport, BookmarkTableRowIdentifierDo, BookmarkTableRowIdentifierStringComponentDo, BooleanColumn, Column, Desktop, NodeBookmarkPageDo, NumberColumn,
   NumberColumnUserFilter, NumberColumnUserFilterStateDo, Outline, OutlineBookmarkDefinitionDo, PageBookmarkDefinitionDo, PageIdDummyPageParamDo, ResetMenu, scout, SearchMenu, Table, TableBookmarkPageDo, TableClientUiPreferenceProfileDo,
-  TableClientUiPreferencesDo, TableColumnClientUiPreferenceDo, TableTextUserFilter, TableTextUserFilterStateDo, UiPreferences, UuidPool
+  TableClientUiPreferencesDo, TableColumnClientUiPreferenceDo, TableTextUserFilter, TableTextUserFilterStateDo, TableUiPreferences, UuidPool
 } from '../../src/index';
 import {
   FRUIT_1_KEY, FRUIT_2_KEY, FRUIT_3_KEY, FRUIT_4_KEY, FRUIT_5_KEY, goToOutline, SPEC_NODE_PAGE_1_UUID, SPEC_NODE_PAGE_2_UUID, SPEC_NODE_PAGE_3_UUID, SPEC_NODE_PAGE_4_UUID, SPEC_OUTLINE_1_ID, SPEC_OUTLINE_1_UUID, SPEC_OUTLINE_2_ID,
-  SPEC_OUTLINE_2_UUID, SPEC_OUTLINE_3_ID, SPEC_OUTLINE_3_UUID, SPEC_TABLE_PAGE_1_UUID, SPEC_TABLE_PAGE_2_UUID,  SPEC_TABLE_PAGE_3_TABLE_COLUMN_1_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_2_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_3_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_4_UUID,
-  SPEC_TABLE_PAGE_3_TABLE_COLUMN_5_UUID, SPEC_TABLE_PAGE_3_TABLE_UUID,SPEC_TABLE_PAGE_3_UUID, specDesktopModel, SpecNodePage1, SpecNodePage2, SpecNodePage3, SpecNodePage4, SpecPageParamDo,
+  SPEC_OUTLINE_2_UUID, SPEC_OUTLINE_3_ID, SPEC_OUTLINE_3_UUID, SPEC_TABLE_PAGE_1_UUID, SPEC_TABLE_PAGE_2_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_1_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_2_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_3_UUID,
+  SPEC_TABLE_PAGE_3_TABLE_COLUMN_4_UUID, SPEC_TABLE_PAGE_3_TABLE_COLUMN_5_UUID, SPEC_TABLE_PAGE_3_TABLE_UUID, SPEC_TABLE_PAGE_3_UUID, specDesktopModel, SpecNodePage1, SpecNodePage2, SpecNodePage3, SpecNodePage4, SpecPageParamDo,
   SpecSearchDo, SpecSearchForm, SpecTablePage1, SpecTablePage2, SpecTablePage3
 } from './bookmark-fixtures';
 
@@ -207,7 +207,7 @@ describe('BookmarkSupport', () => {
       expect(bookmarkedPage.tablePreferences.tileGlobalKey).toBe(undefined);
       expect(bookmarkedPage.tablePreferences.tablePreferenceProfiles).toBeInstanceOf(Map);
       expect(bookmarkedPage.tablePreferences.tablePreferenceProfiles.size).toBe(1);
-      let bookmarkedTableProfile = bookmarkedPage.tablePreferences.tablePreferenceProfiles.get(UiPreferences.TABLE_PREFERENCE_PROFILE_ID_BOOKMARK);
+      let bookmarkedTableProfile = bookmarkedPage.tablePreferences.tablePreferenceProfiles.get(TableUiPreferences.PROFILE_ID_BOOKMARK);
       expect(bookmarkedTableProfile).toBeTruthy();
       expect(bookmarkedTableProfile.tableCustomizerData).toBe(undefined);
       expect(bookmarkedTableProfile.columns).toEqual([
@@ -615,7 +615,7 @@ describe('BookmarkSupport', () => {
               tableId: `${SPEC_TABLE_PAGE_3_TABLE_UUID}|${SPEC_TABLE_PAGE_3_UUID}`,
               tileMode: false,
               tablePreferenceProfiles: new Map([
-                [UiPreferences.TABLE_PREFERENCE_PROFILE_ID_BOOKMARK, scout.create(TableClientUiPreferenceProfileDo, {
+                [TableUiPreferences.PROFILE_ID_BOOKMARK, scout.create(TableClientUiPreferenceProfileDo, {
                   columns: [
                     scout.create(TableColumnClientUiPreferenceDo, {
                       columnId: SPEC_TABLE_PAGE_3_TABLE_COLUMN_1_UUID, // KeyColumn
@@ -1337,7 +1337,7 @@ describe('BookmarkSupport', () => {
             tablePreferences: scout.create(TableClientUiPreferencesDo, {
               tableId: `${SPEC_TABLE_PAGE_3_TABLE_UUID}|${SPEC_TABLE_PAGE_3_UUID}`,
               tablePreferenceProfiles: new Map([
-                [UiPreferences.TABLE_PREFERENCE_PROFILE_ID_BOOKMARK, scout.create(TableClientUiPreferenceProfileDo, {
+                [TableUiPreferences.PROFILE_ID_BOOKMARK, scout.create(TableClientUiPreferenceProfileDo, {
                   columns: [
                     scout.create(TableColumnClientUiPreferenceDo, {
                       columnId: SPEC_TABLE_PAGE_3_TABLE_COLUMN_1_UUID, // KeyColumn
@@ -1431,7 +1431,7 @@ describe('BookmarkSupport', () => {
             tablePreferences: scout.create(TableClientUiPreferencesDo, {
               tableId: `${SPEC_TABLE_PAGE_3_TABLE_UUID}|${SPEC_TABLE_PAGE_3_UUID}`,
               tablePreferenceProfiles: new Map([
-                [UiPreferences.TABLE_PREFERENCE_PROFILE_ID_BOOKMARK, scout.create(TableClientUiPreferenceProfileDo, {
+                [TableUiPreferences.PROFILE_ID_BOOKMARK, scout.create(TableClientUiPreferenceProfileDo, {
                   columns: [
                     scout.create(TableColumnClientUiPreferenceDo, {
                       columnId: SPEC_TABLE_PAGE_3_TABLE_COLUMN_1_UUID, // KeyColumn

--- a/eclipse-scout-core/test/prefs/UiPreferencesSpec.ts
+++ b/eclipse-scout-core/test/prefs/UiPreferencesSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Column, scout, Table, TableClientUiPreferencesDo, uiPreferences, UiPreferences, UiPreferencesDo, UiPreferencesUpdateDo} from '../../src/index';
+import {Column, scout, Table, TableClientUiPreferencesDo, tableUiPreferences, uiPreferences, UiPreferences, UiPreferencesDo, UiPreferencesUpdateDo} from '../../src/index';
 import {SpecUiPreferencesStore} from '../../src/testing';
 
 describe('UiPreferences', () => {
@@ -36,8 +36,8 @@ describe('UiPreferences', () => {
       let store = SpecUiPreferencesStore.get();
       expect(store.loadCount).toBe(0);
       expect(store.subscribers.length).toBe(0);
-      expect(uiPreferences.getTablePreferences(table1)).toBe(undefined);
-      expect(uiPreferences.getTablePreferences(table2)).toBe(undefined);
+      expect(tableUiPreferences.get(table1)).toBe(undefined);
+      expect(tableUiPreferences.get(table2)).toBe(undefined);
       store.preferences = scout.create(UiPreferencesDo, {
         tablePreferences: [
           scout.create(TableClientUiPreferencesDo, {
@@ -55,11 +55,11 @@ describe('UiPreferences', () => {
 
       expect(store.loadCount).toBe(1);
       expect(store.subscribers.length).toBe(1);
-      expect(uiPreferences.getTablePreferences(table1)).toBeInstanceOf(TableClientUiPreferencesDo);
-      expect(uiPreferences.getTablePreferences(table1).tileMode).toBe(false);
+      expect(tableUiPreferences.get(table1)).toBeInstanceOf(TableClientUiPreferencesDo);
+      expect(tableUiPreferences.get(table1).tileMode).toBe(false);
       expect(table1.tileMode).toBe(false);
-      expect(uiPreferences.getTablePreferences(table2)).toBeInstanceOf(TableClientUiPreferencesDo);
-      expect(uiPreferences.getTablePreferences(table2).tileMode).toBe(false);
+      expect(tableUiPreferences.get(table2)).toBeInstanceOf(TableClientUiPreferencesDo);
+      expect(tableUiPreferences.get(table2).tileMode).toBe(false);
       expect(table2.tileMode).toBe(false);
 
       store.subscribers[0](scout.create(UiPreferencesUpdateDo, {
@@ -74,10 +74,10 @@ describe('UiPreferences', () => {
       }));
 
       expect(store.loadCount).toBe(1); // still 1
-      expect(uiPreferences.getTablePreferences(table1)).toBeInstanceOf(TableClientUiPreferencesDo);
-      expect(uiPreferences.getTablePreferences(table1).tileMode).toBe(true);
+      expect(tableUiPreferences.get(table1)).toBeInstanceOf(TableClientUiPreferencesDo);
+      expect(tableUiPreferences.get(table1).tileMode).toBe(true);
       expect(table1.tileMode).toBe(false); // not updated automatically
-      expect(uiPreferences.getTablePreferences(table2)).toBe(undefined);
+      expect(tableUiPreferences.get(table2)).toBe(undefined);
       expect(table2.tileMode).toBe(false);
     });
   });
@@ -96,10 +96,15 @@ describe('UiPreferences', () => {
       let table = scout.create(Table, {
         parent: session.desktop,
         id: 't1',
+        uiPreferencesEnabled: true,
         columns: [
           {
             objectType: Column,
             id: 'c1'
+          },
+          {
+            objectType: Column,
+            id: 'c2'
           }
         ]
       });
@@ -107,20 +112,38 @@ describe('UiPreferences', () => {
       let store = SpecUiPreferencesStore.get();
       expect(store.storeCount).toBe(0);
 
-      uiPreferences.installTableListener(table);
       table.setTileMode(true);
-      table.columns[0].setWidth(123);
+      table.setTileMode(false);
+      jasmine.clock().tick(0);
+      expect(store.storeCount).toBe(1);
+      jasmine.clock().tick(1000);
+      expect(store.storeCount).toBe(1);
 
-      jasmine.clock().tick(1000);
+      table.columns[0].setVisible(false);
+      table.columns[1].setVisible(false);
       expect(store.storeCount).toBe(1);
+      jasmine.clock().tick(0);
+      expect(store.storeCount).toBe(2);
       jasmine.clock().tick(1000);
-      expect(store.storeCount).toBe(1);
+      expect(store.storeCount).toBe(2);
 
       table.columns[0].setWidth(456);
       table.columns[0].setWidth(789);
-      expect(store.storeCount).toBe(1);
-      jasmine.clock().tick(1000);
       expect(store.storeCount).toBe(2);
+      jasmine.clock().tick(333); // less than 750
+      expect(store.storeCount).toBe(2);
+      jasmine.clock().tick(1000);
+      expect(store.storeCount).toBe(3);
+      jasmine.clock().tick(1000);
+      expect(store.storeCount).toBe(3);
+
+      table.setTileMode(true);
+      table.columns[1].setVisible(true);
+      expect(store.storeCount).toBe(3);
+      jasmine.clock().tick(0);
+      expect(store.storeCount).toBe(4);
+      jasmine.clock().tick(1000);
+      expect(store.storeCount).toBe(4);
     });
   });
 });

--- a/eclipse-scout-core/test/table/TableUiPreferencesSpec.ts
+++ b/eclipse-scout-core/test/table/TableUiPreferencesSpec.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  BooleanColumn, Column, DateColumn, NumberColumn, ObjectIdProvider, scout, Table, TableClientUiPreferenceProfileDo, TableClientUiPreferencesDo, TableColumnClientUiPreferenceDo, TableRow, TableTextUserFilter, TextColumnUserFilter, Tile,
-  uiPreferences, UiPreferences, UiPreferencesDo, WidgetModel
+  BooleanColumn, Column, DateColumn, NumberColumn, ObjectIdProvider, scout, Table, TableClientUiPreferenceProfileDo, TableClientUiPreferencesDo, TableColumnClientUiPreferenceDo, TableRow, TableTextUserFilter, tableUiPreferences,
+  TableUiPreferences, TextColumnUserFilter, Tile, uiPreferences, UiPreferencesDo, WidgetModel
 } from '../../src/index';
 import {SpecUiPreferencesStore} from '../../src/testing';
 
@@ -46,7 +46,7 @@ describe('TableUiPreferences', () => {
       expect(prefStore.preferences.tablePreferences[0].tableId).toBe('t1');
       expect(prefStore.preferences.tablePreferences[0].tileMode).toBe(false);
       expect(prefStore.preferences.tablePreferences[0].tablePreferenceProfiles.size).toBe(1);
-      let profile = prefStore.preferences.tablePreferences[0].tablePreferenceProfiles.get(UiPreferences.TABLE_PREFERENCE_PROFILE_ID_GLOBAL);
+      let profile = prefStore.preferences.tablePreferences[0].tablePreferenceProfiles.get(TableUiPreferences.PROFILE_ID_GLOBAL);
       expect(profile).toBeTruthy();
       expect(profile.columns.length).toBe(6);
       expect(profile.columns[0].columnId).toBe('c1');
@@ -66,7 +66,7 @@ describe('TableUiPreferences', () => {
       expect(prefStore.preferences.tablePreferences[0].tableId).toBe('t1');
       expect(prefStore.preferences.tablePreferences[0].tileMode).toBe(false);
       expect(prefStore.preferences.tablePreferences[0].tablePreferenceProfiles.size).toBe(1);
-      profile = prefStore.preferences.tablePreferences[0].tablePreferenceProfiles.get(UiPreferences.TABLE_PREFERENCE_PROFILE_ID_GLOBAL);
+      profile = prefStore.preferences.tablePreferences[0].tablePreferenceProfiles.get(TableUiPreferences.PROFILE_ID_GLOBAL);
       expect(profile).toBeTruthy();
       expect(profile.columns.length).toBe(6);
       expect(profile.columns.map(c => c.columnId)).toEqual(['c1', 'c2', 'c6', 'c3', 'c4', 'c5']);
@@ -231,7 +231,7 @@ describe('TableUiPreferences', () => {
             tableId: 't1',
             tileMode: true,
             tablePreferenceProfiles: new Map([
-              [UiPreferences.TABLE_PREFERENCE_PROFILE_ID_GLOBAL, scout.create(TableClientUiPreferenceProfileDo, {
+              [TableUiPreferences.PROFILE_ID_GLOBAL, scout.create(TableClientUiPreferenceProfileDo, {
                 columns: [
                   scout.create(TableColumnClientUiPreferenceDo, {
                     columnId: 'c2',
@@ -315,7 +315,7 @@ describe('TableUiPreferences', () => {
         parent: session.desktop,
         id: 't1'
       });
-      table.setInitialUiPreferences(uiPreferences.createTablePreferenceProfile(table));
+      table.setInitialUiPreferences(tableUiPreferences.createProfile(table));
 
       let c2 = table.columnById('c2');
       let c3 = table.columnById('c3');
@@ -338,7 +338,7 @@ describe('TableUiPreferences', () => {
         freeText: 'foo'
       }));
 
-      let profile1 = uiPreferences.createTablePreferenceProfile(table);
+      let profile1 = tableUiPreferences.createProfile(table);
 
       // -----
 
@@ -352,11 +352,11 @@ describe('TableUiPreferences', () => {
         text: 'bar'
       }));
 
-      let profile2 = uiPreferences.createTablePreferenceProfile(table);
+      let profile2 = tableUiPreferences.createProfile(table);
 
       // -----
 
-      uiPreferences.applyTablePreferenceProfile(table, profile1);
+      tableUiPreferences.applyProfile(table, profile1);
 
       expect(table.columns.map(c => c.id)).toEqual(['c1', 'c2', 'c6', 'c3', 'c4', 'c5']);
       expect(table.visibleColumns().map(c => c.id)).toEqual(['c2', 'c6', 'c3', 'c4']);
@@ -367,7 +367,7 @@ describe('TableUiPreferences', () => {
       expect(table.columns.map(c => c.sortActive)).toEqual([false, false, false, true, true, false]);
       expect(table.filterCount()).toBe(2);
 
-      uiPreferences.applyTablePreferenceProfile(table, profile2);
+      tableUiPreferences.applyProfile(table, profile2);
 
       expect(table.columns.map(c => c.id)).toEqual(['c1', 'c2', 'c3', 'c6', 'c4', 'c5']);
       expect(table.visibleColumns().map(c => c.id)).toEqual(['c2', 'c3', 'c6', 'c4']);
@@ -389,7 +389,7 @@ describe('TableUiPreferences', () => {
       expect(table.columns.map(c => c.sortActive)).toEqual([false, false, false, false, true, false]);
       expect(table.filterCount()).toBe(0);
 
-      uiPreferences.applyTablePreferenceProfile(table, profile1);
+      tableUiPreferences.applyProfile(table, profile1);
       expect(table.filterCount()).toBe(0);
     });
 
@@ -401,14 +401,14 @@ describe('TableUiPreferences', () => {
         rowIconVisible: true,
         rowIconColumnWidth: 96
       });
-      table.setInitialUiPreferences(uiPreferences.createTablePreferenceProfile(table));
+      table.setInitialUiPreferences(tableUiPreferences.createProfile(table));
       expect(table.columns.length).toBe(6 + 2);
       expect(table.columns.map(c => c.guiOnly ? null : c.id)).toEqual([null, null, 'c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
 
       let c2 = table.columnById('c2');
       c2.setWidth(202);
 
-      let profile = uiPreferences.createTablePreferenceProfile(table);
+      let profile = tableUiPreferences.createProfile(table);
       expect(profile.columns.length).toBe(6);
       expect(profile.columns.map(c => c.columnId)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
 
@@ -416,7 +416,7 @@ describe('TableUiPreferences', () => {
       expect(table.columns.length).toBe(6 + 2);
       expect(table.columns.map(c => c.guiOnly ? null : c.id)).toEqual([null, null, 'c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
       expect(c2.width).toBe(102);
-      uiPreferences.applyTablePreferenceProfile(table, profile);
+      tableUiPreferences.applyProfile(table, profile);
       expect(table.columns.length).toBe(6 + 2);
       expect(table.columns.map(c => c.guiOnly ? null : c.id)).toEqual([null, null, 'c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
       expect(c2.width).toBe(202);
@@ -442,7 +442,7 @@ describe('TableUiPreferences', () => {
       expect(table.columns.map(c => c.visible)).toEqual([false, true, false, true, true, true]);
       expect(table.columns.map(c => c.visibleIgnoreCompacted)).toEqual([false, true, false, true, true, true]);
       expect(table.columns.map(c => c.compacted)).toEqual([false, false, false, false, false, false]);
-      let profile1 = uiPreferences.createTablePreferenceProfile(table);
+      let profile1 = tableUiPreferences.createProfile(table);
       expect(profile1.columns.length).toBe(6);
       expect(profile1.columns.map(c => c.columnId)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
       expect(profile1.columns.map(c => c.visible)).toEqual([false, true, false, true, true, true]);
@@ -455,7 +455,7 @@ describe('TableUiPreferences', () => {
       expect(table.columns.map(c => c.visible)).toEqual([false, false, false, false, false, false, true]);
       expect(table.columns.map(c => c.visibleIgnoreCompacted)).toEqual([false, true, false, true, true, true, true]);
       expect(table.columns.map(c => c.compacted)).toEqual([false, true, true, true, true, true, false]);
-      let profile2 = uiPreferences.createTablePreferenceProfile(table);
+      let profile2 = tableUiPreferences.createProfile(table);
       expect(profile2.columns.length).toBe(6); // <--
       expect(profile2.columns.map(c => c.columnId)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
       expect(profile2.columns.map(c => c.visible)).toEqual([false, true, false, true, true, true]);


### PR DESCRIPTION
The 'uiPreferences' singleton loads and stores the UI preferences for the current user. Custom handlers can register to handle parts of the global UiPreferencesDo object.

All table-specific preference methods were moved to the new 'tableUiPreferences' singleton.

389574