### PR TITLE
PageWithTable: ensure preferences are initialized after detail table

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -92,16 +92,16 @@ export class PageWithTable extends Page implements PageWithTableModel {
     table.on('propertyChange:tableControls', this._tableControlsChangeHandler);
     this._addSearchFormTableControlListeners(this._findSearchFormTableControl(table));
 
-    this._initDetailTableUiPreferences(table);
+    // Ensure _initDetailTableUiPreferences is only called after _initDetailTable has been completed (including subclasses).
+    this.one('propertyChange:detailTable', event => {
+      if (event.newValue === table) {
+        this._initDetailTableUiPreferences(table);
+      }
+    });
   }
 
   protected _initDetailTableUiPreferences(table: Table) {
-    // Wait for event so that changes made by a subclass in _initDetailTable are also saved as initial preferences
-    this.one('propertyChange:detailTable', event => {
-      if (event.newValue === table) {
-        table.setUiPreferencesEnabled(true);
-      }
-    });
+    table.setUiPreferencesEnabled(true);
   }
 
   protected override _destroyDetailTable(table: Table) {

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
@@ -371,4 +371,52 @@ describe('PageWithTable', () => {
     expect(page.childrenLoaded).toBe(true);
     expect(detailTable.loading).toBe(false);
   });
+
+  it('calls _initDetailTableUiPreferences after _initDetailTable', () => {
+    let observedTestValue = 0;
+
+    class SpecPageWithTable1 extends PageWithTable {
+      testValue = 0;
+
+      protected override _initDetailTable(table: Table) {
+        super._initDetailTable(table);
+        this.testValue = 1;
+      }
+
+      protected override _initDetailTableUiPreferences(table: Table) {
+        observedTestValue = this.testValue;
+      }
+    }
+
+    class SpecPageWithTable2 extends SpecPageWithTable1 {
+      protected override _initDetailTable(table: Table) {
+        super._initDetailTable(table);
+        this.testValue = 2;
+      }
+    }
+
+    let page1 = scout.create(SpecPageWithTable1, {
+      parent: outline,
+      detailTable: {
+        objectType: Table
+      }
+    });
+    expect(page1.testValue).toBe(0);
+    expect(observedTestValue).toBe(0);
+    page1.ensureDetailTable();
+    expect(page1.testValue).toBe(1);
+    expect(observedTestValue).toBe(1);
+
+    let page2 = scout.create(SpecPageWithTable2, {
+      parent: outline,
+      detailTable: {
+        objectType: Table
+      }
+    });
+    expect(page2.testValue).toBe(0);
+    expect(observedTestValue).toBe(1);
+    page2.ensureDetailTable();
+    expect(page2.testValue).toBe(2);
+    expect(observedTestValue).toBe(2);
+  });
 });


### PR DESCRIPTION
The UI preferences of the detail table should only be enabled after the detail table has been fully initialized. If a subclass overrides _initDetailTable and make adjustments to the detail table, these changes should also be considered when initializing the preferences. To ensure _initDetailTableUiPreferences is only executed after _initDetailTable has been completed (including subclasses), the listener for the 'detailTable' property has to be added in _initDetailTable, not in _initDetailTableUiPreferences.

389574