### PR TITLE
Improve thread safety of SharedVariableMap

### DIFF
--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/common/context/SharedVariableMapTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/common/context/SharedVariableMapTest.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.scout.rt.platform.context.RunContexts;
+import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.job.Jobs;
 import org.junit.Test;
 
 public class SharedVariableMapTest {
@@ -46,5 +49,50 @@ public class SharedVariableMapTest {
     assertEquals(Map.of("2", 2L, "3", 3L), protocol.get(1));
     assertEquals(Map.of("11", 11L, "22", 22L, "33", 33L), protocol.get(2));
     m.removePropertyChangeListener(propertyChangeListener);
+  }
+
+  @Test
+  public void testConcurrentAccess() {
+    final SharedVariableMap m = new SharedVariableMap();
+    final List<IFuture<Void>> jobs = new ArrayList<>();
+    final int numberOfValues = 1000;
+    final int numberOfJobs = 10;
+
+    // Phase 1: Concurrent put and get
+    for (int i = 0; i < numberOfJobs; i++) {
+      jobs.add(schedulePutAndGetJob(m, i, numberOfValues));
+    }
+    jobs.forEach(IFuture::awaitDoneAndGet);
+    assertEquals(numberOfJobs * numberOfValues, m.size());
+
+    // Phase 2: Concurrent remove and get
+    jobs.clear();
+    for (int i = 0; i < numberOfJobs; i++) {
+      jobs.add(scheduleRemoveAndGetJob(m, i, numberOfValues));
+    }
+    jobs.forEach(IFuture::awaitDoneAndGet);
+    assertEquals(0, m.size());
+  }
+
+  protected IFuture<Void> schedulePutAndGetJob(SharedVariableMap m, int jobNumber, int numberOfValues) {
+    return Jobs.schedule(() -> {
+      for (int i = jobNumber * numberOfValues; i < (jobNumber + 1) * numberOfValues; i++) {
+        m.put(String.valueOf(i), i);
+        if (i % 5 == 0) {
+          m.get(String.valueOf(i)); // Occasionally read a key to test concurrent gets
+        }
+      }
+    }, Jobs.newInput().withName("put-get-job-" + jobNumber).withRunContext(RunContexts.empty()));
+  }
+
+  protected IFuture<Void> scheduleRemoveAndGetJob(SharedVariableMap m, int jobNumber, int numberOfValues) {
+    return Jobs.schedule(() -> {
+      for (int i = jobNumber * numberOfValues; i < (jobNumber + 1) * numberOfValues; i++) {
+        if (i % 5 == 0) {
+          m.get(String.valueOf(i)); // Occasionally read a key to test concurrent gets
+        }
+        m.remove(String.valueOf(i));
+      }
+    }, Jobs.newInput().withName("remove-get-job-" + jobNumber).withRunContext(RunContexts.empty()));
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/context/SharedVariableMap.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/context/SharedVariableMap.java
@@ -28,6 +28,18 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
   private static final long serialVersionUID = 1L;
   public static final String PROP_VALUES = "values";
 
+  /**
+   * Internal variable map.
+   * <p>
+   * Access to this map is synchronized on the instance of {@link SharedVariableMap}
+   * to ensure thread safety for all operations that modify or read the map.
+   * Since {@link HashMap} is not thread-safe, this synchronization protects
+   * against concurrent modifications and ensures visibility of changes across threads.
+   * <p>
+   * <b>Important:</b> Any new method that accesses or modifies {@code m_variables}
+   * <b>must</b> be properly synchronized on the {@link SharedVariableMap} instance.
+   * Omitting synchronization may cause race conditions or data inconsistency.
+   */
   private final Map<String, Object> m_variables;
   private transient BasicPropertySupport m_propertySupport;
 
@@ -52,7 +64,7 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
   /**
    * Update values of this variable map with the new one.
    */
-  public void updateInternal(Map<String, Object> newMap) {
+  public synchronized void updateInternal(Map<String, Object> newMap) {
     if (m_variables.equals(newMap)) {
       return; // nothing changed
     }
@@ -69,38 +81,38 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
    * Fires a change event
    */
   @Override
-  public void clear() {
+  public synchronized void clear() {
     m_variables.clear();
     fireValuesChanged();
   }
 
   @Override
-  public boolean containsKey(Object key) {
+  public synchronized boolean containsKey(Object key) {
     return m_variables.containsKey(key);
   }
 
   @Override
-  public boolean containsValue(Object value) {
+  public synchronized boolean containsValue(Object value) {
     return m_variables.containsValue(value);
   }
 
   @Override
-  public Set<Entry<String, Object>> entrySet() {
+  public synchronized Set<Entry<String, Object>> entrySet() {
     return CollectionUtility.hashSet(m_variables.entrySet());
   }
 
   @Override
-  public Object get(Object key) {
+  public synchronized Object get(Object key) {
     return m_variables.get(key);
   }
 
   @Override
-  public boolean isEmpty() {
+  public synchronized boolean isEmpty() {
     return m_variables.isEmpty();
   }
 
   @Override
-  public Set<String> keySet() {
+  public synchronized Set<String> keySet() {
     return CollectionUtility.hashSet(m_variables.keySet());
   }
 
@@ -108,7 +120,7 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
    * Fires a change event
    */
   @Override
-  public Object put(String key, Object value) {
+  public synchronized Object put(String key, Object value) {
     Object o = m_variables.put(key, value);
     fireValuesChanged();
     return o;
@@ -118,7 +130,7 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
    * Fires a change event
    */
   @Override
-  public void putAll(Map<? extends String, ?> m) {
+  public synchronized void putAll(Map<? extends String, ?> m) {
     m_variables.putAll(m);
     fireValuesChanged();
   }
@@ -127,24 +139,24 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
    * Fires a change event
    */
   @Override
-  public Object remove(Object key) {
+  public synchronized Object remove(Object key) {
     Object o = m_variables.remove(key);
     fireValuesChanged();
     return o;
   }
 
   @Override
-  public int size() {
+  public synchronized int size() {
     return m_variables.size();
   }
 
   @Override
-  public Collection<Object> values() {
+  public synchronized Collection<Object> values() {
     return CollectionUtility.arrayList(m_variables.values());
   }
 
   @Override
-  public String toString() {
+  public synchronized String toString() {
     return m_variables.toString();
   }
 }


### PR DESCRIPTION
- Synchronize all methods accessing m_variables to prevent race conditions
- Add Javadoc clarifying synchronization requirements on m_variables
- Ensure property change events fire consistently after modifications

413519