### PR TITLE
Page: collapse lazy expanded nodes on reload

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithNodes.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithNodes.ts
@@ -54,6 +54,10 @@ export class PageWithNodes extends Page {
   }
 
   protected _onDetailTableReload(event: TableReloadEvent) {
+    if (this.expandedLazy) {
+      // If the page is expanded lazily, all child nodes will be gone -> collapse it to prevent showing the "+" icon without any child nodes
+      this.outline.setNodeExpanded(this, false);
+    }
     this.reloadPage();
   }
 

--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -42,7 +42,7 @@ export class PageWithTable extends Page implements PageWithTableModel {
     this._tableRowUpdateHandler = this._onTableRowsUpdated.bind(this);
     this._tableRowActionHandler = this._onTableRowAction.bind(this);
     this._tableRowOrderChangeHandler = this._onTableRowOrderChanged.bind(this);
-    this._tableDataLoadHandler = (e: TableReloadEvent) => this.loadTableData(e?.reloadReason);
+    this._tableDataLoadHandler = this._onTableReload.bind(this);
   }
 
   protected override _init(model: InitModelOf<this>) {
@@ -157,6 +157,14 @@ export class PageWithTable extends Page implements PageWithTableModel {
 
   protected _onTableRowOrderChanged(event: TableRowOrderChangedEvent) {
     this.outline.mediator.onTableRowOrderChanged(event, this);
+  }
+
+  protected _onTableReload(event: TableReloadEvent) {
+    if (this.expandedLazy) {
+      // If the page is expanded lazily, all child nodes will be gone -> collapse it to prevent showing the "+" icon without any child nodes
+      this.outline.setNodeExpanded(this, false);
+    }
+    this.loadTableData(event.reloadReason);
   }
 
   protected _onTableControlsChange(e: PropertyChangeEvent<TableControl[]>) {

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithNodesSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithNodesSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Outline, Page, PageWithNodes, scout} from '../../../../src/index';
+import {Outline, Page, PageWithNodes, scout, Table} from '../../../../src/index';
 import {OutlineSpecHelper, TableSpecHelper} from '../../../../src/testing/index';
 
 describe('PageWithNodes', () => {
@@ -382,6 +382,81 @@ describe('PageWithNodes', () => {
       expect(detailTable.rows.length).toBe(2);
       expect(detailTable.rows[0].cells[0].text).toBe('Page 104');
       expect(detailTable.rows[1].cells[0].text).toBe('Page 105');
+    });
+
+    it('collapses lazy expanded nodes on reload', () => {
+      class LazyPageWithNodes extends PageWithNodes {
+        constructor() {
+          super();
+          this.lazyExpandingEnabled = true;
+        }
+
+        protected override _createChildPages(): JQuery.Promise<Page[]> {
+          return $.resolvedPromise([
+            scout.create(PageWithNodes, {
+              parent: outline,
+              text: 'Red'
+            }),
+            scout.create(PageWithNodes, {
+              parent: outline,
+              text: 'Green'
+            }),
+            scout.create(PageWithNodes, {
+              parent: outline,
+              text: 'Blue'
+            })
+          ]);
+        }
+      }
+
+      let page = scout.create(LazyPageWithNodes, {
+        parent: outline
+      });
+      outline.insertNode(page);
+      outline.selectNode(page);
+      jasmine.clock().tick(1);
+
+      expect(page.childNodes.length).toBe(3);
+      expect(page.expanded).toBe(false);
+      expect(page.expandedLazy).toBe(false);
+      expect(page.reloadable).toBe(true);
+      expect(page.detailTable).toBeInstanceOf(Table);
+      expect(page.detailTable.rows.length).toBe(3);
+      expect(page.detailTable.hasReloadHandler).toBe(true);
+
+      // -----
+
+      // Drill down to child node -> page should be expanded lazily
+
+      outline.drillDown(page.childNodes[0]);
+      expect(page.expanded).toBe(true);
+      expect(page.expandedLazy).toBe(true);
+
+      // -----
+
+      // Reload page -> should be collapsed automatically
+
+      outline.selectNode(page);
+      page.detailTable.reload();
+      jasmine.clock().tick(1);
+
+      expect(page.childNodes.length).toBe(3);
+      expect(page.expanded).toBe(false);
+      expect(page.expandedLazy).toBe(false);
+
+      // -----
+
+      // Expand page non-lazily and reload -> page should stay expanded
+
+      page.setExpanded(true);
+      expect(page.expanded).toBe(true);
+      expect(page.expandedLazy).toBe(false);
+
+      page.detailTable.reload();
+      jasmine.clock().tick(1);
+      expect(page.childNodes.length).toBe(3);
+      expect(page.expanded).toBe(true);
+      expect(page.expandedLazy).toBe(false);
     });
   });
 

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
@@ -419,4 +419,91 @@ describe('PageWithTable', () => {
     expect(page2.testValue).toBe(2);
     expect(observedTestValue).toBe(2);
   });
+
+  it('collapses lazy expanded nodes on reload', () => {
+    class LazyPageWithTable extends PageWithTable {
+      constructor() {
+        super();
+        this.lazyExpandingEnabled = true;
+      }
+
+      protected override _createDetailTable(): Table {
+        return scout.create(Table, {
+          parent: this.outline,
+          columns: [{
+            id: 'ColorColumn',
+            objectType: Column,
+            primaryKey: true
+          }]
+        });
+      }
+
+      protected override _loadTableData(searchFilter: any): JQuery.Promise<any> {
+        return $.resolvedPromise(['Red', 'Green', 'Blue']);
+      }
+
+      protected override _transformTableDataToTableRows(tableData: any): ObjectOrModel<TableRow>[] {
+        return tableData.map(color => {
+          return {
+            cells: [color]
+          };
+        });
+      }
+
+      protected override _createChildPage(row): Page {
+        return scout.create(Page, {
+          parent: this.outline,
+          text: this.detailTable.columnById('ColorColumn').cellValue(row)
+        });
+      }
+    }
+
+    let page = scout.create(LazyPageWithTable, {
+      parent: outline
+    });
+    outline.insertNode(page);
+    outline.selectNode(page);
+    jasmine.clock().tick(1);
+
+    expect(page.childNodes.length).toBe(3);
+    expect(page.expanded).toBe(false);
+    expect(page.expandedLazy).toBe(false);
+    expect(page.detailTable).toBeInstanceOf(Table);
+    expect(page.detailTable.rows.length).toBe(3);
+    expect(page.detailTable.hasReloadHandler).toBe(true);
+
+    // -----
+
+    // Drill down to child node -> page should be expanded lazily
+
+    outline.drillDown(page.childNodes[0]);
+    expect(page.expanded).toBe(true);
+    expect(page.expandedLazy).toBe(true);
+
+    // -----
+
+    // Reload page -> should be collapsed automatically
+
+    outline.selectNode(page);
+    page.detailTable.reload();
+    jasmine.clock().tick(1);
+
+    expect(page.childNodes.length).toBe(3);
+    expect(page.expanded).toBe(false);
+    expect(page.expandedLazy).toBe(false);
+
+    // -----
+
+    // Expand page non-lazily and reload -> page should stay expanded
+
+    page.setExpanded(true);
+    expect(page.expanded).toBe(true);
+    expect(page.expandedLazy).toBe(false);
+
+    page.detailTable.reload();
+    jasmine.clock().tick(1);
+    expect(page.childNodes.length).toBe(3);
+    expect(page.expanded).toBe(true);
+    expect(page.expandedLazy).toBe(false);
+  });
 });

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/PageTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/PageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,11 +11,21 @@ package org.eclipse.scout.rt.client.ui.desktop.outline.pages;
 
 import static org.junit.Assert.*;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.ui.basic.table.AbstractTable;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
+import org.eclipse.scout.rt.client.ui.basic.table.ITableRow;
+import org.eclipse.scout.rt.client.ui.basic.table.columns.AbstractStringColumn;
+import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
 import org.eclipse.scout.rt.client.ui.desktop.outline.AbstractOutline;
+import org.eclipse.scout.rt.client.ui.desktop.outline.IOutline;
+import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.classid.ClassId;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.shared.services.common.jdbc.SearchFilter;
 import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
 import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
@@ -120,6 +130,54 @@ public class PageTest {
     Mockito.verify(outline).firePageChanged(Mockito.eq(p));
   }
 
+  @Test
+  public void testCollapseLazyNodeOnReload() {
+    IDesktop desktop = TestEnvironmentClientSession.get().getDesktop();
+    desktop.setAvailableOutlines(Collections.singletonList(new LazyPageWithTableOutline()));
+    desktop.setOutline(LazyPageWithTableOutline.class);
+    desktop.activateFirstPage();
+    IOutline outline = desktop.getOutline();
+    LazyPageWithTable page = (LazyPageWithTable) outline.getActivePage();
+
+    assertEquals(3, page.getChildNodeCount());
+    assertFalse(page.isExpanded());
+    assertTrue(page.isExpandedLazy());
+
+    // -----
+
+    // Drill down to child node -> page should be expanded lazily
+
+    outline.getUIFacade().setNodeSelectedAndExpandedFromUI(page.getChildNode(0));
+    assertTrue(page.isExpanded());
+    assertTrue(page.isExpandedLazy());
+
+    // -----
+
+    // Reload page -> should be collapsed automatically
+
+    outline.selectNode(page);
+    page.reloadPage();
+
+    assertEquals(3, page.getChildNodeCount());
+    assertFalse(page.isExpanded());
+    assertFalse(page.isExpandedLazy());
+
+    // -----
+
+    // Expand page non-lazily and reload -> page should stay expanded
+
+    page.setExpanded(true, false);
+    assertTrue(page.isExpanded());
+    assertFalse(page.isExpandedLazy());
+
+    page.reloadPage();
+    assertEquals(3, page.getChildNodeCount());
+    assertTrue(page.isExpanded());
+    assertFalse(page.isExpandedLazy());
+  }
+
+  // ------------------------------------------------------------------
+
   class P_Page extends AbstractPage<ITable> {
     @Override
     protected ITable createTable() {
@@ -176,6 +234,38 @@ public class PageTest {
       P_Outline mock = Mockito.spy(new P_Outline(false));
       mock.callInitializer();
       return mock;
+    }
+  }
+
+  class LazyPageWithTableOutline extends AbstractOutline {
+
+    @Override
+    protected void execCreateChildPages(List<IPage<?>> pageList) {
+      pageList.add(new LazyPageWithTable());
+    }
+  }
+
+  class LazyPageWithTable extends AbstractPageWithTable<LazyPageWithTable.Table> {
+
+    @Override
+    protected void execLoadData(SearchFilter filter) {
+      final Object[][] data = new Object[][]{
+          new Object[]{"red"},
+          new Object[]{"green"},
+          new Object[]{"blue"}
+      };
+      importTableData(data);
+    }
+
+    @Override
+    protected IPage<?> execCreateChildPage(ITableRow row) {
+      return new P_Page();
+    }
+
+    public class Table extends AbstractTable {
+      @Order(10)
+      public class FirstColumn extends AbstractStringColumn {
+      }
     }
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPage.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPage.java
@@ -525,6 +525,10 @@ public abstract class AbstractPage<T extends ITable> extends AbstractTreeNode im
     }
     try {
       tree.setTreeChanging(true);
+      if (this.isExpandedLazy()) {
+        // If the page is expanded lazily, all child nodes will be gone -> collapse it to prevent showing the "+" icon without any child nodes
+        tree.setNodeExpanded(this, false);
+      }
       loadChildren();
     }
     finally {


### PR DESCRIPTION
When a page is expanded lazily (i.e. the node is expanded, but only some of the child nodes are visible, marked by "+" instead of "v" icon) and the table is reloaded, all child pages vanish because they are replaced by new instances. Because the parent node stays expanded, this leaves the "+" icon without any visible child nodes, which is confusing.

To prevent this unwanted state, a lazily expanded page is now automatically collapsed when the data is reloaded. Nothing changes if the page is already fully expanded (it stays expanded).

221481