### PR TITLE
Table: improve tile mode when column structure changes

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -6077,7 +6077,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
       return;
     }
     this._setColumns(columnOrModels, initValue);
-    if (this.rendered) {
+    if (this._isDataRendered()) {
       this._renderColumns();
     }
   }
@@ -6259,14 +6259,14 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   /**
    * Deletes the given {@link Column} from {@link Table.columns}.
    */
-  deleteColumn(column: Column) {
+  deleteColumn(column: Column<any>) {
     this.deleteColumns([column]);
   }
 
   /**
    * Deletes the given {@link Column}s from {@link Table.columns}.
    */
-  deleteColumns(columns: Column[]) {
+  deleteColumns(columns: Column<any>[]) {
     if (!columns?.length) {
       return;
     }

--- a/eclipse-scout-core/src/table/TileTableHeaderBox.ts
+++ b/eclipse-scout-core/src/table/TileTableHeaderBox.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  arrays, Column, EventHandler, FormField, GroupBox, InitModelOf, LogicalGridLayoutConfig, LookupRow, PlaceholderField, PropertyChangeEvent, scout, SmartField, StaticLookupCall, Table, TableGroupEvent, TableSortEvent,
-  TileTableHeaderBoxModel, TileTableHeaderGroupByLookupCall, TileTableHeaderSortByLookupCall, TileTableHeaderSortKey, ValueField
+  arrays, Column, EventHandler, FormField, GroupBox, InitModelOf, LogicalGridLayoutConfig, LookupRow, PlaceholderField, PropertyChangeEvent, scout, SmartField, StaticLookupCall, Table, TableColumnStructureChangedEvent, TableGroupEvent,
+  TableSortEvent, TileTableHeaderBoxModel, TileTableHeaderGroupByLookupCall, TileTableHeaderSortByLookupCall, TileTableHeaderSortKey, ValueField
 } from '../index';
 
 export class TileTableHeaderBox extends GroupBox implements TileTableHeaderBoxModel {
@@ -23,6 +23,7 @@ export class TileTableHeaderBox extends GroupBox implements TileTableHeaderBoxMo
   isSorting: boolean;
   protected _tableGroupHandler: EventHandler<TableGroupEvent>;
   protected _tableSortHandler: EventHandler<TableSortEvent>;
+  protected _tableColumnStructureChangedHandler: EventHandler<TableColumnStructureChangedEvent>;
   protected _destroyHandler: () => void;
 
   constructor() {
@@ -41,18 +42,21 @@ export class TileTableHeaderBox extends GroupBox implements TileTableHeaderBoxMo
 
     this._tableGroupHandler = this._onTableGroup.bind(this);
     this._tableSortHandler = this._onTableSort.bind(this);
+    this._tableColumnStructureChangedHandler = this._onTableColumnStructureChanged.bind(this);
     this._destroyHandler = this._uninstallListeners.bind(this);
   }
 
   protected _installListeners() {
     this.table.on('group', this._tableGroupHandler);
     this.table.on('sort', this._tableSortHandler);
+    this.table.on('columnStructureChanged', this._tableColumnStructureChangedHandler);
     this.table.one('destroy', this._destroyHandler);
   }
 
   protected _uninstallListeners() {
     this.table.off('group', this._tableGroupHandler);
     this.table.off('sort', this._tableSortHandler);
+    this.table.off('columnStructureChanged', this._tableColumnStructureChangedHandler);
   }
 
   protected override _init(model: InitModelOf<this>) {
@@ -190,5 +194,21 @@ export class TileTableHeaderBox extends GroupBox implements TileTableHeaderBoxMo
     if (!this.isSorting) {
       this._syncSortingGroupingFields();
     }
+  }
+
+  protected _onTableColumnStructureChanged(event: TableColumnStructureChangedEvent) {
+    const groupByLookupCall = this.groupByField.lookupCall;
+    if (groupByLookupCall instanceof StaticLookupCall) {
+      groupByLookupCall.refreshData();
+      this.groupByField.setVisible(!arrays.empty(groupByLookupCall.data));
+    }
+
+    const sortByLookupCall = this.sortByField.lookupCall;
+    if (sortByLookupCall instanceof StaticLookupCall) {
+      sortByLookupCall.refreshData();
+      this.sortByField.setVisible(!arrays.empty(sortByLookupCall.data));
+    }
+
+    this._syncSortingGroupingFields();
   }
 }

--- a/eclipse-scout-core/test/table/TileTableHeaderBoxSpec.ts
+++ b/eclipse-scout-core/test/table/TileTableHeaderBoxSpec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {SpecTable, TableSpecHelper} from '../../src/testing/index';
+import {LookupCall, scout, Tile} from '../../src';
+
+describe('TileTableHeaderBox', () => {
+  let session: SandboxSession;
+  let helper: TableSpecHelper;
+  let table: SpecTable;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    helper = new TableSpecHelper(session);
+
+    const model = helper.createModelFixture(3, 5);
+    table = helper.createTable(model);
+
+    table.setTileProducer(row => scout.create(Tile, {parent: table}));
+    table.setTileMode(true);
+
+    table.render();
+  });
+
+  afterEach(() => {
+    session = null;
+  });
+
+  describe('groupBy and sortBy fields', () => {
+
+    it('are updated when column structure changes', async () => {
+      const [column0, column1, column2] = table.columns;
+      const {groupByField, sortByField} = table.tileTableHeader;
+
+      const getLookupKeys = async <T>(lookupCall: LookupCall<T>) => {
+        const lookupResult = await lookupCall.cloneForAll().execute();
+        return lookupResult.lookupRows.map(row => row.key);
+      };
+
+      expect(await getLookupKeys(groupByField.lookupCall)).toEqual([null, column0, column1, column2]);
+      expect(await getLookupKeys(sortByField.lookupCall)).toEqual([
+        {column: column0, asc: true},
+        {column: column0, asc: false},
+        {column: column1, asc: true},
+        {column: column1, asc: false},
+        {column: column2, asc: true},
+        {column: column2, asc: false}
+      ]);
+
+      table.insertColumn(helper.createModelColumn('foo'));
+      expect(table.columns.length).toBe(4);
+      const fooColumn = table.columns[3];
+
+      expect(await getLookupKeys(groupByField.lookupCall)).toEqual([null, column0, column1, column2, fooColumn]);
+      expect(await getLookupKeys(sortByField.lookupCall)).toEqual([
+        {column: column0, asc: true},
+        {column: column0, asc: false},
+        {column: column1, asc: true},
+        {column: column1, asc: false},
+        {column: column2, asc: true},
+        {column: column2, asc: false},
+        {column: fooColumn, asc: true},
+        {column: fooColumn, asc: false}
+      ]);
+
+      groupByField.setValue(fooColumn);
+      sortByField.setValue({column: fooColumn, asc: true});
+      table.deleteColumn(column2);
+
+      expect(await getLookupKeys(groupByField.lookupCall)).toEqual([null, column0, column1, fooColumn]);
+      expect(await getLookupKeys(sortByField.lookupCall)).toEqual([
+        {column: column0, asc: true},
+        {column: column0, asc: false},
+        {column: column1, asc: true},
+        {column: column1, asc: false},
+        {column: fooColumn, asc: true},
+        {column: fooColumn, asc: false}
+      ]);
+      expect(groupByField.value).toBe(fooColumn);
+      expect(sortByField.value).toEqual({column: fooColumn, asc: true});
+
+      table.deleteColumn(fooColumn);
+
+      expect(await getLookupKeys(groupByField.lookupCall)).toEqual([null, column0, column1]);
+      expect(await getLookupKeys(sortByField.lookupCall)).toEqual([
+        {column: column0, asc: true},
+        {column: column0, asc: false},
+        {column: column1, asc: true},
+        {column: column1, asc: false}
+      ]);
+      expect(groupByField.value).toBeNull();
+      expect(sortByField.value).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
When columns are modified using setColumns do not call _renderColumns if data is not rendered.
Update groupBy and sortBy field in TileTableHeaderBox when column structure changes.

378974