### PR TITLE
DataObjectDeserializer: add retainTypeVersion-option

### DIFF
--- a/eclipse-scout-core/src/dataobject/serialize/DataObjectDeserializer.ts
+++ b/eclipse-scout-core/src/dataobject/serialize/DataObjectDeserializer.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {BaseDoEntity, Constructor, dataObjects, DoValueMetaData, doValueMetaData, InitModelOf, ObjectModel, objects, ObjectWithType, scout} from '../../index';
+import {BaseDoEntity, Constructor, dataObjects, DoValueMetaData, doValueMetaData, InitModelOf, ObjectModel, objects, ObjectWithType, Predicate, scout} from '../../index';
 
 export class DataObjectDeserializer implements DataObjectDeserializerModel, ObjectWithType {
 
@@ -16,9 +16,15 @@ export class DataObjectDeserializer implements DataObjectDeserializerModel, Obje
   id: string;
   objectType: string;
   createPojoIfDoIsUnknown: boolean;
+  retainTypeVersion: Predicate<object>;
 
   constructor(model?: InitModelOf<DataObjectDeserializer>) {
     this.createPojoIfDoIsUnknown = !!model?.createPojoIfDoIsUnknown;
+    this.retainTypeVersion = scout.nvl(model?.retainTypeVersion, (obj: object) => !(obj instanceof BaseDoEntity));
+    if (!objects.isFunction(this.retainTypeVersion)) {
+      const retain = !!this.retainTypeVersion;
+      this.retainTypeVersion = () => retain;
+    }
   }
 
   deserialize<T extends object>(value: any, valueMetaData?: DoValueMetaData<T>): T {
@@ -42,10 +48,16 @@ export class DataObjectDeserializer implements DataObjectDeserializerModel, Obje
     const resultObj = this._createResultObject(constructor);
     const proto = Object.getPrototypeOf(constructor).prototype;
     Object.keys(rawObj)
-      .filter(key => key !== '_typeVersion') // Ignore _typeVersion as this is not required on the client. At runtime only the latest version can exist anyway and the backend could re-create this information from its Java annotation.
+      // Ignore _typeVersion as it is handled later on.
+      .filter(key => key !== '_typeVersion')
       .forEach(key => {
         resultObj[key] = this._convertFieldValue(proto, rawObj, key, rawObj[key]);
       });
+
+    if (rawObj.hasOwnProperty('_typeVersion') && this.retainTypeVersion(resultObj)) {
+      resultObj['_typeVersion'] = this._convertFieldValue(proto, rawObj, '_typeVersion', rawObj['_typeVersion']);
+    }
+
     return resultObj;
   }
 
@@ -76,8 +88,9 @@ export class DataObjectDeserializer implements DataObjectDeserializerModel, Obje
 export interface DataObjectDeserializerModel extends ObjectModel<DataObjectDeserializer> {
   /**
    * Controls the kind of object that will be created when deserializing unknown DataObjects.
-   * If true, a pojo will be created for unknown DOs. If false, instances of {@link BaseDoEntity} will be created.
-   * Default is false.
+   * If `true` a pojo will be created for unknown DOs. If `false`, instances of {@link BaseDoEntity} will be created.
+   * Changing the type of the deserialized DataObject may change the deserialization behaviour of the property '_typeVersion' (see {@link retainTypeVersion} for more details).
+   * Default is `false`.
    *
    * A DataObject can be unknown e.g. if:
    * <ol>
@@ -85,5 +98,12 @@ export interface DataObjectDeserializerModel extends ObjectModel<DataObjectDeser
    *   <li>There is no _type attribute and the TypeScript attribute declaration (metadata) does not provide a class type which could be used as fallback.</li>
    * </ol>
    */
-  createPojoIfDoIsUnknown: boolean;
+  createPojoIfDoIsUnknown?: boolean;
+  /**
+   * Controls whether the '_typeVersion' property is retained when deserializing DataObjects.
+   * The property can be given as a {@link boolean} or a {@link Predicate}, whose input is the deserialized DataObject.
+   * If `true`, the '_typeVersion' will be set on the deserialized DataObject. If `false`, it will be ignored.
+   * Default is a {@link Predicate} that ignores the '_typeVersion' if the deserialized DataObject is instance of {@link BaseDoEntity}.
+   */
+  retainTypeVersion?: boolean | Predicate<object>;
 }

--- a/eclipse-scout-core/test/dataobject/DataObjectDeserializerSpec.ts
+++ b/eclipse-scout-core/test/dataobject/DataObjectDeserializerSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, BaseDoEntity, Constructor, DataObjectDeserializer, dataObjects, dates, DefaultDoTypeResolver, DoValueMetaData, ObjectFactory, objects, scout, typeName} from '../../src/index';
+import {arrays, BaseDoEntity, Constructor, DataObjectDeserializer, dataObjects, dates, DefaultDoTypeResolver, DoEntity, DoValueMetaData, ObjectFactory, objects, scout, typeName} from '../../src/index';
 
 describe('DataObjectDeserializer', () => {
 
@@ -131,20 +131,96 @@ describe('DataObjectDeserializer', () => {
     expect(result.num).toBe(1234);
   });
 
-  it('ignores _typeVersion', () => {
-    const result = dataObjects.parse('{' +
-      '  "value": 1234,' +
+  it('ignores _typeVersion depending on retainTypeVersion-option', () => {
+    const json = '{' +
       '  "_type": "whatever",' +
-      '  "_typeVersion": "1.2.3"' +
-      '}') as any;
-    expect(result).toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
-    expect(result._type).toBe('whatever'); // is kept
+      '  "_typeVersion": "1.2.3",' +
+      '  "value": 1234,' +
+      '  "nestedObj": {' +
+      '    "_type": "scout.Fixture01",' +
+      '    "_typeVersion": "3.2.1"' +
+      '  }' +
+      '}';
 
-    // _typeVersion is skipped when deserializing.
-    // _typeVersion is never required as at runtime only the newest typeVersion might exist (only during migration old versions may exist).
-    // Therefore, the _typeVersion is not required on the client as it is a backend-only property required for the migration only.
-    expect(result._typeVersion).toBeUndefined();
-    expect(result.value).toBe(1234);
+    const baseDoEntity = dataObjects.parse(json) as any;
+    expect(baseDoEntity).toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
+    expect(baseDoEntity._type).toBe('whatever'); // is kept
+    // retainTypeVersion is false if object is instance of BaseDoEntity -> _typeVersion is skipped when deserializing
+    expect(baseDoEntity._typeVersion).toBeUndefined();
+    expect(baseDoEntity.value).toBe(1234);
+    expect(baseDoEntity.nestedObj).toBeInstanceOf(Fixture01Do);
+    // retainTypeVersion is false if object is instance of BaseDoEntity -> _typeVersion is skipped when deserializing
+    expect(baseDoEntity.nestedObj._typeVersion).toBeUndefined();
+
+    const baseDoEntityWithTypeVersion = dataObjects.parse(json, null, {retainTypeVersion: true}) as any;
+    expect(baseDoEntityWithTypeVersion).toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
+    expect(baseDoEntityWithTypeVersion._type).toBe('whatever'); // is kept
+    // _typeVersion is NOT skipped when deserializing
+    expect(baseDoEntityWithTypeVersion._typeVersion).toBe('1.2.3');
+    expect(baseDoEntityWithTypeVersion.value).toBe(1234);
+    expect(baseDoEntityWithTypeVersion.nestedObj).toBeInstanceOf(Fixture01Do);
+    // _typeVersion is NOT skipped when deserializing
+    expect(baseDoEntityWithTypeVersion.nestedObj._typeVersion).toBe('3.2.1');
+
+    const baseDoEntityWithoutTypeVersion = dataObjects.parse(json, null, {retainTypeVersion: false}) as any;
+    expect(baseDoEntityWithoutTypeVersion).toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
+    expect(baseDoEntityWithoutTypeVersion._type).toBe('whatever'); // is kept
+    // _typeVersion is skipped when deserializing
+    expect(baseDoEntityWithoutTypeVersion._typeVersion).toBeUndefined();
+    expect(baseDoEntityWithoutTypeVersion.value).toBe(1234);
+    expect(baseDoEntityWithoutTypeVersion.nestedObj).toBeInstanceOf(Fixture01Do);
+    // _typeVersion is skipped when deserializing
+    expect(baseDoEntityWithoutTypeVersion.nestedObj._typeVersion).toBeUndefined();
+
+    const baseDoEntityWithTypeVersionPredicate = dataObjects.parse(json, null, {retainTypeVersion: (obj: DoEntity) => obj._type !== 'whatever'}) as any;
+    expect(baseDoEntityWithTypeVersionPredicate).toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
+    expect(baseDoEntityWithTypeVersionPredicate._type).toBe('whatever'); // is kept
+    // _typeVersion is skipped when deserializing
+    expect(baseDoEntityWithTypeVersionPredicate._typeVersion).toBeUndefined();
+    expect(baseDoEntityWithTypeVersionPredicate.value).toBe(1234);
+    expect(baseDoEntityWithTypeVersionPredicate.nestedObj).toBeInstanceOf(Fixture01Do);
+    // _typeVersion is NOT skipped when deserializing
+    expect(baseDoEntityWithTypeVersionPredicate.nestedObj._typeVersion).toBe('3.2.1');
+
+    const pojo = dataObjects.parse(json, null, {createPojoIfDoIsUnknown: true}) as any;
+    expect(pojo).not.toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
+    expect(pojo._type).toBe('whatever'); // is kept
+    // retainTypeVersion is true if object is not instance of BaseDoEntity -> _typeVersion is NOT skipped when deserializing
+    expect(pojo._typeVersion).toBe('1.2.3');
+    expect(pojo.value).toBe(1234);
+    expect(pojo.nestedObj).toBeInstanceOf(Fixture01Do);
+    // retainTypeVersion is false if object is instance of BaseDoEntity -> _typeVersion is skipped when deserializing
+    expect(pojo.nestedObj._typeVersion).toBeUndefined();
+
+    const pojoWithTypeVersion = dataObjects.parse(json, null, {createPojoIfDoIsUnknown: true, retainTypeVersion: true}) as any;
+    expect(pojoWithTypeVersion).not.toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
+    expect(pojoWithTypeVersion._type).toBe('whatever'); // is kept
+    // _typeVersion is NOT skipped when deserializing
+    expect(pojoWithTypeVersion._typeVersion).toBe('1.2.3');
+    expect(pojoWithTypeVersion.value).toBe(1234);
+    expect(pojoWithTypeVersion.nestedObj).toBeInstanceOf(Fixture01Do);
+    // _typeVersion is NOT skipped when deserializing
+    expect(pojoWithTypeVersion.nestedObj._typeVersion).toBe('3.2.1');
+
+    const pojoWithoutTypeVersion = dataObjects.parse(json, null, {createPojoIfDoIsUnknown: true, retainTypeVersion: false}) as any;
+    expect(pojoWithoutTypeVersion).not.toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
+    expect(pojoWithoutTypeVersion._type).toBe('whatever'); // is kept
+    // _typeVersion is skipped when deserializing
+    expect(pojoWithoutTypeVersion._typeVersion).toBeUndefined();
+    expect(pojoWithoutTypeVersion.value).toBe(1234);
+    expect(pojoWithoutTypeVersion.nestedObj).toBeInstanceOf(Fixture01Do);
+    // _typeVersion is skipped when deserializing
+    expect(pojoWithoutTypeVersion.nestedObj._typeVersion).toBeUndefined();
+
+    const pojoWithTypeVersionPredicate = dataObjects.parse(json, null, {createPojoIfDoIsUnknown: true, retainTypeVersion: (obj: DoEntity) => obj._type !== 'whatever'}) as any;
+    expect(pojoWithTypeVersionPredicate).not.toBeInstanceOf(BaseDoEntity); // as _type cannot be found.
+    expect(pojoWithTypeVersionPredicate._type).toBe('whatever'); // is kept
+    // _typeVersion is skipped when deserializing
+    expect(pojoWithTypeVersionPredicate._typeVersion).toBeUndefined();
+    expect(pojoWithTypeVersionPredicate.value).toBe(1234);
+    expect(pojoWithTypeVersionPredicate.nestedObj).toBeInstanceOf(Fixture01Do);
+    // _typeVersion is NOT skipped when deserializing
+    expect(pojoWithTypeVersionPredicate.nestedObj._typeVersion).toBe('3.2.1');
   });
 
   it('throws if expected and given type differ', () => {


### PR DESCRIPTION
Typically, the _typeVersion can be removed when deserializing data objects. But there may be existing logic that relies on the _typeVersion being present on pojo DOs (e.g. for equals checks). Therefore, introduce the new option retainTypeVersion to enable/disable the removal of the _typeVersion during deserialization. The default value of this option is a predicate that ignores the _typeVersion if the deserialized DataObject is a BaseDoEntity.

410638