### PR TITLE
Remove disabled copy overlay

### DIFF
--- a/eclipse-scout-core/src/form/fields/BasicField.ts
+++ b/eclipse-scout-core/src/form/fields/BasicField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,7 +25,6 @@ export abstract class BasicField<TValue extends TModelValue, TModelValue = TValu
 
   constructor() {
     super();
-    this.disabledCopyOverlay = true;
     this._displayTextModifiedTimeoutId = null;
     this.updateDisplayTextOnModify = false;
     this.updateDisplayTextOnModifyDelay = 250;

--- a/eclipse-scout-core/src/form/fields/FormField.less
+++ b/eclipse-scout-core/src/form/fields/FormField.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -136,10 +136,6 @@
 
   &.has-error > .status {
     #scout.error-status();
-  }
-
-  .disabled-overlay {
-    position: absolute;
   }
 
   &.cell-editor-form-field {

--- a/eclipse-scout-core/src/form/fields/FormField.ts
+++ b/eclipse-scout-core/src/form/fields/FormField.ts
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AbstractLayout, Action, aria, arrays, clipboard, CloneOptions, Column, ContextMenuPopup, Device, dragAndDrop, DragAndDropHandler, DragAndDropOptions, DropType, EnumObject, EventHandler, fields, FieldStatus, FormFieldClipboardExportEvent,
-  FormFieldEventMap, FormFieldLayout, FormFieldModel, FormFieldValidationResultProvider, GridData, GroupBox, HierarchyChangeEvent, HtmlComponent, InitModelOf, KeyStrokeContext, LoadingSupport, Menu, menus as menuUtil, ObjectOrChildModel,
-  ObjectOrModel, ObjectOrType, objects, Predicate, PropertyChangeEvent, scout, Status, StatusMenuMapping, StatusOrModel, strings, styles, TableRow, Tooltip, tooltips, TooltipSupport, TreeVisitor, TreeVisitResult, Widget
+  AbstractLayout, Action, aria, arrays, clipboard, CloneOptions, Column, Device, dragAndDrop, DragAndDropHandler, DragAndDropOptions, DropType, EnumObject, EventHandler, fields, FieldStatus, FormFieldClipboardExportEvent, FormFieldEventMap,
+  FormFieldLayout, FormFieldModel, FormFieldValidationResultProvider, GridData, GroupBox, HierarchyChangeEvent, HtmlComponent, InitModelOf, KeyStrokeContext, LoadingSupport, Menu, menus as menuUtil, ObjectOrChildModel, ObjectOrModel,
+  ObjectOrType, objects, Predicate, PropertyChangeEvent, scout, Status, StatusMenuMapping, StatusOrModel, strings, styles, TableRow, Tooltip, tooltips, TooltipSupport, TreeVisitor, TreeVisitResult, Widget
 } from '../../index';
 import $ from 'jquery';
 
@@ -65,12 +65,6 @@ export class FormField extends Widget implements FormFieldModel {
   onFieldTooltipOptionsCreator: (this: FormField) => InitModelOf<TooltipSupport>;
   dragAndDropHandler: DragAndDropHandler;
   validationResultProvider: FormFieldValidationResultProvider;
-  /**
-   * Some browsers don't support copying text from disabled input fields. If such a browser is detected
-   * and this flag is true (default is false), an overlay DIV is rendered over disabled fields which
-   * provides a custom copy context menu that opens the ClipboardForm.
-   */
-  disabledCopyOverlay: boolean;
 
   $label: JQuery;
   /**
@@ -92,7 +86,6 @@ export class FormField extends Widget implements FormFieldModel {
    */
   $status: JQuery;
   $mandatory: JQuery;
-  $disabledCopyOverlay: JQuery;
   protected _menuPropertyChangeHandler: EventHandler<PropertyChangeEvent<any, Menu>>;
   protected _hierarchyChangeHandler: EventHandler<HierarchyChangeEvent>;
 
@@ -137,9 +130,6 @@ export class FormField extends Widget implements FormFieldModel {
     this.$fieldContainer = null;
     this.$icon = null;
     this.$status = null;
-
-    this.disabledCopyOverlay = false;
-    this.$disabledCopyOverlay = null;
 
     this._addWidgetProperties(['keyStrokes', 'menus', 'statusMenuMappings']);
     this._addCloneProperties(['dropType', 'dropMaximumSize', 'errorStatus', 'fieldStyle', 'gridDataHints', 'gridData', 'label', 'labelVisible', 'labelPosition',
@@ -313,7 +303,6 @@ export class FormField extends Widget implements FormFieldModel {
     this._removeLabel();
     this._removeIcon();
     this.removeMandatoryIndicator();
-    this._removeDisabledCopyOverlay();
     dragAndDrop.uninstallDragAndDropHandler(this);
   }
 
@@ -779,7 +768,6 @@ export class FormField extends Widget implements FormFieldModel {
     if (this.$field) {
       this.$field.setEnabled(this.enabledComputed);
     }
-    this._updateDisabledCopyOverlay();
     this._installOrUninstallDragAndDropHandler();
   }
 
@@ -1381,56 +1369,6 @@ export class FormField extends Widget implements FormFieldModel {
       dropType: () => this.dropType,
       onDrop: event => this.trigger('drop', event)
     };
-  }
-
-  protected _updateDisabledCopyOverlay() {
-    if (this.disabledCopyOverlay && !Device.get().supportsCopyFromDisabledInputFields()) {
-      if (this.enabledComputed) {
-        this._removeDisabledCopyOverlay();
-      } else {
-        this._renderDisabledCopyOverlay();
-        this.revalidateLayout(); // because bounds of overlay is set in FormFieldLayout
-      }
-    }
-  }
-
-  protected _renderDisabledCopyOverlay() {
-    if (!this.$disabledCopyOverlay) {
-      this.$disabledCopyOverlay = this.$container
-        .appendDiv('disabled-overlay')
-        .on('contextmenu', this._createCopyContextMenu.bind(this));
-    }
-  }
-
-  protected _removeDisabledCopyOverlay() {
-    if (this.$disabledCopyOverlay) {
-      this.$disabledCopyOverlay.remove();
-      this.$disabledCopyOverlay = null;
-    }
-  }
-
-  protected _createCopyContextMenu(event: JQuery.ContextMenuEvent) {
-    if (!this.visible || strings.empty(this.displayText)) {
-      return;
-    }
-
-    let menu = scout.create(Menu, {
-      parent: this,
-      text: this.session.text('ui.Copy'),
-      inheritAccessibility: false
-    });
-    menu.on('action', event => this.exportToClipboard());
-
-    let popup = scout.create(ContextMenuPopup, {
-      parent: this,
-      menuItems: [menu],
-      cloneMenuItems: false,
-      location: {
-        x: event.pageX,
-        y: event.pageY
-      }
-    });
-    popup.open();
   }
 
   /**

--- a/eclipse-scout-core/src/form/fields/FormFieldLayout.ts
+++ b/eclipse-scout-core/src/form/fields/FormFieldLayout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AbstractLayout, BasicField, Device, Dimension, EventHandler, FormField, graphics, HtmlComponent, HtmlCompPrefSizeOptions, HtmlEnvironment, Insets, PropertyChangeEvent, Rectangle, scout, scrollbars} from '../../index';
+import {AbstractLayout, BasicField, Dimension, EventHandler, FormField, graphics, HtmlComponent, HtmlCompPrefSizeOptions, HtmlEnvironment, Insets, PropertyChangeEvent, Rectangle, scout, scrollbars} from '../../index';
 
 /**
  * Form-Field Layout, for a form-field with label, status, mandatory-indicator and a field.
@@ -186,37 +186,6 @@ export class FormFieldLayout extends AbstractLayout {
     // Check for scrollbars, update them if necessary
     if (formField.$field) {
       scrollbars.update(formField.$field, true);
-    }
-
-    this._layoutDisabledCopyOverlay();
-  }
-
-  protected _layoutDisabledCopyOverlay() {
-    if (this.formField.$field && this.formField.$disabledCopyOverlay) {
-      let $overlay = this.formField.$disabledCopyOverlay;
-      let $field = this.formField.$field;
-
-      let pos = $field.position();
-      let padding = graphics.insets($field, {
-        includePadding: true
-      });
-
-      // subtract scrollbars sizes from width and height so overlay does not block scrollbars
-      // we read the size from the scrollbar from our device, because we already determined
-      // it on startup. Only do this when element is scrollable.
-      let elem = $field[0];
-      let overflowX = $field.css('overflow-x');
-      let overflowY = $field.css('overflow-y');
-      let scrollHorizontal = overflowX === 'scroll' || overflowX === 'auto' && (elem.scrollWidth - elem.clientWidth) > 0;
-      let scrollVertical = overflowY === 'scroll' || overflowY === 'auto' && (elem.scrollHeight - elem.clientHeight) > 0;
-      let scrollbarSize = Device.get().scrollbarWidth;
-
-      $overlay
-        .css('top', pos.top)
-        .css('left', pos.left)
-        .width($field.width() + padding.horizontal() - (scrollVertical ? scrollbarSize : 0))
-        .height($field.height() + padding.vertical() - (scrollHorizontal ? scrollbarSize : 0));
-
     }
   }
 

--- a/eclipse-scout-core/src/form/fields/datefield/DateField.ts
+++ b/eclipse-scout-core/src/form/fields/datefield/DateField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -69,7 +69,6 @@ export class DateField extends ValueField<Date, Date | string> implements DateFi
     this.dateHasText = false;
     this.dateFocused = false;
     this.dateFormatPattern = null;
-    this.disabledCopyOverlay = true;
     this.hasDate = true;
     this.touchMode = false;
     this.embedded = false;

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -96,7 +96,6 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
     this._currentLookupCall = null;
     this.lookupSeqNo = 0;
     this.initActiveFilter = null;
-    this.disabledCopyOverlay = true;
     this.maxLength = 500;
     this.maxLengthHandler = scout.create(MaxLengthHandler, {
       target: this

--- a/eclipse-scout-core/src/form/fields/stringfield/StringField.ts
+++ b/eclipse-scout-core/src/form/fields/stringfield/StringField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -323,11 +323,6 @@ export class StringField extends BasicField<string> implements StringFieldModel 
   }
 
   protected override _renderDisplayText() {
-    if (this.multilineText && this.$disabledCopyOverlay) {
-      // Changing the value might change the visibility of the scrollbars -> overlay size needs to be adjusted
-      this.invalidateLayoutTree(false);
-    }
-
     if (this.inputObfuscated && this.focused) {
       // If a new display text is set (e.g. because value in model changed) and field is focused,
       // do not display new display text but clear content (as in _onFieldFocus).

--- a/eclipse-scout-core/src/util/Device.ts
+++ b/eclipse-scout-core/src/util/Device.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -498,10 +498,6 @@ export class Device implements DeviceModel, ObjectWithType {
       // Check if scrollbar is vanished if class hybrid-scrollable is applied which hides the scrollbar, see also scrollbars.js and Scrollbar.less
       return this._detectScrollbarWidth('hybrid-scrollable') === 0;
     });
-  }
-
-  supportsCopyFromDisabledInputFields(): boolean {
-    return Device.Browser.FIREFOX !== this.browser;
   }
 
   /**

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts.properties
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts.properties
@@ -58,7 +58,6 @@ ui.ConnectionInterrupted=Connection interrupted
 ui.ConnectionReestablished=Connection reestablished
 ui.Continue=Continue
 ui.ContinueAnyway=Continue anyway
-ui.Copy=Copy
 ui.CopyToClipboardFailedStatus=Could not copy to clipboard
 ui.CopyToClipboardSuccessStatus=Copied to clipboard
 ui.CouldNotCreateElement=Could not create element

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_de.properties
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_de.properties
@@ -58,7 +58,6 @@ ui.ConnectionInterrupted=Verbindung unterbrochen
 ui.ConnectionReestablished=Verbindung wiederhergestellt
 ui.Continue=Weiter
 ui.ContinueAnyway=Trotzdem fortfahren
-ui.Copy=Kopieren
 ui.CopyToClipboardFailedStatus=Kopieren in Zwischenablage fehlgeschlagen
 ui.CopyToClipboardSuccessStatus=In Zwischenablage kopiert
 ui.CouldNotCreateElement=Element konnte nicht erzeugt werden

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_fr.properties
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_fr.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+# Copyright (c) 2010, 2025 BSI Business Systems Integration AG
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,6 @@ ui.ConnectionInterrupted=Connexion interrompue
 ui.ConnectionReestablished=Connexion rétablie
 ui.Continue=Continuer
 ui.ContinueAnyway=Continuer quand même
-ui.Copy=Copier
 ui.CopyToClipboardFailedStatus=Impossible de copier dans le presse-papiers
 ui.CopyToClipboardSuccessStatus=Copié dans le presse-papiers
 ui.Count=Nombre

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_it.properties
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/texts/Texts_it.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+# Copyright (c) 2010, 2025 BSI Business Systems Integration AG
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,6 @@ ui.ConnectionInterrupted=Connessione interrotta
 ui.ConnectionReestablished=Connessione ristabilita
 ui.Continue=Continua
 ui.ContinueAnyway=Continua lo stesso
-ui.Copy=Copia
 ui.CopyToClipboardFailedStatus=Impossibile copiare negli appunti
 ui.CopyToClipboardSuccessStatus=Copiato negli appunti
 ui.Count=Quantità


### PR DESCRIPTION
The overlay prevents a multiline string field to be scrolled when using Firefox. Since the Firefox bug has finally been fixed some years ago, the copy overlay can be removed altogether.

Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=253870
Original ticket: 163273

423418