### PR TITLE
chartJsRenderer: Improve boundary calculation for bubble/stack chart

### DIFF
--- a/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
+++ b/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -2499,7 +2499,11 @@ export class ChartJsRenderer extends AbstractChartRenderer {
 
   protected _adjustSize(config: ChartConfig, chartArea: ChartArea) {
     this._adjustBubbleSizes(config, chartArea);
-    this._adjustGridMaxMin(config, chartArea);
+    // chartJs sets the chartArea depending on the Bubble Sizes and subtracts the max radius from the height / width.
+    // this results in a different grid layout, and we need to refresh before the next calculations.
+    this.refresh();
+    // adjust max and min with the refreshed chartArea
+    this._adjustGridMaxMin(config, this.chartJs.chartArea);
   }
 
   protected _adjustBubbleSizes(config: ChartConfig, chartArea: ChartArea) {
@@ -2569,7 +2573,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
     }));
   }
 
-  protected _computeMaxMinValue(config: ChartConfig, datasets: ChartDataset[], identifier?: string, exact?: boolean, boundRange?: boolean, padding?: number, space?: number): Boundary {
+  protected _computeMaxMinValue(config: ChartConfig, datasets: ChartDataset[], identifier?: string, exact?: boolean, boundRange?: boolean, padding?: number, space?: number, offset?: boolean): Boundary {
     if (!datasets) {
       return;
     }
@@ -2624,6 +2628,13 @@ export class ChartJsRenderer extends AbstractChartRenderer {
     if (padding && space && space > 2 * padding) {
       let valuePerPixel = (maxValue - minValue) / (space - 2 * padding),
         paddingValue = valuePerPixel * padding;
+
+      // When there are only integers and an offset, the offset will cover at least a span of 0.5 (half the space between two ticks, stepSize = 1).
+      // Therefore, a paddingValue between 0 and 0.5 can be eliminated.
+      if (offset && this.onlyIntegers && 0 < paddingValue && paddingValue <= 0.5) {
+        paddingValue = 0;
+      }
+
       maxBoundary = Math.max(maxBoundary, maxValue - adjust + paddingValue);
       minBoundary = Math.min(minBoundary, minValue - adjust - paddingValue);
     }
@@ -2746,12 +2757,16 @@ export class ChartJsRenderer extends AbstractChartRenderer {
       padding = padding + (config.options.elements.point.hoverRadius as number);
     }
 
-    if (offset) {
-      boundary = this._computeMaxMinValue(config, datasets, identifier, labelMap, true);
-    } else {
-      boundary = this._computeMaxMinValue(config, datasets, identifier, labelMap, true, padding, space);
-    }
+    boundary = this._computeMaxMinValue(config, datasets, identifier, labelMap, true, padding, space, offset);
     if (labelMap) {
+      // if we have a labelMap compare the min and max key of the labelMap and the boundary.
+      // in order to show all data and labels we have to take lowest and highest value.
+      const keys = Object.keys(labelMap).map(Number).filter(isFinite);
+      if (keys.length) {
+        boundary.minValue = Math.min(boundary.minValue, Math.min(...keys));
+        boundary.maxValue = Math.max(boundary.maxValue, Math.max(...keys));
+      }
+
       boundary.maxValue = Math.ceil(boundary.maxValue);
       boundary.minValue = Math.floor(boundary.minValue);
     }

--- a/eclipse-scout-chart/test/chart/ChartJsRendererSpec.ts
+++ b/eclipse-scout-chart/test/chart/ChartJsRendererSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -173,7 +173,7 @@ describe('ChartJsRendererSpec', () => {
       });
     });
 
-    it('bubble chart, min/max is set on x and y axis, axis without offset take max(r) into account', () => {
+    it('bubble chart, min/max is set on x and y axis, take max(r) into account', () => {
       let config = $.extend(true, {}, defaultScalesConfig, {
         type: Chart.Type.BUBBLE,
         options: {
@@ -204,16 +204,23 @@ describe('ChartJsRendererSpec', () => {
         yValuePerPixel = (maxY - minY) / (height - 2 * padding),
         yPaddingValue = yValuePerPixel * padding;
 
+      let width = Math.abs(chartArea.right - chartArea.left), // 750
+        maxX = 43,
+        minX = 11,
+        xValuePerPixel = (maxX - minX) / (width - 2 * padding),
+        xPaddingValue = xValuePerPixel * padding; // 2.63..
+
       expect(config.options.scales.x).toEqual({
         minSpaceBetweenTicks: 150, // default value, not part of this test
         offset: true,
-        suggestedMax: 46,
-        suggestedMin: 11,
+        suggestedMax: 46, // boundary after adjust (-11) and rounding function (see ChartJsRenderer._calculateBoundaryPositive) is [0, 35], which already includes the padding (43 - 11 + 2.63.. = 34.63..) -> no xPaddingValue here
+        suggestedMin: 11 - xPaddingValue,
         ticks: {
           maxTicksLimit: 6,
           stepSize: undefined // default value, not part of this test
         }
       });
+
       expect(config.options.scales.y).toEqual({
         minSpaceBetweenTicks: 35, // default value, not part of this test
         suggestedMax: 43 + yPaddingValue,
@@ -225,7 +232,7 @@ describe('ChartJsRendererSpec', () => {
       });
     });
 
-    it('bubble chart, min/max is set on x and y axis, axis without offset take max(r) into account, axis with labelMap calculate exact min/max', () => {
+    it('bubble chart, min/max is set on x and y axis, take max(r) into account, axis with labelMap calculate exact min/max', () => {
 
       let labelMap = {
           11: 'Label 11',
@@ -261,11 +268,24 @@ describe('ChartJsRendererSpec', () => {
 
       renderer._adjustGridMaxMin(config, chartArea);
 
+      let height = Math.abs(chartArea.top - chartArea.bottom),
+        padding = 53, // max(r)
+        maxY = 43,
+        minY = 11,
+        yValuePerPixel = (maxY - minY) / (height - 2 * padding),
+        yPaddingValue = yValuePerPixel * padding;
+
+      let width = Math.abs(chartArea.right - chartArea.left),
+        maxX = 43,
+        minX = 11,
+        xValuePerPixel = (maxX - minX) / (width - 2 * padding),
+        xPaddingValue = xValuePerPixel * padding;
+
       expect(config.options.scales.x).toEqual({
         minSpaceBetweenTicks: 150, // default value, not part of this test
         offset: true,
-        suggestedMax: 43,
-        suggestedMin: 11,
+        suggestedMax: Math.ceil(43 + xPaddingValue),
+        suggestedMin: Math.floor(11 - xPaddingValue),
         ticks: {
           maxTicksLimit: 6,
           stepSize: undefined // default value, not part of this test
@@ -273,8 +293,64 @@ describe('ChartJsRendererSpec', () => {
       });
       expect(config.options.scales.y).toEqual({
         minSpaceBetweenTicks: 35, // default value, not part of this test
-        suggestedMax: 52,
-        suggestedMin: 2,
+        suggestedMax: Math.ceil(43 + yPaddingValue),
+        suggestedMin: Math.floor(11 - yPaddingValue),
+        ticks: {
+          maxTicksLimit: 9,
+          stepSize: undefined // default value, not part of this test
+        }
+      });
+    });
+
+    it('bubble chart, min/max is set on x and y axis, take max(r) into account, axis with labelMap calculate exact min/max considering offset size and labelMap', () => {
+      let labelMap = {
+          0: 'Label 0',
+          1: 'Label 1',
+          2: 'Label 2',
+          3: 'Label 3',
+          4: 'Label 4',
+          5: 'Label 5',
+          6: 'Label 6'
+        },
+        config = $.extend(true, {}, defaultScalesConfig, {
+          type: Chart.Type.BUBBLE,
+          options: {
+            scales: {
+              x: {
+                offset: true
+              }
+            },
+            xLabelMap: labelMap,
+            yLabelMap: labelMap
+          }
+        });
+
+      config.data.datasets[0].data = [
+        {x: 3, y: 0, r: 47},
+        {x: 4, y: 1, r: 29},
+        {x: 2, y: 2, r: 19},
+        {x: 3, y: 3, r: 53},
+        {x: 4, y: 4, r: 13},
+        {x: 5, y: 5, r: 11},
+        {x: 6, y: 6, r: 37}
+      ];
+
+      renderer._adjustGridMaxMin(config, chartArea);
+
+      expect(config.options.scales.x).toEqual({
+        minSpaceBetweenTicks: 150, // default value, not part of this test
+        offset: true,
+        suggestedMax: 6, // offset is sufficient
+        suggestedMin: 0, // offset is sufficient
+        ticks: {
+          maxTicksLimit: 6,
+          stepSize: undefined // default value, not part of this test
+        }
+      });
+      expect(config.options.scales.y).toEqual({
+        minSpaceBetweenTicks: 35, // default value, not part of this test
+        suggestedMax: 8, // offset is not big enough for y scale -> adjust
+        suggestedMin: -2, // offset is not big enough for y scale -> adjust
         ticks: {
           maxTicksLimit: 9,
           stepSize: undefined // default value, not part of this test


### PR DESCRIPTION
1. Bubbles are sometimes cut off by the chartArea. There are 2 reasons for this:

* ChartJs will shrink the chartArea after resizing the bubble, because it subtracts the bubble radius from the available chartArea.

To prevent cut off bubbles, the chart will be refreshed after the adjustment of the bubble radius and will continue the boundary calculation with the new chartArea.

* When an axis has an offset defined, the radius is not considered in the calculation for the suggested min and max value. When there are big bubbles, the offset may not be big enough for the bubble radius, and they will appear outside the chartArea.

The solution for this problem is to always consider the bubble radius for the calculation of the boundary, also when an offset is defined.

2. The axis may have unnecessary whitespace with no data or label at the beginning and end of the scale. This happens when the boundaries got adjusted based on the bubble radius.

To solve this problem the boundary calculation now checks if the axis offset is big enough for the bubble's radius. If so the boundary will not get adjusted.

3. Some labels of the labelMap are not shown, when there is no dataPoint with the values of the label's tick.

The min and max values for calculating the boundaries will now be taken from the dataPoints or the labelMap. The smallest and biggest number will be used.

407411