### PR TITLE
Add ProxiedRestRequestHelper

### DIFF
--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/ProxiedRestRequestHelper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/ProxiedRestRequestHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest;
+
+import jakarta.ws.rs.core.HttpHeaders;
+
+import org.eclipse.scout.rt.dataobject.exception.AccessForbiddenException;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+/**
+ * Helper for checking whether requests are originating from ScoutJS (i.e. proxied REST call).
+ *
+ * <br><b>Example:</b> The following example GET resource is responded with HTTP status code
+ * 403 if it was proxied.
+ * <pre>
+ * &#064;GET
+ * &#064;Path("info")
+ * public String info(@Context HttpHeaders headers) {
+ *   BEANS.get(ProxiedRestRequestHelper.class).throwForbiddenIfProxied(headers);
+ *   return "info";
+ * }
+ * </pre>
+ *
+ * <br><b>Note:</b> this class is considered beta and will be validated again in the context of ticket #419045.
+ *
+ * @see RestHttpHeaders#PROXIED_REQUEST_HTTP_HEADER
+ */
+@ApplicationScoped
+public class ProxiedRestRequestHelper {
+
+  /**
+   * @return {@code true} in case of a proxied ScoutJS request. Otherwise, {@code false}.
+   */
+  public boolean isProxied(HttpHeaders headers) {
+    return Boolean.TRUE.toString().equalsIgnoreCase(headers.getHeaderString(RestHttpHeaders.PROXIED_REQUEST_HTTP_HEADER));
+  }
+
+  /**
+   * @throws AccessForbiddenException
+   *     in case of a proxied ScoutJS request.
+   */
+  public void throwForbiddenIfProxied(HttpHeaders headers) {
+    if (isProxied(headers)) {
+      throw new AccessForbiddenException();
+    }
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/RestHttpHeaders.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/RestHttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,4 +18,11 @@ public final class RestHttpHeaders {
    * HTTP header name for the request Id.
    */
   public static final String REQUEST_ID = "X-ScoutRequestId";
+
+  /**
+   * HTTP header used to mark requests originating from ScoutJS (i.e. proxied REST call).
+   * The header value {@code true} (case-insensitive!) is considered proxied. All other
+   * values or the absence of the header are considered not-proxied.
+   */
+  public static final String PROXIED_REQUEST_HTTP_HEADER = "X-ScoutProxiedRequest";
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/AbstractRestProxyRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/AbstractRestProxyRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,13 @@ import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestContext;
 import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestOptions;
 
 public abstract class AbstractRestProxyRequestHandler extends AbstractUiServletRequestHandler {
+
+  /**
+   * HTTP header used to mark requests originating from ScoutJS (i.e. proxied REST call).
+   * The header value {@code true} (case-insensitive!) is considered proxied. All other
+   * values or the absence of the header are considered not-proxied.
+   */
+  public static final String PROXIED_REQUEST_HTTP_HEADER = "X-ScoutProxiedRequest";
 
   private HttpProxy m_proxy;
 
@@ -71,6 +78,12 @@ public abstract class AbstractRestProxyRequestHandler extends AbstractUiServletR
 
   protected void proxy(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     HttpProxyRequestOptions options = createHttpProxyRequestOptions(req, resp);
+
+    if (options == null) {
+      options = new HttpProxyRequestOptions();
+    }
+    addProxiedRequestHeader(options);
+
     getProxy().proxy(req, resp, options);
   }
 
@@ -78,6 +91,16 @@ public abstract class AbstractRestProxyRequestHandler extends AbstractUiServletR
    * @return options to be used for an HTTP through the proxy
    */
   protected abstract HttpProxyRequestOptions createHttpProxyRequestOptions(HttpServletRequest req, HttpServletResponse resp);
+
+  protected void addProxiedRequestHeader(HttpProxyRequestOptions options) {
+    if (isProxiedRequestHeaderEnabled()) {
+      options.withCustomRequestHeader(PROXIED_REQUEST_HTTP_HEADER, Boolean.TRUE.toString());
+    }
+  }
+
+  protected boolean isProxiedRequestHeaderEnabled() {
+    return true;
+  }
 
   protected HttpProxyRequestContext createHttpProxyRequestContext(HttpServletRequest req) {
     return BEANS.get(HttpProxyRequestContext.class)


### PR DESCRIPTION
The ProxiedRestRequestHelper provides methods to check whether a request was proxied and to throw a AccessForbiddenException if it was proxied. A request is considered proxied if the headers contain the RestHttpHeaders.PROXIED_REQUEST_HTTP_HEADER with value "true". The header is NOT set automatically by the AbstractRestProxyRequestHandler but can be set by its implementations to e.g. mark request originating from ScoutJS.

428123