### PR TITLE
Don't use disabled copy overlay

### DIFF
--- a/eclipse-scout-core/src/util/Device.ts
+++ b/eclipse-scout-core/src/util/Device.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -501,7 +501,7 @@ export class Device implements DeviceModel, ObjectWithType {
   }
 
   supportsCopyFromDisabledInputFields(): boolean {
-    return Device.Browser.FIREFOX !== this.browser;
+    return true; // Every browser supports it now. The disabledCopyOverlay will be removed with 25.2.
   }
 
   /**


### PR DESCRIPTION
The overlay prevents a multiline string field to be scrolled when using Firefox. Since the Firefox bug has finally been fixed some years ago, the copy overlay is not necessary anymore and will be removed with 25.2.

Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=253870
Original ticket: 163273

423418