### PR TITLE
Table: don't throw error when resizing a destroyed column

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -4270,7 +4270,8 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
    * @param width new column size
    */
   resizeColumn(column: Column<any>, width: number) {
-    if (column.fixedWidth) {
+    if (column.fixedWidth || !column.table) {
+      // Do nothing if column has fixed with or if it has been destroyed (column.table is null)
       return;
     }
     width = Math.floor(width);


### PR DESCRIPTION
If the columns of a table get destroyed while a column is being resized, an exception occurs because column.table is null in Column.setWidth.

This may happen if the table organizer menu is open, a profile activated and the column resized before the activation finishes (which will replace all columns).

428173