### PR TITLE
Revert adding property to ITreeNode

### DIFF
--- a/eclipse-scout-core/src/tree/TreeNode.ts
+++ b/eclipse-scout-core/src/tree/TreeNode.ts
@@ -32,7 +32,6 @@ export class TreeNode implements TreeNodeModel, ObjectWithType {
   parentNode: TreeNode;
   session: Session;
   text: string;
-  plainTextTitle: string;
   tooltipText: string;
   foregroundColor: string;
   backgroundColor: string;
@@ -88,7 +87,6 @@ export class TreeNode implements TreeNodeModel, ObjectWithType {
     this.rendered = false;
     this.session = null;
     this.text = null;
-    this.plainTextTitle = null;
 
     this._loadChildrenPromise = null;
   }
@@ -227,10 +225,6 @@ export class TreeNode implements TreeNodeModel, ObjectWithType {
 
   setText(text: string) {
     this.text = text;
-  }
-
-  setPlainTextTitle(plainTextTitle: string) {
-    this.plainTextTitle = plainTextTitle;
   }
 
   /**

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/bookmark/DefaultBookmarkAdapter.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/bookmark/DefaultBookmarkAdapter.java
@@ -37,12 +37,12 @@ public class DefaultBookmarkAdapter implements IBookmarkAdapter {
 
   @Override
   public String getTitle() {
-    return m_page.toPlainTextTitle();
+    return m_page.toPlainText();
   }
 
   @Override
   public String getText() {
-    return m_page.toPlainTextTitle();
+    return m_page.toPlainText();
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
@@ -1055,7 +1055,7 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
         if (pathStr.length() != 0) {
           pathStr.insert(0, delimiter);
         }
-        pathStr.insert(0, node.toPlainTextTitle());
+        pathStr.insert(0, node.toPlainText());
       }
       // next
       node = node.getParentNode();
@@ -2548,7 +2548,7 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
               interceptDecorateCell(node, node.getCellForUpdate());
             }
             catch (Exception t) {
-              LOG.warn("node {} ({})", node.getClass(), node.toPlainTextTitle(), t);
+              LOG.warn("node {} ({})", node.getClass(), node.toPlainText(), t);
             }
           }
         }
@@ -2780,7 +2780,7 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
         StringBuilder msg = new StringBuilder();
         for (ITreeNode node : nodes) {
           msg.append("[");
-          msg.append(node.toPlainTextTitle());
+          msg.append(node.toPlainText());
           msg.append("]");
         }
         throw BEANS.get(PlatformExceptionTranslator.class).translate(e)
@@ -2812,7 +2812,7 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
       catch (RuntimeException e) {
         if (node != null) {
           throw BEANS.get(PlatformExceptionTranslator.class).translate(e)
-              .withContextInfo("node", node.toPlainTextTitle());
+              .withContextInfo("node", node.toPlainText());
         }
         throw e;
       }
@@ -2846,7 +2846,7 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
       catch (RuntimeException e) {
         if (node != null) {
           throw BEANS.get(PlatformExceptionTranslator.class).translate(e)
-              .withContextInfo("cell", node.toPlainTextTitle());
+              .withContextInfo("cell", node.toPlainText());
         }
         throw e;
       }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTreeNode.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTreeNode.java
@@ -415,22 +415,12 @@ public abstract class AbstractTreeNode implements ITreeNode, ICellObserver, ICon
   }
 
   @Override
-  public String getPlainTextTitle() {
-    return m_plainTextTitle;
-  }
-
-  @Override
-  public void setPlainTextTitle(String cellTitle) {
-    m_plainTextTitle = cellTitle;
-  }
-
-  @Override
   public final void decorateCell() {
     try {
       interceptDecorateCell(m_cell);
     }
     catch (Exception t) {
-      LOG.error("node {} {}", getClass(), toPlainTextTitle(), t);
+      LOG.error("node {} {}", getClass(), toPlainText(), t);
     }
   }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeNode.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeNode.java
@@ -135,15 +135,8 @@ public interface ITreeNode extends IVisibleDimension, IEnabledDimension, IContex
 
   Cell getCellForUpdate();
 
-  /**
-   * Makes it possible to differentiate between the cell text (which could be html) and what the cell represents (e.g. a label)
-   */
-  String getPlainTextTitle();
-
-  void setPlainTextTitle(String title);
-
-  default String toPlainTextTitle() {
-    return getPlainTextTitle() == null ? getCell().toPlainText() : getPlainTextTitle();
+  default String toPlainText() {
+    return getCell().toPlainText();
   }
 
   Object getPrimaryKey();

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/DesktopEvent.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/DesktopEvent.java
@@ -214,7 +214,7 @@ public class DesktopEvent extends EventObject implements IModelEvent {
       buf.append(" ").append(m_messageBox.getHeader());
     }
     if (m_outline != null) {
-      buf.append(" ").append(m_outline.getRootNode().toPlainTextTitle());
+      buf.append(" ").append(m_outline.getRootNode().toPlainText());
     }
     buf.append("]");
     return buf.toString();

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/bookmark/AbstractBookmarkTreeField.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/bookmark/AbstractBookmarkTreeField.java
@@ -833,7 +833,7 @@ public abstract class AbstractBookmarkTreeField extends AbstractTreeField {
         ITree tree = getTree();
         for (ITreeNode node : tree.getSelectedNodes()) {
           if (isBookmarkNode(node)) {
-            items.add(node.toPlainTextTitle());
+            items.add(node.toPlainText());
             filteredNodes.add(node);
           }
         }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/bookmark/view/BookmarkViewForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/bookmark/view/BookmarkViewForm.java
@@ -172,7 +172,7 @@ public class BookmarkViewForm extends AbstractForm {
            */
           @Override
           public boolean accept(ITreeNode node, int level) {
-            String text = node.toPlainTextTitle();
+            String text = node.toPlainText();
             return text == null || m_lowercaseFilterPattern == null || m_lowercaseFilterPattern.matcher(text.toLowerCase()).matches();
           }
         }

--- a/org.eclipse.scout.rt.datamodel.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/composer/internal/ComposerDisplayTextBuilder.java
+++ b/org.eclipse.scout.rt.datamodel.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/composer/internal/ComposerDisplayTextBuilder.java
@@ -63,7 +63,7 @@ public class ComposerDisplayTextBuilder {
   private void visitOrNodes(List<? extends EitherOrNode> nodes, StringBuilder buf, String prefix) {
     for (EitherOrNode node : nodes) {
       buf.append(prefix);
-      buf.append(node.toPlainTextTitle());
+      buf.append(node.toPlainText());
       buf.append("\n");
       // add children
       visitAndNodes(node.getChildNodes(), buf, prefix + " ");
@@ -72,7 +72,7 @@ public class ComposerDisplayTextBuilder {
 
   private void visitEntityNode(EntityNode node, StringBuilder buf, String prefix) {
     buf.append(prefix);
-    buf.append(node.toPlainTextTitle());
+    buf.append(node.toPlainText());
     buf.append("\n");
     // add children
     visitAndNodes(node.getChildNodes(), buf, prefix + " ");
@@ -80,7 +80,7 @@ public class ComposerDisplayTextBuilder {
 
   private void visitAttributeNode(AttributeNode node, StringBuilder buf, String prefix) {
     buf.append(prefix);
-    buf.append(node.toPlainTextTitle());
+    buf.append(node.toPlainText());
     buf.append("\n");
     // add children
     visitAndNodes(node.getChildNodes(), buf, prefix + " ");

--- a/org.eclipse.scout.rt.datamodel.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/composer/node/AbstractComposerNode.java
+++ b/org.eclipse.scout.rt.datamodel.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/composer/node/AbstractComposerNode.java
@@ -104,6 +104,6 @@ public abstract class AbstractComposerNode extends AbstractTreeNode {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "[" + toPlainTextTitle() + "]";
+    return getClass().getSimpleName() + "[" + toPlainText() + "]";
   }
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/tree/JsonTree.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/tree/JsonTree.java
@@ -641,7 +641,6 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
       putProperty(jsonNode, "leaf", node.isLeaf());
       putProperty(jsonNode, "enabled", node.isEnabled());
       putProperty(jsonNode, "lazyExpandingEnabled", node.isLazyExpandingEnabled());
-      putProperty(jsonNode, "plainTextTitle", node.getPlainTextTitle());
 
       jsonNodes.put(jsonNode);
     }
@@ -754,7 +753,6 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
     }
     JSONObject jsonEvent = new JSONObject();
     putProperty(jsonEvent, PROP_NODE_ID, nodeId);
-    putProperty(jsonEvent, "plainTextTitle", modelNode.getPlainTextTitle());
     putCellProperties(jsonEvent, modelNode.getCell());
     addActionEvent(EVENT_NODE_CHANGED, jsonEvent);
   }
@@ -952,7 +950,6 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
     putProperty(json, "enabled", node.isEnabled());
     putProperty(json, "iconId", BinaryResourceUrlUtility.createIconUrl(node.getCell().getIconId()));
     putProperty(json, "initialExpanded", node.isInitialExpanded());
-    putProperty(json, "plainTextTitle", node.getPlainTextTitle());
     putChildNodeIndex(json, node, childIndexes);
     putCellProperties(json, node.getCell());
     JSONArray jsonChildNodes = new JSONArray();

--- a/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/json/defaultValues.json
+++ b/org.eclipse.scout.rt.ui.html/src/main/resources/org/eclipse/scout/rt/ui/html/json/defaultValues.json
@@ -459,8 +459,7 @@
       "lazyExpandingEnabled": false,
       "leaf": false,
       "childNodes": [],
-      "filterAccepted": true,
-      "plainTextTitle": null
+      "filterAccepted": true
     },
     "Page": {
       "detailTableVisible": true,


### PR DESCRIPTION
The property plainTextTitle was reverted. If you need to give a plain text title you can override the method toPlainText.

319634