### PR TITLE
DesktopNotification: don't fail if parent is destroyed

### DIFF
--- a/eclipse-scout-core/src/desktop/notification/DesktopNotification.ts
+++ b/eclipse-scout-core/src/desktop/notification/DesktopNotification.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -61,6 +61,11 @@ export class DesktopNotification extends ScoutNotification implements DesktopNot
 
   protected override _init(model: InitModelOf<this>) {
     super._init(model);
+
+    // A desktop notification belongs to the desktop and should stay visible until it is closed.
+    this.setParent(this.session.desktop);
+    this.setOwner(this.parent);
+
     let defaults = this.session.desktop.nativeNotificationDefaults;
     if (defaults) {
       this.nativeNotificationTitle = model.nativeNotificationTitle !== undefined ? model.nativeNotificationTitle : defaults.title;
@@ -238,8 +243,8 @@ export class DesktopNotification extends ScoutNotification implements DesktopNot
   }
 
   fadeOut() {
-    // prevent fadeOut from running more than once (for instance from the click of a user).
-    if (this._removing) {
+    // prevent fadeOut from running more than once (for instance from the click of a user) and do nothing if it is already being destroyed.
+    if (this._removing || this.destroying) {
       return;
     }
     this._removing = true;

--- a/eclipse-scout-core/src/util/clipboard.ts
+++ b/eclipse-scout-core/src/util/clipboard.ts
@@ -140,7 +140,7 @@ export const clipboard = {
     scout.assertParameter('parent', parent);
     status = status || clipboard._successStatus(parent.session);
     let notification = scout.create(DesktopNotification, {
-      parent: parent.findDesktop(), // use desktop as parent in case the given parent widget is destroyed before the notification duration has elapsed
+      parent: parent,
       closable: false,
       duration: status.isValid() ? 1234 : 3456, // use longer duration for errors because error message is longer
       status: status

--- a/eclipse-scout-core/test/desktop/notification/DesktopNotificationSpec.ts
+++ b/eclipse-scout-core/test/desktop/notification/DesktopNotificationSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {DesktopNotification, scout, Status, Widget} from '../../../src/index';
+import {DesktopNotification, scout, Status, StringField, Widget} from '../../../src/index';
 
 describe('DesktopNotification', () => {
   let session: SandboxSession, $sandbox: JQuery,
@@ -75,6 +75,69 @@ describe('DesktopNotification', () => {
     expect(notification.$container.find('.closer').length).toBe(1);
     expect(notification.$container.find('.desktop-notification-content').text()).toBe('bar');
     expect(notification.$container.hasClass('ok')).toBe(true);
+  });
+
+  it('initially ensures parent and owner point to desktop', () => {
+    let field = scout.create(StringField, {parent: session.desktop});
+    let notification = scout.create(DesktopNotification, {parent: field});
+    expect(notification.parent).toBe(session.desktop);
+    expect(notification.owner).toBe(session.desktop);
+    notification.show();
+
+    field.destroy();
+    expect(notification.destroyed).toBe(false);
+    expect(notification.rendered).toBe(true);
+  });
+
+  it('allows changing owner', () => {
+    // Changing owner is not explicitly prevented by the notification so it should be asserted that it behaves correctly,
+    // however it is probably used very rarely if at all.
+    let field = scout.create(StringField, {parent: session.desktop});
+    field.render();
+    let notification = scout.create(DesktopNotification, {parent: session.desktop});
+    notification.setOwner(field);
+    expect(notification.owner).toBe(field);
+
+    notification.show();
+    field.destroy();
+    expect(notification.destroyed).toBe(true);
+
+    // Also behaves correctly if field was never rendered
+    field = scout.create(StringField, {parent: session.desktop});
+    notification = scout.create(DesktopNotification, {parent: session.desktop});
+    notification.setOwner(field);
+    expect(notification.owner).toBe(field);
+
+    notification.show();
+    field.destroy();
+    expect(notification.destroyed).toBe(true);
+  });
+
+  it('allows changing parent', () => {
+    // Changing parent is not explicitly prevented by the notification so it should be asserted that it behaves correctly,
+    // however it is probably used very rarely if at all.
+    let field = scout.create(StringField, {parent: session.desktop});
+    field.render();
+    let notification = scout.create(DesktopNotification, {parent: session.desktop});
+    notification.setParent(field);
+    expect(notification.parent).toBe(field);
+
+    notification.show();
+    field.destroy();
+    expect(notification.destroyed).toBe(true);
+  });
+
+  it('does not vanish if parent is destroyed and was never rendered', () => {
+    let field = scout.create(StringField, {parent: session.desktop});
+    let notification = scout.create(DesktopNotification, {parent: session.desktop});
+    notification.setParent(field);
+    expect(notification.parent).toBe(field);
+
+    notification.show();
+    field.destroy();
+    expect(notification.destroyed).toBe(false);
+    expect(notification.rendered).toBe(true);
+    expect(notification.parent).toBe(session.desktop);
   });
 
   describe('native notification', () => {


### PR DESCRIPTION
If parent is destroyed while desktop notification is open, an error occurs.

The error occurs because the parent of the notification calls notification.destroy(). This triggers the remove
handler of the desktop that calls notification.fadeOut() which calls destroy() again even though the notification is already being destroyed.

Cannot read properties of null (reading '_removeChild')
    at DesktopNotification.destroy (Widget.ts:336:16)

Also, if parent is not the desktop, the notification is removed when the parent is removed. This may be confusing and the notification won't be rendered again if the parent is re-rendered. Therefore, the parent and owner should always be the desktop. Instead of enforcing that the passed parent needs to be the desktop, the notification now automatically changes the parent and the owner. This makes it easier to use and as it is very common to write {parent: this}. If really a different parent or owner than the desktop should be used, it is still possible by explicitly calling setParent/setOwner afterward.

411504