### PR TITLE
OrganizeColumnsForm: save preferences when resetting table

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableOrganizer.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableOrganizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@ package org.eclipse.scout.rt.client.ui.basic.table;
 
 import java.util.List;
 
+import org.eclipse.scout.rt.client.ui.ClientUIPreferences;
 import org.eclipse.scout.rt.client.ui.basic.table.columns.IColumn;
 import org.eclipse.scout.rt.client.ui.basic.table.customizer.ITableCustomizer;
 import org.eclipse.scout.rt.client.ui.basic.table.organizer.IShowInvisibleColumnsForm;
@@ -90,6 +91,7 @@ public class TableOrganizer implements ITableOrganizer {
     List<IColumn<?>> visibleColumns = columnSet.getVisibleColumns();
     visibleColumns.remove(column);
     columnSet.setVisibleColumns(visibleColumns);
+    ClientUIPreferences.getInstance().setAllTableColumnPreferences(m_table);
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsForm.java
@@ -1097,6 +1097,7 @@ public class OrganizeColumnsForm extends AbstractForm implements IOrganizeColumn
 
   public void resetAll() {
     m_organizedTable.reset(false);
+    ClientUIPreferences.getInstance().removeTableColumnsConfig(m_organizedTable, null); // clear global profile
     if (isCustomizable() && m_organizedTable.getReloadHandler() != null) {
       m_organizedTable.getReloadHandler().reload(IReloadReason.ORGANIZE_COLUMNS);
     }
@@ -1105,6 +1106,7 @@ public class OrganizeColumnsForm extends AbstractForm implements IOrganizeColumn
 
   public void applyConfig(String configName) {
     applyConfigImpl(configName);
+    ClientUIPreferences.getInstance().setAllTableColumnPreferences(m_organizedTable, null); // save new state as global profile
     if (isCustomizable() && m_organizedTable.getReloadHandler() != null) {
       m_organizedTable.getReloadHandler().reload(IReloadReason.ORGANIZE_COLUMNS);
     }


### PR DESCRIPTION
With the recent refactoring, the code that stored the new table preferences after certain operations was removed (execRowsChecked).

This changes stores the preferences again on the following operations:
- Hide column
- Load profile
- Reset to factory settings

The last operation now removes the global profile instead of saving the factory state in the preferences. This saves data. And if we change the table later, users that have already reset the preferences for the table will see them automatically.

429573