### PR TITLE
Fix row filter for tables in tile mode

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/TableTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/TableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -632,6 +632,42 @@ public class TableTest {
     assertEquals(0, table.getTableTileGridMediator().getTileMappings().size());
   }
 
+  @Test
+  public void testUpdateProgrammedFilterForTableWithTiles() {
+    P_TableWithTiles table = new P_TableWithTiles();
+    table.init();
+    fillTable(table);
+
+    assertEquals(5, table.getFilteredRowCount());
+    assertEquals(5, table.getRowCount());
+    assertNotNull(table.getTableTileGridMediator());
+    assertEquals(table.getRowCount(), table.getTableTileGridMediator().getTileMappings().size());
+
+    // test programmed filter added
+    ITableRowFilter programmedTableRowFilter = r -> table.getFirstColumn().getValue(r) <= 10;
+    table.addRowFilter(programmedTableRowFilter);
+    assertEquals(2, table.getFilteredRowCount());
+    assertEquals(5, table.getRowCount());
+    assertNotNull(table.getTableTileGridMediator());
+    assertEquals(table.getFilteredRowCount(), table.getTableTileGridMediator().getTileMappings().size());
+
+    // test programmed filter removed
+    table.removeRowFilter(programmedTableRowFilter);
+    assertEquals(5, table.getFilteredRowCount());
+    assertEquals(5, table.getRowCount());
+    assertNotNull(table.getTableTileGridMediator());
+    assertEquals(table.getRowCount(), table.getTableTileGridMediator().getTileMappings().size());
+
+    // test programmed filter and user filter added
+    table.addRowFilter(programmedTableRowFilter);
+    UserTableRowFilter userRowFilter = new UserTableRowFilter(CollectionUtility.hashSet(table.getRow(0)));
+    table.addRowFilter(userRowFilter);
+    assertEquals(1, table.getFilteredRowCount());
+    assertEquals(5, table.getRowCount());
+    assertNotNull(table.getTableTileGridMediator());
+    assertEquals("Tile deleted by user filter should not be deleted from the mapping since the ui handles this filter", 2, table.getTableTileGridMediator().getTileMappings().size());
+  }
+
   private void assertValidTestTable(P_Table table, int status) {
     assertRowCount(2, 0, table);
     assertStatusAndTable(table, status, table.getRow(0));
@@ -681,7 +717,7 @@ public class TableTest {
   }
 
   /**
-   * @param expectedStatus
+   * @param status
    * @return
    */
   private static String decodeStatus(int status) {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableTileGridMediator.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableTileGridMediator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,6 +88,23 @@ public class TableTileGridMediator extends AbstractPropertyObserver implements I
         case TableEvent.TYPE_ALL_ROWS_DELETED:
           tileMappings.forEach(tm -> tm.getTile().dispose());
           setTileMappings(new ArrayList<>());
+          break;
+        case TableEvent.TYPE_ROW_FILTER_CHANGED:
+          List<ITableRow> filteredRows = m_table.getRows().stream()
+              // Analogous to JsonTable.preprocessBufferedEvents() do not consider user filtered rows here, since these are handled directly by ui.
+              .filter(row -> row.isFilterAccepted() || row.isRejectedByUser())
+              .collect(Collectors.toList());
+
+          // delete tiles which are not accepted by filter
+          Predicate<ITableRowTileMapping> filteredOutPredicate = m -> !filteredRows.contains(m.getTableRow());
+          tileMappings.stream().filter(filteredOutPredicate).forEach(m -> m.getTile().dispose());
+          tileMappings.removeIf(filteredOutPredicate);
+
+          // insert non-existing tiles
+          filteredRows.removeAll(tileMappings.stream().map(ITableRowTileMapping::getTableRow).collect(Collectors.toList()));
+          tileMappings.addAll(m_table.createTiles(filterTopLevelTableRows(filteredRows)));
+
+          setTileMappings(tileMappings);
           break;
       }
     }

--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumExpectedConditions.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumExpectedConditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -301,6 +301,15 @@ public final class SeleniumExpectedConditions {
    */
   public static ExpectedCondition<List<WebElement>> tableToHaveNumberOfRows(final WebElement parentElement, final int numRows) {
     return containerToHaveNumberOfChildDivs(parentElement, "table-row", numRows);
+  }
+
+  /**
+   * @param parentElement
+   *     if not null, findElement below the given parent, if null, findElements in document
+   * @return The tiles found by the expected condition
+   */
+  public static ExpectedCondition<List<WebElement>> tableToHaveNumberOfTiles(final WebElement parentElement, final int numTiles) {
+    return containerToHaveNumberOfChildDivs(parentElement, "tile", numTiles);
   }
 
   /**


### PR DESCRIPTION
TableTileGridMediator now also handles
TableEvent.TYPE_ROW_FILTER_CHANGED such that tiles are indeed filtered by a programmed row filter.

427908