### PR TITLE
Reload tiles when form is activated and data was changed

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/datachange/ActiveFormDataChangeManagerTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/datachange/ActiveFormDataChangeManagerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.desktop.datachange;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.assertTrue;
+
+import org.eclipse.scout.rt.client.IClientSession;
+import org.eclipse.scout.rt.client.session.ClientSessionProvider;
+import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
+import org.eclipse.scout.rt.client.ui.form.AbstractForm;
+import org.eclipse.scout.rt.client.ui.form.fields.groupbox.AbstractGroupBox;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.platform.classid.ClassId;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(TestEnvironmentClientSession.class)
+public class ActiveFormDataChangeManagerTest {
+
+  private static final String TEST_DATA_TYPE = "testDataType";
+
+  @Test
+  public void testActiveFormDataChangeManager(){
+    IDesktop desktop = ClientSessionProvider.currentSession().getDesktop();
+
+    IDataChangeListener formOneChangeListenerMock = Mockito.mock(IDataChangeListener.class);
+    IDataChangeListener formTwoChangeListenerMock = Mockito.mock(IDataChangeListener.class);
+
+    TestForm formOne = new TestForm();
+    BEANS.get(ActiveFormDataChangeManager.class).add(formOne, formOneChangeListenerMock, true, TEST_DATA_TYPE);
+    formOne.start();
+
+    desktop.dataChanged(TEST_DATA_TYPE);
+    Mockito.verify(formOneChangeListenerMock).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+    Mockito.verify(formTwoChangeListenerMock, Mockito.never()).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+
+    TestForm formTwo = new TestForm();
+    BEANS.get(ActiveFormDataChangeManager.class).add(formTwo, formTwoChangeListenerMock, true, TEST_DATA_TYPE);
+    formTwo.start();
+
+    desktop.dataChanged(TEST_DATA_TYPE);
+    Mockito.verify(formOneChangeListenerMock).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+    Mockito.verify(formTwoChangeListenerMock).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+
+    formOne.activate();
+    Mockito.verify(formOneChangeListenerMock, Mockito.times(2)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+    Mockito.verify(formTwoChangeListenerMock).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+
+    desktop.dataChanged(TEST_DATA_TYPE);
+    Mockito.verify(formOneChangeListenerMock, Mockito.times(3)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+    Mockito.verify(formTwoChangeListenerMock).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+
+    formTwo.activate();
+    Mockito.verify(formOneChangeListenerMock, Mockito.times(3)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+    Mockito.verify(formTwoChangeListenerMock, Mockito.times(2)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+
+    formTwo.doClose();
+
+    desktop.dataChanged(TEST_DATA_TYPE);
+    Mockito.verify(formOneChangeListenerMock, Mockito.times(3)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+    Mockito.verify(formTwoChangeListenerMock, Mockito.times(2)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+
+    formOne.activate();
+    Mockito.verify(formOneChangeListenerMock, Mockito.times(4)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+    Mockito.verify(formTwoChangeListenerMock, Mockito.times(2)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+
+    formOne.doClose();
+    desktop.dataChanged(TEST_DATA_TYPE);
+    Mockito.verify(formOneChangeListenerMock, Mockito.times(4)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+    Mockito.verify(formTwoChangeListenerMock, Mockito.times(2)).dataChanged(ArgumentMatchers.argThat(e -> e.getDataType().equals(TEST_DATA_TYPE)));
+
+    // ensure all managers are removed
+    assertTrue(BEANS.get(ActiveFormDataChangeManager.class).getDataChangeManagers().isEmpty());
+  }
+
+  @ClassId("0e6769a8-81c4-4292-8e3c-1abb6ebddec4")
+  public static class TestForm extends AbstractForm {
+
+    @Order(10)
+    @ClassId("367f05c7-cecc-4392-9595-9134cc7a31c0")
+    public class MainBox extends AbstractGroupBox {
+
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/datachange/ActiveFormDataChangeManager.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/datachange/ActiveFormDataChangeManager.java
@@ -1,0 +1,75 @@
+package org.eclipse.scout.rt.client.ui.desktop.datachange;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.scout.rt.client.IClientSession;
+import org.eclipse.scout.rt.client.session.ClientSessionProvider;
+import org.eclipse.scout.rt.client.ui.desktop.DesktopEvent;
+import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
+import org.eclipse.scout.rt.client.ui.form.FormEvent;
+import org.eclipse.scout.rt.client.ui.form.IForm;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.BEANS;
+
+/**
+ * Data change manager which may be used to avoid data-change notifications for hidden forms.
+ * Events for listeners registered to this manager will be buffered until the form is activated.
+ */
+@ApplicationScoped
+public class ActiveFormDataChangeManager implements IDataChangeListener {
+
+  protected static final String DATA_CHANGE_MANAGERS_KEY = "activeFormDataChangeManagers";
+
+  protected Map<IForm, IDataChangeManager> getDataChangeManagers() {
+    IClientSession clientSession = ClientSessionProvider.currentSession();
+    @SuppressWarnings("unchecked") Map<IForm, IDataChangeManager> dataChangeManagers =
+        (Map<IForm, IDataChangeManager>) clientSession.getData(DATA_CHANGE_MANAGERS_KEY);
+    if (dataChangeManagers == null) {
+      dataChangeManagers = new HashMap<>();
+      clientSession.setData(DATA_CHANGE_MANAGERS_KEY, dataChangeManagers);
+      attachToDesktop(clientSession.getDesktop());
+    }
+    return dataChangeManagers;
+  }
+
+  protected void attachToDesktop(IDesktop desktop) {
+    desktop.addPropertyChangeListener(IDesktop.PROP_IN_BACKGROUND, e -> onDesktopInBackground((boolean) e.getNewValue()));
+    desktop.addDesktopListener(e -> onFormActivate(e.getForm()), DesktopEvent.TYPE_FORM_ACTIVATE);
+    desktop.dataChangeListeners().add(this, true);
+  }
+
+  @Override
+  public void dataChanged(DataChangeEvent event) {
+    getDataChangeManagers().values().forEach(m -> m.fireEvent(event));
+  }
+
+  public void add(IForm form, IDataChangeListener listener, boolean weak, Object... dataTypes) {
+    getDataChangeManagers()
+        .computeIfAbsent(form, this::createDataChangeManager)
+        .add(listener, weak, dataTypes);
+  }
+
+  public void remove(IDataChangeListener listener) {
+    getDataChangeManagers().values().forEach(m -> m.remove(listener));
+  }
+
+  protected IDataChangeManager createDataChangeManager(IForm form) {
+    form.addFormListener(e -> onFormClosed(e.getForm()), FormEvent.TYPE_CLOSED);
+    return BEANS.get(IDataChangeManager.class);
+  }
+
+  protected void onFormActivate(IForm activatedForm) {
+    getDataChangeManagers().forEach((f, m) -> m.setBuffering(f != activatedForm));
+  }
+
+  protected void onFormClosed(IForm closedForm) {
+    getDataChangeManagers().remove(closedForm);
+  }
+
+  protected void onDesktopInBackground(boolean inBackground) {
+    if (!inBackground) {
+      getDataChangeManagers().values().forEach(m -> m.setBuffering(true));
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/tile/AbstractTile.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/tile/AbstractTile.java
@@ -21,8 +21,10 @@ import org.eclipse.scout.rt.client.job.ModelJobs;
 import org.eclipse.scout.rt.client.session.ClientSessionProvider;
 import org.eclipse.scout.rt.client.ui.AbstractWidget;
 import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
+import org.eclipse.scout.rt.client.ui.desktop.datachange.ActiveFormDataChangeManager;
 import org.eclipse.scout.rt.client.ui.desktop.datachange.DataChangeEvent;
 import org.eclipse.scout.rt.client.ui.desktop.datachange.IDataChangeListener;
+import org.eclipse.scout.rt.client.ui.form.FormUtility;
 import org.eclipse.scout.rt.client.ui.form.IForm;
 import org.eclipse.scout.rt.client.ui.form.fields.GridData;
 import org.eclipse.scout.rt.platform.BEANS;
@@ -315,14 +317,23 @@ public abstract class AbstractTile extends AbstractWidget implements ITile {
           interceptDataChanged(event);
         }
       };
+      IForm rootForm = FormUtility.findRootForm(getParentOfType(IForm.class));
+      IDesktop desktop = IDesktop.CURRENT.get();
+      boolean isView = desktop.getViews().contains(rootForm);
+      if (isView) {
+        BEANS.get(ActiveFormDataChangeManager.class).add(rootForm, m_internalDataChangeListener, true, dataTypes);
+      }
+      else {
+        desktop.dataChangeDesktopInForegroundListeners().add(m_internalDataChangeListener, true, dataTypes);
+      }
     }
-    IDesktop.CURRENT.get().dataChangeDesktopInForegroundListeners().add(m_internalDataChangeListener, true, dataTypes);
   }
 
   @Override
   public void unregisterDataChangeListener(Object... dataTypes) {
     if (m_internalDataChangeListener != null) {
       ClientSessionProvider.currentSession().getDesktop().removeDataChangeListener(m_internalDataChangeListener, dataTypes);
+      BEANS.get(ActiveFormDataChangeManager.class).remove(m_internalDataChangeListener);
     }
   }
 


### PR DESCRIPTION
Buffer data-change-events on tiles if another form or the desktop is active. As soon as the form is activated the buffering is disabled and the buffered events will be delivered to the listeners.

393494