### PR TITLE
Simplify testing of data object value migrations

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDataObjectMigrator.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/migration/TestDataObjectMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,5 +22,13 @@ public class TestDataObjectMigrator extends DataObjectMigrator {
   @Override
   public boolean applyStructureMigration(DataObjectMigrationContext ctx, IDataObject dataObject, NamespaceVersion toVersion) {
     return super.applyStructureMigration(ctx, dataObject, toVersion);
+  }
+
+  /**
+   * Override to change visibility from protected to public.
+   */
+  @Override
+  public <T extends IDataObject> DataObjectMigratorResult<T> applyValueMigration(DataObjectMigrationContext ctx, T dataObject) {
+    return super.applyValueMigration(ctx, dataObject);
   }
 }


### PR DESCRIPTION
Change visibility of TestDataObjectMigrator#applyValueMigration allowing tests to directly invoke value migrations. Follows the same approach as TestDataObjectMigrator#applyStructureMigration.