### PR TITLE
CellEditor: complete cell edit if another popup opens

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
@@ -327,7 +327,14 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
       selectedLookupRow = this._getSelectedLookupRow(searchTextChanged);
 
     this._setProperty('displayText', searchText);
+
+    let oldDeferred = this._acceptInputDeferred;
     this._acceptInputDeferred = $.Deferred();
+    if (oldDeferred.state() === 'pending') {
+      // Ensure old deferred will always be resolved
+      this._acceptInputDeferred.promise().then(() => oldDeferred.resolve());
+    }
+
     this._flushLookupStatus();
     this._clearPendingLookup();
 

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -558,6 +558,7 @@ export * from './table/columns/ColumnOptimalWidthMeasurer';
 export * from './table/columns/AlphanumericSortingStringColumn';
 export * from './table/columns/BeanColumn';
 export * from './table/columns/BooleanColumn';
+export * from './table/columns/BooleanColumnModel';
 export * from './table/columns/CompactColumn';
 export * from './table/columns/CompactBean';
 export * from './table/columns/CompactLine';

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -3615,6 +3615,17 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
       this.updateBuffer.one('complete', () => this.startCellEdit(column, row, field));
       return;
     }
+    if (this.cellEditorPopup) {
+      if (this.cellEditorPopup.cell.field === field) {
+        if (this.cellEditorPopup.rendered) {
+          // Do nothing if the editor is already open for the given field
+          return this.cellEditorPopup;
+        }
+      } else {
+        // Destroy existing editor if startCellEdit is called without completing or cancelling the existing editor first
+        this.endCellEdit(this.cellEditorPopup.cell.field);
+      }
+    }
 
     this.trigger('startCellEdit', {
       column: column,

--- a/eclipse-scout-core/src/table/columns/BooleanColumn.ts
+++ b/eclipse-scout-core/src/table/columns/BooleanColumn.ts
@@ -7,13 +7,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Cell, CheckBoxField, Column, comparators, scout, TableRow} from '../../index';
+import {BooleanColumnModel, Cell, CheckBoxField, Column, comparators, scout, TableRow} from '../../index';
 
 /**
- * May be an ordinary boolean column or the table's checkable column (table.checkableColumn)
- * Difference: the table's checkable column represents the row.checked state, other boolean columns represent their own value.
+ * A column holding boolean values represented by check boxes.
  */
-export class BooleanColumn extends Column<boolean> {
+export class BooleanColumn extends Column<boolean> implements BooleanColumnModel {
+  declare model: BooleanColumnModel;
   triStateEnabled: boolean;
 
   constructor() {

--- a/eclipse-scout-core/src/table/columns/BooleanColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/BooleanColumnModel.ts
@@ -7,18 +7,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ValueFieldModel} from '../../../index';
+import {ColumnModel} from '../../index';
 
-export interface CheckBoxFieldModel extends ValueFieldModel<boolean> {
+export interface BooleanColumnModel extends ColumnModel<boolean> {
   /**
-   * Specifies whether the value can represent three states.
+   * Specifies whether the cell values can represent three states.
    *
    * - true: the value can be true, false or null. Null is the third state that represents "undefined".
-   * - false: the value can be true or false. It is never null (setting the value to null will automatically convert it to false).
+   * - false: the value can be true or false. The value is never null (setting the value to null will automatically convert it to false).
    *
    * Default is false.
    */
   triStateEnabled?: boolean;
-  wrapText?: boolean;
-  keyStroke?: string;
 }

--- a/eclipse-scout-core/src/table/columns/ColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/ColumnModel.ts
@@ -199,7 +199,9 @@ export interface ColumnModel<TValue = string> extends ObjectModelWithUuid<Column
   htmlEnabled?: boolean;
 
   /**
-   * Configures whether this column value is mandatory (required). This only affects editable columns (see {@link editable}).
+   * Configures whether the cells of this column require a value.
+   *
+   * This only affects {@link editable} columns.
    *
    * Default is false.
    */
@@ -274,6 +276,10 @@ export interface ColumnModel<TValue = string> extends ObjectModelWithUuid<Column
   showSeparator?: boolean;
 
   /**
+   * Defines the {@link StringFieldModel.maxLength} of the text in the cell editor if the column is {@link editable}.
+   *
+   * This property will only be passed to the cell editor and has no effect on the column itself.
+   *
    * Default is 4000.
    */
   maxLength?: number;
@@ -284,6 +290,14 @@ export interface ColumnModel<TValue = string> extends ObjectModelWithUuid<Column
   text?: string;
 
   /**
+   * Configures whether the text in this column is automatically wrapped if it is wider than the column (_soft wrap_).
+   *
+   * The property only has an effect if {@link Table.multilineText} is enabled.
+   * Explicit line breaks are not affected.
+   *
+   * By default, the property only affects the displayed cell text.
+   * Whether the cell editor applies automatic text wrapping as well depends on the specific column type.
+   *
    * Default is false.
    */
   textWrap?: boolean;

--- a/eclipse-scout-core/src/table/columns/DateColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/DateColumnModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,24 @@ import {ColumnModel, DateFormat} from '../../index';
 export interface DateColumnModel extends ColumnModel<Date> {
   format?: DateFormat | string;
   groupFormat?: DateFormat | string;
+  /**
+   * Configures whether the values of this column should show the date.
+   *
+   * If {@link format} is set, this configuration has no effect.
+   *
+   * The property will also be passed to the cell editor if the column is {@link editable}.
+   *
+   * Default is true.
+   */
   hasDate?: boolean;
+  /**
+   * Configures whether the values of this column should show the time.
+   *
+   * If {@link format} is set, this configuration has no effect.
+   *
+   * The property will also be passed to the cell editor if the column is {@link editable}.
+   *
+   * Default is false.
+   */
   hasTime?: boolean;
 }

--- a/eclipse-scout-core/src/table/columns/LookupCallColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/LookupCallColumnModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,23 +11,35 @@ import {CodeType, ColumnModel, LookupCallOrModel} from '../../index';
 
 export interface LookupCallColumnModel<TValue, TKey = TValue> extends ColumnModel<TValue> {
   /**
-   * Configures the {@link LookupCall} that is used to resolve the values and to load the proposals if the column is editable.
+   * Configures the {@link LookupCall} that is used to format the values.
+   *
+   * The property will also be passed to the cell editor if the column is {@link editable}.
+   *
+   * Default is null.
    */
   lookupCall?: LookupCallOrModel<TKey>;
   /**
    * If set, a {@link CodeLookupCall} is created and used for the property {@link lookupCall}.
    *
    * The property accepts a {@link CodeType} class or a {@link CodeType.id} (see {@link CodeTypeCache.get}).
+   *
+   * It will also be passed to the cell editor if the column is {@link editable}.
+   *
+   * Default is null.
    */
   codeType?: string | (new() => CodeType<TKey>);
   /**
-   * Configures the {@link SmartFieldModel.browseHierarchy} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.browseHierarchy} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is false.
    */
   browseHierarchy?: boolean;
   /**
-   * Configures the {@link SmartFieldModel.browseMaxRowCount} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.browseMaxRowCount} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is {@link SmartField.DEFAULT_BROWSE_MAX_COUNT}.
    */
   browseMaxRowCount?: number;
 }

--- a/eclipse-scout-core/src/table/columns/NumberColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/NumberColumnModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,20 @@ export interface NumberColumnModel extends ColumnModel<number> {
    * @see NumberField.fractionDigits
    */
   fractionDigits?: number;
+  /**
+   * Defines the {@link NumberFieldModel.minValue} of the cell editor if the column is {@link editable}.
+   *
+   * The property will only be passed to the cell editor and has no effect on the column itself.
+   *
+   * Default is null.
+   */
   minValue?: number;
+  /**
+   * Defines the {@link NumberFieldModel.maxValue} of the cell editor if the column is {@link editable}.
+   *
+   * The property will only be passed to the cell editor and has no effect on the column itself.
+   *
+   * Default is null.
+   */
   maxValue?: number;
 }

--- a/eclipse-scout-core/src/table/columns/SmartColumn.ts
+++ b/eclipse-scout-core/src/table/columns/SmartColumn.ts
@@ -17,7 +17,7 @@ import {Cell, codes, CodeType, LookupCallColumn, LookupCallOrModel, LookupRow, o
  * It should be used instead of the property selectedRows from Table.js which must not be used here.
  * 'row' can be null or undefined in some cases. Hence, some care is needed when listening to this event.
  */
-export class SmartColumn<TValue> extends LookupCallColumn<TValue> {
+export class SmartColumn<TValue> extends LookupCallColumn<TValue> implements SmartColumnModel<TValue> {
   declare model: SmartColumnModel<TValue>;
   declare eventMap: SmartColumnEventMap<TValue>;
   declare self: SmartColumn<any>;

--- a/eclipse-scout-core/src/table/columns/SmartColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/SmartColumnModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,18 +11,24 @@ import {LookupCallColumnModel} from '../../index';
 
 export interface SmartColumnModel<TValue> extends LookupCallColumnModel<TValue> {
   /**
-   * Configures the {@link SmartFieldModel.browseAutoExpandAll} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.browseAutoExpandAll} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is true.
    */
   browseAutoExpandAll?: boolean;
   /**
-   * Configures the {@link SmartFieldModel.browseLoadIncremental} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.browseLoadIncremental} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is false.
    */
   browseLoadIncremental?: boolean;
   /**
-   * Configures the {@link SmartFieldModel.activeFilterEnabled} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.activeFilterEnabled} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is false.
    */
   activeFilterEnabled?: boolean;
 }

--- a/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
+++ b/eclipse-scout-core/src/table/editor/CellEditorPopup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AbstractLayout, Cell, CellEditorCancelEditKeyStroke, CellEditorCompleteEditKeyStroke, CellEditorPopupLayout, CellEditorPopupModel, CellEditorTabKeyStroke, Column, EventHandler, events, graphics, InitModelOf, KeyStroke,
+  AbstractLayout, Cell, CellEditorCancelEditKeyStroke, CellEditorCompleteEditKeyStroke, CellEditorPopupLayout, CellEditorPopupModel, CellEditorTabKeyStroke, Column, Event, EventHandler, events, graphics, InitModelOf, KeyStroke,
   KeyStrokeManagerKeyStrokeEvent, Point, Popup, Rectangle, scout, SomeRequired, Table, TableRow, TableRowOrderChangeAnimationEvent, TableRowOrderChangedEvent, ValueField, widgets
 } from '../../index';
 import $ from 'jquery';
@@ -41,6 +41,7 @@ export class CellEditorPopup<TValue> extends Popup implements CellEditorPopupMod
 
     this.table = options.column.table;
     this.link(this.cell.field);
+    this.on('close', this._onClose.bind(this));
   }
 
   protected override _createLayout(): AbstractLayout {
@@ -218,6 +219,12 @@ export class CellEditorPopup<TValue> extends Popup implements CellEditorPopupMod
   cancelEdit() {
     this.table.cancelCellEdit();
     this.remove();
+  }
+
+  protected _onClose(event: Event<Popup>) {
+    // Ensure current value is not discarded on unexpected close() calls, e.g. if another popup opens
+    event.preventDefault();
+    this.completeEdit();
   }
 
   protected override _onMouseDownOutside(event: MouseEvent) {

--- a/eclipse-scout-core/src/testing/form/fields/smartfield/SpecSmartField.ts
+++ b/eclipse-scout-core/src/testing/form/fields/smartfield/SpecSmartField.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {LookupCall, SmartField, SmartFieldLookupResult} from '../../../../index';
+
+export class SpecSmartField extends SmartField<number> {
+  declare _userWasTyping: boolean;
+  declare _lastSearchText: string;
+  declare _pendingOpenPopup: boolean;
+
+  override _readSearchText(): string {
+    return super._readSearchText();
+  }
+
+  override _onFieldKeyUp(event: JQuery.KeyUpEvent) {
+    super._onFieldKeyUp(event);
+  }
+
+  override _acceptByText(sync: boolean, searchText: string) {
+    super._acceptByText(sync, searchText);
+  }
+
+  override _lookupByTextOrAll(browse?: boolean, searchText?: string, searchAlways?: boolean): JQuery.Promise<any> {
+    return super._lookupByTextOrAll(browse, searchText, searchAlways);
+  }
+
+  override _lookupByTextOrAllDone(result: SmartFieldLookupResult<number>) {
+    super._lookupByTextOrAllDone(result);
+  }
+
+  override _executeLookup(lookupCall: LookupCall<number>, abortExisting?: boolean): JQuery.Promise<SmartFieldLookupResult<number>> {
+    return super._executeLookup(lookupCall, abortExisting);
+  }
+
+  override _formatValue(value: number): string | JQuery.Promise<string> {
+    return super._formatValue(value);
+  }
+
+  override _copyValuesFromField(otherField: SmartField<number>) {
+    super._copyValuesFromField(otherField);
+  }
+
+  override _getLastSearchText(): string {
+    return super._getLastSearchText();
+  }
+}

--- a/eclipse-scout-core/src/testing/form/fields/smartfield/proposalFieldSpecHelper.ts
+++ b/eclipse-scout-core/src/testing/form/fields/smartfield/proposalFieldSpecHelper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -112,10 +112,6 @@ export class SpecProposalField extends ProposalField {
   override acceptInput(sync?: boolean): JQuery.Promise<void> | void {
     this._acceptInputEnabled = true; // accept all inputs, no need for a timeout
     return super.acceptInput(sync);
-  }
-
-  override _acceptInput(sync: boolean, searchText: string, searchTextEmpty: boolean, searchTextChanged: boolean, selectedLookupRow: LookupRow<string>): JQuery.Promise<void> | void {
-    return super._acceptInput(sync, searchText, searchTextEmpty, searchTextChanged, selectedLookupRow);
   }
 }
 

--- a/eclipse-scout-core/src/testing/index.ts
+++ b/eclipse-scout-core/src/testing/index.ts
@@ -26,6 +26,7 @@ export * from './form/FormSpecHelper';
 export * from './form/fields/CloneSpecHelper';
 export * from './form/fields/beanfield/TestBeanField';
 export * from './form/fields/smartfield/proposalFieldSpecHelper';
+export * from './form/fields/smartfield/SpecSmartField';
 export * from './form/fields/tabbox/TabBoxSpecHelper';
 export * from './desktop/outline/OutlineSpecHelper';
 export * from './lookup/DummyLookupCall';

--- a/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -155,7 +155,10 @@ describe('ProposalField', () => {
   it('should clear error status on search text change', () => {
     field.setErrorStatus(Status.error('functional'));
     expect(field.errorStatus.containsStatus(Status)).toBe(true);
-    field._acceptInput(false, 'Bar', false, true, null);
+    field.render();
+    field.$field.val('Bar');
+    field._userWasTyping = true;
+    field.acceptInput();
     expect(field['getErrorStatus']).toBeUndefined();
   });
 

--- a/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.ts
@@ -8,60 +8,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  fields, keys, LookupResult, LookupRow, PrepopulatedLookupCall, ProposalChooser, QueryBy, scout, SmartField, SmartFieldModel, SmartFieldMultiline, SmartFieldPopup, SmartFieldTouchPopup, StaticLookupCall, Status, strings,
-  ValidationFailedStatus
+  fields, FullModelOf, InitModelOf, keys, LookupCall, LookupResult, LookupRow, ObjectOrModel, PrepopulatedLookupCall, ProposalChooser, QueryBy, scout, SmartField, SmartFieldModel, SmartFieldMultiline, SmartFieldPopup, SmartFieldTouchPopup,
+  StaticLookupCall, Status, strings, ValidationFailedStatus
 } from '../../../../src/index';
-import {ColumnDescriptorDummyLookupCall, DelayedStaticLookupCall, DummyLookupCall, FormSpecHelper, JQueryTesting, MicrotaskStaticLookupCall} from '../../../../src/testing/index';
-import {LookupCall} from '../../../../src/lookup/LookupCall';
-import {SmartFieldLookupResult} from '../../../../src/form/fields/smartfield/SmartField';
-import {FullModelOf, InitModelOf, ObjectOrModel} from '../../../../src/scout';
+import {ColumnDescriptorDummyLookupCall, DelayedStaticLookupCall, DummyLookupCall, FormSpecHelper, JQueryTesting, MicrotaskStaticLookupCall, SpecSmartField} from '../../../../src/testing/index';
 import $ from 'jquery';
 
 describe('SmartField', () => {
 
   let session: SandboxSession, field: SpecSmartField, lookupRow: LookupRow<number>, helper: FormSpecHelper;
-
-  class SpecSmartField extends SmartField<number> {
-    declare _userWasTyping: boolean;
-    declare _lastSearchText: string;
-    declare _pendingOpenPopup: boolean;
-
-    override _readSearchText(): string {
-      return super._readSearchText();
-    }
-
-    override _onFieldKeyUp(event: JQuery.KeyUpEvent) {
-      super._onFieldKeyUp(event);
-    }
-
-    override _acceptByText(sync: boolean, searchText: string) {
-      super._acceptByText(sync, searchText);
-    }
-
-    override _lookupByTextOrAll(browse?: boolean, searchText?: string, searchAlways?: boolean): JQuery.Promise<any> {
-      return super._lookupByTextOrAll(browse, searchText, searchAlways);
-    }
-
-    override _lookupByTextOrAllDone(result: SmartFieldLookupResult<number>) {
-      super._lookupByTextOrAllDone(result);
-    }
-
-    override _executeLookup(lookupCall: LookupCall<number>, abortExisting?: boolean): JQuery.Promise<SmartFieldLookupResult<number>> {
-      return super._executeLookup(lookupCall, abortExisting);
-    }
-
-    override _formatValue(value: number): string | JQuery.Promise<string> {
-      return super._formatValue(value);
-    }
-
-    override _copyValuesFromField(otherField: SmartField<number>) {
-      super._copyValuesFromField(otherField);
-    }
-
-    override _getLastSearchText(): string {
-      return super._getLastSearchText();
-    }
-  }
 
   class SpecSmartFieldTouchPopup extends SmartFieldTouchPopup<number> {
     declare _widget: ProposalChooser<number, any, any>;

--- a/eclipse-scout-core/test/table/editor/CellEditorSpec.ts
+++ b/eclipse-scout-core/test/table/editor/CellEditorSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Cell, CellEditorPopup, Column, FormField, keys, scout, SmartColumn, SmartField, StaticLookupCall, Status, StringField, Table, TableRow, Widget} from '../../../src/index';
+import {Cell, CellEditorPopup, Column, FormField, keys, Popup, scout, SmartColumn, SmartField, StaticLookupCall, Status, StringField, Table, TableRow, Widget} from '../../../src/index';
 import {FormSpecHelper, JQueryTesting, TableSpecHelper} from '../../../src/testing/index';
 
 describe('CellEditor', () => {
@@ -28,10 +28,7 @@ describe('CellEditor', () => {
     session = null;
     jasmine.Ajax.uninstall();
     jasmine.clock().uninstall();
-    let popup = findPopup();
-    if (popup) {
-      popup.close();
-    }
+    findPopup()?.destroy();
   });
 
   class DummyLookupCall extends StaticLookupCall<string> {
@@ -453,6 +450,61 @@ describe('CellEditor', () => {
 
       popup.position(); // Must not fail if popup is not rendered
     });
+
+    it('does nothing if the editor is already open for the given field', () => {
+      table.columns[0].setEditable(true);
+      let triggeredEvents = 0;
+      table.on('startCellEdit', event => {
+        triggeredEvents++;
+      });
+
+      let field = createStringField();
+      let popup = table.startCellEdit(table.columns[0], table.rows[0], field);
+      expect(popup.cell.field).toBe(field);
+      assertCellEditorIsOpen(table, table.columns[0], table.rows[0]);
+
+      let popup2 = table.startCellEdit(table.columns[0], table.rows[0], field);
+      expect(popup).toBe(popup2);
+      assertCellEditorIsOpen(table, table.columns[0], table.rows[0]);
+      expect(triggeredEvents).toBe(1);
+    });
+
+    it('ends existing cell edit if an editor is open', () => {
+      table.columns[0].setEditable(true);
+      table.insertColumn({
+        objectType: SmartColumn,
+        lookupCall: {objectType: DummyLookupCall},
+        editable: true
+      });
+      table.insertRows({cells: ['a', 'b', 'key0']});
+      let field = table.columns[2].createEditor(table.rows[0]);
+      table.startCellEdit(table.columns[2], table.rows[0], field);
+      jasmine.clock().tick(500);
+      assertCellEditorIsOpen(table, table.columns[2], table.rows[0]);
+      let popup = table.cellEditorPopup;
+      expect(popup.cell.field).toBe(field);
+      expect(field.rendered).toBe(true);
+
+      // Start cell edit on same cell again
+      let field2 = table.columns[2].createEditor(table.rows[0]);
+      table.startCellEdit(table.columns[2], table.rows[0], field2);
+      assertCellEditorIsOpen(table, table.columns[2], table.rows[0]);
+      let popup2 = table.cellEditorPopup;
+      expect(popup2.cell.field).toBe(field2);
+      expect(field2.rendered).toBe(true);
+      expect(popup.destroyed).toBe(true);
+      expect(field.destroyed).toBe(true);
+
+      // Start cell edit on another cell
+      let field3 = table.columns[0].createEditor(table.rows[0]);
+      table.startCellEdit(table.columns[0], table.rows[0], field3);
+      assertCellEditorIsOpen(table, table.columns[0], table.rows[0]);
+      let popup3 = table.cellEditorPopup;
+      expect(popup3.cell.field).toBe(field3);
+      expect(field3.rendered).toBe(true);
+      expect(popup2.destroyed).toBe(true);
+      expect(field2.destroyed).toBe(true);
+    });
   });
 
   describe('completeCellEdit', () => {
@@ -640,6 +692,17 @@ describe('CellEditor', () => {
       table.completeCellEdit();
       // CompleteCellEdit triggers updateRows which would reopen the editor -> this must not happen if the editor was closed
       expect(triggeredStartCellEditEvent).toBe(null);
+    });
+
+    it('is called when another popup opens', () => {
+      table.columns[0].setEditable(true);
+      table.prepareCellEdit(table.columns[0], table.rows[0]);
+      jasmine.clock().tick(0);
+      table.cellEditorPopup.cell.field.setValue('my new value');
+
+      scout.create(Popup, {parent: session.desktop}).open();
+      expect(table.rows[0].cells[0].value).toBe('my new value');
+      expect(table.cellEditorPopup).toBe(null);
     });
   });
 
@@ -995,6 +1058,24 @@ describe('CellEditor', () => {
 
       expect($('.tooltip').length).toBe(0);
       expect(table.tooltips.length).toBe(0);
+    });
+  });
+
+  describe('close', () => {
+    it('calls completeCellEdit', () => {
+      let model = helper.createModelFixture(2, 2);
+      let table = helper.createTable(model);
+      table.render();
+      table.columns[0].setEditable(true);
+      table.prepareCellEdit(table.columns[0], table.rows[0]);
+      spyOn(table, 'completeCellEdit');
+      jasmine.clock().tick(0);
+
+      // Editing is normally finished by calling completeCellEdit or cancelCellEdit
+      // Calling close just destroys the editor, and it will be re-opened once the table resp. the row will be re-rendered again because the table still has a reference.
+      // This is not expected -> if close is called (e.g. if another popup opens) the cell edit should be completed
+      table.cellEditorPopup.close();
+      expect(table.completeCellEdit).toHaveBeenCalled();
     });
   });
 });

--- a/eclipse-scout-core/test/table/editor/CellEditorSpec.ts
+++ b/eclipse-scout-core/test/table/editor/CellEditorSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {Cell, CellEditorPopup, Column, FormField, keys, Popup, scout, SmartColumn, SmartField, StaticLookupCall, Status, StringField, Table, TableRow, Widget} from '../../../src/index';
-import {FormSpecHelper, JQueryTesting, TableSpecHelper} from '../../../src/testing/index';
+import {FormSpecHelper, JQueryTesting, SpecSmartField, TableSpecHelper} from '../../../src/testing/index';
 
 describe('CellEditor', () => {
   let session: SandboxSession;
@@ -508,7 +508,7 @@ describe('CellEditor', () => {
   });
 
   describe('completeCellEdit', () => {
-    let table;
+    let table: Table;
 
     beforeEach(() => {
       let model = helper.createModelFixture(2, 2);
@@ -707,10 +707,11 @@ describe('CellEditor', () => {
   });
 
   describe('completeCellEdit in SmartColumn', () => {
-    let table;
+    let table: Table;
+    let lookupCall: DummyLookupCall;
 
     beforeEach(() => {
-      let lookupCall = new DummyLookupCall();
+      lookupCall = new DummyLookupCall();
       lookupCall.init({session: session});
 
       table = helper.createTable({
@@ -778,14 +779,33 @@ describe('CellEditor', () => {
       table.markRowsAsNonChanged();
       table.prepareCellEdit(table.columns[0], table.rows[0], true);
       jasmine.clock().tick(300);
-      table.cellEditorPopup.cell.field.$field.val('Key 1');
-      table.cellEditorPopup.cell.field._userWasTyping = true;
+      let field = table.cellEditorPopup.cell.field as SpecSmartField;
+      field.$field.val('Key 1');
+      field._userWasTyping = true;
       table.cellEditorPopup.completeEdit(); // Will execute table.completeCellEdit async
       table.remove();
       jasmine.clock().tick(300);
       expect(table.rows[0].cells[0].value).toBe('key1');
       expect(table.rows[0].cells[0].text).toBe('Key 1');
       expect(table.rows[0].status).toBe(TableRow.Status.UPDATED);
+    });
+
+    it('closes the editor even if acceptInput was called again', async () => {
+      jasmine.clock().uninstall();
+      table.columns[0].setEditable(true);
+      lookupCall.setDelay(5);
+      await table.prepareCellEdit(table.columns[0], table.rows[0], true);
+      let popup = table.cellEditorPopup;
+      let field = popup.cell.field as SpecSmartField;
+      field.$field.val('asdf');
+      field._userWasTyping = true;
+
+      let completed = table.cellEditorPopup.completeEdit();
+      setTimeout(() => table.cellEditorPopup.cell.field.acceptInput()); // May happen if another popup opens that requests the focus -> smart field loses focus and accepts input
+      await completed;
+      await popup.when('destroy');
+      expect(table.cellEditorPopup).toBe(null);
+      expect(table.cell(table.columns[0], table.rows[0]).text).toBe('asdf');
     });
   });
 

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractStringColumnTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractStringColumnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,7 +55,7 @@ public class AbstractStringColumnTest {
     TestStringColumn col = table.getTestStringColumn();
     col.setMaxLength(1);
     table.addRowByArray(new Object[]{"text"});
-    assertEquals("t", table.getCell(0, 0).getValue());
+    assertEquals("t…", table.getCell(0, 0).getValue());
   }
 
   public class TestTable extends AbstractTable {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableUtility.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 public final class TableUtility {
   private static final Logger LOG = LoggerFactory.getLogger(TableUtility.class);
+  private static HtmlHelper s_htmlHelper;
 
   private TableUtility() {
   }
@@ -189,7 +190,6 @@ public final class TableUtility {
    * </ul>
    */
   public static Object[][] exportRowsAsCSV(List<? extends ITableRow> rows, List<? extends IColumn> columns, boolean includeLineForColumnNames, boolean includeLineForColumnTypes, boolean includeLineForColumnFormats) {
-    final HtmlHelper htmlHelper = BEANS.get(HtmlHelper.class);
     int nr = rows.size();
     Object[][] a = new Object[nr + (includeLineForColumnNames ? 1 : 0) + (includeLineForColumnTypes ? 1 : 0) + (includeLineForColumnFormats ? 1 : 0)][columns.size()];
     for (int c = 0; c < columns.size(); c++) {
@@ -243,7 +243,7 @@ public final class TableUtility {
       int csvRowIndex = 0;
       if (includeLineForColumnNames) {
         IHeaderCell headerCell = columns.get(c).getHeaderCell();
-        a[csvRowIndex][c] = headerCell.isHtmlEnabled() ? htmlHelper.toPlainText(headerCell.getText()) : headerCell.getText();
+        a[csvRowIndex][c] = headerCell.isHtmlEnabled() ? getHtmlHelper().toPlainText(headerCell.getText()) : headerCell.getText();
         csvRowIndex++;
       }
       if (includeLineForColumnTypes) {
@@ -275,7 +275,7 @@ public final class TableUtility {
           }
           //special intercept for html
           if (type == String.class && text != null && columns.get(c).isHtmlEnabled()) {
-            text = htmlHelper.toPlainText(text);
+            text = getHtmlHelper().toPlainText(text);
           }
           a[csvRowIndex][c] = text;
         }
@@ -283,6 +283,16 @@ public final class TableUtility {
       }
     }
     return a;
+  }
+
+  /**
+   * @return a cached {@link HtmlHelper} that can be used inside loops to avoid many `BEANS.get` calls.
+   */
+  public static HtmlHelper getHtmlHelper() {
+    if (s_htmlHelper == null) {
+      s_htmlHelper = BEANS.get(HtmlHelper.class);
+    }
+    return s_htmlHelper;
   }
 
   @FunctionalInterface

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractStringColumn.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractStringColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.client.ui.basic.table.columns;
 import org.eclipse.scout.rt.client.extension.ui.basic.table.columns.IStringColumnExtension;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.basic.table.ITableRow;
+import org.eclipse.scout.rt.client.ui.basic.table.TableUtility;
 import org.eclipse.scout.rt.client.ui.form.fields.IFormField;
 import org.eclipse.scout.rt.client.ui.form.fields.IValueField;
 import org.eclipse.scout.rt.client.ui.form.fields.stringfield.AbstractStringField;
@@ -42,12 +43,11 @@ public abstract class AbstractStringColumn extends AbstractColumn<String> implem
    */
 
   /**
-   * Configures the maximum length of text in this column. This configuration only limits the text length in case of
-   * editable cells.
+   * Configures the maximum length of text in this column. This value is also used by the cell editor if the column is editable.
    * <p>
    * Subclasses can override this method. Default is {@code 4000}.
    *
-   * @return Maximum length of text in an editable cell.
+   * @return Maximum length of text
    */
   @ConfigProperty(ConfigProperty.INTEGER)
   @Order(130)
@@ -185,7 +185,12 @@ public abstract class AbstractStringColumn extends AbstractColumn<String> implem
   protected String/* validValue */ validateValueInternal(ITableRow row, String rawValue) {
     String value = super.validateValueInternal(row, rawValue);
     if (value != null && value.length() > getMaxLength()) {
-      value = value.substring(0, getMaxLength());
+      if (isHtmlEnabled()) {
+        value = TableUtility.getHtmlHelper().truncate(value, getMaxLength(), true);
+      }
+      else {
+        value = value.substring(0, getMaxLength()) + "…";
+      }
     }
     return StringUtility.nullIfEmpty(value);
   }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/CompactLineBlock.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/CompactLineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,7 +9,7 @@
  */
 package org.eclipse.scout.rt.client.ui.basic.table.columns;
 
-import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.client.ui.basic.table.TableUtility;
 import org.eclipse.scout.rt.platform.html.HTML;
 import org.eclipse.scout.rt.platform.html.HtmlHelper;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
@@ -22,7 +22,6 @@ public class CompactLineBlock {
   private boolean m_encodeHtmlEnabled = true;
   private boolean m_nlToBrEnabled;
   private boolean m_htmlToPlainTextEnabled;
-  private HtmlHelper m_htmlHelper;
 
   public CompactLineBlock() {
   }
@@ -113,10 +112,7 @@ public class CompactLineBlock {
   }
 
   protected HtmlHelper getHtmlHelper() {
-    if (m_htmlHelper == null) {
-      m_htmlHelper = BEANS.get(HtmlHelper.class);
-    }
-    return m_htmlHelper;
+    return TableUtility.getHtmlHelper();
   }
 
   public String build() {

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
@@ -252,4 +252,241 @@ public class HtmlHelperTest {
     assertEquals("\u0027\u0027\u0027", helper.toPlainText("&#39;&#x27;&apos;"));
     assertEquals("hi", helper.toPlainText("&#x68;&#x69;"));
   }
+
+  @Test
+  public void testTruncate() {
+    HtmlHelper helper = BEANS.get(HtmlHelper.class);
+
+    // Without tags
+    assertEquals("12345", helper.truncate("12345", 6));
+    assertEquals("12345", helper.truncate("12345", 5));
+    assertEquals("1234", helper.truncate("12345", 4));
+    assertEquals("1", helper.truncate("12345", 1));
+    assertEquals("", helper.truncate("12345", 0));
+
+    // Surrounding tags
+    assertEquals("<div>12345</div>", helper.truncate("<div>12345</div>", 100));
+    assertEquals("<div>12345</div>", helper.truncate("<div>12345</div>", 6));
+    assertEquals("<div>12345</div>", helper.truncate("<div>12345</div>", 5));
+    assertEquals("<div>1234</div>", helper.truncate("<div>12345</div>", 4));
+    assertEquals("<div>1</div>", helper.truncate("<div>12345</div>", 1));
+    assertEquals("", helper.truncate("<div>12345</div>", 0));
+
+    // Inline tags
+    assertEquals("1<bold>2</bold>345", helper.truncate("1<bold>2</bold>345", 6));
+    assertEquals("1<bold>2</bold>345", helper.truncate("1<bold>2</bold>345", 5));
+    assertEquals("1<bold>2</bold>34", helper.truncate("1<bold>2</bold>345", 4));
+    assertEquals("1<bold>2</bold>", helper.truncate("1<bold>2</bold>345", 2));
+    assertEquals("1", helper.truncate("1<bold>2</bold>345", 1));
+    assertEquals("", helper.truncate("1<bold>2</bold>345", 0));
+
+    // Surrounding and inline tags
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 6));
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 5));
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">34</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 4));
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\"></span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 2));
+    assertEquals("<div>1<bold></bold><span style=\"color: blue;\"></span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 1));
+    assertEquals("", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 0));
+
+    // Tags in attributes
+    assertEquals("1<a title=\"<div>asdf\">234</a>5", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 6));
+    assertEquals("1<a title=\"<div>asdf\">234</a>5", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 5));
+    assertEquals("1<a title=\"<div>asdf\">234</a>", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 4));
+    assertEquals("1<a title=\"<div>asdf\">2</a>", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 2));
+    assertEquals("1", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 1));
+    assertEquals("", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 0));
+    assertEquals("1<a title=\"</div>asdf\">234</a>", helper.truncate("1<a title=\"</div>asdf\">234</a>5", 4)); // CLosing tag in attribute
+
+    // Void tags
+    assertEquals("1<br>2<img src=\"http://asdf.com\">345", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 6));
+    assertEquals("1<br>2<img src=\"http://asdf.com\">345", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 5));
+    assertEquals("1<br>2<img src=\"http://asdf.com\">34", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 4));
+    // The result 1<br>2 would be even better but this would require a detection for void tags which just makes the implementation more complex with little benefit
+    assertEquals("1<br>2<img src=\"http://asdf.com\">", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 2));
+    assertEquals("1", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 1));
+    assertEquals("", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 0));
+
+    // Void tags with surrounding tags
+    assertEquals("<div>1<br>234</div>", helper.truncate("<div>1<br>2345</div>", 4));
+    assertEquals("<div>1<br></div>", helper.truncate("<div>1<br>2345</div>", 1));
+    assertEquals("<div>1<img src=\"http://asdf.com\">234</div>", helper.truncate("<div>1<img src=\"http://asdf.com\">2345</div>", 4));
+    assertEquals("<div>1<img src=\"http://asdf.com\"></div>", helper.truncate("<div>1<img src=\"http://asdf.com\">2345</div>", 1));
+    assertEquals("<div>1<img src=\"blob:abc\">234</div>", helper.truncate("<div>1<img src=\"blob:abc\">2345</div>", 4));
+    assertEquals("<div>1<img src=\"blob:abc\"></div>", helper.truncate("<div>1<img src=\"blob:abc\">2345</div>", 1));
+
+    // Self-closing tags
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />345", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 6));
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />345", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 5));
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />34", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 4));
+    assertEquals("1<br/>2", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 2));
+    assertEquals("1", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 1));
+    assertEquals("", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 0));
+
+    // Self-closing tags with surrounding tags
+    assertEquals("<div>1<br/>234</div>", helper.truncate("<div>1<br/>2345</div>", 4));
+    assertEquals("<div>1<br/></div>", helper.truncate("<div>1<br/>2345</div>", 1));
+    assertEquals("<div>1<img src=\"http://asdf.com\"/>234</div>", helper.truncate("<div>1<img src=\"http://asdf.com\"/>2345</div>", 4));
+    assertEquals("<div>1<img src=\"http://asdf.com\"/></div>", helper.truncate("<div>1<img src=\"http://asdf.com\"/>2345</div>", 1));
+    assertEquals("<div>1<img src=\"blob:abc\"/>234</div>", helper.truncate("<div>1<img src=\"blob:abc\"/>2345</div>", 4));
+    assertEquals("<div>1<img src=\"blob:abc\"/></div>", helper.truncate("<div>1<img src=\"blob:abc\"/>2345</div>", 1));
+
+    // Character references (html entities)
+    assertEquals("1&gt;345&#60;78&#x3C;", helper.truncate("1&gt;345&#60;78&#x3C;", 10));
+    assertEquals("1&gt;345&#60;78&#x3C;", helper.truncate("1&gt;345&#60;78&#x3C;", 9));
+    assertEquals("1&gt;345&#60;78", helper.truncate("1&gt;345&#60;78&#x3C;", 8));
+    assertEquals("1&gt;3", helper.truncate("1&gt;345&#60;78&#x3C;", 3));
+    assertEquals("1&gt;", helper.truncate("1&gt;345&#60;78&#x3C;", 2));
+    assertEquals("1", helper.truncate("1&gt;345&#60;78&#x3C;", 1));
+    assertEquals("", helper.truncate("1&gt;345&#60;78&#x3C;", 0));
+
+    // Character references in attributes
+    assertEquals("1<a title=\"&gt;abc\">234</a>5", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 5));
+    assertEquals("1<a title=\"&gt;abc\">234</a>", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 4));
+    assertEquals("1<a title=\"&gt;abc\">2</a>", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 2));
+    assertEquals("1", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 1));
+    assertEquals("", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 0));
+
+    // Attributes with " or ' and escaped
+    assertEquals("1<a title=\"&gt;abc&quot;hi&quot;\">234</a>", helper.truncate("1<a title=\"&gt;abc&quot;hi&quot;\">234</a>5", 4));
+    assertEquals("1<a title='&gt;abc&quot;hi&quot;'>234</a>", helper.truncate("1<a title='&gt;abc&quot;hi&quot;'>234</a>5", 4));
+    assertEquals("1<a title='&gt;abc&apos;hi&apos;'>234</a>", helper.truncate("1<a title='&gt;abc&apos;hi&apos;'>234</a>5", 4));
+
+    // Comments
+    assertEquals("<div>12<!-- comment -->345</div>", helper.truncate("<div>12<!-- comment -->345</div>", 6));
+    assertEquals("<div>12<!-- comment -->345</div>", helper.truncate("<div>12<!-- comment -->345</div>", 5));
+    assertEquals("<div>12<!-- comment -->3</div>", helper.truncate("<div>12<!-- comment -->345</div>", 3));
+    assertEquals("<div>1<!-- comment --></div>", helper.truncate("<div>12<!-- comment -->345</div>", 1));
+    assertEquals("", helper.truncate("<div>12<!-- comment -->345</div>", 0));
+    assertEquals("1", helper.truncate("12<!-- comment -->", 1));
+    assertEquals("<div>12<!-- <comment> -->34</div>", helper.truncate("<div>12<!-- <comment> -->345</div>", 4));
+    assertEquals("<div>12<!-- <comment> --></div>", helper.truncate("<div>12<!-- <comment> -->345</div>", 2));
+
+    // Invalid html
+    assertEquals("<div>1<div>2</div></div>345", helper.truncate("<div>1<div>2</div></div>345</div>", 5));
+    assertEquals("<div>1<div>2</div></div>", helper.truncate("<div>1<div>2</div></div>345</div>", 2));
+    assertEquals("1</div>2<bold>345</bold>", helper.truncate("1</div>2<bold>345</bold>", 5));
+    assertEquals("1</div>2<bold>34</bold>", helper.truncate("1</div>2<bold>345</bold>", 4));
+    assertEquals("1</div>2", helper.truncate("1</div>2<bold>345</bold>", 2));
+    // Everything after & counts as one until ;. Browsers may be more lenient and still render &gt without ; or render &asdf as it is. We simplify ignore these cases as we cannot assume what the browser will do.
+    assertEquals("1&gt345&#60;78", helper.truncate("1&gt345&#60;78&#x3C;", 4));
+    assertEquals("<!-- 123", helper.truncate("<!-- 123", 2));
+
+    // Corner cases
+    assertEquals(null, helper.truncate(null, 6));
+    assertEquals("", helper.truncate("12345", -1));
+  }
+
+  @Test
+  public void truncateWithEllipsis() {
+    HtmlHelper helper = BEANS.get(HtmlHelper.class);
+
+    // Without tags
+    assertEquals("12345", helper.truncate("12345", 5, true));
+    assertEquals("1234…", helper.truncate("12345", 4, true));
+    assertEquals("1…", helper.truncate("12345", 1, true));
+    assertEquals("…", helper.truncate("12345", 0, true));
+
+    // Surrounding tags
+    assertEquals("<div>12345</div>", helper.truncate("<div>12345</div>", 5, true));
+    assertEquals("<div>1234…</div>", helper.truncate("<div>12345</div>", 4, true));
+    assertEquals("<div>1…</div>", helper.truncate("<div>12345</div>", 1, true));
+    assertEquals("…", helper.truncate("<div>12345</div>", 0, true));
+
+    // Inline tags
+    assertEquals("1<bold>2</bold>345", helper.truncate("1<bold>2</bold>345", 5, true));
+    assertEquals("1<bold>2</bold>34…", helper.truncate("1<bold>2</bold>345", 4, true));
+    assertEquals("1<bold>2…</bold>", helper.truncate("1<bold>2</bold>345", 2, true));
+    assertEquals("1…", helper.truncate("1<bold>2</bold>345", 1, true));
+    assertEquals("…", helper.truncate("1<bold>2</bold>345", 0, true));
+
+    // Surrounding and inline tags
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 5, true));
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">34…</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 4, true));
+    assertEquals("<div>1<bold>2…</bold><span style=\"color: blue;\"></span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 2, true));
+    assertEquals("<div>1…<bold></bold><span style=\"color: blue;\"></span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 1, true));
+    assertEquals("…", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 0, true));
+
+    // Tags in attributes
+    assertEquals("1<a title=\"<div>asdf\">234</a>5", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 5, true));
+    assertEquals("1<a title=\"<div>asdf\">234…</a>", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 4, true));
+    assertEquals("1<a title=\"<div>asdf\">2…</a>", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 2, true));
+    assertEquals("1…", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 1, true));
+    assertEquals("…", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 0, true));
+    assertEquals("1<a title=\"</div>asdf\">234…</a>", helper.truncate("1<a title=\"</div>asdf\">234</a>5", 4, true)); // CLosing tag in attribute
+
+    // Void tags
+    assertEquals("1<br>2<img src=\"http://asdf.com\">345", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 5, true));
+    assertEquals("1<br>2<img src=\"http://asdf.com\">34…", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 4, true));
+    // The result 1<br>2 would be even better but this would require a detection for void tags which just makes the implementation more complex with little benefit
+    assertEquals("1<br>2…<img src=\"http://asdf.com\">", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 2, true));
+    assertEquals("1…", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 1, true));
+    assertEquals("…", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 0, true));
+
+    // Void tags with surrounding tags
+    assertEquals("<div>1…<br></div>", helper.truncate("<div>1<br>2345</div>", 1, true));
+    assertEquals("<div>1<img src=\"http://asdf.com\">234…</div>", helper.truncate("<div>1<img src=\"http://asdf.com\">2345</div>", 4, true));
+    assertEquals("<div>1…<img src=\"http://asdf.com\"></div>", helper.truncate("<div>1<img src=\"http://asdf.com\">2345</div>", 1, true));
+    assertEquals("<div>1<img src=\"blob:abc\">234…</div>", helper.truncate("<div>1<img src=\"blob:abc\">2345</div>", 4, true));
+    assertEquals("<div>1…<img src=\"blob:abc\"></div>", helper.truncate("<div>1<img src=\"blob:abc\">2345</div>", 1, true));
+
+    // Self-closing tags
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />345", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 5, true));
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />34…", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 4, true));
+    assertEquals("1<br/>2…", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 2, true));
+    assertEquals("1…", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 1, true));
+    assertEquals("…", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 0, true));
+
+    // Self-closing tags with surrounding tags
+    assertEquals("<div>1<br/>234…</div>", helper.truncate("<div>1<br/>2345</div>", 4, true));
+    assertEquals("<div>1…<br/></div>", helper.truncate("<div>1<br/>2345</div>", 1, true));
+    assertEquals("<div>1<img src=\"http://asdf.com\"/>234…</div>", helper.truncate("<div>1<img src=\"http://asdf.com\"/>2345</div>", 4, true));
+    assertEquals("<div>1…<img src=\"http://asdf.com\"/></div>", helper.truncate("<div>1<img src=\"http://asdf.com\"/>2345</div>", 1, true));
+    assertEquals("<div>1<img src=\"blob:abc\"/>234…</div>", helper.truncate("<div>1<img src=\"blob:abc\"/>2345</div>", 4, true));
+    assertEquals("<div>1…<img src=\"blob:abc\"/></div>", helper.truncate("<div>1<img src=\"blob:abc\"/>2345</div>", 1, true));
+
+    // Character references (html entities)
+    assertEquals("1&gt;345&#60;78&#x3C;", helper.truncate("1&gt;345&#60;78&#x3C;", 9, true));
+    assertEquals("1&gt;345&#60;78…", helper.truncate("1&gt;345&#60;78&#x3C;", 8, true));
+    assertEquals("1&gt;3…", helper.truncate("1&gt;345&#60;78&#x3C;", 3, true));
+    assertEquals("1&gt;…", helper.truncate("1&gt;345&#60;78&#x3C;", 2, true));
+    assertEquals("1…", helper.truncate("1&gt;345&#60;78&#x3C;", 1, true));
+    assertEquals("…", helper.truncate("1&gt;345&#60;78&#x3C;", 0, true));
+
+    // Character references in attributes
+    assertEquals("1<a title=\"&gt;abc\">234</a>5", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 5, true));
+    assertEquals("1<a title=\"&gt;abc\">234…</a>", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 4, true));
+    assertEquals("1<a title=\"&gt;abc\">2…</a>", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 2, true));
+    assertEquals("1…", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 1, true));
+    assertEquals("…", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 0, true));
+
+    // Attributes with " or ' and escaped
+    assertEquals("1<a title=\"&gt;abc&quot;hi&quot;\">234…</a>", helper.truncate("1<a title=\"&gt;abc&quot;hi&quot;\">234</a>5", 4, true));
+    assertEquals("1<a title='&gt;abc&quot;hi&quot;'>234…</a>", helper.truncate("1<a title='&gt;abc&quot;hi&quot;'>234</a>5", 4, true));
+    assertEquals("1<a title='&gt;abc&apos;hi&apos;'>234…</a>", helper.truncate("1<a title='&gt;abc&apos;hi&apos;'>234</a>5", 4, true));
+
+    // Comments
+    assertEquals("<div>12<!-- comment -->345</div>", helper.truncate("<div>12<!-- comment -->345</div>", 5, true));
+    assertEquals("<div>12<!-- comment -->3…</div>", helper.truncate("<div>12<!-- comment -->345</div>", 3, true));
+    assertEquals("<div>1…<!-- comment --></div>", helper.truncate("<div>12<!-- comment -->345</div>", 1, true));
+    assertEquals("…", helper.truncate("<div>12<!-- comment -->345</div>", 0, true));
+    assertEquals("1…", helper.truncate("12<!-- comment -->", 1, true));
+    assertEquals("<div>12<!-- <comment> -->34…</div>", helper.truncate("<div>12<!-- <comment> -->345</div>", 4, true));
+    assertEquals("<div>12…<!-- <comment> --></div>", helper.truncate("<div>12<!-- <comment> -->345</div>", 2, true));
+
+    // Invalid html
+    assertEquals("<div>1<div>2</div></div>345…", helper.truncate("<div>1<div>2</div></div>345</div>", 5, true));
+    assertEquals("<div>1<div>2…</div></div>", helper.truncate("<div>1<div>2</div></div>345</div>", 2, true));
+    assertEquals("1</div>2<bold>345</bold>", helper.truncate("1</div>2<bold>345</bold>", 5, true));
+    assertEquals("1</div>2<bold>34…</bold>", helper.truncate("1</div>2<bold>345</bold>", 4, true));
+    assertEquals("1</div>2…", helper.truncate("1</div>2<bold>345</bold>", 2, true));
+    // Everything after & counts as one until ;. Browsers may be more lenient and still render &gt without ; or render &asdf as it is. We simplify ignore these cases as we cannot assume what the browser will do.
+    assertEquals("1&gt345&#60;78…", helper.truncate("1&gt345&#60;78&#x3C;", 4, true));
+    assertEquals("<!-- 123", helper.truncate("<!-- 123", 2, true));
+
+    // Corner cases
+    assertEquals("", helper.truncate("", 5, true));
+    assertEquals("", helper.truncate("", 0, true));
+    assertEquals(null, helper.truncate(null, 5, true));
+    assertEquals("…", helper.truncate("1", 0, true));
+  }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
@@ -13,6 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 
 /**
@@ -271,5 +272,145 @@ public class HtmlHelper {
       result.append(c);
     }
     return result.toString();
+  }
+
+  /**
+   * Truncates the text content of the given html using {@link #truncate(String, Integer, boolean)} without adding an ellipsis.
+   */
+  public String truncate(String html, Integer maxLength) {
+    return truncate(html, maxLength, false);
+  }
+
+  /**
+   * Truncates the text content of the given html without removing the html tags surrounding the remaining text.
+   * The html tags that follow the remaining text and don't close a tag opened before the text may be removed.
+   *
+   * @param html
+   *     the html content to truncate
+   * @param maxLength
+   *     the maximum length the truncated text will have
+   * @param addEllipsis
+   *     true to add an ellipsis character at the position where the text was truncated
+   */
+  public String truncate(String html, Integer maxLength, boolean addEllipsis) {
+    if (StringUtility.isNullOrEmpty(html)) {
+      return html;
+    }
+    if (maxLength <= 0) {
+      return addEllipsis ? "…" : "";
+    }
+    int size = html.length();
+    if (size <= maxLength) {
+      // Content fits completely with all tags, just return it as it is
+      return html;
+    }
+
+    boolean inTag = false;
+    boolean inEntity = false;
+    boolean inAttr = false;
+    boolean inComment = false;
+    char attrChar = '"';
+    int numOpenTags = 0;
+    int numTextChars = 0;
+    int ellipsisPos = -1;
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < size; i++) {
+      char character = html.charAt(i);
+      if (numTextChars >= maxLength && !inTag && !inEntity && numOpenTags == 0) {
+        insertEllipsis(result, ellipsisPos);
+        // Abort if max length is reached but not in the middle of a tag or entity and only if all open tags are closed
+        break;
+      }
+      char prevChar = i > 1 ? html.charAt(i - 1) : '\0';
+      char nextChar = i < size - 1 ? html.charAt(i + 1) : '\0';
+      if (!inComment && character == '<' && i + 4 < size && "<!--".equals(html.substring(i, i + 4))) {
+        // Comment found <!--
+        inComment = true;
+        result.append(character);
+        continue;
+      }
+      if (inComment && i - 2 >= 0 && "-->".equals(html.substring(i - 2, i + 1))) {
+        // Closing comment found -->
+        inComment = false;
+        result.append(character);
+        continue;
+      }
+      if (!inComment && !inTag && character == '<') {
+        inTag = true;
+        if (nextChar == '/') {
+          // Closing tag found, e.g. </div>
+          numOpenTags = Math.max(numOpenTags - 1, 0);
+        }
+        else {
+          // Opening tag found e.g. <div>
+          numOpenTags++;
+        }
+        result.append(character);
+        continue;
+      }
+      if (inTag && !inAttr && character == '>') {
+        inTag = false;
+        if (prevChar == '/') {
+          // Self-closing tag found, e.g. <br/>
+          numOpenTags = Math.max(numOpenTags - 1, 0);
+        }
+        result.append(character);
+        continue;
+      }
+      if (inTag && !inAttr && ObjectUtility.isOneOf(character, '"', '\'')) {
+        // Attribute found with " or '
+        inAttr = true;
+        attrChar = character;
+        result.append(character);
+        continue;
+      }
+      if (inAttr && character == attrChar) {
+        // Closing attribute found
+        inAttr = false;
+        result.append(character);
+        continue;
+      }
+      if (!inComment && !inEntity && !inAttr && character == '&') {
+        // HTML entity (character reference) found, e.g. &gt;
+        inEntity = true;
+        result.append(character);
+        continue;
+      }
+      if (inEntity && character == ';') {
+        // Closing HTML entity found -> counts as one character
+        inEntity = false;
+        numTextChars++;
+        result.append(character);
+        ellipsisPos = updateEllipsisPos(result, maxLength, addEllipsis, ellipsisPos, numTextChars);
+        continue;
+      }
+      if (inTag || inEntity || inComment) {
+        result.append(character);
+        continue;
+      }
+      numTextChars++;
+      if (numTextChars <= maxLength) {
+        result.append(character);
+        ellipsisPos = updateEllipsisPos(result, maxLength, addEllipsis, ellipsisPos, numTextChars);
+      }
+      else {
+        insertEllipsis(result, ellipsisPos);
+        ellipsisPos = -1;
+      }
+    }
+    return result.toString();
+  }
+
+  protected int updateEllipsisPos(StringBuilder result, int maxLength, boolean addEllipsis, int ellipsisPos, int numChars) {
+    if (addEllipsis && numChars == maxLength) {
+      ellipsisPos = result.length();
+    }
+    return ellipsisPos;
+  }
+
+  protected void insertEllipsis(StringBuilder text, int position) {
+    if (position > -1) {
+      text.insert(position, '…');
+    }
   }
 }


### PR DESCRIPTION
Popup._onPopupOpen calls close() but that should not be called for cell editors because it just closes the editor without correctly cancelling or completing the edit.
Instead of extracting the close() call of _onPopupOpen in a method with a name to be defined, close() now just delegates to completeCellEdit().

417214