### PR TITLE
FocusManager: prevent scrolling when activating focus context

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.ts
+++ b/eclipse-scout-core/src/focus/FocusContext.ts
@@ -246,8 +246,8 @@ export class FocusContext {
   /**
    * Calls {@link #validateAndSetFocus} with {@link #lastValidFocusedElement}.
    */
-  validateFocus(filter?: () => boolean) {
-    this.validateAndSetFocus(this.lastValidFocusedElement, filter);
+  validateFocus(filter?: () => boolean, options?: FocusContextFocusOptions) {
+    this.validateAndSetFocus(this.lastValidFocusedElement, filter, options);
   }
 
   /**

--- a/eclipse-scout-core/src/focus/FocusManager.ts
+++ b/eclipse-scout-core/src/focus/FocusManager.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, Device, DisplayParent, filters, FocusContext, FocusRule, focusUtils, GlassPaneRenderer, scout, Session} from '../index';
+import {arrays, Device, DisplayParent, filters, FocusContext, FocusContextFocusOptions, FocusRule, focusUtils, GlassPaneRenderer, scout, Session} from '../index';
 import $ from 'jquery';
 
 export interface FocusManagerOptions {
@@ -197,7 +197,7 @@ export class FocusManager implements FocusManagerOptions {
       return;
     }
     this._pushIfAbsentElseMoveTop(focusContext);
-    this.validateFocus();
+    this.validateFocus(null, {preventScroll: true});
   }
 
   /**
@@ -268,11 +268,12 @@ export class FocusManager implements FocusManagerOptions {
    * Enforces proper focus on the currently active focus context.
    *
    * @param filter Filter to exclude elements to gain focus.
+   * @param options options to customize the focus
    */
-  validateFocus(filter?: () => boolean) {
+  validateFocus(filter?: () => boolean, options?: FocusContextFocusOptions) {
     let activeContext = this._findActiveContext();
     if (activeContext) {
-      activeContext.validateFocus(filter);
+      activeContext.validateFocus(filter, options);
     }
   }
 


### PR DESCRIPTION
When a focus context is activated when a dialog is clicked, the current scroll position should not be changed.

Consider this case:
- A dialog is open with a text area with a long text.
- The user places the cursor at the beginning of the text area.
- The user presses Ctrl-F to invoke the browser-native search bar.
- The user types a text that is in the text area but outside the current view port. The browser highlights the found word and scrolls it into view automatically.
- The user now clicks the text area.
- In some browsers (e.g. Chrome), this causes the text area to jump back to the previous cursor position at the start of the field.

This happens because clicking the text area "activates" the dialog and the focus context:
o Form#_onDialogMouseDown
o FormController#_activateDialog
o Desktop#moveOverlaysBehindAndFocus
o FocusManager#activateFocusContext

It is ok to validate an activate the focus context, but the scroll position should not change in this case (the user can only click elements that are currently within the view port).

395445