### PR TITLE
Mark Desktop not-ready when the last gui is detached

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktopTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktopTest.java
@@ -113,6 +113,26 @@ public class AbstractDesktopTest {
   }
 
   @Test
+  public void testReady() {
+    AbstractDesktop d = new AbstractDesktop(){};
+    d.init();
+    d.getUIFacade().openFromUI();
+    assertFalse(d.isReady());
+    d.getUIFacade().fireGuiAttached(); // first attach
+    assertFalse(d.isReady());
+    d.getUIFacade().readyFromUI(); // simulate Browser ready
+    assertTrue(d.isReady());
+    d.getUIFacade().fireGuiAttached(); // second attach
+    assertTrue(d.isReady());
+    d.getUIFacade().fireGuiDetached(); // second detach
+    assertTrue(d.isReady()); // must still be ready as there is one gui still attached (even though the first has already detached).
+    d.getUIFacade().fireGuiDetached(); // last gui has detached
+    assertFalse(d.isReady());
+    d.dispose();
+    assertFalse(d.isReady());
+  }
+
+  @Test
   public void testDisplayStyle() {
     IDesktop desktop;
 
@@ -357,8 +377,8 @@ public class AbstractDesktopTest {
       f.start();
 
       // the openForms listBox should only have one (checked) entry for the top form (form_1)
-      assertEquals(f.getOpenFormsField().getValue().size(), 1);
-      assertEquals(f.getOpenFormsField().getCheckedKeyCount(), 1);
+      assertEquals(1, f.getOpenFormsField().getValue().size());
+      assertEquals(1, f.getOpenFormsField().getCheckedKeyCount());
       // the value of that single entry should be all the forms in the displayParent hierarchy with unsaved changes
       assertTrue(CollectionUtility.firstElement(f.getOpenFormsField().getValue()).containsAll(CollectionUtility.hashSet(form_1, form_1_1, form_1_1_1)));
     }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/AbstractDesktop.java
@@ -2287,10 +2287,11 @@ public abstract class AbstractDesktop extends AbstractWidget implements IDesktop
   }
 
   private void detachGui() {
-    setReadyInternal(false);
     setAttachedGuiCount(m_attachedGuiCount - 1);
     if (m_attachedGuiCount == 0) {
-      //this is the last call to detachGui, call extensions
+      setReadyInternal(false);
+
+      // this is the last call to detachGui, call extensions
       for (IDesktopExtension ext : getDesktopExtensions()) {
         try {
           ContributionCommand cc = ext.guiDetachedDelegate();


### PR DESCRIPTION
Might happen if a Browser tab is duplicated and then closed again. On duplication the attachCount is 2. If one tab is closed, the Desktop is still ready (in the first tab).
Only set ready=false when the last gui is detached.

430278