### PR TITLE
StringColumn: truncate html content correctly

### DIFF
--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -558,6 +558,7 @@ export * from './table/columns/ColumnOptimalWidthMeasurer';
 export * from './table/columns/AlphanumericSortingStringColumn';
 export * from './table/columns/BeanColumn';
 export * from './table/columns/BooleanColumn';
+export * from './table/columns/BooleanColumnModel';
 export * from './table/columns/CompactColumn';
 export * from './table/columns/CompactBean';
 export * from './table/columns/CompactLine';

--- a/eclipse-scout-core/src/table/columns/BooleanColumn.ts
+++ b/eclipse-scout-core/src/table/columns/BooleanColumn.ts
@@ -7,13 +7,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Cell, CheckBoxField, Column, comparators, scout, TableRow} from '../../index';
+import {BooleanColumnModel, Cell, CheckBoxField, Column, comparators, scout, TableRow} from '../../index';
 
 /**
- * May be an ordinary boolean column or the table's checkable column (table.checkableColumn)
- * Difference: the table's checkable column represents the row.checked state, other boolean columns represent their own value.
+ * A column holding boolean values represented by check boxes.
  */
-export class BooleanColumn extends Column<boolean> {
+export class BooleanColumn extends Column<boolean> implements BooleanColumnModel {
+  declare model: BooleanColumnModel;
   triStateEnabled: boolean;
 
   constructor() {

--- a/eclipse-scout-core/src/table/columns/BooleanColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/BooleanColumnModel.ts
@@ -7,18 +7,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ValueFieldModel} from '../../../index';
+import {ColumnModel} from '../../index';
 
-export interface CheckBoxFieldModel extends ValueFieldModel<boolean> {
+export interface BooleanColumnModel extends ColumnModel<boolean> {
   /**
-   * Specifies whether the value can represent three states.
+   * Specifies whether the cell values can represent three states.
    *
    * - true: the value can be true, false or null. Null is the third state that represents "undefined".
-   * - false: the value can be true or false. It is never null (setting the value to null will automatically convert it to false).
+   * - false: the value can be true or false. The value is never null (setting the value to null will automatically convert it to false).
    *
    * Default is false.
    */
   triStateEnabled?: boolean;
-  wrapText?: boolean;
-  keyStroke?: string;
 }

--- a/eclipse-scout-core/src/table/columns/ColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/ColumnModel.ts
@@ -199,7 +199,9 @@ export interface ColumnModel<TValue = string> extends ObjectModelWithUuid<Column
   htmlEnabled?: boolean;
 
   /**
-   * Configures whether this column value is mandatory (required). This only affects editable columns (see {@link editable}).
+   * Configures whether the cells of this column require a value.
+   *
+   * This only affects {@link editable} columns.
    *
    * Default is false.
    */
@@ -274,6 +276,10 @@ export interface ColumnModel<TValue = string> extends ObjectModelWithUuid<Column
   showSeparator?: boolean;
 
   /**
+   * Defines the {@link StringFieldModel.maxLength} of the text in the cell editor if the column is {@link editable}.
+   *
+   * This property will only be passed to the cell editor and has no effect on the column itself.
+   *
    * Default is 4000.
    */
   maxLength?: number;
@@ -284,6 +290,14 @@ export interface ColumnModel<TValue = string> extends ObjectModelWithUuid<Column
   text?: string;
 
   /**
+   * Configures whether the text in this column is automatically wrapped if it is wider than the column (_soft wrap_).
+   *
+   * The property only has an effect if {@link Table.multilineText} is enabled.
+   * Explicit line breaks are not affected.
+   *
+   * By default, the property only affects the displayed cell text.
+   * Whether the cell editor applies automatic text wrapping as well depends on the specific column type.
+   *
    * Default is false.
    */
   textWrap?: boolean;

--- a/eclipse-scout-core/src/table/columns/DateColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/DateColumnModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,24 @@ import {ColumnModel, DateFormat} from '../../index';
 export interface DateColumnModel extends ColumnModel<Date> {
   format?: DateFormat | string;
   groupFormat?: DateFormat | string;
+  /**
+   * Configures whether the values of this column should show the date.
+   *
+   * If {@link format} is set, this configuration has no effect.
+   *
+   * The property will also be passed to the cell editor if the column is {@link editable}.
+   *
+   * Default is true.
+   */
   hasDate?: boolean;
+  /**
+   * Configures whether the values of this column should show the time.
+   *
+   * If {@link format} is set, this configuration has no effect.
+   *
+   * The property will also be passed to the cell editor if the column is {@link editable}.
+   *
+   * Default is false.
+   */
   hasTime?: boolean;
 }

--- a/eclipse-scout-core/src/table/columns/LookupCallColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/LookupCallColumnModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,23 +11,35 @@ import {CodeType, ColumnModel, LookupCallOrModel} from '../../index';
 
 export interface LookupCallColumnModel<TValue, TKey = TValue> extends ColumnModel<TValue> {
   /**
-   * Configures the {@link LookupCall} that is used to resolve the values and to load the proposals if the column is editable.
+   * Configures the {@link LookupCall} that is used to format the values.
+   *
+   * The property will also be passed to the cell editor if the column is {@link editable}.
+   *
+   * Default is null.
    */
   lookupCall?: LookupCallOrModel<TKey>;
   /**
    * If set, a {@link CodeLookupCall} is created and used for the property {@link lookupCall}.
    *
    * The property accepts a {@link CodeType} class or a {@link CodeType.id} (see {@link CodeTypeCache.get}).
+   *
+   * It will also be passed to the cell editor if the column is {@link editable}.
+   *
+   * Default is null.
    */
   codeType?: string | (new() => CodeType<TKey>);
   /**
-   * Configures the {@link SmartFieldModel.browseHierarchy} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.browseHierarchy} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is false.
    */
   browseHierarchy?: boolean;
   /**
-   * Configures the {@link SmartFieldModel.browseMaxRowCount} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.browseMaxRowCount} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is {@link SmartField.DEFAULT_BROWSE_MAX_COUNT}.
    */
   browseMaxRowCount?: number;
 }

--- a/eclipse-scout-core/src/table/columns/NumberColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/NumberColumnModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,20 @@ export interface NumberColumnModel extends ColumnModel<number> {
    * @see NumberField.fractionDigits
    */
   fractionDigits?: number;
+  /**
+   * Defines the {@link NumberFieldModel.minValue} of the cell editor if the column is {@link editable}.
+   *
+   * The property will only be passed to the cell editor and has no effect on the column itself.
+   *
+   * Default is null.
+   */
   minValue?: number;
+  /**
+   * Defines the {@link NumberFieldModel.maxValue} of the cell editor if the column is {@link editable}.
+   *
+   * The property will only be passed to the cell editor and has no effect on the column itself.
+   *
+   * Default is null.
+   */
   maxValue?: number;
 }

--- a/eclipse-scout-core/src/table/columns/SmartColumn.ts
+++ b/eclipse-scout-core/src/table/columns/SmartColumn.ts
@@ -17,7 +17,7 @@ import {Cell, codes, CodeType, LookupCallColumn, LookupCallOrModel, LookupRow, o
  * It should be used instead of the property selectedRows from Table.js which must not be used here.
  * 'row' can be null or undefined in some cases. Hence, some care is needed when listening to this event.
  */
-export class SmartColumn<TValue> extends LookupCallColumn<TValue> {
+export class SmartColumn<TValue> extends LookupCallColumn<TValue> implements SmartColumnModel<TValue> {
   declare model: SmartColumnModel<TValue>;
   declare eventMap: SmartColumnEventMap<TValue>;
   declare self: SmartColumn<any>;

--- a/eclipse-scout-core/src/table/columns/SmartColumnModel.ts
+++ b/eclipse-scout-core/src/table/columns/SmartColumnModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,18 +11,24 @@ import {LookupCallColumnModel} from '../../index';
 
 export interface SmartColumnModel<TValue> extends LookupCallColumnModel<TValue> {
   /**
-   * Configures the {@link SmartFieldModel.browseAutoExpandAll} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.browseAutoExpandAll} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is true.
    */
   browseAutoExpandAll?: boolean;
   /**
-   * Configures the {@link SmartFieldModel.browseLoadIncremental} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.browseLoadIncremental} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is false.
    */
   browseLoadIncremental?: boolean;
   /**
-   * Configures the {@link SmartFieldModel.activeFilterEnabled} of the cell editor if the column is editable.
+   * Configures the {@link SmartFieldModel.activeFilterEnabled} of the cell editor if the column is {@link editable}.
    * Does not have an effect otherwise.
+   *
+   * Default is false.
    */
   activeFilterEnabled?: boolean;
 }

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractStringColumnTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractStringColumnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,7 +55,7 @@ public class AbstractStringColumnTest {
     TestStringColumn col = table.getTestStringColumn();
     col.setMaxLength(1);
     table.addRowByArray(new Object[]{"text"});
-    assertEquals("t", table.getCell(0, 0).getValue());
+    assertEquals("t…", table.getCell(0, 0).getValue());
   }
 
   public class TestTable extends AbstractTable {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableUtility.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 public final class TableUtility {
   private static final Logger LOG = LoggerFactory.getLogger(TableUtility.class);
+  private static HtmlHelper s_htmlHelper;
 
   private TableUtility() {
   }
@@ -189,7 +190,6 @@ public final class TableUtility {
    * </ul>
    */
   public static Object[][] exportRowsAsCSV(List<? extends ITableRow> rows, List<? extends IColumn> columns, boolean includeLineForColumnNames, boolean includeLineForColumnTypes, boolean includeLineForColumnFormats) {
-    final HtmlHelper htmlHelper = BEANS.get(HtmlHelper.class);
     int nr = rows.size();
     Object[][] a = new Object[nr + (includeLineForColumnNames ? 1 : 0) + (includeLineForColumnTypes ? 1 : 0) + (includeLineForColumnFormats ? 1 : 0)][columns.size()];
     for (int c = 0; c < columns.size(); c++) {
@@ -243,7 +243,7 @@ public final class TableUtility {
       int csvRowIndex = 0;
       if (includeLineForColumnNames) {
         IHeaderCell headerCell = columns.get(c).getHeaderCell();
-        a[csvRowIndex][c] = headerCell.isHtmlEnabled() ? htmlHelper.toPlainText(headerCell.getText()) : headerCell.getText();
+        a[csvRowIndex][c] = headerCell.isHtmlEnabled() ? getHtmlHelper().toPlainText(headerCell.getText()) : headerCell.getText();
         csvRowIndex++;
       }
       if (includeLineForColumnTypes) {
@@ -275,7 +275,7 @@ public final class TableUtility {
           }
           //special intercept for html
           if (type == String.class && text != null && columns.get(c).isHtmlEnabled()) {
-            text = htmlHelper.toPlainText(text);
+            text = getHtmlHelper().toPlainText(text);
           }
           a[csvRowIndex][c] = text;
         }
@@ -283,6 +283,16 @@ public final class TableUtility {
       }
     }
     return a;
+  }
+
+  /**
+   * @return a cached {@link HtmlHelper} that can be used inside loops to avoid many `BEANS.get` calls.
+   */
+  public static HtmlHelper getHtmlHelper() {
+    if (s_htmlHelper == null) {
+      s_htmlHelper = BEANS.get(HtmlHelper.class);
+    }
+    return s_htmlHelper;
   }
 
   @FunctionalInterface

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractStringColumn.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractStringColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.client.ui.basic.table.columns;
 import org.eclipse.scout.rt.client.extension.ui.basic.table.columns.IStringColumnExtension;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.basic.table.ITableRow;
+import org.eclipse.scout.rt.client.ui.basic.table.TableUtility;
 import org.eclipse.scout.rt.client.ui.form.fields.IFormField;
 import org.eclipse.scout.rt.client.ui.form.fields.IValueField;
 import org.eclipse.scout.rt.client.ui.form.fields.stringfield.AbstractStringField;
@@ -42,12 +43,11 @@ public abstract class AbstractStringColumn extends AbstractColumn<String> implem
    */
 
   /**
-   * Configures the maximum length of text in this column. This configuration only limits the text length in case of
-   * editable cells.
+   * Configures the maximum length of text in this column. This value is also used by the cell editor if the column is editable.
    * <p>
    * Subclasses can override this method. Default is {@code 4000}.
    *
-   * @return Maximum length of text in an editable cell.
+   * @return Maximum length of text
    */
   @ConfigProperty(ConfigProperty.INTEGER)
   @Order(130)
@@ -185,7 +185,12 @@ public abstract class AbstractStringColumn extends AbstractColumn<String> implem
   protected String/* validValue */ validateValueInternal(ITableRow row, String rawValue) {
     String value = super.validateValueInternal(row, rawValue);
     if (value != null && value.length() > getMaxLength()) {
-      value = value.substring(0, getMaxLength());
+      if (isHtmlEnabled()) {
+        value = TableUtility.getHtmlHelper().truncate(value, getMaxLength(), true);
+      }
+      else {
+        value = value.substring(0, getMaxLength()) + "…";
+      }
     }
     return StringUtility.nullIfEmpty(value);
   }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/CompactLineBlock.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/CompactLineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,7 +9,7 @@
  */
 package org.eclipse.scout.rt.client.ui.basic.table.columns;
 
-import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.client.ui.basic.table.TableUtility;
 import org.eclipse.scout.rt.platform.html.HTML;
 import org.eclipse.scout.rt.platform.html.HtmlHelper;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
@@ -22,7 +22,6 @@ public class CompactLineBlock {
   private boolean m_encodeHtmlEnabled = true;
   private boolean m_nlToBrEnabled;
   private boolean m_htmlToPlainTextEnabled;
-  private HtmlHelper m_htmlHelper;
 
   public CompactLineBlock() {
   }
@@ -113,10 +112,7 @@ public class CompactLineBlock {
   }
 
   protected HtmlHelper getHtmlHelper() {
-    if (m_htmlHelper == null) {
-      m_htmlHelper = BEANS.get(HtmlHelper.class);
-    }
-    return m_htmlHelper;
+    return TableUtility.getHtmlHelper();
   }
 
   public String build() {

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
@@ -252,4 +252,241 @@ public class HtmlHelperTest {
     assertEquals("\u0027\u0027\u0027", helper.toPlainText("&#39;&#x27;&apos;"));
     assertEquals("hi", helper.toPlainText("&#x68;&#x69;"));
   }
+
+  @Test
+  public void testTruncate() {
+    HtmlHelper helper = BEANS.get(HtmlHelper.class);
+
+    // Without tags
+    assertEquals("12345", helper.truncate("12345", 6));
+    assertEquals("12345", helper.truncate("12345", 5));
+    assertEquals("1234", helper.truncate("12345", 4));
+    assertEquals("1", helper.truncate("12345", 1));
+    assertEquals("", helper.truncate("12345", 0));
+
+    // Surrounding tags
+    assertEquals("<div>12345</div>", helper.truncate("<div>12345</div>", 100));
+    assertEquals("<div>12345</div>", helper.truncate("<div>12345</div>", 6));
+    assertEquals("<div>12345</div>", helper.truncate("<div>12345</div>", 5));
+    assertEquals("<div>1234</div>", helper.truncate("<div>12345</div>", 4));
+    assertEquals("<div>1</div>", helper.truncate("<div>12345</div>", 1));
+    assertEquals("", helper.truncate("<div>12345</div>", 0));
+
+    // Inline tags
+    assertEquals("1<bold>2</bold>345", helper.truncate("1<bold>2</bold>345", 6));
+    assertEquals("1<bold>2</bold>345", helper.truncate("1<bold>2</bold>345", 5));
+    assertEquals("1<bold>2</bold>34", helper.truncate("1<bold>2</bold>345", 4));
+    assertEquals("1<bold>2</bold>", helper.truncate("1<bold>2</bold>345", 2));
+    assertEquals("1", helper.truncate("1<bold>2</bold>345", 1));
+    assertEquals("", helper.truncate("1<bold>2</bold>345", 0));
+
+    // Surrounding and inline tags
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 6));
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 5));
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">34</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 4));
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\"></span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 2));
+    assertEquals("<div>1<bold></bold><span style=\"color: blue;\"></span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 1));
+    assertEquals("", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 0));
+
+    // Tags in attributes
+    assertEquals("1<a title=\"<div>asdf\">234</a>5", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 6));
+    assertEquals("1<a title=\"<div>asdf\">234</a>5", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 5));
+    assertEquals("1<a title=\"<div>asdf\">234</a>", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 4));
+    assertEquals("1<a title=\"<div>asdf\">2</a>", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 2));
+    assertEquals("1", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 1));
+    assertEquals("", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 0));
+    assertEquals("1<a title=\"</div>asdf\">234</a>", helper.truncate("1<a title=\"</div>asdf\">234</a>5", 4)); // CLosing tag in attribute
+
+    // Void tags
+    assertEquals("1<br>2<img src=\"http://asdf.com\">345", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 6));
+    assertEquals("1<br>2<img src=\"http://asdf.com\">345", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 5));
+    assertEquals("1<br>2<img src=\"http://asdf.com\">34", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 4));
+    // The result 1<br>2 would be even better but this would require a detection for void tags which just makes the implementation more complex with little benefit
+    assertEquals("1<br>2<img src=\"http://asdf.com\">", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 2));
+    assertEquals("1", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 1));
+    assertEquals("", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 0));
+
+    // Void tags with surrounding tags
+    assertEquals("<div>1<br>234</div>", helper.truncate("<div>1<br>2345</div>", 4));
+    assertEquals("<div>1<br></div>", helper.truncate("<div>1<br>2345</div>", 1));
+    assertEquals("<div>1<img src=\"http://asdf.com\">234</div>", helper.truncate("<div>1<img src=\"http://asdf.com\">2345</div>", 4));
+    assertEquals("<div>1<img src=\"http://asdf.com\"></div>", helper.truncate("<div>1<img src=\"http://asdf.com\">2345</div>", 1));
+    assertEquals("<div>1<img src=\"blob:abc\">234</div>", helper.truncate("<div>1<img src=\"blob:abc\">2345</div>", 4));
+    assertEquals("<div>1<img src=\"blob:abc\"></div>", helper.truncate("<div>1<img src=\"blob:abc\">2345</div>", 1));
+
+    // Self-closing tags
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />345", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 6));
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />345", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 5));
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />34", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 4));
+    assertEquals("1<br/>2", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 2));
+    assertEquals("1", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 1));
+    assertEquals("", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 0));
+
+    // Self-closing tags with surrounding tags
+    assertEquals("<div>1<br/>234</div>", helper.truncate("<div>1<br/>2345</div>", 4));
+    assertEquals("<div>1<br/></div>", helper.truncate("<div>1<br/>2345</div>", 1));
+    assertEquals("<div>1<img src=\"http://asdf.com\"/>234</div>", helper.truncate("<div>1<img src=\"http://asdf.com\"/>2345</div>", 4));
+    assertEquals("<div>1<img src=\"http://asdf.com\"/></div>", helper.truncate("<div>1<img src=\"http://asdf.com\"/>2345</div>", 1));
+    assertEquals("<div>1<img src=\"blob:abc\"/>234</div>", helper.truncate("<div>1<img src=\"blob:abc\"/>2345</div>", 4));
+    assertEquals("<div>1<img src=\"blob:abc\"/></div>", helper.truncate("<div>1<img src=\"blob:abc\"/>2345</div>", 1));
+
+    // Character references (html entities)
+    assertEquals("1&gt;345&#60;78&#x3C;", helper.truncate("1&gt;345&#60;78&#x3C;", 10));
+    assertEquals("1&gt;345&#60;78&#x3C;", helper.truncate("1&gt;345&#60;78&#x3C;", 9));
+    assertEquals("1&gt;345&#60;78", helper.truncate("1&gt;345&#60;78&#x3C;", 8));
+    assertEquals("1&gt;3", helper.truncate("1&gt;345&#60;78&#x3C;", 3));
+    assertEquals("1&gt;", helper.truncate("1&gt;345&#60;78&#x3C;", 2));
+    assertEquals("1", helper.truncate("1&gt;345&#60;78&#x3C;", 1));
+    assertEquals("", helper.truncate("1&gt;345&#60;78&#x3C;", 0));
+
+    // Character references in attributes
+    assertEquals("1<a title=\"&gt;abc\">234</a>5", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 5));
+    assertEquals("1<a title=\"&gt;abc\">234</a>", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 4));
+    assertEquals("1<a title=\"&gt;abc\">2</a>", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 2));
+    assertEquals("1", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 1));
+    assertEquals("", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 0));
+
+    // Attributes with " or ' and escaped
+    assertEquals("1<a title=\"&gt;abc&quot;hi&quot;\">234</a>", helper.truncate("1<a title=\"&gt;abc&quot;hi&quot;\">234</a>5", 4));
+    assertEquals("1<a title='&gt;abc&quot;hi&quot;'>234</a>", helper.truncate("1<a title='&gt;abc&quot;hi&quot;'>234</a>5", 4));
+    assertEquals("1<a title='&gt;abc&apos;hi&apos;'>234</a>", helper.truncate("1<a title='&gt;abc&apos;hi&apos;'>234</a>5", 4));
+
+    // Comments
+    assertEquals("<div>12<!-- comment -->345</div>", helper.truncate("<div>12<!-- comment -->345</div>", 6));
+    assertEquals("<div>12<!-- comment -->345</div>", helper.truncate("<div>12<!-- comment -->345</div>", 5));
+    assertEquals("<div>12<!-- comment -->3</div>", helper.truncate("<div>12<!-- comment -->345</div>", 3));
+    assertEquals("<div>1<!-- comment --></div>", helper.truncate("<div>12<!-- comment -->345</div>", 1));
+    assertEquals("", helper.truncate("<div>12<!-- comment -->345</div>", 0));
+    assertEquals("1", helper.truncate("12<!-- comment -->", 1));
+    assertEquals("<div>12<!-- <comment> -->34</div>", helper.truncate("<div>12<!-- <comment> -->345</div>", 4));
+    assertEquals("<div>12<!-- <comment> --></div>", helper.truncate("<div>12<!-- <comment> -->345</div>", 2));
+
+    // Invalid html
+    assertEquals("<div>1<div>2</div></div>345", helper.truncate("<div>1<div>2</div></div>345</div>", 5));
+    assertEquals("<div>1<div>2</div></div>", helper.truncate("<div>1<div>2</div></div>345</div>", 2));
+    assertEquals("1</div>2<bold>345</bold>", helper.truncate("1</div>2<bold>345</bold>", 5));
+    assertEquals("1</div>2<bold>34</bold>", helper.truncate("1</div>2<bold>345</bold>", 4));
+    assertEquals("1</div>2", helper.truncate("1</div>2<bold>345</bold>", 2));
+    // Everything after & counts as one until ;. Browsers may be more lenient and still render &gt without ; or render &asdf as it is. We simplify ignore these cases as we cannot assume what the browser will do.
+    assertEquals("1&gt345&#60;78", helper.truncate("1&gt345&#60;78&#x3C;", 4));
+    assertEquals("<!-- 123", helper.truncate("<!-- 123", 2));
+
+    // Corner cases
+    assertEquals(null, helper.truncate(null, 6));
+    assertEquals("", helper.truncate("12345", -1));
+  }
+
+  @Test
+  public void truncateWithEllipsis() {
+    HtmlHelper helper = BEANS.get(HtmlHelper.class);
+
+    // Without tags
+    assertEquals("12345", helper.truncate("12345", 5, true));
+    assertEquals("1234…", helper.truncate("12345", 4, true));
+    assertEquals("1…", helper.truncate("12345", 1, true));
+    assertEquals("…", helper.truncate("12345", 0, true));
+
+    // Surrounding tags
+    assertEquals("<div>12345</div>", helper.truncate("<div>12345</div>", 5, true));
+    assertEquals("<div>1234…</div>", helper.truncate("<div>12345</div>", 4, true));
+    assertEquals("<div>1…</div>", helper.truncate("<div>12345</div>", 1, true));
+    assertEquals("…", helper.truncate("<div>12345</div>", 0, true));
+
+    // Inline tags
+    assertEquals("1<bold>2</bold>345", helper.truncate("1<bold>2</bold>345", 5, true));
+    assertEquals("1<bold>2</bold>34…", helper.truncate("1<bold>2</bold>345", 4, true));
+    assertEquals("1<bold>2…</bold>", helper.truncate("1<bold>2</bold>345", 2, true));
+    assertEquals("1…", helper.truncate("1<bold>2</bold>345", 1, true));
+    assertEquals("…", helper.truncate("1<bold>2</bold>345", 0, true));
+
+    // Surrounding and inline tags
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 5, true));
+    assertEquals("<div>1<bold>2</bold><span style=\"color: blue;\">34…</span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 4, true));
+    assertEquals("<div>1<bold>2…</bold><span style=\"color: blue;\"></span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 2, true));
+    assertEquals("<div>1…<bold></bold><span style=\"color: blue;\"></span></div>", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 1, true));
+    assertEquals("…", helper.truncate("<div>1<bold>2</bold><span style=\"color: blue;\">345</span></div>", 0, true));
+
+    // Tags in attributes
+    assertEquals("1<a title=\"<div>asdf\">234</a>5", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 5, true));
+    assertEquals("1<a title=\"<div>asdf\">234…</a>", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 4, true));
+    assertEquals("1<a title=\"<div>asdf\">2…</a>", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 2, true));
+    assertEquals("1…", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 1, true));
+    assertEquals("…", helper.truncate("1<a title=\"<div>asdf\">234</a>5", 0, true));
+    assertEquals("1<a title=\"</div>asdf\">234…</a>", helper.truncate("1<a title=\"</div>asdf\">234</a>5", 4, true)); // CLosing tag in attribute
+
+    // Void tags
+    assertEquals("1<br>2<img src=\"http://asdf.com\">345", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 5, true));
+    assertEquals("1<br>2<img src=\"http://asdf.com\">34…", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 4, true));
+    // The result 1<br>2 would be even better but this would require a detection for void tags which just makes the implementation more complex with little benefit
+    assertEquals("1<br>2…<img src=\"http://asdf.com\">", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 2, true));
+    assertEquals("1…", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 1, true));
+    assertEquals("…", helper.truncate("1<br>2<img src=\"http://asdf.com\">345", 0, true));
+
+    // Void tags with surrounding tags
+    assertEquals("<div>1…<br></div>", helper.truncate("<div>1<br>2345</div>", 1, true));
+    assertEquals("<div>1<img src=\"http://asdf.com\">234…</div>", helper.truncate("<div>1<img src=\"http://asdf.com\">2345</div>", 4, true));
+    assertEquals("<div>1…<img src=\"http://asdf.com\"></div>", helper.truncate("<div>1<img src=\"http://asdf.com\">2345</div>", 1, true));
+    assertEquals("<div>1<img src=\"blob:abc\">234…</div>", helper.truncate("<div>1<img src=\"blob:abc\">2345</div>", 4, true));
+    assertEquals("<div>1…<img src=\"blob:abc\"></div>", helper.truncate("<div>1<img src=\"blob:abc\">2345</div>", 1, true));
+
+    // Self-closing tags
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />345", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 5, true));
+    assertEquals("1<br/>2<img src=\"http://asdf.com\" />34…", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 4, true));
+    assertEquals("1<br/>2…", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 2, true));
+    assertEquals("1…", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 1, true));
+    assertEquals("…", helper.truncate("1<br/>2<img src=\"http://asdf.com\" />345", 0, true));
+
+    // Self-closing tags with surrounding tags
+    assertEquals("<div>1<br/>234…</div>", helper.truncate("<div>1<br/>2345</div>", 4, true));
+    assertEquals("<div>1…<br/></div>", helper.truncate("<div>1<br/>2345</div>", 1, true));
+    assertEquals("<div>1<img src=\"http://asdf.com\"/>234…</div>", helper.truncate("<div>1<img src=\"http://asdf.com\"/>2345</div>", 4, true));
+    assertEquals("<div>1…<img src=\"http://asdf.com\"/></div>", helper.truncate("<div>1<img src=\"http://asdf.com\"/>2345</div>", 1, true));
+    assertEquals("<div>1<img src=\"blob:abc\"/>234…</div>", helper.truncate("<div>1<img src=\"blob:abc\"/>2345</div>", 4, true));
+    assertEquals("<div>1…<img src=\"blob:abc\"/></div>", helper.truncate("<div>1<img src=\"blob:abc\"/>2345</div>", 1, true));
+
+    // Character references (html entities)
+    assertEquals("1&gt;345&#60;78&#x3C;", helper.truncate("1&gt;345&#60;78&#x3C;", 9, true));
+    assertEquals("1&gt;345&#60;78…", helper.truncate("1&gt;345&#60;78&#x3C;", 8, true));
+    assertEquals("1&gt;3…", helper.truncate("1&gt;345&#60;78&#x3C;", 3, true));
+    assertEquals("1&gt;…", helper.truncate("1&gt;345&#60;78&#x3C;", 2, true));
+    assertEquals("1…", helper.truncate("1&gt;345&#60;78&#x3C;", 1, true));
+    assertEquals("…", helper.truncate("1&gt;345&#60;78&#x3C;", 0, true));
+
+    // Character references in attributes
+    assertEquals("1<a title=\"&gt;abc\">234</a>5", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 5, true));
+    assertEquals("1<a title=\"&gt;abc\">234…</a>", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 4, true));
+    assertEquals("1<a title=\"&gt;abc\">2…</a>", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 2, true));
+    assertEquals("1…", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 1, true));
+    assertEquals("…", helper.truncate("1<a title=\"&gt;abc\">234</a>5", 0, true));
+
+    // Attributes with " or ' and escaped
+    assertEquals("1<a title=\"&gt;abc&quot;hi&quot;\">234…</a>", helper.truncate("1<a title=\"&gt;abc&quot;hi&quot;\">234</a>5", 4, true));
+    assertEquals("1<a title='&gt;abc&quot;hi&quot;'>234…</a>", helper.truncate("1<a title='&gt;abc&quot;hi&quot;'>234</a>5", 4, true));
+    assertEquals("1<a title='&gt;abc&apos;hi&apos;'>234…</a>", helper.truncate("1<a title='&gt;abc&apos;hi&apos;'>234</a>5", 4, true));
+
+    // Comments
+    assertEquals("<div>12<!-- comment -->345</div>", helper.truncate("<div>12<!-- comment -->345</div>", 5, true));
+    assertEquals("<div>12<!-- comment -->3…</div>", helper.truncate("<div>12<!-- comment -->345</div>", 3, true));
+    assertEquals("<div>1…<!-- comment --></div>", helper.truncate("<div>12<!-- comment -->345</div>", 1, true));
+    assertEquals("…", helper.truncate("<div>12<!-- comment -->345</div>", 0, true));
+    assertEquals("1…", helper.truncate("12<!-- comment -->", 1, true));
+    assertEquals("<div>12<!-- <comment> -->34…</div>", helper.truncate("<div>12<!-- <comment> -->345</div>", 4, true));
+    assertEquals("<div>12…<!-- <comment> --></div>", helper.truncate("<div>12<!-- <comment> -->345</div>", 2, true));
+
+    // Invalid html
+    assertEquals("<div>1<div>2</div></div>345…", helper.truncate("<div>1<div>2</div></div>345</div>", 5, true));
+    assertEquals("<div>1<div>2…</div></div>", helper.truncate("<div>1<div>2</div></div>345</div>", 2, true));
+    assertEquals("1</div>2<bold>345</bold>", helper.truncate("1</div>2<bold>345</bold>", 5, true));
+    assertEquals("1</div>2<bold>34…</bold>", helper.truncate("1</div>2<bold>345</bold>", 4, true));
+    assertEquals("1</div>2…", helper.truncate("1</div>2<bold>345</bold>", 2, true));
+    // Everything after & counts as one until ;. Browsers may be more lenient and still render &gt without ; or render &asdf as it is. We simplify ignore these cases as we cannot assume what the browser will do.
+    assertEquals("1&gt345&#60;78…", helper.truncate("1&gt345&#60;78&#x3C;", 4, true));
+    assertEquals("<!-- 123", helper.truncate("<!-- 123", 2, true));
+
+    // Corner cases
+    assertEquals("", helper.truncate("", 5, true));
+    assertEquals("", helper.truncate("", 0, true));
+    assertEquals(null, helper.truncate(null, 5, true));
+    assertEquals("…", helper.truncate("1", 0, true));
+  }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
@@ -13,6 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 
 /**
@@ -271,5 +272,145 @@ public class HtmlHelper {
       result.append(c);
     }
     return result.toString();
+  }
+
+  /**
+   * Truncates the text content of the given html using {@link #truncate(String, Integer, boolean)} without adding an ellipsis.
+   */
+  public String truncate(String html, Integer maxLength) {
+    return truncate(html, maxLength, false);
+  }
+
+  /**
+   * Truncates the text content of the given html without removing the html tags surrounding the remaining text.
+   * The html tags that follow the remaining text and don't close a tag opened before the text may be removed.
+   *
+   * @param html
+   *     the html content to truncate
+   * @param maxLength
+   *     the maximum length the truncated text will have
+   * @param addEllipsis
+   *     true to add an ellipsis character at the position where the text was truncated
+   */
+  public String truncate(String html, Integer maxLength, boolean addEllipsis) {
+    if (StringUtility.isNullOrEmpty(html)) {
+      return html;
+    }
+    if (maxLength <= 0) {
+      return addEllipsis ? "…" : "";
+    }
+    int size = html.length();
+    if (size <= maxLength) {
+      // Content fits completely with all tags, just return it as it is
+      return html;
+    }
+
+    boolean inTag = false;
+    boolean inEntity = false;
+    boolean inAttr = false;
+    boolean inComment = false;
+    char attrChar = '"';
+    int numOpenTags = 0;
+    int numTextChars = 0;
+    int ellipsisPos = -1;
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < size; i++) {
+      char character = html.charAt(i);
+      if (numTextChars >= maxLength && !inTag && !inEntity && numOpenTags == 0) {
+        insertEllipsis(result, ellipsisPos);
+        // Abort if max length is reached but not in the middle of a tag or entity and only if all open tags are closed
+        break;
+      }
+      char prevChar = i > 1 ? html.charAt(i - 1) : '\0';
+      char nextChar = i < size - 1 ? html.charAt(i + 1) : '\0';
+      if (!inComment && character == '<' && i + 4 < size && "<!--".equals(html.substring(i, i + 4))) {
+        // Comment found <!--
+        inComment = true;
+        result.append(character);
+        continue;
+      }
+      if (inComment && i - 2 >= 0 && "-->".equals(html.substring(i - 2, i + 1))) {
+        // Closing comment found -->
+        inComment = false;
+        result.append(character);
+        continue;
+      }
+      if (!inComment && !inTag && character == '<') {
+        inTag = true;
+        if (nextChar == '/') {
+          // Closing tag found, e.g. </div>
+          numOpenTags = Math.max(numOpenTags - 1, 0);
+        }
+        else {
+          // Opening tag found e.g. <div>
+          numOpenTags++;
+        }
+        result.append(character);
+        continue;
+      }
+      if (inTag && !inAttr && character == '>') {
+        inTag = false;
+        if (prevChar == '/') {
+          // Self-closing tag found, e.g. <br/>
+          numOpenTags = Math.max(numOpenTags - 1, 0);
+        }
+        result.append(character);
+        continue;
+      }
+      if (inTag && !inAttr && ObjectUtility.isOneOf(character, '"', '\'')) {
+        // Attribute found with " or '
+        inAttr = true;
+        attrChar = character;
+        result.append(character);
+        continue;
+      }
+      if (inAttr && character == attrChar) {
+        // Closing attribute found
+        inAttr = false;
+        result.append(character);
+        continue;
+      }
+      if (!inComment && !inEntity && !inAttr && character == '&') {
+        // HTML entity (character reference) found, e.g. &gt;
+        inEntity = true;
+        result.append(character);
+        continue;
+      }
+      if (inEntity && character == ';') {
+        // Closing HTML entity found -> counts as one character
+        inEntity = false;
+        numTextChars++;
+        result.append(character);
+        ellipsisPos = updateEllipsisPos(result, maxLength, addEllipsis, ellipsisPos, numTextChars);
+        continue;
+      }
+      if (inTag || inEntity || inComment) {
+        result.append(character);
+        continue;
+      }
+      numTextChars++;
+      if (numTextChars <= maxLength) {
+        result.append(character);
+        ellipsisPos = updateEllipsisPos(result, maxLength, addEllipsis, ellipsisPos, numTextChars);
+      }
+      else {
+        insertEllipsis(result, ellipsisPos);
+        ellipsisPos = -1;
+      }
+    }
+    return result.toString();
+  }
+
+  protected int updateEllipsisPos(StringBuilder result, int maxLength, boolean addEllipsis, int ellipsisPos, int numChars) {
+    if (addEllipsis && numChars == maxLength) {
+      ellipsisPos = result.length();
+    }
+    return ellipsisPos;
+  }
+
+  protected void insertEllipsis(StringBuilder text, int position) {
+    if (position > -1) {
+      text.insert(position, '…');
+    }
   }
 }


### PR DESCRIPTION
Currently, if a column has a max length and htmlEnabled set to true, the html content may be truncated incorrectly resulting in UI errors. This happens because the Scout JS table just concatenates the table rows together and if the cells contain html tags especially <div> that are not closed, the rows won't be built correctly.

Now, only the text inside the html content will be truncated preserving the html tags.

426350