### PR TITLE
BinaryRefResourceLoader: do not create HttpSession unnecessarily

### DIFF
--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/BinaryRefResourceLoader.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/loader/BinaryRefResourceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -52,7 +52,7 @@ public class BinaryRefResourceLoader extends AbstractResourceLoader {
 
   @Override
   public IHttpResourceCache getCache(HttpCacheKey cacheKey) {
-    HttpSession httpSession = getRequest().getSession();
+    HttpSession httpSession = getRequest().getSession(false);
     if (httpSession == null) {
       return null;
     }
@@ -103,7 +103,7 @@ public class BinaryRefResourceLoader extends AbstractResourceLoader {
 
   @Override
   public BinaryResource loadResource(String pathInfo) {
-    HttpSession httpSession = getRequest().getSession();
+    HttpSession httpSession = getRequest().getSession(false);
     if (httpSession == null) {
       return null;
     }


### PR DESCRIPTION
If the BinaryRefResourceLoader creates a new HttpSession, there is no possibility the requested object is part of an existing cache. Therefore, the handler tries to load the requested object for which a ClientSession is resolved. As the HttpSession is newly created there will never be a ClientSession associated to it and the handler will return null.
Therefore, do not create a new HttpSession if the request does not already have a session and exit early.

430777