### PR TITLE
Remove SharedVariableMap from server session

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/clientnotification/ClientSessionRegistryTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/clientnotification/ClientSessionRegistryTest.java
@@ -41,7 +41,7 @@ public class ClientSessionRegistryTest {
    */
   @Test
   public void testRegisteredWhenSessionStarted() {
-    ClientSessionRegistry reg = new TestClientSessionRegistry();
+    ClientSessionRegistry reg = new ClientSessionRegistry();
     startSession(reg);
 
     final List<IClientSession> userSessions = reg.getClientSessionsForUser(m_clientSession.getUserId());
@@ -52,7 +52,7 @@ public class ClientSessionRegistryTest {
 
   @Test
   public void testUnRegisteredWhenSessionStopped() {
-    ClientSessionRegistry reg = new TestClientSessionRegistry();
+    ClientSessionRegistry reg = new ClientSessionRegistry();
     startSession(reg);
     reg.sessionStopped(m_clientSession);
     final List<IClientSession> userSessions = reg.getClientSessionsForUser(m_clientSession.getUserId());
@@ -63,12 +63,5 @@ public class ClientSessionRegistryTest {
   private void startSession(ClientSessionRegistry reg) {
     reg.register(m_clientSession, m_clientSession.getId());
     reg.sessionStarted(m_clientSession);
-  }
-
-  class TestClientSessionRegistry extends ClientSessionRegistry {
-    @Override
-    protected void ensureUserIdAvailable(IClientSession session) {
-      //nop
-    }
   }
 }

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/servicetunnel/ClientServiceTunnelIdSignatureTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/servicetunnel/ClientServiceTunnelIdSignatureTest.java
@@ -24,10 +24,14 @@ import jakarta.ws.rs.core.Response.Status;
 import org.eclipse.scout.rt.dataobject.DataObjectHolder;
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoEntityHolder;
+import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.IIdSignatureDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.fixture.FixtureIntegerId;
 import org.eclipse.scout.rt.dataobject.id.IdCodec;
 import org.eclipse.scout.rt.dataobject.id.IdCodec.IdCodecFlag;
+import org.eclipse.scout.rt.jackson.dataobject.JacksonDataObjectMapper;
+import org.eclipse.scout.rt.jackson.dataobject.JacksonIdSignatureDataObjectMapper;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
@@ -60,6 +64,10 @@ public class ClientServiceTunnelIdSignatureTest {
         new BeanMetaData(P_IdCodec.class).withReplace(true)
     );
     BEANS.get(TestingRestClientConfigFactory.class).setupMockConnectorProvider();
+
+    // create new instance of data object mapper because of the serializer cache. Otherwise, the replaced codec would still be used after the test
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(IDataObjectMapper.class, new JacksonDataObjectMapper()).withApplicationScoped(true)));
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(IIdSignatureDataObjectMapper.class, new JacksonIdSignatureDataObjectMapper()).withApplicationScoped(true)));
   }
 
   @AfterClass

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsFormTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsFormTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/AbstractClientSession.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/AbstractClientSession.java
@@ -10,6 +10,7 @@
 package org.eclipse.scout.rt.client;
 
 import static java.util.Collections.*;
+import static org.eclipse.scout.rt.shared.ISessionVariable.SHARED_CONTEXT_USER_ID;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -38,7 +39,6 @@ import org.eclipse.scout.rt.platform.annotations.ConfigProperty;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.context.PropertyMap;
 import org.eclipse.scout.rt.platform.exception.PlatformError;
-import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.job.IExecutionSemaphore;
 import org.eclipse.scout.rt.platform.job.IFuture;
 import org.eclipse.scout.rt.platform.job.Jobs;
@@ -49,15 +49,17 @@ import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.eclipse.scout.rt.platform.util.event.FastListenerList;
 import org.eclipse.scout.rt.platform.util.event.IFastListenerList;
+import org.eclipse.scout.rt.shared.ISessionVariable;
 import org.eclipse.scout.rt.shared.extension.AbstractExtension;
 import org.eclipse.scout.rt.shared.extension.IExtensibleObject;
 import org.eclipse.scout.rt.shared.extension.IExtension;
 import org.eclipse.scout.rt.shared.extension.ObjectExtensions;
 import org.eclipse.scout.rt.shared.services.common.context.SharedVariableMap;
-import org.eclipse.scout.rt.shared.services.common.ping.IPingService;
 import org.eclipse.scout.rt.shared.services.common.security.ILogoutService;
 import org.eclipse.scout.rt.shared.session.IGlobalSessionListener;
 import org.eclipse.scout.rt.shared.session.ISessionListener;
+import org.eclipse.scout.rt.shared.session.ISessionService;
+import org.eclipse.scout.rt.shared.session.LoadInitialSharedVariablesResponse;
 import org.eclipse.scout.rt.shared.session.SessionData;
 import org.eclipse.scout.rt.shared.session.SessionEvent;
 import org.eclipse.scout.rt.shared.session.SessionMetricsHelper;
@@ -165,7 +167,7 @@ public abstract class AbstractClientSession extends AbstractPropertyObserver imp
    */
   @Override
   public String getUserId() {
-    return getSharedContextVariable("userId", String.class);
+    return getSharedContextVariable(SHARED_CONTEXT_USER_ID, String.class);
   }
 
   @Override
@@ -289,25 +291,27 @@ public abstract class AbstractClientSession extends AbstractPropertyObserver imp
   }
 
   /**
-   * replace the shared variable map with a new version.
-   *
-   * @param newMap
-   *     map to replace the current one with
+   * Sets a single shared variable and fires a change event. If the variable already exists, its value will be overwritten.
    */
-  @Override
-  public void replaceSharedVariableMapInternal(Map<String, Object> newMap) {
-    m_sharedVariableMap.updateInternal(newMap);
+  protected void setSharedVariable(String variableName, Object newValue) {
+    m_sharedVariableMap.put(variableName, newValue);
   }
 
   /**
-   * Pings the server to get the initial shared variables. Blocks until the initial version of the shared variables is
-   * available or the timeout is reached.
-   *
-   * @throws ProcessingException
-   *     if interrupted (and the variables are not initialized)
+   * Sets multiple shared variables and fires a change event. Existing entries with the same keys will be overwritten.
    */
-  protected void initializeSharedVariables() {
-    BEANS.get(IPingService.class).ping("");
+  @Override
+  public void setSharedVariables(Map<String, Object> variables) {
+    m_sharedVariableMap.putAll(variables);
+  }
+
+  /**
+   * Loads the initial shared variables from the server. Blocks until the initial version of the variables is
+   * available or the timeout is reached.
+   */
+  protected void loadInitialSharedVariables() {
+    LoadInitialSharedVariablesResponse initialVariablesResponse = BEANS.get(ISessionService.class).loadInitialSharedVariables();
+    setSharedVariables(initialVariablesResponse.getVariables());
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/IClientSession.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/IClientSession.java
@@ -125,8 +125,6 @@ public interface IClientSession extends ISession, IPropertyObserver {
    */
   void setMemoryPolicy(IMemoryPolicy memoryPolicy);
 
-  void replaceSharedVariableMapInternal(Map<String, Object> newMap);
-
   /**
    * Returns the <em>one-permit</em> {@link IExecutionSemaphore} to run model jobs of this session in sequence, meaning
    * that only one model job is active at any given time for this session.
@@ -138,4 +136,17 @@ public interface IClientSession extends ISession, IPropertyObserver {
    * map} that should be accessible in the browser. Never returns {@code null}.
    */
   Set<String> getExposedSharedVariables();
+
+  /**
+   * @return the variable map holding additional information used by the client session
+   */
+  Map<String, Object> getSharedVariableMap();
+
+  /**
+   * Sets multiple shared variables and fires a change event. Existing entries with the same keys will be overwritten.
+   *
+   * @param variables
+   *     map of variables that should be set
+   */
+  void setSharedVariables(Map<String, Object> variables);
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/clientnotification/ClientSessionRegistry.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/clientnotification/ClientSessionRegistry.java
@@ -24,7 +24,6 @@ import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.shared.ISession;
-import org.eclipse.scout.rt.shared.services.common.ping.IPingService;
 import org.eclipse.scout.rt.shared.session.IGlobalSessionListener;
 import org.eclipse.scout.rt.shared.session.SessionEvent;
 import org.slf4j.Logger;
@@ -80,7 +79,6 @@ public class ClientSessionRegistry implements IClientSessionRegistry, IGlobalSes
    * session.
    */
   public void sessionStarted(final IClientSession session) {
-    ensureUserIdAvailable(session);
     checkSession(session);
     LOG.debug("Register client session [sessionId={}, userId={}].", session.getId(), session.getUserId());
     registerUser(session);
@@ -121,14 +119,6 @@ public class ClientSessionRegistry implements IClientSessionRegistry, IGlobalSes
         m_userToSessions.put(session.getUserId(), sessionRefs);
       }
     }
-  }
-
-  /**
-   * Make sure, the userid is set on the session. A first server-lookup creates the server session and synchronized the
-   * userid.
-   */
-  protected void ensureUserIdAvailable(IClientSession session) {
-    BEANS.get(IPingService.class).ping("ensure shared context is loaded...");
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/context/SharedContextNotificationHandler.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/context/SharedContextNotificationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,10 +9,14 @@
  */
 package org.eclipse.scout.rt.client.context;
 
+import java.util.Map;
+
 import org.eclipse.scout.rt.client.IClientSession;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.shared.notification.INotificationHandler;
 import org.eclipse.scout.rt.shared.services.common.context.SharedContextChangedNotification;
+import org.eclipse.scout.rt.shared.session.ISessionService;
 
 /**
  * Handler for {@link SharedContextChangedNotification}
@@ -23,6 +27,11 @@ public class SharedContextNotificationHandler implements INotificationHandler<Sh
   public void handleNotification(SharedContextChangedNotification notification) {
     // the client session must be available for shared context variable updates otherwise it is a wrong usage of the notification.
     IClientSession session = (IClientSession) Assertions.assertNotNull(IClientSession.CURRENT.get());
-    session.replaceSharedVariableMapInternal(notification.getSharedVariableMap());
+    Map<String, Object> variables = notification.getSharedVariableMap();
+    if (variables == null) {
+      // no changed variables provided in the notification. load the variables from backend.
+      variables = BEANS.get(ISessionService.class).loadInitialSharedVariables().getVariables();
+    }
+    session.setSharedVariables(variables);
   }
 }

--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/server/IdSignatureRestFilterTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/server/IdSignatureRestFilterTest.java
@@ -13,6 +13,7 @@ import static org.eclipse.scout.rt.platform.util.CollectionUtility.*;
 import static org.junit.Assert.*;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.ws.rs.client.ClientRequestFilter;
@@ -20,10 +21,14 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation.Builder;
 import jakarta.ws.rs.core.MediaType;
 
+import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.IIdSignatureDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.IPrettyPrintDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.fixture.FixtureIntegerId;
 import org.eclipse.scout.rt.dataobject.id.IdCodec;
+import org.eclipse.scout.rt.jackson.dataobject.JacksonDataObjectMapper;
+import org.eclipse.scout.rt.jackson.dataobject.JacksonIdSignatureDataObjectMapper;
+import org.eclipse.scout.rt.jackson.dataobject.JacksonPrettyPrintDataObjectMapper;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
@@ -44,17 +49,22 @@ import org.junit.runner.RunWith;
 @RunWith(PlatformTestRunner.class)
 public class IdSignatureRestFilterTest {
 
-  protected static IBean<?> s_bean;
+  protected static List<IBean<?>> s_beans = new ArrayList<>();
 
   @BeforeClass
   public static void beforeClass() {
-    s_bean = BeanTestingHelper.get().registerBean(new BeanMetaData(P_IdCodec.class).withReplace(true));
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(P_IdCodec.class).withReplace(true)));
     BEANS.get(JerseyTestApplication.class).ensureStarted();
+
+    // create new instance of data object mapper because of the serializer cache. Otherwise, the replaced codec would still be used after the test
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(IDataObjectMapper.class, new JacksonDataObjectMapper()).withApplicationScoped(true)));
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(IPrettyPrintDataObjectMapper.class, new JacksonPrettyPrintDataObjectMapper()).withApplicationScoped(true)));
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(IIdSignatureDataObjectMapper.class, new JacksonIdSignatureDataObjectMapper()).withApplicationScoped(true)));
   }
 
   @AfterClass
   public static void afterClass() {
-    BeanTestingHelper.get().unregisterBean(s_bean);
+    BeanTestingHelper.get().unregisterBeans(s_beans);
   }
 
   protected Builder request(ClientRequestFilter... filters) {

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/AbstractServerSessionTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/AbstractServerSessionTest.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 import org.eclipse.scout.rt.platform.serialization.IObjectSerializer;
 import org.eclipse.scout.rt.platform.serialization.SerializationUtility;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
-import org.eclipse.scout.rt.testing.platform.util.ScoutAssert;
 import org.eclipse.scout.rt.testing.server.runner.RunWithServerSession;
 import org.eclipse.scout.rt.testing.server.runner.ServerTestRunner;
 import org.junit.Before;
@@ -64,6 +63,5 @@ public class AbstractServerSessionTest {
   private void assertSessionsEquals(IServerSession expected, IServerSession actual) {
     assertEquals(expected.getId(), actual.getId());
     assertEquals(expected.getUserId(), actual.getUserId());
-    ScoutAssert.assertListEquals(expected.getSharedVariableMap().entrySet(), actual.getSharedVariableMap().entrySet());
   }
 }

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelIdSignatureTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelIdSignatureTest.java
@@ -24,10 +24,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.scout.rt.dataobject.DataObjectHolder;
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoEntityHolder;
+import org.eclipse.scout.rt.dataobject.IDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.IIdSignatureDataObjectMapper;
 import org.eclipse.scout.rt.dataobject.fixture.FixtureIntegerId;
 import org.eclipse.scout.rt.dataobject.id.IdCodec;
 import org.eclipse.scout.rt.dataobject.id.IdCodec.IdCodecFlag;
+import org.eclipse.scout.rt.jackson.dataobject.JacksonDataObjectMapper;
+import org.eclipse.scout.rt.jackson.dataobject.JacksonIdSignatureDataObjectMapper;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
@@ -68,6 +72,10 @@ public class ServiceTunnelIdSignatureTest {
         new BeanMetaData(P_IdCodec.class).withReplace(true)
     );
     BEANS.get(TestingRestClientConfigFactory.class).setupMockConnectorProvider();
+
+    // create new instance of data object mapper because of the serializer cache. Otherwise, the replaced codec would still be used after the test
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(IDataObjectMapper.class, new JacksonDataObjectMapper()).withApplicationScoped(true)));
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(IIdSignatureDataObjectMapper.class, new JacksonIdSignatureDataObjectMapper()).withApplicationScoped(true)));
   }
 
   @AfterClass

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelServiceTest.java
@@ -137,7 +137,6 @@ public class ServiceTunnelServiceTest {
 
     final TestServerSession testServerSession = new TestServerSession();
     testServerSession.start("testSessionId");
-    testServerSession.setSharedContextVariable("userId", String.class, "testUser");
 
     HttpServletRequest requestMock = mock(HttpServletRequest.class);
     HttpSession testHttpSession = mock(HttpSession.class);

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/AbstractServerSession.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/AbstractServerSession.java
@@ -13,7 +13,6 @@ import static org.eclipse.scout.rt.platform.util.Assertions.*;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.eclipse.scout.rt.platform.BEANS;
@@ -21,14 +20,10 @@ import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.annotations.ConfigOperation;
 import org.eclipse.scout.rt.platform.job.IFuture;
 import org.eclipse.scout.rt.platform.job.Jobs;
-import org.eclipse.scout.rt.platform.util.CollectionUtility;
-import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.eclipse.scout.rt.platform.util.event.FastListenerList;
 import org.eclipse.scout.rt.platform.util.event.IFastListenerList;
 import org.eclipse.scout.rt.rest.cancellation.RestRequestCancellationRegistry;
 import org.eclipse.scout.rt.security.IAccessControlService;
-import org.eclipse.scout.rt.server.clientnotification.ClientNotificationRegistry;
-import org.eclipse.scout.rt.server.clientnotification.IClientNodeId;
 import org.eclipse.scout.rt.server.context.ServerRunContext;
 import org.eclipse.scout.rt.server.extension.IServerSessionExtension;
 import org.eclipse.scout.rt.server.extension.ServerSessionChains.ServerSessionLoadSessionChain;
@@ -38,8 +33,6 @@ import org.eclipse.scout.rt.shared.extension.IExtensibleObject;
 import org.eclipse.scout.rt.shared.extension.IExtension;
 import org.eclipse.scout.rt.shared.extension.ObjectExtensions;
 import org.eclipse.scout.rt.shared.job.filter.future.SessionFutureFilter;
-import org.eclipse.scout.rt.shared.services.common.context.SharedContextChangedNotification;
-import org.eclipse.scout.rt.shared.services.common.context.SharedVariableMap;
 import org.eclipse.scout.rt.shared.services.common.security.ILogoutService;
 import org.eclipse.scout.rt.shared.session.IGlobalSessionListener;
 import org.eclipse.scout.rt.shared.session.ISessionListener;
@@ -66,13 +59,12 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
   private volatile boolean m_active;
   private volatile boolean m_stopping;
   private final SessionData m_sessionData;
-  private final SharedVariableMap m_sharedVariableMap;
+  private String m_userId;
   private final ObjectExtensions<AbstractServerSession, IServerSessionExtension<? extends AbstractServerSession>> m_objectExtensions;
 
   public AbstractServerSession(boolean autoInitConfig) {
     m_eventListeners = new FastListenerList<>();
     m_sessionData = new SessionData();
-    m_sharedVariableMap = new SharedVariableMap();
     m_objectExtensions = new ObjectExtensions<>(this, true);
 
     m_sessionMetrics.sessionCreated(SESSION_TYPE);
@@ -81,30 +73,8 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
     }
   }
 
-  @Override
-  public Map<String, Object> getSharedVariableMap() {
-    return CollectionUtility.copyMap(m_sharedVariableMap);
-  }
-
-  /**
-   * do not use this internal method directly
-   */
-  protected <T> T getSharedContextVariable(String name, Class<T> type) {
-    Object o = m_sharedVariableMap.get(name);
-    return TypeCastUtility.castValue(o, type);
-  }
-
-  /**
-   * do not use this internal method directly
-   */
-  protected <T> void setSharedContextVariable(String name, Class<T> type, T value) {
-    T typedValue = TypeCastUtility.castValue(value, type);
-    m_sharedVariableMap.put(name, typedValue);
-  }
-
   private void assignUserId() {
-    String userId = BEANS.get(IAccessControlService.class).getUserIdOfCurrentSubject();
-    setUserIdInternal(userId);
+    m_userId = BEANS.get(IAccessControlService.class).getUserIdOfCurrentSubject();
   }
 
   /**
@@ -122,11 +92,7 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
 
   @Override
   public final String getUserId() {
-    return getSharedContextVariable("userId", String.class);
-  }
-
-  private void setUserIdInternal(String newValue) {
-    setSharedContextVariable("userId", String.class, newValue);
+    return m_userId;
   }
 
   @Override
@@ -153,18 +119,6 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
       return;
     }
 
-    m_sharedVariableMap.addPropertyChangeListener(e -> {
-      if (IClientNodeId.CURRENT.get() != null) {
-        String sessionId = getId();
-        if (sessionId != null) {
-          SharedContextChangedNotification notification = new SharedContextChangedNotification(CollectionUtility.copyMap(m_sharedVariableMap));
-          BEANS.get(ClientNotificationRegistry.class).putTransactionalForSession(sessionId, notification);
-        }
-        else {
-          LOG.warn("No sessionId set");
-        }
-      }
-    });
     m_initialized = true;
   }
 

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/IInitialSharedVariableContributor.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/IInitialSharedVariableContributor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.session;
+
+import java.util.Map;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.shared.session.ISessionService;
+
+@ApplicationScoped
+public interface IInitialSharedVariableContributor {
+
+  /**
+   * Contributor for client session variables initially loaded by {@link ISessionService}
+   */
+  void contribute(Map<String, Object> variables);
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/SessionService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/SessionService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.session;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.shared.session.ISessionService;
+import org.eclipse.scout.rt.shared.session.LoadInitialSharedVariablesResponse;
+
+public class SessionService implements ISessionService {
+
+  @Override
+  public LoadInitialSharedVariablesResponse loadInitialSharedVariables() {
+    Map<String, Object> variables = new HashMap<>();
+
+    BEANS.all(IInitialSharedVariableContributor.class).forEach(c -> c.contribute(variables));
+
+    return BEANS.get(LoadInitialSharedVariablesResponse.class)
+        .withVariables(variables);
+  }
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/UserIdSharedVariableContributor.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/UserIdSharedVariableContributor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.session;
+
+import static org.eclipse.scout.rt.shared.ISessionVariable.SHARED_CONTEXT_USER_ID;
+
+import java.util.Map;
+
+import org.eclipse.scout.rt.server.AbstractServerSession;
+
+public class UserIdSharedVariableContributor implements IInitialSharedVariableContributor {
+
+  @Override
+  public void contribute(Map<String, Object> variables) {
+    variables.put(SHARED_CONTEXT_USER_ID, AbstractServerSession.CURRENT.get().getUserId());
+  }
+}

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/common/context/SharedVariableMapTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/common/context/SharedVariableMapTest.java
@@ -11,8 +11,10 @@ package org.eclipse.scout.rt.shared.services.common.context;
 
 import static org.junit.Assert.assertEquals;
 
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -26,15 +28,17 @@ public class SharedVariableMapTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testUpdateInternal() {
-    List<Map<String, Object>> protocol = new ArrayList<>();
+    List<PropertyChangeEvent> protocol = new ArrayList<>();
     SharedVariableMap m = new SharedVariableMap();
     m.put("1", 1L);
     m.put("2", 2L);
     assertEquals(2, m.size());
 
-    PropertyChangeListener propertyChangeListener = e -> protocol.add((Map<String, Object>) e.getNewValue());
+    PropertyChangeListener propertyChangeListener = e -> protocol.add(e);
     m.addPropertyChangeListener(propertyChangeListener);
     m.put("3", 3L);
+    m.clear();
+    m.putAll(Map.of("1", 1L, "2", 2L, "3", 3L));
     m.remove("1");
     m.updateInternal(Map.of("11", 11L, "22", 22L, "33", 33L));
     m.updateInternal(Map.of("33", 33L, "11", 11L, "22", 22L)); // this update is ignored (no changes)
@@ -44,10 +48,22 @@ public class SharedVariableMapTest {
     assertEquals(22L, m.get("22"));
     assertEquals(33L, m.get("33"));
 
-    assertEquals(3, protocol.size());
-    assertEquals(Map.of("1", 1L, "2", 2L, "3", 3L), protocol.get(0));
-    assertEquals(Map.of("2", 2L, "3", 3L), protocol.get(1));
-    assertEquals(Map.of("11", 11L, "22", 22L, "33", 33L), protocol.get(2));
+    assertEquals(5, protocol.size());
+    // put
+    assertEquals(Map.of("1", 1L, "2", 2L), protocol.get(0).getOldValue());
+    assertEquals(Map.of("1", 1L, "2", 2L, "3", 3L), protocol.get(0).getNewValue());
+    // clear
+    assertEquals(Map.of("1", 1L, "2", 2L, "3", 3L), protocol.get(1).getOldValue());
+    assertEquals(Collections.emptyMap(), protocol.get(1).getNewValue());
+    // putAll
+    assertEquals(Collections.emptyMap(), protocol.get(2).getOldValue());
+    assertEquals(Map.of("1", 1L, "2", 2L, "3", 3L), protocol.get(2).getNewValue());
+    // remove
+    assertEquals(Map.of("1", 1L, "2", 2L, "3", 3L), protocol.get(3).getOldValue());
+    assertEquals(Map.of("2", 2L, "3", 3L), protocol.get(3).getNewValue());
+    // updateInternal
+    assertEquals(Map.of("2", 2L, "3", 3L), protocol.get(4).getOldValue());
+    assertEquals(Map.of("11", 11L, "22", 22L, "33", 33L), protocol.get(4).getNewValue());
     m.removePropertyChangeListener(propertyChangeListener);
   }
 

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/ISession.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/ISession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,11 +9,11 @@
  */
 package org.eclipse.scout.rt.shared;
 
-import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.event.IFastListenerList;
+import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.shared.session.ISessionListener;
 
 /**
@@ -33,15 +33,9 @@ public interface ISession {
   String getId();
 
   /**
-   * Shared context variable containing the authenticated userId in lowercase
+   * Authenticated userId, extracted by {@link IAccessControlService#getUserIdOfCurrentSubject()}
    */
   String getUserId();
-
-  /**
-   * @return the shared variable map. Shared variables are automatically updated on the client by client notifications
-   * when changed on the server.
-   */
-  Map<String, Object> getSharedVariableMap();
 
   /**
    * Returns true if the session has been loaded and is running.

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/ISessionVariable.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/ISessionVariable.java
@@ -7,16 +7,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.server;
+package org.eclipse.scout.rt.shared;
 
-public class TestServerSession extends AbstractServerSession {
-  private static final long serialVersionUID = 782294551137415747L;
+public interface ISessionVariable {
 
-  public TestServerSession() {
-    super(true);
-  }
-
-  @Override
-  protected void execLoadSession() {
-  }
+  String SHARED_CONTEXT_USER_ID = "userId";
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/context/SharedVariableMap.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/context/SharedVariableMap.java
@@ -63,18 +63,22 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
 
   /**
    * Update values of this variable map with the new one.
+   * <p>
+   * Fires a change event
    */
   public synchronized void updateInternal(Map<String, Object> newMap) {
     if (m_variables.equals(newMap)) {
       return; // nothing changed
     }
 
+    Map<String, Object> oldVariables = CollectionUtility.copyMap(m_variables);
     m_variables.clear();
-    putAll(newMap); // fires a value changed event
+    m_variables.putAll(newMap);
+    fireValuesChanged(oldVariables);
   }
 
-  private void fireValuesChanged() {
-    m_propertySupport.firePropertyChange(PROP_VALUES, null, CollectionUtility.copyMap(m_variables));
+  private void fireValuesChanged(Map<String, Object> oldVariables) {
+    m_propertySupport.firePropertyChange(PROP_VALUES, oldVariables, CollectionUtility.copyMap(m_variables));
   }
 
   /**
@@ -82,8 +86,9 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
    */
   @Override
   public synchronized void clear() {
+    Map<String, Object> oldVariables = CollectionUtility.copyMap(m_variables);
     m_variables.clear();
-    fireValuesChanged();
+    fireValuesChanged(oldVariables);
   }
 
   @Override
@@ -121,8 +126,9 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
    */
   @Override
   public synchronized Object put(String key, Object value) {
+    Map<String, Object> oldVariables = CollectionUtility.copyMap(m_variables);
     Object o = m_variables.put(key, value);
-    fireValuesChanged();
+    fireValuesChanged(oldVariables);
     return o;
   }
 
@@ -131,8 +137,9 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
    */
   @Override
   public synchronized void putAll(Map<? extends String, ?> m) {
+    Map<String, Object> oldVariables = CollectionUtility.copyMap(m_variables);
     m_variables.putAll(m);
-    fireValuesChanged();
+    fireValuesChanged(oldVariables);
   }
 
   /**
@@ -140,8 +147,9 @@ public class SharedVariableMap implements Serializable, Map<String, Object> {
    */
   @Override
   public synchronized Object remove(Object key) {
+    Map<String, Object> oldVariables = CollectionUtility.copyMap(m_variables);
     Object o = m_variables.remove(key);
-    fireValuesChanged();
+    fireValuesChanged(oldVariables);
     return o;
   }
 

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/session/ISessionService.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/session/ISessionService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.session;
+
+import org.eclipse.scout.rt.platform.service.IService;
+import org.eclipse.scout.rt.shared.TunnelToServer;
+
+/**
+ * Service supporting creation and handling of client sessions
+ */
+@TunnelToServer
+public interface ISessionService extends IService {
+
+  /**
+   * Load initial shared variables on start of client session.
+   */
+  LoadInitialSharedVariablesResponse loadInitialSharedVariables();
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/session/LoadInitialSharedVariablesResponse.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/session/LoadInitialSharedVariablesResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.session;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.eclipse.scout.rt.platform.Bean;
+
+@Bean
+public class LoadInitialSharedVariablesResponse implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private Map<String, Object> m_variables;
+
+  public Map<String, Object> getVariables() {
+    return m_variables;
+  }
+
+  public LoadInitialSharedVariablesResponse withVariables(Map<String, Object> variables) {
+    m_variables = variables;
+    return this;
+  }
+}


### PR DESCRIPTION
As part of the move toward a stateless server session, the m_sharedVariableMap has been removed from the server session.

The SharedVariableMap has been renamed to VariableMap and is now used exclusively on the client side.

Instead of synchronizing variables from server to client, the client session initializes its VariableMap using the ISessionService.

To support updates after initialization, the server can send a client notification. A corresponding handler on the client side should process the notification and update the relevant variables on the client session.

423389