### PR TITLE
Cell: add helper functions for cssClass

### DIFF
--- a/eclipse-scout-core/src/carousel/Carousel.ts
+++ b/eclipse-scout-core/src/carousel/Carousel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, CarouselEventMap, CarouselLayout, CarouselModel, Device, events, GridData, HtmlComponent, InitModelOf, ObjectOrChildModel, SingleLayout, Widget} from '../index';
+import {arrays, CarouselEventMap, CarouselLayout, CarouselModel, Device, events, GridData, HtmlComponent, InitModelOf, ObjectOrChildModel, SingleLayout, styles, Widget} from '../index';
 
 export class Carousel extends Widget implements CarouselModel {
   declare model: CarouselModel;
@@ -206,7 +206,7 @@ export class Carousel extends Widget implements CarouselModel {
 
       // Add the CSS classes of the widget to be able to style the carousel items.
       // Use a suffix to prevent conflicts
-      let cssClasses = widget.cssClassAsArray();
+      let cssClasses = styles.cssClassAsArray(widget.cssClass);
       cssClasses.forEach(cssClass => $carouselItem.addClass(cssClass + '-carousel-item'));
       return $carouselItem;
     });

--- a/eclipse-scout-core/src/cell/Cell.ts
+++ b/eclipse-scout-core/src/cell/Cell.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {CellModel, InitModelOf, Status, strings, ValueField} from '../index';
+import {CellModel, InitModelOf, Status, strings, styles, ValueField} from '../index';
 import $ from 'jquery';
 
 /**
@@ -113,6 +113,46 @@ export class Cell<TValue = any> implements CellModel<TValue> {
 
   setCssClass(cssClass: string) {
     this.cssClass = cssClass;
+  }
+
+  /**
+   * Adds the given css class to {@link Cell#cssClass}.
+   *
+   * @see styles#addCssClass
+   * @param cssClass may contain multiple css classes separated by space.
+   */
+  addCssClass(cssClass: string) {
+    this.setCssClass(styles.addCssClass(this.cssClass, cssClass));
+  }
+
+  /**
+   * Removes the given css class from {@link Cell#cssClass}.
+   *
+   * @see styles#removeCssClass
+   * @param cssClass may contain multiple css classes separated by space.
+   */
+  removeCssClass(cssClass: string) {
+    this.setCssClass(styles.removeCssClass(this.cssClass, cssClass));
+  }
+
+  /**
+   * Toggles the given css class in {@link Cell#cssClass}.
+   *
+   * @see styles#toggleCssClass
+   * @param cssClass may contain multiple css classes separated by space.
+   */
+  toggleCssClass(cssClass: string, condition: boolean) {
+    this.setCssClass(styles.toggleCssClass(this.cssClass, cssClass, condition));
+  }
+
+  /**
+   * Checks whether the css class is contained in {@link Cell#cssClass}.
+   *
+   * @see styles#hasCssClass
+   * @param cssClass may contain multiple css classes separated by space.
+   */
+  hasCssClass(cssClass: string): boolean {
+    return styles.hasCssClass(this.cssClass, cssClass);
   }
 
   setSortCode(sortCode: number) {

--- a/eclipse-scout-core/src/util/styles.ts
+++ b/eclipse-scout-core/src/util/styles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -497,6 +497,78 @@ export const styles = {
       style += 'font-family: ' + cssFontFamily + '; ';
     }
     return style;
+  },
+
+  /**
+   * Adds the css classes to the existing css classes.
+   *
+   * @param cssClass existing cssClass, multiple css classes separated by space.
+   * @param cssClassToAdd may contain multiple css classes separated by space.
+   */
+  addCssClass(cssClass: string, cssClassToAdd: string): string {
+    const cssClasses = styles.cssClassAsArray(cssClass);
+    const cssClassesToAdd = styles.cssClassAsArray(cssClassToAdd);
+
+    for (const cssClassToAdd of cssClassesToAdd) {
+      arrays.pushSet(cssClasses, cssClassToAdd);
+    }
+
+    return arrays.format(cssClasses, ' ');
+  },
+
+  /**
+   * Removes the css classes to the existing css classes.
+   *
+   * @param cssClass existing cssClass, multiple css classes separated by space.
+   * @param cssClassToRemove may contain multiple css classes separated by space.
+   */
+  removeCssClass(cssClass: string, cssClassToRemove: string): string {
+    const cssClasses = styles.cssClassAsArray(cssClass);
+    const cssClassesToRemove = styles.cssClassAsArray(cssClassToRemove);
+
+    arrays.removeAll(cssClasses, cssClassesToRemove);
+
+    return arrays.format(cssClasses, ' ');
+  },
+
+  /**
+   * Toggles, i.e. adds (see {@link styles#addCssClass}) or removes (see {@link styles#removeCssClass}), the css classes depending on the condition.
+   *
+   * @param cssClass existing cssClass, multiple css classes separated by space.
+   * @param cssClassToToggle may contain multiple css classes separated by space.
+   */
+  toggleCssClass(cssClass: string, cssClassToToggle: string, condition: boolean): string {
+    return condition
+      ? styles.addCssClass(cssClass, cssClassToToggle)
+      : styles.removeCssClass(cssClass, cssClassToToggle);
+  },
+
+  /**
+   * Checks whether the css classes are contained in the existing css classes.
+   *
+   * @param cssClass existing cssClass, multiple css classes separated by space.
+   * @param cssClassToFind may contain multiple css classes separated by space.
+   */
+  hasCssClass(cssClass: string, cssClassToFind: string): boolean {
+    const cssClasses = styles.cssClassAsArray(cssClass);
+    const cssClassesToFind = styles.cssClassAsArray(cssClassToFind);
+
+    return arrays.containsAll(cssClasses, cssClassesToFind);
+  },
+
+  /**
+   * Splits the css classes into an array.
+   *
+   * @param cssClass multiple css classes separated by space.
+   */
+  cssClassAsArray(cssClass: string): string[] {
+    cssClass ||= '';
+    cssClass = cssClass.trim();
+
+    if (!cssClass.length) {
+      return [];
+    }
+    return cssClass.split(' ').filter(Boolean);
   },
 
   _getElement(): HTMLDivElement {

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -10,7 +10,7 @@
 import {
   Action, arrays, DeferredGlassPaneTarget, Desktop, Device, EnumObject, EventDelegator, EventHandler, filters, focusUtils, Form, FullModelOf, graphics, HtmlComponent, icons, InitModelOf, inspector, KeyStroke, KeyStrokeContext, LayoutData,
   LoadingSupport, LogicalGrid, ModelAdapter, objectFactoryHints, ObjectIdProvider, ObjectOrChildModel, ObjectOrType, objects, ObjectWithType, ObjectWithUuid, Predicate, PropertyDecoration, PropertyEventEmitter, scout,
-  ScrollbarInstallOptions, scrollbars, ScrollOptions, ScrollToOptions, Session, SomeRequired, strings, texts, TreeVisitResult, UuidPathOptions, WidgetEventMap, WidgetModel
+  ScrollbarInstallOptions, scrollbars, ScrollOptions, ScrollToOptions, Session, SomeRequired, strings, styles, texts, TreeVisitResult, UuidPathOptions, WidgetEventMap, WidgetModel
 } from '../index';
 import $ from 'jquery';
 
@@ -1083,48 +1083,28 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
    * @param cssClass may contain multiple css classes separated by space.
    */
   addCssClass(cssClass: string) {
-    let cssClasses = this.cssClassAsArray();
-    let cssClassesToAdd = Widget.cssClassAsArray(cssClass);
-    cssClassesToAdd.forEach(newCssClass => {
-      if (cssClasses.indexOf(newCssClass) >= 0) {
-        return;
-      }
-      cssClasses.push(newCssClass);
-    });
-    this.setProperty('cssClass', arrays.format(cssClasses, ' '));
+    this.setProperty('cssClass', styles.addCssClass(this.cssClass, cssClass));
   }
 
   /**
    * @param cssClass may contain multiple css classes separated by space.
    */
   removeCssClass(cssClass: string) {
-    let cssClasses = this.cssClassAsArray();
-    let cssClassesToRemove = Widget.cssClassAsArray(cssClass);
-    if (arrays.removeAll(cssClasses, cssClassesToRemove)) {
-      this.setProperty('cssClass', arrays.format(cssClasses, ' '));
-    }
+    this.setProperty('cssClass', styles.removeCssClass(this.cssClass, cssClass));
   }
 
   /**
    * @param cssClass may contain multiple css classes separated by space.
    */
   toggleCssClass(cssClass: string, condition: boolean) {
-    if (condition) {
-      this.addCssClass(cssClass);
-    } else {
-      this.removeCssClass(cssClass);
-    }
+    this.setProperty('cssClass', styles.toggleCssClass(this.cssClass, cssClass, condition));
   }
 
   /**
    * @returns true, if the {@link cssClass} property contains the given css class.
    */
   hasCssClass(cssClass: string): boolean {
-    return this.cssClassAsArray().includes(cssClass);
-  }
-
-  cssClassAsArray(): string[] {
-    return Widget.cssClassAsArray(this.cssClass);
+    return styles.hasCssClass(this.cssClass, cssClass);
   }
 
   /**
@@ -2458,19 +2438,6 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
    */
   isAttachedAndRendered(): boolean {
     return (this.rendered || this.rendering) && this.$container.isAttached();
-  }
-
-  /* --- STATIC HELPERS ------------------------------------------------------------- */
-
-  static cssClassAsArray(cssClass: string): string[] {
-    let cssClasses = [],
-      cssClassesStr = cssClass || '';
-
-    cssClassesStr = cssClassesStr.trim();
-    if (cssClassesStr.length > 0) {
-      cssClasses = cssClassesStr.split(' ');
-    }
-    return cssClasses;
   }
 }
 

--- a/eclipse-scout-core/test/util/stylesSpec.ts
+++ b/eclipse-scout-core/test/util/stylesSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -326,6 +326,312 @@ describe('styles', () => {
       expect(styles.rgbToHex('rgba(18,58,188,0.5)', true)).toEqual('#123abc');
       expect(styles.rgbToHex('rgba(171,205,239,0.3)', true)).toEqual('#abcdef');
       expect(styles.rgbToHex('rgba(255,255,255,0.1)', true)).toEqual('#ffffff');
+    });
+  });
+
+  describe('modifying css classes', () => {
+
+    it('adds css class', () => {
+      expect(styles.addCssClass(null, null)).toBe('');
+      expect(styles.addCssClass('', null)).toBe('');
+      expect(styles.addCssClass('foo', null)).toBe('foo');
+      expect(styles.addCssClass('foo bar', null)).toBe('foo bar');
+      expect(styles.addCssClass('bar foo', null)).toBe('bar foo');
+      expect(styles.addCssClass('   foo   bar   ', null)).toBe('foo bar');
+      expect(styles.addCssClass('foo bar foo', null)).toBe('foo bar foo');
+
+      expect(styles.addCssClass(null, '')).toBe('');
+      expect(styles.addCssClass('', '')).toBe('');
+      expect(styles.addCssClass('foo', '')).toBe('foo');
+      expect(styles.addCssClass('foo bar', '')).toBe('foo bar');
+      expect(styles.addCssClass('bar foo', '')).toBe('bar foo');
+      expect(styles.addCssClass('   foo   bar   ', '')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar foo', '')).toBe('foo bar foo');
+
+      expect(styles.addCssClass(null, 'foo')).toBe('foo');
+      expect(styles.addCssClass('', 'foo')).toBe('foo');
+      expect(styles.addCssClass('foo', 'foo')).toBe('foo');
+      expect(styles.addCssClass('foo bar', 'foo')).toBe('foo bar');
+      expect(styles.addCssClass('bar foo', 'foo')).toBe('bar foo');
+      expect(styles.addCssClass('   foo   bar   ', 'foo')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar foo', 'foo')).toBe('foo bar foo');
+
+      expect(styles.addCssClass(null, 'bar')).toBe('bar');
+      expect(styles.addCssClass('', 'bar')).toBe('bar');
+      expect(styles.addCssClass('foo', 'bar')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar', 'bar')).toBe('foo bar');
+      expect(styles.addCssClass('bar foo', 'bar')).toBe('bar foo');
+      expect(styles.addCssClass('   foo   bar   ', 'bar')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar foo', 'bar')).toBe('foo bar foo');
+
+      expect(styles.addCssClass(null, '   foo   ')).toBe('foo');
+      expect(styles.addCssClass('', '   foo   ')).toBe('foo');
+      expect(styles.addCssClass('foo', '   foo   ')).toBe('foo');
+      expect(styles.addCssClass('foo bar', '   foo   ')).toBe('foo bar');
+      expect(styles.addCssClass('bar foo', '   foo   ')).toBe('bar foo');
+      expect(styles.addCssClass('   foo   bar   ', '   foo   ')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar foo', '   foo   ')).toBe('foo bar foo');
+
+      expect(styles.addCssClass(null, 'foo bar')).toBe('foo bar');
+      expect(styles.addCssClass('', 'foo bar')).toBe('foo bar');
+      expect(styles.addCssClass('foo', 'foo bar')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar', 'foo bar')).toBe('foo bar');
+      expect(styles.addCssClass('bar foo', 'foo bar')).toBe('bar foo');
+      expect(styles.addCssClass('   foo   bar   ', 'foo bar')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar foo', 'foo bar')).toBe('foo bar foo');
+
+      expect(styles.addCssClass(null, 'foo bar foo')).toBe('foo bar');
+      expect(styles.addCssClass('', 'foo bar foo')).toBe('foo bar');
+      expect(styles.addCssClass('foo', 'foo bar foo')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar', 'foo bar foo')).toBe('foo bar');
+      expect(styles.addCssClass('bar foo', 'foo bar foo')).toBe('bar foo');
+      expect(styles.addCssClass('   foo   bar   ', 'foo bar foo')).toBe('foo bar');
+      expect(styles.addCssClass('foo bar foo', 'foo bar foo')).toBe('foo bar foo');
+    });
+
+    it('removes css class', () => {
+      expect(styles.removeCssClass(null, null)).toBe('');
+      expect(styles.removeCssClass('', null)).toBe('');
+      expect(styles.removeCssClass('foo', null)).toBe('foo');
+      expect(styles.removeCssClass('foo bar', null)).toBe('foo bar');
+      expect(styles.removeCssClass('bar foo', null)).toBe('bar foo');
+      expect(styles.removeCssClass('   foo   bar   ', null)).toBe('foo bar');
+      expect(styles.removeCssClass('foo bar foo', null)).toBe('foo bar foo');
+
+      expect(styles.removeCssClass(null, '')).toBe('');
+      expect(styles.removeCssClass('', '')).toBe('');
+      expect(styles.removeCssClass('foo', '')).toBe('foo');
+      expect(styles.removeCssClass('foo bar', '')).toBe('foo bar');
+      expect(styles.removeCssClass('bar foo', '')).toBe('bar foo');
+      expect(styles.removeCssClass('   foo   bar   ', '')).toBe('foo bar');
+      expect(styles.removeCssClass('foo bar foo', '')).toBe('foo bar foo');
+
+      expect(styles.removeCssClass(null, 'foo')).toBe('');
+      expect(styles.removeCssClass('', 'foo')).toBe('');
+      expect(styles.removeCssClass('foo', 'foo')).toBe('');
+      expect(styles.removeCssClass('foo bar', 'foo')).toBe('bar');
+      expect(styles.removeCssClass('bar foo', 'foo')).toBe('bar');
+      expect(styles.removeCssClass('   foo   bar   ', 'foo')).toBe('bar');
+      expect(styles.removeCssClass('foo bar foo', 'foo')).toBe('bar');
+
+      expect(styles.removeCssClass(null, 'bar')).toBe('');
+      expect(styles.removeCssClass('', 'bar')).toBe('');
+      expect(styles.removeCssClass('foo', 'bar')).toBe('foo');
+      expect(styles.removeCssClass('foo bar', 'bar')).toBe('foo');
+      expect(styles.removeCssClass('bar foo', 'bar')).toBe('foo');
+      expect(styles.removeCssClass('   foo   bar   ', 'bar')).toBe('foo');
+      expect(styles.removeCssClass('foo bar foo', 'bar')).toBe('foo foo');
+
+      expect(styles.removeCssClass(null, '   foo   ')).toBe('');
+      expect(styles.removeCssClass('', '   foo   ')).toBe('');
+      expect(styles.removeCssClass('foo', '   foo   ')).toBe('');
+      expect(styles.removeCssClass('foo bar', '   foo   ')).toBe('bar');
+      expect(styles.removeCssClass('bar foo', '   foo   ')).toBe('bar');
+      expect(styles.removeCssClass('   foo   bar   ', '   foo   ')).toBe('bar');
+      expect(styles.removeCssClass('foo bar foo', '   foo   ')).toBe('bar');
+
+      expect(styles.removeCssClass(null, 'foo bar')).toBe('');
+      expect(styles.removeCssClass('', 'foo bar')).toBe('');
+      expect(styles.removeCssClass('foo', 'foo bar')).toBe('');
+      expect(styles.removeCssClass('foo bar', 'foo bar')).toBe('');
+      expect(styles.removeCssClass('bar foo', 'foo bar')).toBe('');
+      expect(styles.removeCssClass('   foo   bar   ', 'foo bar')).toBe('');
+      expect(styles.removeCssClass('foo bar foo', 'foo bar')).toBe('');
+
+      expect(styles.removeCssClass(null, 'foo bar foo')).toBe('');
+      expect(styles.removeCssClass('', 'foo bar foo')).toBe('');
+      expect(styles.removeCssClass('foo', 'foo bar foo')).toBe('');
+      expect(styles.removeCssClass('foo bar', 'foo bar foo')).toBe('');
+      expect(styles.removeCssClass('bar foo', 'foo bar foo')).toBe('');
+      expect(styles.removeCssClass('   foo   bar   ', 'foo bar foo')).toBe('');
+      expect(styles.removeCssClass('foo bar foo', 'foo bar foo')).toBe('');
+    });
+
+    it('toggles css class', () => {
+      expect(styles.toggleCssClass(null, null, true)).toBe('');
+      expect(styles.toggleCssClass('', null, true)).toBe('');
+      expect(styles.toggleCssClass('foo', null, true)).toBe('foo');
+      expect(styles.toggleCssClass('foo bar', null, true)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', null, true)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', null, true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', null, true)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, '', true)).toBe('');
+      expect(styles.toggleCssClass('', '', true)).toBe('');
+      expect(styles.toggleCssClass('foo', '', true)).toBe('foo');
+      expect(styles.toggleCssClass('foo bar', '', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', '', true)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', '', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', '', true)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, 'foo', true)).toBe('foo');
+      expect(styles.toggleCssClass('', 'foo', true)).toBe('foo');
+      expect(styles.toggleCssClass('foo', 'foo', true)).toBe('foo');
+      expect(styles.toggleCssClass('foo bar', 'foo', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', 'foo', true)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', 'foo', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', 'foo', true)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, 'bar', true)).toBe('bar');
+      expect(styles.toggleCssClass('', 'bar', true)).toBe('bar');
+      expect(styles.toggleCssClass('foo', 'bar', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar', 'bar', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', 'bar', true)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', 'bar', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', 'bar', true)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, '   foo   ', true)).toBe('foo');
+      expect(styles.toggleCssClass('', '   foo   ', true)).toBe('foo');
+      expect(styles.toggleCssClass('foo', '   foo   ', true)).toBe('foo');
+      expect(styles.toggleCssClass('foo bar', '   foo   ', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', '   foo   ', true)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', '   foo   ', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', '   foo   ', true)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, 'foo bar', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('', 'foo bar', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo', 'foo bar', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar', 'foo bar', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', 'foo bar', true)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', 'foo bar', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', 'foo bar', true)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, 'foo bar foo', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('', 'foo bar foo', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo', 'foo bar foo', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar', 'foo bar foo', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', 'foo bar foo', true)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', 'foo bar foo', true)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', 'foo bar foo', true)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, null, false)).toBe('');
+      expect(styles.toggleCssClass('', null, false)).toBe('');
+      expect(styles.toggleCssClass('foo', null, false)).toBe('foo');
+      expect(styles.toggleCssClass('foo bar', null, false)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', null, false)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', null, false)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', null, false)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, '', false)).toBe('');
+      expect(styles.toggleCssClass('', '', false)).toBe('');
+      expect(styles.toggleCssClass('foo', '', false)).toBe('foo');
+      expect(styles.toggleCssClass('foo bar', '', false)).toBe('foo bar');
+      expect(styles.toggleCssClass('bar foo', '', false)).toBe('bar foo');
+      expect(styles.toggleCssClass('   foo   bar   ', '', false)).toBe('foo bar');
+      expect(styles.toggleCssClass('foo bar foo', '', false)).toBe('foo bar foo');
+
+      expect(styles.toggleCssClass(null, 'foo', false)).toBe('');
+      expect(styles.toggleCssClass('', 'foo', false)).toBe('');
+      expect(styles.toggleCssClass('foo', 'foo', false)).toBe('');
+      expect(styles.toggleCssClass('foo bar', 'foo', false)).toBe('bar');
+      expect(styles.toggleCssClass('bar foo', 'foo', false)).toBe('bar');
+      expect(styles.toggleCssClass('   foo   bar   ', 'foo', false)).toBe('bar');
+      expect(styles.toggleCssClass('foo bar foo', 'foo', false)).toBe('bar');
+
+      expect(styles.toggleCssClass(null, 'bar', false)).toBe('');
+      expect(styles.toggleCssClass('', 'bar', false)).toBe('');
+      expect(styles.toggleCssClass('foo', 'bar', false)).toBe('foo');
+      expect(styles.toggleCssClass('foo bar', 'bar', false)).toBe('foo');
+      expect(styles.toggleCssClass('bar foo', 'bar', false)).toBe('foo');
+      expect(styles.toggleCssClass('   foo   bar   ', 'bar', false)).toBe('foo');
+      expect(styles.toggleCssClass('foo bar foo', 'bar', false)).toBe('foo foo');
+
+      expect(styles.toggleCssClass(null, '   foo   ', false)).toBe('');
+      expect(styles.toggleCssClass('', '   foo   ', false)).toBe('');
+      expect(styles.toggleCssClass('foo', '   foo   ', false)).toBe('');
+      expect(styles.toggleCssClass('foo bar', '   foo   ', false)).toBe('bar');
+      expect(styles.toggleCssClass('bar foo', '   foo   ', false)).toBe('bar');
+      expect(styles.toggleCssClass('   foo   bar   ', '   foo   ', false)).toBe('bar');
+      expect(styles.toggleCssClass('foo bar foo', '   foo   ', false)).toBe('bar');
+
+      expect(styles.toggleCssClass(null, 'foo bar', false)).toBe('');
+      expect(styles.toggleCssClass('', 'foo bar', false)).toBe('');
+      expect(styles.toggleCssClass('foo', 'foo bar', false)).toBe('');
+      expect(styles.toggleCssClass('foo bar', 'foo bar', false)).toBe('');
+      expect(styles.toggleCssClass('bar foo', 'foo bar', false)).toBe('');
+      expect(styles.toggleCssClass('   foo   bar   ', 'foo bar', false)).toBe('');
+      expect(styles.toggleCssClass('foo bar foo', 'foo bar', false)).toBe('');
+
+      expect(styles.toggleCssClass(null, 'foo bar foo', false)).toBe('');
+      expect(styles.toggleCssClass('', 'foo bar foo', false)).toBe('');
+      expect(styles.toggleCssClass('foo', 'foo bar foo', false)).toBe('');
+      expect(styles.toggleCssClass('foo bar', 'foo bar foo', false)).toBe('');
+      expect(styles.toggleCssClass('bar foo', 'foo bar foo', false)).toBe('');
+      expect(styles.toggleCssClass('   foo   bar   ', 'foo bar foo', false)).toBe('');
+      expect(styles.toggleCssClass('foo bar foo', 'foo bar foo', false)).toBe('');
+    });
+
+    it('has css class', () => {
+      expect(styles.hasCssClass(null, null)).toBeTrue();
+      expect(styles.hasCssClass('', null)).toBeTrue();
+      expect(styles.hasCssClass('foo', null)).toBeTrue();
+      expect(styles.hasCssClass('foo bar', null)).toBeTrue();
+      expect(styles.hasCssClass('bar foo', null)).toBeTrue();
+      expect(styles.hasCssClass('   foo   bar   ', null)).toBeTrue();
+      expect(styles.hasCssClass('foo bar foo', null)).toBeTrue();
+
+      expect(styles.hasCssClass(null, '')).toBeTrue();
+      expect(styles.hasCssClass('', '')).toBeTrue();
+      expect(styles.hasCssClass('foo', '')).toBeTrue();
+      expect(styles.hasCssClass('foo bar', '')).toBeTrue();
+      expect(styles.hasCssClass('bar foo', '')).toBeTrue();
+      expect(styles.hasCssClass('   foo   bar   ', '')).toBeTrue();
+      expect(styles.hasCssClass('foo bar foo', '')).toBeTrue();
+
+      expect(styles.hasCssClass(null, 'foo')).toBeFalse();
+      expect(styles.hasCssClass('', 'foo')).toBeFalse();
+      expect(styles.hasCssClass('foo', 'foo')).toBeTrue();
+      expect(styles.hasCssClass('foo bar', 'foo')).toBeTrue();
+      expect(styles.hasCssClass('bar foo', 'foo')).toBeTrue();
+      expect(styles.hasCssClass('   foo   bar   ', 'foo')).toBeTrue();
+      expect(styles.hasCssClass('foo bar foo', 'foo')).toBeTrue();
+
+      expect(styles.hasCssClass(null, 'bar')).toBeFalse();
+      expect(styles.hasCssClass('', 'bar')).toBeFalse();
+      expect(styles.hasCssClass('foo', 'bar')).toBeFalse();
+      expect(styles.hasCssClass('foo bar', 'bar')).toBeTrue();
+      expect(styles.hasCssClass('bar foo', 'bar')).toBeTrue();
+      expect(styles.hasCssClass('   foo   bar   ', 'bar')).toBeTrue();
+      expect(styles.hasCssClass('foo bar foo', 'bar')).toBeTrue();
+
+      expect(styles.hasCssClass(null, '   foo   ')).toBeFalse();
+      expect(styles.hasCssClass('', '   foo   ')).toBeFalse();
+      expect(styles.hasCssClass('foo', '   foo   ')).toBeTrue();
+      expect(styles.hasCssClass('foo bar', '   foo   ')).toBeTrue();
+      expect(styles.hasCssClass('bar foo', '   foo   ')).toBeTrue();
+      expect(styles.hasCssClass('   foo   bar   ', '   foo   ')).toBeTrue();
+      expect(styles.hasCssClass('foo bar foo', '   foo   ')).toBeTrue();
+
+      expect(styles.hasCssClass(null, 'foo bar')).toBeFalse();
+      expect(styles.hasCssClass('', 'foo bar')).toBeFalse();
+      expect(styles.hasCssClass('foo', 'foo bar')).toBeFalse();
+      expect(styles.hasCssClass('foo bar', 'foo bar')).toBeTrue();
+      expect(styles.hasCssClass('bar foo', 'foo bar')).toBeTrue();
+      expect(styles.hasCssClass('   foo   bar   ', 'foo bar')).toBeTrue();
+      expect(styles.hasCssClass('foo bar foo', 'foo bar')).toBeTrue();
+
+      expect(styles.hasCssClass(null, 'foo bar foo')).toBeFalse();
+      expect(styles.hasCssClass('', 'foo bar foo')).toBeFalse();
+      expect(styles.hasCssClass('foo', 'foo bar foo')).toBeFalse();
+      expect(styles.hasCssClass('foo bar', 'foo bar foo')).toBeTrue();
+      expect(styles.hasCssClass('bar foo', 'foo bar foo')).toBeTrue();
+      expect(styles.hasCssClass('   foo   bar   ', 'foo bar foo')).toBeTrue();
+      expect(styles.hasCssClass('foo bar foo', 'foo bar foo')).toBeTrue();
+    });
+
+    it('splits css class to array', () => {
+      expect(styles.cssClassAsArray(null)).toEqual([]);
+      expect(styles.cssClassAsArray('')).toEqual([]);
+      expect(styles.cssClassAsArray(' ')).toEqual([]);
+      expect(styles.cssClassAsArray('   ')).toEqual([]);
+
+      expect(styles.cssClassAsArray('foo')).toEqual(['foo']);
+      expect(styles.cssClassAsArray(' foo ')).toEqual(['foo']);
+      expect(styles.cssClassAsArray('   foo   ')).toEqual(['foo']);
+
+      expect(styles.cssClassAsArray('foo bar')).toEqual(['foo', 'bar']);
+      expect(styles.cssClassAsArray(' foo bar ')).toEqual(['foo', 'bar']);
+      expect(styles.cssClassAsArray('   foo   bar   ')).toEqual(['foo', 'bar']);
     });
   });
 });


### PR DESCRIPTION
Adding, removing and toggling css classes was only implemented for widgets. Move to styles utility and use it to implement adding, removing and toggling cssClasses on the Cell.