### PR TITLE
Table: prevent error when hierarchical table contains orphaned rows

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/HierarchicalTableTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/HierarchicalTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -50,9 +50,8 @@ public class HierarchicalTableTest {
   }
 
   /**
-   * Table expect always to have all parent rows
+   * Table ignores rows with non-existing parent.
    */
-  @Test(expected = IllegalArgumentException.class)
   public void testAddRowsWithInvalidRowList() {
     P_SinglePrimaryKeyColumnTable table = new P_SinglePrimaryKeyColumnTable();
     table.init();
@@ -61,12 +60,14 @@ public class HierarchicalTableTest {
     rows.add(table.createRow(new Object[]{2, null}));
     rows.add(table.createRow(new Object[]{3, 4}));
     table.addRows(rows);
+
+    assertEquals(3, table.getRowCount());
+    assertEquals(2, table.getFilteredRowCount());
   }
 
   /**
-   * Table expect always to have all parent rows
+   * Table ignores rows with non-existing parent.
    */
-  @Test(expected = IllegalArgumentException.class)
   public void testAddRowWithUnresolvedParentRow() {
     P_SinglePrimaryKeyColumnTable table = new P_SinglePrimaryKeyColumnTable();
     table.init();
@@ -74,8 +75,12 @@ public class HierarchicalTableTest {
     rows.add(table.createRow(new Object[]{1, null}));
     rows.add(table.createRow(new Object[]{2, null}));
     table.addRows(rows);
+    assertEquals(2, table.getRowCount());
+    assertEquals(2, table.getFilteredRowCount());
 
     table.addRow(table.createRow(new Object[]{3, 4}));
+    assertEquals(3, table.getRowCount());
+    assertEquals(2, table.getFilteredRowCount());
   }
 
   /**

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -649,10 +649,10 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
    * Subclasses can override this method. Default is {@link TriState#UNDEFINED}
    *
    * @return <ul>
-   *         <li>{@link TriState#TRUE} if the tooltip should always be shown if the cell content is truncated</li>
-   *         <li>{@link TriState#FALSE} if the tooltip should never be shown</li>
-   *         <li>{@link TriState#UNDEFINED} cell tooltip is only shown if it is not possible to resize the column</li>
-   *         </ul>
+   * <li>{@link TriState#TRUE} if the tooltip should always be shown if the cell content is truncated</li>
+   * <li>{@link TriState#FALSE} if the tooltip should never be shown</li>
+   * <li>{@link TriState#UNDEFINED} cell tooltip is only shown if it is not possible to resize the column</li>
+   * </ul>
    */
   @ConfigProperty(ConfigProperty.BOOLEAN)
   @Order(270)
@@ -3250,13 +3250,18 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
 
   private void rebuildTreeStructureInternal() {
     List<ITableRow> rootNodes = new ArrayList<>();
+    Set<ITableRow> orphanRows = new HashSet<>();
     Map<ITableRow/*parent*/, List<ITableRow> /*child rows*/> parentToChildren = new HashMap<>();
     m_rows.forEach(row -> {
       List<Object> parentRowKeys = getParentRowKeys(row);
       if (parentRowKeys.stream().filter(Objects::nonNull).findAny().orElse(null) != null) {
         ITableRow parentRow = getRowByKey(parentRowKeys);
         if (parentRow == null) {
-          throw new IllegalArgumentException("Could not find the parent row of '" + row + "'. parent keys are defined.");
+          LOG.warn("Ignoring row with key {} because its parent key {} could not be found. {}", row.getKeyValues(), row.getParentKeyValues(), row);
+          row.setParentRowInternal(null);
+          rootNodes.add(row);
+          orphanRows.add(row);
+          return;
         }
         parentToChildren.computeIfAbsent(parentRow, children -> new ArrayList<>())
             .add(row);
@@ -3266,6 +3271,10 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
         rootNodes.add(row);
       }
     });
+    getRowFilters().stream().filter(f -> f instanceof P_OrphanRowFilter).forEach(this::removeRowFilter);
+    if (!orphanRows.isEmpty()) {
+      addRowFilter(new P_OrphanRowFilter(orphanRows));
+    }
 
     m_rootRows = Collections.synchronizedList(rootNodes);
     boolean hierarchical = !parentToChildren.isEmpty();
@@ -5114,6 +5123,32 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
 
     public IFormField getFormField() {
       return m_formField;
+    }
+  }
+
+  /**
+   * Filter that hides orphaned rows, i.e. rows that have a non-null {@link ITableRow#getParentKeyValues() parent key},
+   * but no such parent row exists. This can happen for example due to a row limit.
+   */
+  protected static class P_OrphanRowFilter implements ITableRowFilter {
+
+    protected final Set<ITableRow> m_orphanRows;
+
+    /**
+     * @param orphanRows
+     *     set of orphaned rows (rows with non-existing parent) that are to be filtered by this filter
+     */
+    public P_OrphanRowFilter(Set<ITableRow> orphanRows) {
+      m_orphanRows = Assertions.assertNotNull(orphanRows);
+    }
+
+    public Set<ITableRow> getOrphanRows() {
+      return m_orphanRows;
+    }
+
+    @Override
+    public boolean accept(ITableRow row) {
+      return !m_orphanRows.contains(row);
     }
   }
 


### PR DESCRIPTION
When table data is hierarchical, rows can define other rows as their parent. If that reference is invalid (i.e. a key that does not exist), an error was thrown in Table#rebuildTreeStructureInternal. This causes the table to be unusable for the user. Because invalid parent references can happen due to row limits, we should handle this case more gracefully. The easiest solution is to simply add a row filter that hides such orphaned rows.

301956