### PR TITLE
Move user preferences from shared to client

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/services/common/prefs/PreferencesTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/services/common/prefs/PreferencesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,17 +7,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.shared.services.common.prefs;
+package org.eclipse.scout.rt.client.services.common.prefs;
 
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.scout.rt.client.IClientSession;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
-import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.Test;
@@ -38,13 +38,13 @@ public class PreferencesTest {
     prefs.putInt("int", 123);
     prefs.putLong("long", 123L);
 
-    assertEquals(true, prefs.isDirty());
+    assertTrue(prefs.isDirty());
     assertEquals("X", prefs.name());
     assertEquals(7, prefs.keys().size());
     assertEquals("Any", prefs.get("any", null));
     assertEquals("Xyz", prefs.get("xyz", "Xyz"));
-    assertEquals(true, prefs.getBoolean("bool", false));
-    assertEquals(true, prefs.getBoolean("xyz", true));
+    assertTrue(prefs.getBoolean("bool", false));
+    assertTrue(prefs.getBoolean("xyz", true));
     assertArrayEquals(new byte[]{(byte) 1, (byte) 2, (byte) 3}, prefs.getByteArray("byte", null));
     assertArrayEquals(new byte[]{(byte) 9,}, prefs.getByteArray("xyz", new byte[]{(byte) 9,}));
     assertEquals(1.23, prefs.getDouble("double", 0), 0.0);
@@ -164,7 +164,7 @@ public class PreferencesTest {
     private boolean m_flushed = false;
 
     @Override
-    public IPreferences getPreferences(ISession userScope, String nodeId) {
+    public IPreferences getPreferences(IClientSession userScope, String nodeId) {
       return null;
     }
 

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/ClientUIPreferencesTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/ClientUIPreferencesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,9 @@ import static org.junit.Assert.*;
 
 import java.util.Set;
 
+import org.eclipse.scout.rt.client.services.common.prefs.AbstractUserPreferencesStorageService;
+import org.eclipse.scout.rt.client.services.common.prefs.IPreferences;
+import org.eclipse.scout.rt.client.services.common.prefs.IUserPreferencesStorageService;
 import org.eclipse.scout.rt.client.session.ClientSessionProvider;
 import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
 import org.eclipse.scout.rt.client.ui.basic.table.AbstractTable;
@@ -26,9 +29,6 @@ import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.shared.prefs.CustomClientPreferenceId;
-import org.eclipse.scout.rt.shared.services.common.prefs.AbstractUserPreferencesStorageService;
-import org.eclipse.scout.rt.shared.services.common.prefs.IPreferences;
-import org.eclipse.scout.rt.shared.services.common.prefs.IUserPreferencesStorageService;
 import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
 import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/AbstractUserPreferencesStorageService.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/AbstractUserPreferencesStorageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,18 +7,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.shared.services.common.prefs;
+package org.eclipse.scout.rt.client.services.common.prefs;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.scout.rt.client.IClientSession;
 import org.eclipse.scout.rt.platform.util.StringUtility;
-import org.eclipse.scout.rt.shared.ISession;
 
 /**
  * Abstract implementation to store the preferences on the session.
  *
- * @see Preferences#get(ISession, String)
+ * @see Preferences#get(IClientSession, String)
  * @since 5.1
  */
 public abstract class AbstractUserPreferencesStorageService implements IUserPreferencesStorageService {
@@ -27,7 +27,7 @@ public abstract class AbstractUserPreferencesStorageService implements IUserPref
 
   @Override
   @SuppressWarnings("unchecked")
-  public IPreferences getPreferences(ISession session, String nodeId) {
+  public IPreferences getPreferences(IClientSession session, String nodeId) {
     if (session == null) {
       throw new IllegalArgumentException("No user scope available.");
     }
@@ -60,7 +60,7 @@ public abstract class AbstractUserPreferencesStorageService implements IUserPref
   /**
    * @return Gets the user scope identifier for the given session.
    */
-  protected String getUserScope(ISession session) {
+  protected String getUserScope(IClientSession session) {
     String userId = session.getUserId();
     if (StringUtility.hasText(userId)) {
       return userId.trim();

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/FileSystemUserPreferencesStorageService.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/FileSystemUserPreferencesStorageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,8 +32,6 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.config.ConfigUtility;
 import org.eclipse.scout.rt.platform.config.IConfigProperty;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
-import org.eclipse.scout.rt.shared.services.common.prefs.AbstractUserPreferencesStorageService;
-import org.eclipse.scout.rt.shared.services.common.prefs.IPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/IPreferenceChangeListener.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/IPreferenceChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.shared.services.common.prefs;
+package org.eclipse.scout.rt.client.services.common.prefs;
 
 import java.util.EventListener;
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/IPreferences.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/IPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,21 +7,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.shared.services.common.prefs;
+package org.eclipse.scout.rt.client.services.common.prefs;
 
 import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
 import java.util.prefs.BackingStoreException;
 
+import org.eclipse.scout.rt.client.IClientSession;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.util.event.IFastListenerList;
-import org.eclipse.scout.rt.shared.ISession;
 
 /**
  * Preferences store for a single node of a single user scope.
  *
- * @see Preferences#get(ISession, String)
+ * @see Preferences#get(IClientSession, String)
  * @see IUserPreferencesService
  * @since 5.1
  */
@@ -335,11 +335,11 @@ public interface IPreferences extends Serializable {
   String name();
 
   /**
-   * Gets the {@link ISession} that represents the user scope of this node.
+   * Gets the {@link IClientSession} that represents the user scope of this node.
    *
-   * @return The {@link ISession} this node belongs to.
+   * @return The {@link IClientSession} this node belongs to.
    */
-  ISession userScope();
+  IClientSession userScope();
 
   /**
    * Forces any changes in the contents of this node and its descendants to the persistent store.

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/IUserPreferencesService.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/IUserPreferencesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,16 +7,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.shared.services.common.prefs;
+package org.eclipse.scout.rt.client.services.common.prefs;
 
+import org.eclipse.scout.rt.client.IClientSession;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.service.IService;
-import org.eclipse.scout.rt.shared.ISession;
 
 /**
  * Service capable to get user preferences.
  *
- * @see Preferences#get(ISession, String)
+ * @see Preferences#get(IClientSession, String)
  * @since 5.1
  */
 public interface IUserPreferencesService extends IService {
@@ -25,7 +25,7 @@ public interface IUserPreferencesService extends IService {
    * Gets the {@link IPreferences} for the given <code>nodeId</code> and the given <code>userScope</code>
    *
    * @param userScope
-   *     The {@link ISession} for which the settings should be retrieved. Must not be <code>null</code>.
+   *     The {@link IClientSession} for which the settings should be retrieved. Must not be <code>null</code>.
    * @param nodeId
    *     The id of the node to retrieve. Must not be <code>null</code>.
    * @return The {@link IPreferences} for the given node and scope.
@@ -34,5 +34,5 @@ public interface IUserPreferencesService extends IService {
    * @throws IllegalArgumentException
    *     if the session or nodeId is <code>null</code>.
    */
-  IPreferences getPreferences(ISession userScope, String nodeId);
+  IPreferences getPreferences(IClientSession userScope, String nodeId);
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/IUserPreferencesStorageService.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/IUserPreferencesStorageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,15 +7,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.shared.services.common.prefs;
+package org.eclipse.scout.rt.client.services.common.prefs;
 
+import org.eclipse.scout.rt.client.IClientSession;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
-import org.eclipse.scout.rt.shared.ISession;
 
 /**
  * User preference service that is capable to persist preferences to a preference store.
  *
- * @see Preferences#get(ISession, String)
+ * @see Preferences#get(IClientSession, String)
  * @since 5.1
  */
 public interface IUserPreferencesStorageService extends IUserPreferencesService {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/PreferenceChangeEvent.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/PreferenceChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.shared.services.common.prefs;
+package org.eclipse.scout.rt.client.services.common.prefs;
 
 import java.util.EventObject;
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/Preferences.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/prefs/Preferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.scout.rt.shared.services.common.prefs;
+package org.eclipse.scout.rt.client.services.common.prefs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.scout.rt.client.IClientSession;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.util.Base64Utility;
@@ -24,7 +25,6 @@ import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.event.FastListenerList;
 import org.eclipse.scout.rt.platform.util.event.IFastListenerList;
-import org.eclipse.scout.rt.shared.ISession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,12 +62,12 @@ public class Preferences implements IPreferences {
   private static final long serialVersionUID = 1L;
 
   private final String m_name;
-  private final transient ISession m_session;
+  private final transient IClientSession m_session;
   private final Map<String, String> m_prefs;
   private final transient FastListenerList<IPreferenceChangeListener> m_eventListeners;
   private boolean m_dirty;
 
-  protected Preferences(String name, ISession userScope) {
+  protected Preferences(String name, IClientSession userScope) {
     this(name, userScope, new LinkedHashMap<>(), false);
   }
 
@@ -75,7 +75,7 @@ public class Preferences implements IPreferences {
     this(other.m_name, other.m_session, other.m_prefs, other.m_dirty);
   }
 
-  protected Preferences(String name, ISession userScope, Map<String, String> prefs, boolean dirty) {
+  protected Preferences(String name, IClientSession userScope, Map<String, String> prefs, boolean dirty) {
     m_name = name;
     m_session = userScope;
     m_prefs = prefs;
@@ -91,7 +91,7 @@ public class Preferences implements IPreferences {
    * Gets the {@link IPreferences} for the given <code>nodeId</code> and the given <code>userScope</code>
    *
    * @param userScope
-   *     The {@link ISession} for which the settings should be retrieved. Must not be <code>null</code>.
+   *     The {@link IClientSession} for which the settings should be retrieved. Must not be <code>null</code>.
    * @param nodeId
    *     The id of the node to retrieve. Must not be <code>null</code>.
    * @return The {@link IPreferences} for the given node and scope.
@@ -100,7 +100,7 @@ public class Preferences implements IPreferences {
    * @throws IllegalArgumentException
    *     if the session or nodeId is <code>null</code>.
    */
-  public static IPreferences get(ISession userScope, String nodeId) {
+  public static IPreferences get(IClientSession userScope, String nodeId) {
     IUserPreferencesService service = BEANS.get(IUserPreferencesService.class);
     if (service == null) {
       LOG.warn("No preferences service could be found!");
@@ -374,7 +374,7 @@ public class Preferences implements IPreferences {
   }
 
   @Override
-  public ISession userScope() {
+  public IClientSession userScope() {
     return m_session;
   }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/ClientUIPreferences.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/ClientUIPreferences.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.scout.rt.client.IClientSession;
+import org.eclipse.scout.rt.client.services.common.prefs.IPreferences;
+import org.eclipse.scout.rt.client.services.common.prefs.Preferences;
 import org.eclipse.scout.rt.client.session.ClientSessionProvider;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.basic.table.columns.IColumn;
@@ -32,12 +34,9 @@ import org.eclipse.scout.rt.platform.util.BooleanUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.TypeCastUtility;
-import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.dimension.IDimensions;
 import org.eclipse.scout.rt.shared.prefs.CustomClientPreferenceId;
 import org.eclipse.scout.rt.shared.prefs.ICustomClientPreferenceDo;
-import org.eclipse.scout.rt.shared.services.common.prefs.IPreferences;
-import org.eclipse.scout.rt.shared.services.common.prefs.Preferences;
 import org.eclipse.scout.rt.shared.ui.UiDeviceType;
 import org.eclipse.scout.rt.shared.ui.UiLayer;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
@@ -56,7 +55,7 @@ public class ClientUIPreferences {
   /**
    * @return a new instance of the {@link ClientUIPreferences}
    * @throws IllegalArgumentException
-   *     When no {@link IClientSession} is available in the current thread context ( {@link ISession#CURRENT}).
+   *     When no {@link IClientSession} is available in the current thread context ( {@link IClientSession#CURRENT}).
    */
   public static ClientUIPreferences getInstance() {
     return getInstance(ClientSessionProvider.currentSession());
@@ -98,7 +97,7 @@ public class ClientUIPreferences {
   protected String getUserAgentPrefix() {
     UserAgent currentUserAgent;
     if (m_prefs != null && m_prefs.userScope() instanceof IClientSession) {
-      currentUserAgent = ((IClientSession) m_prefs.userScope()).getUserAgent();
+      currentUserAgent = m_prefs.userScope().getUserAgent();
     }
     else {
       currentUserAgent = UserAgentUtility.getCurrentUserAgent();


### PR DESCRIPTION
As part of the move toward a stateless server session, the
IPreferences, IUserPreferencesService, IUserPreferencesStorageService,
IPreferenceChangeListener and their corresponding implementations
have been moved from shared to client

423389