### PR TITLE
Always use CustomHttpRequestRetryStrategy

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,6 +88,7 @@ import org.eclipse.scout.rt.platform.util.TypeCastUtility;
 import org.eclipse.scout.rt.platform.util.concurrent.ICancellable;
 import org.eclipse.scout.rt.rest.IRestHttpRequestUriEncoder;
 import org.eclipse.scout.rt.rest.client.RestClientProperties;
+import org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory;
 import org.eclipse.scout.rt.shared.http.HttpClientMetricsHelper;
 import org.eclipse.scout.rt.shared.http.proxy.ConfigurableProxySelector;
 import org.glassfish.jersey.client.ClientProperties;
@@ -142,7 +143,10 @@ public class ScoutApacheConnector implements Connector {
     boolean enableCookies = initCookieConfig(config, clientBuilder, requestConfigBuilder);
     m_cookieStore = createCookieStore(clientBuilder, enableCookies);
 
-    // (4) setup and build HTTP client
+    // (4) setup custom retry handling
+    BEANS.get(ApacheHttpTransportFactory.class).addRetrySettings(clientBuilder);
+
+    // (5) setup and build HTTP client
     m_requestConfig = buildRequestConfig(requestConfigBuilder);
     clientBuilder.setDefaultRequestConfig(m_requestConfig);
     clientBuilder.disableDefaultUserAgent(); // disable sending user agent header like "Apache-HttpClient/4.5.13 (Java/1.8.0_191)"

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/ApacheHttpTransportFactory.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/ApacheHttpTransportFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.DefaultClientConnectionReuseStrategy;
-import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -109,17 +108,12 @@ public class ApacheHttpTransportFactory implements IHttpTransportFactory {
     }
   }
 
-  protected void addRetrySettings(HttpClientBuilder builder) {
+  public void addRetrySettings(HttpClientBuilder builder) {
     // see very similar code in org.eclipse.scout.rt.shared.http.async.DefaultAsyncHttpClientManager.addRetrySettings(HttpAsyncClientBuilder), unfortunately there is no common interface
     final boolean retryOnNoHttpResponseException = CONFIG.getPropertyValue(ApacheHttpTransportRetryOnNoHttpResponseExceptionProperty.class);
     final boolean retryOnSocketExceptionByConnectionReset = CONFIG.getPropertyValue(ApacheHttpTransportRetryOnSocketExceptionByConnectionResetProperty.class);
-    if (retryOnNoHttpResponseException || retryOnSocketExceptionByConnectionReset) {
-      CustomHttpRequestRetryStrategy retryStrategy = new CustomHttpRequestRetryStrategy(1, retryOnNoHttpResponseException, retryOnSocketExceptionByConnectionReset);
-      retryStrategy.enable(builder);
-    }
-    else {
-      builder.setRetryStrategy(new DefaultHttpRequestRetryStrategy());
-    }
+    CustomHttpRequestRetryStrategy retryStrategy = new CustomHttpRequestRetryStrategy(1, retryOnNoHttpResponseException, retryOnSocketExceptionByConnectionReset);
+    retryStrategy.enable(builder);
   }
 
   protected void addRedirectSettings(HttpClientBuilder builder) {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/async/DefaultAsyncHttpClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ import org.apache.hc.client5.http.async.AsyncExecCallback;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.DefaultClientConnectionReuseStrategy;
-import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
@@ -143,13 +142,8 @@ public class DefaultAsyncHttpClientManager extends AbstractAsyncHttpClientManage
     // see very similar code in org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory.addRetrySettings(HttpClientBuilder), unfortunately there is no common interface
     final boolean retryOnNoHttpResponseException = CONFIG.getPropertyValue(ApacheHttpTransportRetryOnNoHttpResponseExceptionProperty.class);
     final boolean retryOnSocketExceptionByConnectionReset = CONFIG.getPropertyValue(ApacheHttpTransportRetryOnSocketExceptionByConnectionResetProperty.class);
-    if (retryOnNoHttpResponseException || retryOnSocketExceptionByConnectionReset) {
-      CustomHttpRequestRetryStrategy retryStrategy = new CustomHttpRequestRetryStrategy(1, retryOnNoHttpResponseException, retryOnSocketExceptionByConnectionReset);
-      retryStrategy.enable(builder);
-    }
-    else {
-      builder.setRetryStrategy(new DefaultHttpRequestRetryStrategy());
-    }
+    CustomHttpRequestRetryStrategy retryStrategy = new CustomHttpRequestRetryStrategy(1, retryOnNoHttpResponseException, retryOnSocketExceptionByConnectionReset);
+    retryStrategy.enable(builder);
   }
 
   protected void addRedirectSettings(HttpAsyncClientBuilder builder) {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/retry/CustomHttpRequestRetryStrategy.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/http/retry/CustomHttpRequestRetryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.shared.http.retry;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,6 +36,7 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.NoHttpResponseException;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -53,6 +55,12 @@ public class CustomHttpRequestRetryStrategy extends DefaultHttpRequestRetryStrat
 
   public static final String RETRY_ENABLER_EXEC_CHAIN_NAME = OneTimeRetryPrepareExecChainHandler.class.getSimpleName();
 
+  /**
+   * Certain status codes may be retried by the super-class, see {@link #retryRequest(HttpResponse, int, HttpContext)}; this extension allows a header to be set on response as hint to disapprove an additional retry. This extension will
+   * honor this header (regardless of its value) and avoid retrying responses supplying this header; however other clients may behave differently.
+   */
+  public static final String FINAL_RESPONSE_HEADER = "X-Scout-Final-Response";
+
   private final Set<Class<? extends IOException>> m_nonRetriableClasses;
   private final boolean m_retryOnNoHttpResponseException;
   private final boolean m_retryOnSocketExceptionByConnectionReset;
@@ -66,6 +74,7 @@ public class CustomHttpRequestRetryStrategy extends DefaultHttpRequestRetryStrat
             UnknownHostException.class,
             ConnectException.class,
             ConnectionClosedException.class,
+            NoRouteToHostException.class,
             SSLException.class),
         retryOnNoHttpResponseException,
         retryOnSocketExceptionByConnectionReset,
@@ -121,11 +130,9 @@ public class CustomHttpRequestRetryStrategy extends DefaultHttpRequestRetryStrat
     if (this.m_nonRetriableClasses.contains(exception.getClass())) {
       return false;
     }
-    else {
-      for (final Class<? extends IOException> rejectException : this.m_nonRetriableClasses) {
-        if (rejectException.isInstance(exception)) {
-          return false;
-        }
+    for (final Class<? extends IOException> rejectException : this.m_nonRetriableClasses) {
+      if (rejectException.isInstance(exception)) {
+        return false;
       }
     }
     if (request instanceof CancellableDependency && ((CancellableDependency) request).isCancelled()) {
@@ -134,6 +141,24 @@ public class CustomHttpRequestRetryStrategy extends DefaultHttpRequestRetryStrat
 
     // Retry if the request is considered idempotent or for stale socket channel (assumption)
     return handleAsIdempotent(request) || detectStaleSocketChannel(exception);
+  }
+
+  @Override
+  public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
+    boolean skipRetryByHeaderSetOnResponse = isFinalResponse(response);
+    if (skipRetryByHeaderSetOnResponse) {
+      LOG.trace("Respect response header {} to skip retry", FINAL_RESPONSE_HEADER);
+      return false;
+    }
+
+    return super.retryRequest(response, execCount, context);
+  }
+
+  /**
+   * @return true if {@link #FINAL_RESPONSE_HEADER} is set for response regardless of header value (and thus retry should be skipped regardless of status code)
+   */
+  protected boolean isFinalResponse(HttpResponse response) {
+    return response.containsHeader(FINAL_RESPONSE_HEADER);
   }
 
   /**


### PR DESCRIPTION
- Previously not used at all for ScoutApacheConnector, honor retry config properties also here

- Always use strategy regardless how retry config properties are defined

- Add header X-Scout-Final-Response to disapprove automatic retry by status code

429204