### PR TITLE
Convert nbsp to normal spaces when converting html to plain text

### DIFF
--- a/eclipse-scout-core/src/encoder/PlainTextEncoder.ts
+++ b/eclipse-scout-core/src/encoder/PlainTextEncoder.ts
@@ -73,9 +73,15 @@ export class PlainTextEncoder {
       text = text.trim();
     }
 
+    // Decore character references
     let textarea = this._cachedElement.get();
     textarea.innerHTML = text;
-    return textarea.value;
+    text = textarea.value;
+
+    // Convert non-breaking spaces to normal spaces
+    text = text.replace(/\u00A0/g, ' ');
+
+    return text;
   }
 
   removeAttributeValues(text: string): string {

--- a/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.ts
+++ b/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.ts
@@ -100,7 +100,7 @@ describe('PlainTextEncoder', () => {
 
   it('converts &nbsp;, &amp;, &gt;, &lt;', () => {
     let htmlText = '<b>first&nbsp;word</b>&nbsp;next word';
-    expect(encoder.encode(htmlText)).toBe('first word next word');
+    expect(encoder.encode(htmlText)).toBe('first word next word');
 
     htmlText = '<b>first&amp;word</b>&amp;next word';
     expect(encoder.encode(htmlText)).toBe('first&word&next word');
@@ -290,10 +290,10 @@ describe('PlainTextEncoder', () => {
     expect(encoder.encode('one\rtwo')).toBe('onetwo');
     expect(encoder.encode('one<br/>\r\ntwo')).toBe('one\ntwo');
     expect(encoder.encode('one   two')).toBe('one two');
-    expect(encoder.encode('one&nbsp;&nbsp; two')).toBe('one\u00a0\u00a0 two');
+    expect(encoder.encode('one&nbsp;&nbsp; two')).toBe('one   two');
     expect(encoder.encode('one &#9; two')).toBe('one \t two');
     expect(encoder.encode(' one <br>\n two  <br>\n   three ')).toBe('one\ntwo\nthree');
-    expect(encoder.encode('a<br>\n&nbsp;&nbsp;b<br>\n&nbsp;&nbsp;&nbsp;&nbsp;c')).toBe('a\n\u00A0\u00A0b\n\u00A0\u00A0\u00A0\u00A0c');
+    expect(encoder.encode('a<br>\n&nbsp;&nbsp;b<br>\n&nbsp;&nbsp;&nbsp;&nbsp;c')).toBe('a\n  b\n    c');
   });
 
   it('decodes special characters', () => {
@@ -328,8 +328,8 @@ describe('PlainTextEncoder', () => {
       expect(encoder.encode('one&#9;two')).toBe('one\ttwo');
       expect(encoder.encode('one &#9; two')).toBe('one \t two');
       expect(encoder.encode('one   two')).toBe('one two');
-      expect(encoder.encode('one&nbsp;&nbsp; two')).toBe('one\u00A0\u00A0 two');
-      expect(encoder.encode('one&#160;&#xa0;&#Xa0;&#xA0;two')).toBe('one\u00A0\u00A0\u00A0\u00A0two'); // HTML5 spec allows for mixed case hex values.
+      expect(encoder.encode('one&nbsp;&nbsp; two')).toBe('one   two');
+      expect(encoder.encode('one&#160;&#xa0;&#Xa0;&#xA0;two')).toBe('one    two'); // HTML5 spec allows for mixed case hex values.
       expect(encoder.encode('one&#x9;&#X9;two')).toBe('one\t\ttwo'); // HTML5 spec allows for mixed case hex values.
       expect(encoder.encode('<div class="rte-line">Unter<u>rasch</u>u<span class="rte-highlight" style="background-color: rgb(255, 219, 157)">ngs</span>feier<br></div>')).toBe('Unterraschungsfeier'); // Formating tags within a single word.
       expect(encoder.encode('<h1>Header 1</h1><h1>Header 2</h1>')).toBe('Header 1\nHeader 2'); // Headers
@@ -360,7 +360,7 @@ describe('PlainTextEncoder', () => {
       expect(encoder.encode('<html><head>one &amp; two</head><body>three</body></html>')).toBe('one & two\nthree'); // [?!] does not handle <head> differently than any other tag
       expect(encoder.encode('<html><body><div class="rte-line">Unter<u>rasch</u>u<span class="rte-highlight" style="background-color: rgb(255, 219, 157)">ngs</span>feier<br></div></body></html>')).toBe('Unterraschungsfeier');
       expect(encoder.encode('<p>Z1</p><span></span><p>Z2</p>')).toBe('Z1\nZ2');
-      expect(encoder.encode('<html><body><div><div><p>Guten Tag<o:p></o:p></p></div><div><p><o:p>&nbsp;</o:p></span></p></div><div><p><span>Zeile 2<o:p></o:p></span></p></div></div></body></html>')).toBe('Guten Tag\n\n\u00A0\n\nZeile 2');
+      expect(encoder.encode('<html><body><div><div><p>Guten Tag<o:p></o:p></p></div><div><p><o:p>&nbsp;</o:p></span></p></div><div><p><span>Zeile 2<o:p></o:p></span></p></div></div></body></html>')).toBe('Guten Tag\n\n \n\nZeile 2');
       expect(encoder.encode('&#8217;')).toBe('’');
       expect(encoder.encode('&#43;')).toBe('+');
       expect(encoder.encode('&#x2B;')).toBe('+');
@@ -371,9 +371,9 @@ describe('PlainTextEncoder', () => {
       expect(encoder.encode('a<br>b')).toBe('a\nb');
       expect(encoder.encode('a <br/> b')).toBe('a\nb');
       expect(encoder.encode('a    <br/> b')).toBe('a\nb');
-      expect(encoder.encode('a&nbsp;<br/> b')).toBe('a\u00A0\nb');
-      expect(encoder.encode('a  &nbsp;  <br/>  b  ')).toBe('a \u00A0\nb');
-      expect(encoder.encode('a<br>&nbsp;&nbsp;b<br>&nbsp;&nbsp;&nbsp;&nbsp;c')).toBe('a\n\u00A0\u00A0b\n\u00A0\u00A0\u00A0\u00A0c');
+      expect(encoder.encode('a&nbsp;<br/> b')).toBe('a \nb');
+      expect(encoder.encode('a  &nbsp;  <br/>  b  ')).toBe('a  \nb');
+      expect(encoder.encode('a<br>&nbsp;&nbsp;b<br>&nbsp;&nbsp;&nbsp;&nbsp;c')).toBe('a\n  b\n    c');
       expect(encoder.encode('<br/>line')).toBe('line');
       expect(encoder.encode('<br/>line', {trim: false})).toBe('\nline');
       expect(encoder.encode('<p>line1<br>\nx</p><p>line2</p>')).toBe('line1\nx\nline2');

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/html/HtmlHelperTest.java
@@ -46,8 +46,8 @@ public class HtmlHelperTest {
     assertEquals("one \t two", helper.toPlainText("one &#9; two"));
     assertEquals("one\ttwo", helper.toPlainText("one" + StringUtility.HTML_ENCODED_TAB + "two"));
     assertEquals("one two", helper.toPlainText("one   two"));
-    assertEquals("one\u00A0\u00A0 two", helper.toPlainText("one&nbsp;&nbsp; two"));
-    assertEquals("one\u00A0\u00A0\u00A0\u00A0two", helper.toPlainText("one&#160;&#xa0;&#Xa0;&#xA0;two")); // HTML5 spec allows for mixed case hex values.
+    assertEquals("one   two", helper.toPlainText("one&nbsp;&nbsp; two"));
+    assertEquals("one    two", helper.toPlainText("one&#160;&#xa0;&#Xa0;&#xA0;two")); // HTML5 spec allows for mixed case hex values.
     assertEquals("one\t\ttwo", helper.toPlainText("one&#x9;&#X9;two")); // HTML5 spec allows for mixed case hex values.
     assertEquals("Unterraschungsfeier", helper.toPlainText("<div class=\"rte-line\">Unter<u>rasch</u>u<span class=\"rte-highlight\" style=\"background-color: rgb(255, 219, 157)\">ngs</span>feier<br></div>")); // Formating tags within a single word.
     assertEquals("Header 1\nHeader 2", helper.toPlainText("<h1>Header 1</h1><h1>Header 2</h1>")); // Headers
@@ -81,7 +81,7 @@ public class HtmlHelperTest {
     assertEquals("Unterraschungsfeier",
         helper.toPlainText("<html><body><div class=\"rte-line\">Unter<u>rasch</u>u<span class=\"rte-highlight\" style=\"background-color: rgb(255, 219, 157)\">ngs</span>feier<br></div></body></html>"));
     assertEquals("Z1\nZ2", helper.toPlainText("<p>Z1</p><span></span><p>Z2</p>"));
-    assertEquals("Guten Tag\n\n\u00A0\n\nZeile 2", helper.toPlainText("<html><body><div><div><p>Guten Tag<o:p></o:p></p></div><div><p><o:p>&nbsp;</o:p></span></p></div><div><p><span>Zeile 2<o:p></o:p></span></p></div></div></body></html>"));
+    assertEquals("Guten Tag\n\n \n\nZeile 2", helper.toPlainText("<html><body><div><div><p>Guten Tag<o:p></o:p></p></div><div><p><o:p>&nbsp;</o:p></span></p></div><div><p><span>Zeile 2<o:p></o:p></span></p></div></div></body></html>"));
     assertEquals("’", helper.toPlainText("&#8217;"));
     assertEquals("+", helper.toPlainText("&#43;"));
     assertEquals("+", helper.toPlainText("&#x2B;"));
@@ -92,9 +92,9 @@ public class HtmlHelperTest {
     assertEquals("a\nb", helper.toPlainText("a<br>b"));
     assertEquals("a\nb", helper.toPlainText("a <br/> b"));
     assertEquals("a\nb", helper.toPlainText("a    <br/> b"));
-    assertEquals("a\u00A0\nb", helper.toPlainText("a&nbsp;<br/> b"));
-    assertEquals("a \u00A0\nb", helper.toPlainText("a  &nbsp;  <br/>  b  "));
-    assertEquals("a\n\u00A0\u00A0b\n\u00A0\u00A0\u00A0\u00A0c", helper.toPlainText("a<br>&nbsp;&nbsp;b<br>&nbsp;&nbsp;&nbsp;&nbsp;c"));
+    assertEquals("a \nb", helper.toPlainText("a&nbsp;<br/> b"));
+    assertEquals("a  \nb", helper.toPlainText("a  &nbsp;  <br/>  b  "));
+    assertEquals("a\n  b\n    c", helper.toPlainText("a<br>&nbsp;&nbsp;b<br>&nbsp;&nbsp;&nbsp;&nbsp;c"));
     assertEquals("line", helper.toPlainText("<br/>line"));
     assertEquals("\nline", helper.toPlainTextNoTrim("<br/>line"));
     assertEquals("line1\nx\nline2", helper.toPlainText("<p>line1<br>\nx</p><p>line2</p>"));

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/html/HtmlHelper.java
@@ -113,6 +113,9 @@ public class HtmlHelper {
     // character references
     s = BEANS.get(HtmlEntities.class).unescapeAll(s);
 
+    // convert non-breaking spaces to normal spaces
+    s = s.replaceAll("\u00A0", " ");
+
     return s;
   }
 


### PR DESCRIPTION
Although preserving non-breaking-spaces (U+00A0) would be technically correct, it seems to run against user expectations. Therefore, the HtmlHelper and the PlainTextEncoder now convert nbsp characters to normal spaces just before returning the result. This means, nbsp are still visible as spaces in the output (as they would be in the browser) and are not automatically compacted.

413114