### PR TITLE
Assertions: Add assertion methods without varargs to reduce allocations

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/AssertionsTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/AssertionsTest.java
@@ -15,14 +15,9 @@ import java.math.BigDecimal;
 import java.util.Date;
 
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class AssertionsTest {
-
-  @Rule
-  public ExpectedException expectedEx = ExpectedException.none();
 
   @Test
   public void testInstance() {
@@ -43,16 +38,20 @@ public class AssertionsTest {
 
   @Test
   public void testInstanceCustomMessage() {
-    expectedEx.expect(AssertionException.class);
-    expectedEx.expectMessage("custom arg1");
-    Assertions.assertInstance(new Object(), String.class, "custom {}", "arg1");
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertInstance(new Object(), String.class, "custom"));
+    assertEquals("Assertion error: custom", e.getMessage());
+  }
+
+  @Test
+  public void testInstanceCustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertInstance(new Object(), String.class, "custom {}", "arg1"));
+    assertEquals("Assertion error: custom arg1", e.getMessage());
   }
 
   @Test
   public void testInstanceCustomMessageNullValue() {
-    expectedEx.expect(AssertionException.class);
-    expectedEx.expectMessage("custom arg1");
-    Assertions.assertInstance(null, String.class, "custom {}", "arg1");
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertInstance(null, String.class, "custom {}", "arg1"));
+    assertEquals("Assertion error: custom arg1", e.getMessage());
   }
 
   @Test
@@ -79,9 +78,14 @@ public class AssertionsTest {
 
   @Test
   public void testTypeCustomMessage() {
-    expectedEx.expect(AssertionException.class);
-    expectedEx.expectMessage("custom arg1");
-    Assertions.assertType(new Object(), String.class, "custom {}", "arg1");
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertType(new Object(), String.class, "custom"));
+    assertEquals("Assertion error: custom", e.getMessage());
+  }
+
+  @Test
+  public void testTypeCustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertType(new Object(), String.class, "custom {}", "arg1"));
+    assertEquals("Assertion error: custom arg1", e.getMessage());
   }
 
   @Test
@@ -101,50 +105,54 @@ public class AssertionsTest {
   }
 
   @Test
+  public void testNotNullCustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotNull(null, "custom"));
+    assertEquals("Assertion error: custom", e.getMessage());
+  }
+
+  @Test
+  public void testNotNullCustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotNull(null, "custom {}", "arg1"));
+    assertEquals("Assertion error: custom arg1", e.getMessage());
+  }
+
+  @Test
   public void testNotNullOrEmpty_Positive() {
     assertEquals("NOT-NULL", Assertions.assertNotNullOrEmpty("NOT-NULL"));
   }
 
-  @Test
+  @Test(expected = AssertionException.class)
   public void testNotNullOrEmpty_Negative1() {
-    // Verify 'NULL'
-    try {
-      Assertions.assertNotNullOrEmpty(null);
-      fail();
-    }
-    catch (AssertionException e) {
-      // NOOP
-    }
+    Assertions.assertNotNullOrEmpty(null);
+  }
 
-    // Verify 'empty'
-    try {
-      Assertions.assertNotNullOrEmpty("");
-      fail();
-    }
-    catch (AssertionException e) {
-      // NOOP
-    }
+  @Test(expected = AssertionException.class)
+  public void testNotNullOrEmpty_Negative2() {
+    Assertions.assertNotNullOrEmpty("");
   }
 
   @Test
-  public void testNotNullOrEmpty_Negative2() {
-    // Verify 'NULL'
-    try {
-      Assertions.assertNotNullOrEmpty(null, "failure");
-      fail();
-    }
-    catch (AssertionException e) {
-      // NOOP
-    }
+  public void testNotNullOrEmpty_Negative1_CustomMessage() {
+    AssertionException e1 = assertThrows(AssertionException.class, () -> Assertions.assertNotNullOrEmpty(null, "failure"));
+    assertEquals("Assertion error: failure", e1.getMessage());
+  }
 
-    // Verify 'empty'
-    try {
-      Assertions.assertNotNullOrEmpty("", "failure");
-      fail();
-    }
-    catch (AssertionException e) {
-      // NOOP
-    }
+  @Test
+  public void testNotNullOrEmpty_Negative2_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotNullOrEmpty("", "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testNotNullOrEmpty_Negative1_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotNullOrEmpty(null, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
+  }
+
+  @Test
+  public void testNotNullOrEmpty_Negative2_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotNullOrEmpty("", "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
   }
 
   @Test
@@ -158,6 +166,18 @@ public class AssertionsTest {
   }
 
   @Test
+  public void testTrue_Negative_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertTrue(false, "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testTrue_Negative_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertTrue(false, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
+  }
+
+  @Test
   public void testFalse_Positive() {
     assertFalse(Assertions.assertFalse(false));
   }
@@ -168,13 +188,37 @@ public class AssertionsTest {
   }
 
   @Test
-  public void testNull_positive() {
+  public void testFalse_Negative_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertFalse(true, "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testFalse_Negative_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertFalse(true, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
+  }
+
+  @Test
+  public void testNull_Positive() {
     assertNull(Assertions.assertNull(null));
   }
 
   @Test(expected = AssertionException.class)
-  public void testNull_negative() {
+  public void testNull_Negative() {
     Assertions.assertNull(new Object());
+  }
+
+  @Test
+  public void testNull_Negative_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNull(new Object(), "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testNull_Negative_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNull(new Object(), "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
   }
 
   @Test
@@ -193,6 +237,18 @@ public class AssertionsTest {
   }
 
   @Test
+  public void testLess_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertLess(1, 0, "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testLess_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertLess(1, 0, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
+  }
+
+  @Test
   public void testLessOrEqual1() {
     assertEquals(1, Assertions.assertLessOrEqual(1, 2).intValue());
   }
@@ -205,6 +261,18 @@ public class AssertionsTest {
   @Test(expected = AssertionException.class)
   public void testLessOrEqual3() {
     Assertions.assertLessOrEqual(1, 0);
+  }
+
+  @Test
+  public void testLessOrEqual_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertLessOrEqual(1, 0, "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testLessOrEqual_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertLessOrEqual(1, 0, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
   }
 
   @Test(expected = AssertionException.class)
@@ -222,6 +290,18 @@ public class AssertionsTest {
     assertEquals(1, Assertions.assertGreater(1, 0).intValue());
   }
 
+  @Test
+  public void testGreater_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertGreater(1, 2, "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testGreater_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertGreater(1, 2, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
+  }
+
   @Test(expected = AssertionException.class)
   public void testGreaterOrEqual1() {
     Assertions.assertGreaterOrEqual(1, 2);
@@ -235,6 +315,18 @@ public class AssertionsTest {
   @Test
   public void testGreaterOrEqual3() {
     assertEquals(1, Assertions.assertGreaterOrEqual(1, 0).intValue());
+  }
+
+  @Test
+  public void testGreaterOrEqual_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertGreaterOrEqual(1, 2, "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testGreaterOrEqual_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertGreaterOrEqual(1, 2, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
   }
 
   @Test(expected = AssertionException.class)
@@ -253,6 +345,18 @@ public class AssertionsTest {
   }
 
   @Test
+  public void testEqual_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertEqual(1, 0, "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testEqual_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertEqual(1, 0, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
+  }
+
+  @Test
   public void testEquals1() {
     assertEquals("value", Assertions.assertEquals("value", "value"));
   }
@@ -260,6 +364,18 @@ public class AssertionsTest {
   @Test(expected = AssertionException.class)
   public void testEquals2() {
     Assertions.assertEquals("value", "something other");
+  }
+
+  @Test
+  public void testEquals_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertEquals("value", "something other", "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testEquals_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertEquals("value", "something other", "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
   }
 
   @Test(expected = AssertionException.class)
@@ -273,6 +389,18 @@ public class AssertionsTest {
   }
 
   @Test
+  public void testNotEquals_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotEquals("value", "value", "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testNotEquals_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotEquals("value", "value", "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
+  }
+
+  @Test
   public void testSame() {
     Object object = new Object();
     assertSame(object, Assertions.assertSame(object, object));
@@ -281,6 +409,18 @@ public class AssertionsTest {
   @Test(expected = AssertionException.class)
   public void testSame2() {
     Assertions.assertSame(new Object(), new Object());
+  }
+
+  @Test
+  public void testSame_CustomMessage() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertSame(new Object(), new Object(), "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testSame_CustomMessageWithArgs() {
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertSame(new Object(), new Object(), "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
   }
 
   @Test(expected = AssertionException.class)
@@ -296,6 +436,20 @@ public class AssertionsTest {
   }
 
   @Test
+  public void testNotSame_CustomMessage() {
+    Object object = new Object();
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotSame(object, object, "failure"));
+    assertEquals("Assertion error: failure", e.getMessage());
+  }
+
+  @Test
+  public void testNotSame_CustomMessageWithArgs() {
+    Object object = new Object();
+    AssertionException e = assertThrows(AssertionException.class, () -> Assertions.assertNotSame(object, object, "failure {}", "arg1"));
+    assertEquals("Assertion error: failure arg1", e.getMessage());
+  }
+
+  @Test
   public void testFail() {
     // 1. Test with simple message
     try {
@@ -306,7 +460,7 @@ public class AssertionsTest {
       assertEquals("Assertion error: failure", e.getMessage());
     }
 
-    // 2. Test with message with message arguments
+    // 2. Test with message and message arguments
     try {
       Assertions.fail("failure [{}, {}]", "A", "B");
       fail();

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/exception/PlatformException.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/exception/PlatformException.java
@@ -32,6 +32,13 @@ public class PlatformException extends RuntimeException implements IThrowableWit
   private final List<String> m_contextInfos = new ArrayList<>();
 
   /**
+   * Creates a {@link PlatformException} with a simple message without message arguments.
+   */
+  public PlatformException(final String message) {
+    super(message, null);
+  }
+
+  /**
    * Creates a {@link PlatformException} from the given message.
    * <p>
    * Optionally, <em>formatting anchors</em> in the form of {} pairs can be used in the message, which will be replaced

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/Assertions.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/Assertions.java
@@ -41,6 +41,24 @@ public final class Assertions {
    * @param value
    *     the value to be tested.
    * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return the given value if <code>null</code>.
+   * @throws AssertionException
+   *     if the given value is not <code>null</code>.
+   */
+  public static <T> T assertNull(final T value, final String msg) {
+    if (value != null) {
+      fail(msg);
+    }
+    return value;
+  }
+
+  /**
+   * Asserts the given value to be <code>null</code>.
+   *
+   * @param value
+   *     the value to be tested.
+   * @param msg
    *     message if the assertion fails, with support for <em>formatting anchors</em> in the form of {} pairs.
    * @param msgArgs
    *     optional arguments to substitute <em>formatting anchors</em> in the message.
@@ -66,6 +84,24 @@ public final class Assertions {
    */
   public static <T> T assertNotNull(final T value) {
     return assertNotNull(value, "expected 'non-null' object but was 'null'");
+  }
+
+  /**
+   * Asserts the given value not to be <code>null</code>.
+   *
+   * @param value
+   *     the value to be tested.
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return the given value if not <code>null</code>.
+   * @throws AssertionException
+   *     if the given value is <code>null</code>.
+   */
+  public static <T> T assertNotNull(final T value, final String msg) {
+    if (value == null) {
+      fail(msg);
+    }
+    return value;
   }
 
   /**
@@ -113,6 +149,24 @@ public final class Assertions {
    * @param value
    *     the value to be tested.
    * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return the given value if not <code>null</code> or <code>empty</code>.
+   * @throws AssertionException
+   *     if the given value is <code>null</code> or <code>empty</code>.
+   */
+  public static String assertNotNullOrEmpty(final String value, final String msg) {
+    if (value == null || value.isEmpty()) {
+      fail(msg);
+    }
+    return value;
+  }
+
+  /**
+   * Asserts the given value not to be <code>null</code> or <code>empty</code>.
+   *
+   * @param value
+   *     the value to be tested.
+   * @param msg
    *     message if the assertion fails, with support for <em>formatting anchors</em> in the form of {} pairs.
    * @param msgArgs
    *     optional arguments to substitute <em>formatting anchors</em> in the message.
@@ -138,6 +192,24 @@ public final class Assertions {
    */
   public static boolean assertTrue(final boolean value) {
     return assertTrue(value, "expected 'true' but was 'false'.");
+  }
+
+  /**
+   * Asserts the given value to be <code>true</code>.
+   *
+   * @param value
+   *     the value to be tested.
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return always <code>true</code>.
+   * @throws AssertionException
+   *     if the given value is <code>false</code>.
+   */
+  public static boolean assertTrue(final boolean value, final String msg) {
+    if (!value) {
+      fail(msg);
+    }
+    return value;
   }
 
   /**
@@ -179,6 +251,24 @@ public final class Assertions {
    * @param value
    *     the value to be tested.
    * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return always <code>false</code>.
+   * @throws AssertionException
+   *     if the given value is <code>true</code>.
+   */
+  public static boolean assertFalse(final boolean value, final String msg) {
+    if (value) {
+      fail(msg);
+    }
+    return value;
+  }
+
+  /**
+   * Asserts the given value to be <code>false</code>.
+   *
+   * @param value
+   *     the value to be tested.
+   * @param msg
    *     message if the assertion fails, with support for <em>formatting anchors</em> in the form of {} pairs.
    * @param msgArgs
    *     optional arguments to substitute <em>formatting anchors</em> in the message.
@@ -206,6 +296,26 @@ public final class Assertions {
    */
   public static <T> T assertEquals(final T value1, final Object value2) {
     return assertEquals(value1, value2, "expected value1 to be equals with value2 [value1={}, value2={}]", value1, value2);
+  }
+
+  /**
+   * Asserts <code>value1</code> to be equals with <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if equals with <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is not equals with <code>value2</code>.
+   */
+  public static <T> T assertEquals(final T value1, final Object value2, final String msg) {
+    if (ObjectUtility.notEquals(value1, value2)) {
+      fail(msg);
+    }
+    return value1;
   }
 
   /**
@@ -253,6 +363,26 @@ public final class Assertions {
    * @param value2
    *     the value to be tested against.
    * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if not equals with <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is equals with <code>value2</code>.
+   */
+  public static <T> T assertNotEquals(final T value1, final Object value2, final String msg) {
+    if (ObjectUtility.equals(value1, value2)) {
+      fail(msg);
+    }
+    return value1;
+  }
+
+  /**
+   * Asserts <code>value1</code> not to be equal with <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
    *     message if the assertion fails, with support for <em>formatting anchors</em> in the form of {} pairs.
    * @param msgArgs
    *     optional arguments to substitute <em>formatting anchors</em> in the message.
@@ -280,6 +410,26 @@ public final class Assertions {
    */
   public static <T> T assertSame(final T value1, final Object value2) {
     return assertSame(value1, value2, "expected value1 to be equals with value2 [value1={}, value2={}]", value1, value2);
+  }
+
+  /**
+   * Asserts <code>value1</code> to be same as <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if same as <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is not same as <code>value2</code>.
+   */
+  public static <T> T assertSame(final T value1, final Object value2, final String msg) {
+    if (value1 != value2) { //NOSONAR
+      fail(msg);
+    }
+    return value1;
   }
 
   /**
@@ -327,6 +477,26 @@ public final class Assertions {
    * @param value2
    *     the value to be tested against.
    * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if not same as <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is same as <code>value2</code>.
+   */
+  public static <T> T assertNotSame(final T value1, final Object value2, final String msg) {
+    if (value1 == value2) { //NOSONAR
+      fail(msg);
+    }
+    return value1;
+  }
+
+  /**
+   * Asserts <code>value1</code> not to be same as <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
    *     message if the assertion fails, with support for <em>formatting anchors</em> in the form of {} pairs.
    * @param msgArgs
    *     optional arguments to substitute <em>formatting anchors</em> in the message.
@@ -354,6 +524,26 @@ public final class Assertions {
    */
   public static <T extends Comparable<T>> T assertEqual(final T value1, final T value2) {
     return assertEqual(value1, value2, "expected value1 to be equals with value2 [value1={}, value2={}]", value1, value2);
+  }
+
+  /**
+   * Asserts <code>value1</code> to be equal <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if equal <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is not equal <code>value2</code>.
+   */
+  public static <T extends Comparable<T>> T assertEqual(final T value1, final T value2, final String msg) {
+    if (value1.compareTo(value2) != 0) {
+      fail(msg);
+    }
+    return value1;
   }
 
   /**
@@ -401,6 +591,26 @@ public final class Assertions {
    * @param value2
    *     the value to be tested against.
    * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if greater <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is not greater <code>value2</code>.
+   */
+  public static <T extends Comparable<T>> T assertGreater(final T value1, final T value2, final String msg) {
+    if (value1.compareTo(value2) <= 0) {
+      fail(msg);
+    }
+    return value1;
+  }
+
+  /**
+   * Asserts <code>value1</code> to be greater <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
    *     message if the assertion fails, with support for <em>formatting anchors</em> in the form of {} pairs.
    * @param msgArgs
    *     optional arguments to substitute <em>formatting anchors</em> in the message.
@@ -428,6 +638,26 @@ public final class Assertions {
    */
   public static <T extends Comparable<T>> T assertGreaterOrEqual(final T value1, final T value2) {
     return assertGreaterOrEqual(value1, value2, "expected value1 to be '>=' value2 [value1={}, value2={}]", value1, value2);
+  }
+
+  /**
+   * Asserts <code>value1</code> to be greater or equal <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if greater or equal <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is not greater or equal <code>value2</code>.
+   */
+  public static <T extends Comparable<T>> T assertGreaterOrEqual(final T value1, final T value2, final String msg) {
+    if (value1.compareTo(value2) < 0) {
+      fail(msg);
+    }
+    return value1;
   }
 
   /**
@@ -475,6 +705,26 @@ public final class Assertions {
    * @param value2
    *     the value to be tested against.
    * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if less <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is not less <code>value2</code>.
+   */
+  public static <T extends Comparable<T>> T assertLess(final T value1, final T value2, final String msg) {
+    if (value1.compareTo(value2) >= 0) {
+      fail(msg);
+    }
+    return value1;
+  }
+
+  /**
+   * Asserts <code>value1</code> to be less <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
    *     message if the assertion fails, with support for <em>formatting anchors</em> in the form of {} pairs.
    * @param msgArgs
    *     optional arguments to substitute <em>formatting anchors</em> in the message.
@@ -502,6 +752,26 @@ public final class Assertions {
    */
   public static <T extends Comparable<T>> T assertLessOrEqual(final T value1, final T value2) {
     return assertLessOrEqual(value1, value2, "expected value1 to be '<=' value2 [value1={}, value2={}]", value1, value2);
+  }
+
+  /**
+   * Asserts <code>value1</code> to be less or equal <code>value2</code>.
+   *
+   * @param value1
+   *     the value to be tested.
+   * @param value2
+   *     the value to be tested against.
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value1</code> if less or equal <code>value2</code>.
+   * @throws AssertionException
+   *     if <code>value1</code> is not less or equal <code>value2</code>.
+   */
+  public static <T extends Comparable<T>> T assertLessOrEqual(final T value1, final T value2, final String msg) {
+    if (value1.compareTo(value2) > 0) {
+      fail(msg);
+    }
+    return value1;
   }
 
   /**
@@ -541,6 +811,28 @@ public final class Assertions {
    */
   public static <T> T assertInstance(final Object value, final Class<T> clazz) {
     return assertInstance(value, clazz, "expected 'value' to be an instance of 'class' [value={}, class={}]", value, clazz);
+  }
+
+  /**
+   * Asserts <code>value</code> to be an instance of <code>clazz</code>. A <code>null</code> value is not instance of
+   * any type, therefore an {@link AssertionException} is thrown for value <code>null</code>.
+   *
+   * @param value
+   *     object to be tested.
+   * @param clazz
+   *     class to be tested against.
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value</code>, if it is an instance of <code>clazz</code>
+   * @throws AssertionException
+   *     if <code>value</code> is not an instance of <code>clazz</code>
+   * @see #assertType(Object, Class, String, Object...)}
+   */
+  public static <T> T assertInstance(final Object value, final Class<T> clazz, final String msg) {
+    if (!clazz.isInstance(value)) {
+      fail(msg);
+    }
+    return clazz.cast(value);
   }
 
   /**
@@ -593,6 +885,28 @@ public final class Assertions {
    * @param clazz
    *     class to be tested against.
    * @param msg
+   *     message if the assertion fails, without message arguments.
+   * @return <code>value</code>, if it is of type <code>clazz</code>
+   * @throws AssertionException
+   *     if <code>value</code> is not of type <code>clazz</code>
+   * @see #assertInstance(Object, Class, String, Object...)}
+   */
+  public static <T> T assertType(final Object value, final Class<T> clazz, final String msg) {
+    if (value == null) {
+      return null;
+    }
+    return assertInstance(value, clazz, msg);
+  }
+
+  /**
+   * Asserts <code>value</code> to be of type <code>clazz</code>. A <code>null</code> value may be of any type,
+   * therefore no {@link AssertionException} is thrown for value <code>null</code>.
+   *
+   * @param value
+   *     object to be tested.
+   * @param clazz
+   *     class to be tested against.
+   * @param msg
    *     message if the assertion fails, with support for <em>formatting anchors</em> in the form of {} pairs.
    * @param msgArgs
    *     optional arguments to substitute <em>formatting anchors</em> in the message.
@@ -606,6 +920,16 @@ public final class Assertions {
       return null;
     }
     return assertInstance(value, clazz, msg, msgArgs);
+  }
+
+  /**
+   * To always throw an {@code AssertionException}.
+   *
+   * @param msg
+   *     message if the assertion fails, without message arguments.
+   */
+  public static <T> T fail(final String msg) {
+    throw new AssertionException("Assertion error: " + msg);
   }
 
   /**
@@ -626,6 +950,10 @@ public final class Assertions {
   public static class AssertionException extends PlatformException {
 
     private static final long serialVersionUID = 1L;
+
+    public AssertionException(final String msg) {
+      super(msg);
+    }
 
     public AssertionException(final String msg, final Object... msgArgs) {
       super(msg, msgArgs);


### PR DESCRIPTION
Add new assertion method variants (e.g., `assertNull`) that accept a plain message string without varargs. This avoids unnecessary object allocations when no message formatting is needed, improving performance in common use cases.

These methods preserve the original behavior while providing a more efficient option for static messages.

431962