### PR TITLE
Table: improve alignment of aggregate symbols

### DIFF
--- a/eclipse-scout-core/src/style/sizes.less
+++ b/eclipse-scout-core/src/style/sizes.less
@@ -297,7 +297,7 @@
 @tab-item-title-padding-bottom: @group-box-title-padding-bottom;
 @tab-item-title-padding-top: @group-box-title-padding-top;
 @tab-item-title-margin-top: @group-box-header-margin-top;
-@table-aggregate-cell-font-icon-line-height: 14px;
+@table-aggregate-cell-font-icon-line-height: normal;
 @table-aggregate-sum-avg-font-icon-size: 13px;
 @table-aggregate-min-max-font-icon-size: 15px;
 @table-aggregate-row-font-size: @font-size-smaller;

--- a/eclipse-scout-core/src/table/Table.less
+++ b/eclipse-scout-core/src/table/Table.less
@@ -523,6 +523,7 @@
     color: @text-color;
     vertical-align: middle;
     line-height: @table-aggregate-cell-font-icon-line-height;
+    min-width: auto;
   }
 
   &.sum > .table-cell-icon,


### PR DESCRIPTION
Since table cell icons now have a min-width, some aggregate symbols (avg and sum) have too much space to the number.

The icon is too large with 125% zoom which increases the height of the aggregate row and makes the alignment with the number harder.

It is not possible to set a correct line-height because the height of the text depends on the zoom-level. A line-height is actually not necessary because vertical-align is set to middle. Regular cell icons have a line height because they are aligned top which is important for multiline text.

433066