### PR TITLE
Form: open() should always activate form

### DIFF
--- a/eclipse-scout-core/src/desktop/Desktop.ts
+++ b/eclipse-scout-core/src/desktop/Desktop.ts
@@ -9,8 +9,7 @@
  */
 import {
   AbstractLayout, Action, arrays, BenchColumnLayoutData, BusyIndicatorOptions, BusySupport, cookies, DeferredGlassPaneTarget, DesktopBench, DesktopEventMap, DesktopFormController, DesktopHeader, DesktopLayout, DesktopModel,
-  DesktopNavigation, DesktopNotification, Device, DisableBrowserF5ReloadKeyStroke, DisableBrowserTabSwitchingKeyStroke, DisplayChild, DisplayParent, DisplayViewId, EnumObject, Event, EventEmitter, EventHandler, FileChooser,
-  FileChooserController, Form,
+  DesktopNavigation, DesktopNotification, Device, DisableBrowserF5ReloadKeyStroke, DisableBrowserTabSwitchingKeyStroke, DisplayParent, DisplayViewId, EnumObject, Event, EventEmitter, EventHandler, FileChooser, FileChooserController, Form,
   GlassPaneTarget, HtmlComponent, HtmlEnvironment, InitModelOf, KeyStrokeContext, Menu, MessageBox, MessageBoxController, NativeNotificationVisibility, ObjectIdProvider, ObjectOrChildModel, ObjectOrModel, objects,
   OfflineDesktopNotification, OpenUriHandler, Outline, OutlineContent, OutlineViewButton, Popup, ReloadPageOptions, ResponsiveHandler, scout, SimpleTabArea, SimpleTabBox, Splitter, SplitterMoveEndEvent, SplitterMoveEvent,
   SplitterPositionChangeEvent, strings, styles, Tooltip, Tree, TreeDisplayStyle, UnsavedFormChangesForm, URL, ViewButton, webstorage, Widget, widgets
@@ -1193,7 +1192,7 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
     let displayParent: DisplayParent = form.displayParent || this;
     form.setDisplayParent(displayParent);
 
-    this._setFormActivated(form);
+    this.activateForm(form);
     // register listener to recover active form when child dialog is removed
     displayParent.formController.registerAndRender(form, position, true);
   }
@@ -1319,6 +1318,9 @@ export class Desktop extends Widget implements DesktopModel, DisplayParent {
    * Only one form can be active at once. The currently active form is reflected by {@link activeForm}.
    */
   activateForm(form: Form) {
+    if (this.activeForm === form) {
+      return;
+    }
     let displayParent = form?.displayParent || this;
     displayParent.formController.activateForm(form);
   }

--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -982,9 +982,6 @@ export class Form extends Widget implements FormModel, DisplayParent {
   }
 
   protected _onDialogMouseDown() {
-    if (this.session.desktop.activeForm === this) {
-      return;
-    }
     this.activate();
   }
 

--- a/eclipse-scout-core/test/desktop/DesktopSpec.ts
+++ b/eclipse-scout-core/test/desktop/DesktopSpec.ts
@@ -1229,7 +1229,7 @@ describe('Desktop', () => {
       expect(desktopOverlayHtmlElements()).toEqual(widgetHtmlElements([dialog0]));
     });
 
-    it('is called on form mousedown but only once', async () => {
+    it('is called on form mousedown', async () => {
       let dialog = formHelper.createFormWithOneField({
         modal: false
       });
@@ -1240,9 +1240,23 @@ describe('Desktop', () => {
       let spy = spyOn(desktop, 'activateForm').and.callThrough();
       JQueryTesting.triggerMouseDownCapture(dialog.$container);
       expect(desktop.activeForm).toBe(dialog);
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('does nothing if the form is already active', async () => {
+      let dialog = formHelper.createFormWithOneField({
+        modal: false
+      });
+      await dialog.open();
+      session.desktop.activateForm(null);
+      expect(desktop.activeForm).toBe(null);
+
+      let spy = spyOn(desktop.formController, 'activateForm').and.callThrough();
+      desktop.activateForm(dialog);
+      expect(desktop.activeForm).toBe(dialog);
       expect(spy.calls.count()).toBe(1);
 
-      JQueryTesting.triggerMouseDownCapture(dialog.$container);
+      desktop.activateForm(dialog);
       expect(desktop.activeForm).toBe(dialog);
       expect(spy.calls.count()).toBe(1);
     });
@@ -1446,6 +1460,21 @@ describe('Desktop', () => {
       expect(dialog.rendered).toBe(true);
       expect(desktop.activeForm).toBe(dialog);
     });
+
+    it('will be set to the form that was just opened even if display parent is outline', async () => {
+      let outline = outlineHelper.createOutlineWithOneDetailForm();
+      let form = formHelper.createViewWithOneField({displayParent: outline});
+      expect(desktop.outline).toBe(null);
+      expect(desktop.activeForm).toBe(null);
+
+      await form.open();
+      expect(desktop.outline).toBe(outline);
+      expect(desktop.activeForm).toBe(form);
+
+      form.close();
+      expect(desktop.outline).toBe(outline);
+      expect(desktop.activeForm).toBe(null);
+    });
   });
 
   describe('createFormExclusive', () => {
@@ -1537,6 +1566,7 @@ describe('Desktop', () => {
       let outline = outlineHelper.createOutlineWithOneDetailForm();
       let form = session.desktop.createFormExclusive(() => formHelper.createViewWithOneField({displayParent: outline}), 5);
       await form.open();
+      expect(session.desktop.activeForm).toBe(form);
 
       // Should only activate form
       let form2 = session.desktop.createFormExclusive(() => formHelper.createViewWithOneField(), 5);


### PR DESCRIPTION
If the display parent of a form is an inactive outline, form.open() does not show the form and does not set the form as activeForm on the desktop.
However, calling form.open() again activates the form which will select the outline and set the form as activeForm on the desktop. -> The first call should already do that.

Also, activateForm should do nothing if the form is already active.

431068