### PR TITLE
Improve preserveAndSetProperty

### DIFF
--- a/eclipse-scout-core/src/form/fields/groupbox/GroupBox.ts
+++ b/eclipse-scout-core/src/form/fields/groupbox/GroupBox.ts
@@ -84,7 +84,6 @@ export class GroupBox extends CompositeField implements GroupBoxModel {
     this.$body = null;
     this.$title = null;
     this.$subLabel = null;
-    this._statusPositionOrig = null;
   }
 
   static BorderDecoration = {

--- a/eclipse-scout-core/src/form/fields/tabbox/TabBox.ts
+++ b/eclipse-scout-core/src/form/fields/tabbox/TabBox.ts
@@ -44,7 +44,6 @@ export class TabBox extends CompositeField implements TabBoxModel {
     this.tabAreaStyle = TabArea.DisplayStyle.DEFAULT;
 
     this._$tabContent = null;
-    this._statusPositionOrig = null;
     this._addWidgetProperties(['tabItems', 'selectedTab']);
     this._addPreserveOnPropertyChangeProperties(['selectedTab']);
 

--- a/eclipse-scout-core/src/popup/Popup.ts
+++ b/eclipse-scout-core/src/popup/Popup.ts
@@ -78,7 +78,6 @@ export class Popup extends Widget implements PopupModel {
     this.windowPaddingX = 10;
     this.windowPaddingY = 5;
     this.withGlassPane = false;
-    this._withGlassPane = null;
     this.withFocusContext = true;
     this.initialFocus = () => FocusRule.AUTO;
     this.focusableContainer = false;
@@ -95,11 +94,8 @@ export class Popup extends Widget implements PopupModel {
     this.boundToAnchor = true;
     this.withArrow = false;
     this.closeOnAnchorMouseDown = true;
-    this._closeOnAnchorMouseDown = null;
     this.closeOnMouseDownOutside = true;
-    this._closeOnMouseDownOutside = null;
     this.closeOnOtherPopupOpen = true;
-    this._closeOnOtherPopupOpen = null;
     this.modal = false;
     this._openLater = false;
 

--- a/eclipse-scout-core/src/widget/widgets.ts
+++ b/eclipse-scout-core/src/widget/widgets.ts
@@ -62,9 +62,11 @@ export const widgets = {
   /**
    * Sets a property using the given setter after reading the value using the getter and preserving it on the preserver using the preserverName.
    * The preserved property can be reset using {@link resetProperty}.
+   *
+   * *Note*: The property will only be preserved if the preserved property is undefined, so it must not be initialized to null or any other value.
    */
   preserveAndSetProperty(setter: () => void, getter: () => any, preserver: object, preserverName: string) {
-    if (preserver[preserverName] === null) {
+    if (preserver[preserverName] === undefined) {
       preserver[preserverName] = getter();
     }
     setter();
@@ -72,14 +74,11 @@ export const widgets = {
 
   /**
    * Resets a property that has been preserved on the preserver by {@link preserveAndSetProperty} using the given setter. Sets the preserved property to null afterward.
-   * @param setter
-   * @param preserver
-   * @param preserverName
    */
   resetProperty(setter: (value) => void, preserver: object, preserverName: string) {
-    if (preserver[preserverName] != null) {
+    if (preserver[preserverName] !== undefined) {
       setter(preserver[preserverName]);
-      preserver[preserverName] = null;
+      preserver[preserverName] = undefined;
     }
   }
 };

--- a/eclipse-scout-core/test/util/widgetsSpec.ts
+++ b/eclipse-scout-core/test/util/widgetsSpec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {scout, StringField, widgets} from '../../src';
+
+describe('widgets', () => {
+  let session: SandboxSession;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+  });
+
+  describe('preserveAndSetProperty', () => {
+    it('preserves and sets the property that can be reset using resetProperty', () => {
+      let field = scout.create(StringField, {parent: session.desktop});
+      expect(field.updateDisplayTextOnModifyDelay).toBe(250);
+      expect(field['__spec.updateDisplayTextOnModifyDelay']).toBeUndefined();
+
+      widgets.preserveAndSetProperty(() => field.setUpdateDisplayTextOnModifyDelay(500), () => field.updateDisplayTextOnModifyDelay, field, '__spec.updateDisplayTextOnModifyDelay');
+      expect(field.updateDisplayTextOnModifyDelay).toBe(500);
+      expect(field['__spec.updateDisplayTextOnModifyDelay']).toBe(250);
+
+      field.setUpdateDisplayTextOnModifyDelay(800);
+      expect(field.updateDisplayTextOnModifyDelay).toBe(800);
+      expect(field['__spec.updateDisplayTextOnModifyDelay']).toBe(250);
+
+      widgets.resetProperty((preservedValue: number) => field.setUpdateDisplayTextOnModifyDelay(preservedValue), field, '__spec.updateDisplayTextOnModifyDelay');
+      expect(field.updateDisplayTextOnModifyDelay).toBe(250);
+      expect(field['__spec.updateDisplayTextOnModifyDelay']).toBeUndefined();
+    });
+
+    it('can preserve null', () => {
+      let field = scout.create(StringField, {parent: session.desktop});
+      expect(field.value).toBe(null);
+      expect(field['__spec.value']).toBeUndefined();
+
+      widgets.preserveAndSetProperty(() => field.setValue('abc'), () => field.value, field, '__spec.value');
+      expect(field.value).toBe('abc');
+      expect(field['__spec.value']).toBe(null);
+
+      field.setValue('zzz');
+      expect(field.value).toBe('zzz');
+      expect(field['__spec.value']).toBe(null);
+
+      widgets.resetProperty((preservedValue: string) => field.setValue(preservedValue), field, '__spec.value');
+      expect(field.value).toBe(null);
+      expect(field['__spec.value']).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
The function only works if the preserved value is initialized to null. This is not intuitive and does not work if the value should be preserved without adjusting the preserver.
Also, it is not possible to preserve null values.

The function now expects the preserved value to be undefined initially.

Migration: if the member that holds the preserved value was initialized with null, remove the initialization so it will be initialized with undefined.

428304