### PR TITLE
RestRequestCancellationRegistry: Do not keep threads interrupted

### DIFF
--- a/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/cancellation/RestRequestCancellationRegistryTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/cancellation/RestRequestCancellationRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@ import static org.junit.Assert.*;
 
 import org.eclipse.scout.rt.dataobject.exception.AccessForbiddenException;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.context.RunMonitor;
 import org.eclipse.scout.rt.platform.holders.ObjectHolder;
 import org.eclipse.scout.rt.platform.holders.StringHolder;
@@ -107,9 +108,17 @@ public class RestRequestCancellationRegistryTest {
     assertFalse(m_registry.cancel("1", null));
     assertFalse(m_runMonitor.isCancelled());
 
-    assertNotNull(m_registry.register("1", null, m_runMonitor));
-    assertTrue(m_registry.cancel("1", null));
-    assertTrue(m_runMonitor.isCancelled());
+    IRegistrationHandle otherHandle = m_registry.register("1", null, m_runMonitor);
+    assertNotNull(otherHandle);
+    RunContexts.empty().withRunMonitor(m_runMonitor).run(() -> {
+      assertTrue(m_registry.cancel("1", null));
+      assertTrue(m_runMonitor.isCancelled());
+
+      // reset interruption state on dispose
+      assertTrue(Thread.currentThread().isInterrupted());
+      otherHandle.dispose();
+      assertFalse(Thread.currentThread().isInterrupted());
+    });
   }
 
   @Test

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/cancellation/RestRequestCancellationRegistry.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/cancellation/RestRequestCancellationRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -52,7 +52,13 @@ public class RestRequestCancellationRegistry {
       return null;
     }
 
-    return () -> cancellationInfos.remove(requestId);
+    return () -> {
+      RequestCancellationInfo info = cancellationInfos.remove(requestId);
+      if (info != null && info.getRunMonitor().isCancelled() && Thread.interrupted()) {
+        // as thread may be used by other operations as well; interrupted state must be reset after previous interruption
+        LOG.trace("Reset interrupted state for cancelled and interrupted request {}", requestId);
+      }
+    };
   }
 
   public boolean cancel(String requestId, Object userId) {


### PR DESCRIPTION
We interrupt these threads to cancel an action however the threads may be reused by other actions (e.g. Jetty thread pooling); interrupted state should be reset on disposal.

372827
425245