### PR TITLE
IRestResource: Content type text/html with charset UTF-8

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/RestClientTestEchoServlet.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/RestClientTestEchoServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,7 @@ import org.eclipse.scout.rt.platform.util.IOUtility;
 import org.eclipse.scout.rt.platform.util.IRegistrationHandle;
 import org.eclipse.scout.rt.platform.util.SleepUtil;
 import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.rest.IRestResource;
 import org.eclipse.scout.rt.rest.error.ErrorDo;
 import org.eclipse.scout.rt.rest.error.ErrorResponse;
 import org.slf4j.Logger;
@@ -165,7 +166,7 @@ public class RestClientTestEchoServlet extends HttpServlet {
                   HTML.div(status == null ? "unknown" : status.getReasonPhrase())))
           .toHtml();
       resp.getOutputStream().print(content);
-      resp.setContentType(MediaType.TEXT_HTML);
+      resp.setContentType(IRestResource.TEXT_HTML_UTF8);
     }
   }
 

--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/RestClientTestEchoServlet.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/RestClientTestEchoServlet.java
@@ -33,7 +33,7 @@ import org.eclipse.scout.rt.platform.util.IOUtility;
 import org.eclipse.scout.rt.platform.util.IRegistrationHandle;
 import org.eclipse.scout.rt.platform.util.SleepUtil;
 import org.eclipse.scout.rt.platform.util.StringUtility;
-import org.eclipse.scout.rt.rest.IRestResource;
+import org.eclipse.scout.rt.rest.IRestMediaType;
 import org.eclipse.scout.rt.rest.error.ErrorDo;
 import org.eclipse.scout.rt.rest.error.ErrorResponse;
 import org.slf4j.Logger;
@@ -166,7 +166,7 @@ public class RestClientTestEchoServlet extends HttpServlet {
                   HTML.div(status == null ? "unknown" : status.getReasonPhrase())))
           .toHtml();
       resp.getOutputStream().print(content);
-      resp.setContentType(IRestResource.TEXT_HTML_UTF8);
+      resp.setContentType(IRestMediaType.TEXT_HTML_UTF8);
     }
   }
 

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/IRestMediaType.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/IRestMediaType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest;
+
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Commonly used media types for Scout REST resources.
+ *
+ * @see MediaType MediaType for a set of builtin default media types.
+ */
+public interface IRestMediaType {
+
+  /**
+   * When returning responses with content type text/html, it is best practice to include a charset.
+   * Use this constant in annotation {@link Produces} instead of {@link MediaType#TEXT_HTML}.
+   */
+  String TEXT_HTML_UTF8 = "text/html;charset=UTF-8";
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/IRestResource.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/IRestResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,9 @@
  */
 package org.eclipse.scout.rt.rest;
 
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
 import org.eclipse.scout.rt.platform.Bean;
 
 /**
@@ -16,4 +19,10 @@ import org.eclipse.scout.rt.platform.Bean;
  */
 @Bean
 public interface IRestResource {
+
+  /**
+   * When returning responses with content type text/html, it is best practice to include a charset.
+   * Use this constant in annotation {@link Produces} instead of {@link MediaType#TEXT_HTML}.
+   */
+  String TEXT_HTML_UTF8 = "text/html;charset=UTF-8";
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/IRestResource.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/IRestResource.java
@@ -9,9 +9,6 @@
  */
 package org.eclipse.scout.rt.rest;
 
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
-
 import org.eclipse.scout.rt.platform.Bean;
 
 /**
@@ -19,10 +16,4 @@ import org.eclipse.scout.rt.platform.Bean;
  */
 @Bean
 public interface IRestResource {
-
-  /**
-   * When returning responses with content type text/html, it is best practice to include a charset.
-   * Use this constant in annotation {@link Produces} instead of {@link MediaType#TEXT_HTML}.
-   */
-  String TEXT_HTML_UTF8 = "text/html;charset=UTF-8";
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
@@ -72,6 +72,7 @@ import org.eclipse.scout.rt.platform.util.IOUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.date.DateUtility;
+import org.eclipse.scout.rt.rest.IRestMediaType;
 import org.eclipse.scout.rt.rest.IRestResource;
 import org.eclipse.scout.rt.rest.RestApplicationScope;
 import org.eclipse.scout.rt.rest.RestApplicationScopes;
@@ -426,7 +427,7 @@ public class ApiDocGenerator {
     // Main HTML content
     final IHtmlDocument html = toHtml(scope, getResourceDescriptors());
     return Response.ok()
-        .type(IRestResource.TEXT_HTML_UTF8)
+        .type(IRestMediaType.TEXT_HTML_UTF8)
         .entity(html.toHtml())
         .build();
   }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -426,7 +426,7 @@ public class ApiDocGenerator {
     // Main HTML content
     final IHtmlDocument html = toHtml(scope, getResourceDescriptors());
     return Response.ok()
-        .type(MediaType.TEXT_HTML)
+        .type(IRestResource.TEXT_HTML_UTF8)
         .entity(html.toHtml())
         .build();
   }


### PR DESCRIPTION
- Added constant in IRestResource for html endpoints to include the default charset UTF-8.
- Security: Including a charset is best practice. Guarantees that clients interpret the payload as UTF-8. Reduces the risk of XSS.

#434062