### PR TITLE
Tree: collapse lazy expanded nodes if all child nodes are removed

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithNodes.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithNodes.ts
@@ -54,10 +54,6 @@ export class PageWithNodes extends Page {
   }
 
   protected _onDetailTableReload(event: TableReloadEvent) {
-    if (this.expandedLazy) {
-      // If the page is expanded lazily, all child nodes will be gone -> collapse it to prevent showing the "+" icon without any child nodes
-      this.outline.setNodeExpanded(this, false);
-    }
     this.reloadPage();
   }
 

--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -160,10 +160,6 @@ export class PageWithTable extends Page implements PageWithTableModel {
   }
 
   protected _onTableReload(event: TableReloadEvent) {
-    if (this.expandedLazy) {
-      // If the page is expanded lazily, all child nodes will be gone -> collapse it to prevent showing the "+" icon without any child nodes
-      this.outline.setNodeExpanded(this, false);
-    }
     this.loadTableData(event.reloadReason);
   }
 

--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -2501,6 +2501,14 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
       this._removeNodes(deletedNodes, parentNode || parentNodesToReindex);
     }
 
+    arrays.ensure(parentNode || parentNodesToReindex).forEach(p => {
+      if (p.expandedLazy && !p.childNodes.length) {
+        // If the parent node is expanded lazy, deleting all child nodes will result in the parent node showing the "+" icon without any child nodes (even if new child nodes are inserted again).
+        // Therefore, collapse parent node as this would be confusing for the user.
+        this.setNodeExpanded(p, false);
+      }
+    });
+
     this.trigger('nodesDeleted', {
       nodes: nodes,
       parentNode: parentNode
@@ -2534,6 +2542,12 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
     // remove node from html document
     if (this.rendered) {
       this._removeNodes(nodes, parentNode);
+    }
+
+    if (parentNode?.expandedLazy) {
+      // If the parent node is expanded lazy, deleting all child nodes will result in the parent node showing the "+" icon without any child nodes (even if new child nodes are inserted again).
+      // Therefore, collapse parent node as this would be confusing for the user.
+      this.setNodeExpanded(parentNode, false);
     }
 
     this.trigger('allChildNodesDeleted', {

--- a/eclipse-scout-core/test/tree/TreeSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeSpec.ts
@@ -887,6 +887,57 @@ describe('Tree', () => {
         tree.render();
         expect(tree.calculateViewRangeSize()).toBe(4);
       });
+
+      it('collapses lazy expanded node if all child nodes were deleted', () => {
+        // smaller tree is enough for this test
+        model = helper.createModelFixture(3, 1, false);
+        tree = helper.createTree(model);
+        [node0, node1, node2] = tree.nodes;
+        node0.lazyExpandingEnabled = true;
+
+        const [node0Child0, node0Child1, node0Child2] = node0.childNodes;
+        const [node1Child0, node1Child1, node1Child2] = node1.childNodes;
+
+        // selecting a node expands its parent lazy
+        tree.selectNodes(node0Child0);
+        tree.expandNode(node1);
+
+        // node0 is expanded lazy
+        expect(node0.expanded).toBeTrue();
+        expect(node0.expandedLazy).toBeTrue();
+
+        // node1 is expanded
+        expect(node1.expanded).toBeTrue();
+        expect(node1.expandedLazy).toBeFalse();
+
+        expect(tree.visibleNodesFlat).toEqual([node0, node0Child0, node1, node1Child0, node1Child1, node1Child2, node2]);
+
+        // deleting only some of the child nodes does not collapse parents
+        tree.deleteNodes([node0Child2, node1Child2]);
+
+        // node0 is expanded lazy
+        expect(node0.expanded).toBeTrue();
+        expect(node0.expandedLazy).toBeTrue();
+
+        // node1 is expanded
+        expect(node1.expanded).toBeTrue();
+        expect(node1.expandedLazy).toBeFalse();
+
+        expect(tree.visibleNodesFlat).toEqual([node0, node0Child0, node1, node1Child0, node1Child1, node2]);
+
+        // deleting all child nodes collapses lazy expanded parents
+        tree.deleteNodes([node0Child0, node0Child1, node1Child0, node1Child1]);
+
+        // node0 is no longer expanded
+        expect(node0.expanded).toBeFalse();
+        expect(node0.expandedLazy).toBeFalse();
+
+        // node1 is still expanded
+        expect(node1.expanded).toBeTrue();
+        expect(node1.expandedLazy).toBeFalse();
+
+        expect(tree.visibleNodesFlat).toEqual([node0, node1, node2]);
+      });
     });
 
     describe('deleting a root node', () => {
@@ -1035,7 +1086,7 @@ describe('Tree', () => {
       node2 = tree.nodes[2];
       node1Child0 = node1.childNodes[0];
       node1Child1 = node1.childNodes[1];
-      node1Child2 = node1.childNodes[1];
+      node1Child2 = node1.childNodes[2];
     });
 
     it('deletes all nodes from model', () => {
@@ -1080,6 +1131,52 @@ describe('Tree', () => {
       expect(node1Child2.$node).toBe(null);
     });
 
+    it('collapses lazy expanded node', () => {
+      tree.collapseAll();
+      node0.lazyExpandingEnabled = true;
+
+      const [node0Child0] = node0.childNodes;
+
+      // selecting a node expands its parent lazy
+      tree.selectNodes(node0Child0);
+      tree.expandNode(node1);
+
+      // node0 is expanded lazy
+      expect(node0.expanded).toBeTrue();
+      expect(node0.expandedLazy).toBeTrue();
+
+      // node1 is expanded
+      expect(node1.expanded).toBeTrue();
+      expect(node1.expandedLazy).toBeFalse();
+
+      expect(tree.visibleNodesFlat).toEqual([node0, node0Child0, node1, node1Child0, node1Child1, node1Child2, node2]);
+
+      // deleting all child nodes collapses lazy expanded parents
+      tree.deleteAllChildNodes(node0);
+
+      // node0 is no longer expanded
+      expect(node0.expanded).toBeFalse();
+      expect(node0.expandedLazy).toBeFalse();
+
+      // node1 is still expanded
+      expect(node1.expanded).toBeTrue();
+      expect(node1.expandedLazy).toBeFalse();
+
+      expect(tree.visibleNodesFlat).toEqual([node0, node1, node1Child0, node1Child1, node1Child2, node2]);
+
+      // deleting all child nodes does not collapse expanded parent if it is not expanded lazy
+      tree.deleteAllChildNodes(node1);
+
+      // node0 is no longer expanded
+      expect(node0.expanded).toBeFalse();
+      expect(node0.expandedLazy).toBeFalse();
+
+      // node1 is still expanded
+      expect(node1.expanded).toBeTrue();
+      expect(node1.expandedLazy).toBeFalse();
+
+      expect(tree.visibleNodesFlat).toEqual([node0, node1, node2]);
+    });
   });
 
   describe('checkNodes', () => {

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTreeTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -527,6 +527,59 @@ public class AbstractTreeTest {
     assertEquals(2, recentEvents.size());
     assertTrue(recentEvents.contains(customEvent));
     assertTrue(recentEvents.contains(scrollToSelectionEvent));
+  }
+
+  @Test
+  public void testCollapsesLazyExpandedNodeIfAllChildNodesWereDeleted() {
+    var tree = new P_Tree();
+    var node0 = new P_TreeNode("0");
+    var node1 = new P_TreeNode("1");
+    var node0Child0 = new P_TreeNode("0_0");
+    var node0Child1 = new P_TreeNode("0_1");
+    var node0Child2 = new P_TreeNode("0_2");
+    var node1Child0 = new P_TreeNode("1_0");
+    var node1Child1 = new P_TreeNode("1_1");
+    var node1Child2 = new P_TreeNode("1_2");
+
+    node0.setLazyExpandingEnabled(true);
+    tree.addChildNodes(tree.getRootNode(), List.of(node0, node1));
+    tree.addChildNodes(node0, List.of(node0Child0, node0Child1, node0Child2));
+    tree.addChildNodes(node1, List.of(node1Child0, node1Child1, node1Child2));
+
+    tree.setNodeExpanded(node0, true);
+    tree.setNodeExpanded(node1, true);
+
+    // node0 is expanded lazy
+    assertTrue(node0.isExpanded());
+    assertTrue(node0.isExpandedLazy());
+
+    // node1 is expanded
+    assertTrue(node1.isExpanded());
+    assertFalse(node1.isExpandedLazy());
+
+    // deleting only some of the child nodes does not collapse parents
+    tree.removeChildNodes(node0, List.of(node0Child2));
+    tree.removeChildNodes(node1, List.of(node1Child2));
+
+    // node0 is expanded lazy
+    assertTrue(node0.isExpanded());
+    assertTrue(node0.isExpandedLazy());
+
+    // node1 is expanded
+    assertTrue(node1.isExpanded());
+    assertFalse(node1.isExpandedLazy());
+
+    // deleting all child nodes collapses lazy expanded parents
+    tree.removeChildNodes(node0, List.of(node0Child0, node0Child1));
+    tree.removeChildNodes(node1, List.of(node1Child0, node1Child1));
+
+    // node0 is no longer expanded
+    assertFalse(node0.isExpanded());
+    assertFalse(node0.isExpandedLazy());
+
+    // node1 is still expanded
+    assertTrue(node1.isExpanded());
+    assertFalse(node1.isExpandedLazy());
   }
 
   public static class P_Tree extends AbstractTree {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
@@ -1791,6 +1791,9 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
         applyNodeFiltersRecInternal(child, parent.isFilterAccepted(), level);
       }
       if (parent.getChildNodeCount() == 0) {
+        if (parent.isExpandedLazy()) {
+          setNodeExpanded(parent, false);
+        }
         fireAllChildNodesDeleted(parent, children);
       }
       else {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPage.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPage.java
@@ -525,10 +525,6 @@ public abstract class AbstractPage<T extends ITable> extends AbstractTreeNode im
     }
     try {
       tree.setTreeChanging(true);
-      if (this.isExpandedLazy()) {
-        // If the page is expanded lazily, all child nodes will be gone -> collapse it to prevent showing the "+" icon without any child nodes
-        tree.setNodeExpanded(this, false);
-      }
       loadChildren();
     }
     finally {


### PR DESCRIPTION
When a node is expanded lazily (i.e. the node is expanded, but only some of the child nodes are visible, marked by "+" instead of "v" icon) and the child nodes are deleted, the parent node must not stay expanded, if there are no child nodes left that can be expanded using the "+" icon.

This was implemented explicitly for pages and was now moved to the tree in general. If the node is fully expanded it stays expanded.

427023