### PR TITLE
TreeAdapter: mark remote nodes

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
@@ -306,7 +306,8 @@ export class OutlineAdapter extends TreeAdapter {
       objectType: pageModel.jsPageObjectType,
       pageParam: pageParam,
       classId: pageModel.classId,
-      modelClass: pageModel.modelClass
+      modelClass: pageModel.modelClass,
+      __hybrid: true
     };
   }
 
@@ -323,9 +324,6 @@ export class OutlineAdapter extends TreeAdapter {
 
   protected override _initNodeModel(nodeModel?: TreeNodeModel): ChildModelOf<Page> {
     const model = super._initNodeModel(nodeModel) as ChildModelOf<Page>;
-    // This marker is only set for pages that represent a remote page on the UI server. It prevents menus from being inherited
-    // from the parent table page, because in the case of Java pages that is already done on the server.
-    model.remote = true;
     model.pageParam = dataObjects.deserialize(model.pageParam);
     return model;
   }

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -677,6 +677,7 @@ export * from './tree/keystrokes/TreeCollapseAllKeyStroke';
 export * from './tree/keystrokes/TreeCollapseOrDrillUpKeyStroke';
 export * from './tree/keystrokes/TreeExpandOrDrillDownKeyStroke';
 export * from './tree/CompactTree';
+export * from './tree/CompactTreeAdapter';
 export * from './tree/CompactTreeNode';
 export * from './tree/keystrokes/AbstractCompactTreeControlKeyStroke';
 export * from './tree/keystrokes/CompactTreeUpKeyStroke';

--- a/eclipse-scout-core/src/testing/tree/TreeSpecHelper.ts
+++ b/eclipse-scout-core/src/testing/tree/TreeSpecHelper.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, CompactTree, InitModelOf, ModelAdapter, ObjectIdProvider, ObjectType, RemoteEvent, Session, Tree, TreeAdapter, TreeModel, TreeNode, TreeNodeModel, Widget} from '../../index';
+import {arrays, CompactTree, CompactTreeAdapter, InitModelOf, ModelAdapter, ObjectIdProvider, ObjectType, RemoteEvent, Session, Tree, TreeAdapter, TreeModel, TreeNode, TreeNodeModel, Widget} from '../../index';
 import {SpecTree} from '../index';
 import $ from 'jquery';
 
@@ -89,7 +89,7 @@ export class TreeSpecHelper {
 
   createCompactTreeAdapter(model: InitModelOf<TreeAdapter>): TreeAdapter {
     model.objectType = 'Tree:Compact';
-    let tree = new TreeAdapter();
+    let tree = new CompactTreeAdapter();
     tree.init(model);
     return tree;
   }

--- a/eclipse-scout-core/src/tree/CompactTreeAdapter.ts
+++ b/eclipse-scout-core/src/tree/CompactTreeAdapter.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {App, CompactTree, objects, TreeAdapter} from '../index';
+
+export class CompactTreeAdapter extends TreeAdapter {
+  declare widget: CompactTree;
+
+  protected override _getDefaultNodeObjectType(): string {
+    return 'CompactTreeNode';
+  }
+
+  /**
+   * Static method to modify the prototype of CompactTree.
+   */
+  static modifyCompactTreePrototype() {
+    if (!App.get().remote) {
+      return;
+    }
+
+    objects.replacePrototypeFunction(CompactTree, '_createTreeNode', TreeAdapter._createTreeNodeRemote, true);
+  }
+}
+
+App.addListener('bootstrap', CompactTreeAdapter.modifyCompactTreePrototype);

--- a/eclipse-scout-core/src/tree/TreeAdapter.ts
+++ b/eclipse-scout-core/src/tree/TreeAdapter.ts
@@ -56,23 +56,34 @@ export class TreeAdapter extends ModelAdapter {
   }
 
   protected _onWidgetNodeClick(event: TreeNodeClickEvent) {
+    if (!TreeAdapter.isRemote(event.node)) {
+      return;
+    }
     this._send('nodeClick', {
       nodeId: event.node.id
     });
   }
 
   protected _onWidgetNodeAction(event: TreeNodeActionEvent) {
+    if (!TreeAdapter.isRemote(event.node)) {
+      return;
+    }
     this._send('nodeAction', {
       nodeId: event.node.id
     });
   }
 
   protected _onWidgetNodesSelected(event: TreeNodesSelectedEvent) {
-    let nodeIds = this.widget.nodesToIds(this.widget.selectedNodes);
+    const selectedNodes = arrays.ensure(this.widget.selectedNodes)
+      .filter(node => TreeAdapter.isRemote(node));
+    const nodeIds = this.widget.nodesToIds(selectedNodes);
     this._sendNodesSelected(nodeIds, event.debounce);
   }
 
   protected _onWidgetNodeExpanded(event: TreeNodeExpandedEvent) {
+    if (!TreeAdapter.isRemote(event.node)) {
+      return;
+    }
     this._send('nodeExpanded', {
       nodeId: event.node.id,
       expanded: event.expanded,
@@ -81,7 +92,10 @@ export class TreeAdapter extends ModelAdapter {
   }
 
   protected _onWidgetNodesChecked(event: TreeNodesCheckedEvent) {
-    this._sendNodesChecked(event.nodes);
+    const nodes = arrays.ensure(event.nodes)
+      .filter(node => TreeAdapter.isRemote(node));
+
+    this._sendNodesChecked(nodes);
   }
 
   protected _sendNodesChecked(nodes: TreeNode[]) {
@@ -282,6 +296,7 @@ export class TreeAdapter extends ModelAdapter {
     nodeModel = nodeModel || {};
     nodeModel.objectType = scout.nvl(nodeModel.objectType, this._getDefaultNodeObjectType());
     defaultValues.applyTo(nodeModel);
+    nodeModel.remote = true;
     return nodeModel as ChildModelOf<TreeNode>;
   }
 
@@ -319,6 +334,24 @@ export class TreeAdapter extends ModelAdapter {
     objects.replacePrototypeFunction(Tree, '_createTreeNode', TreeAdapter._createTreeNodeRemote, true);
     objects.replacePrototypeFunction(Tree, '_updateMarkChildrenChecked', TreeAdapter._updateMarkChildrenCheckedRemote, true);
   }
+
+  static isRemote(node: AdapterTreeNode, includeHybrid = true): boolean {
+    if (node?.remote) {
+      return true;
+    }
+    return includeHybrid ? !!node.__hybrid : false;
+  }
 }
 
 App.addListener('bootstrap', TreeAdapter.modifyTreePrototype);
+
+export interface AdapterTreeNode extends TreeNode {
+  /**
+   * This marker indicates a {@link TreeNode} that represent a remote node on the UI server.
+   */
+  remote?: boolean;
+  /**
+   * This marker indicates a {@link TreeNode} that represent a hybrid node on the UI server (i.e. a remote node where the representation on the UI server is just a wrapper).
+   */
+  __hybrid?: boolean;
+}

--- a/eclipse-scout-core/test/desktop/outline/OutlineAdapterSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineAdapterSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {OutlineSpecHelper, TableSpecHelper, TreeSpecHelper} from '../../../src/testing';
-import {BaseDoEntity, DataObjectInventory, defaultValues, ObjectFactory, ObjectIdProvider, objects, Outline, Page, PageParamDo, PageWithNodes, typeName} from '../../../src';
+import {AdapterTreeNode, BaseDoEntity, DataObjectInventory, defaultValues, ObjectFactory, ObjectIdProvider, objects, Outline, Page, PageParamDo, PageWithNodes, typeName} from '../../../src';
 
 describe('OutlineAdapter', () => {
   let session: SandboxSession;
@@ -390,6 +390,26 @@ describe('OutlineAdapter', () => {
       let legacyDataObject = node['legacyDataObject'];
       expect(objects.isPojo(legacyDataObject)).toBe(true);
       expect(legacyDataObject.prop).toBe(5);
+    });
+
+    it('is marked with __hybrid', () => {
+      const treeHelper = new TreeSpecHelper(session);
+      const model = helper.createModelFixture(1);
+      const adapter = helper.createOutlineAdapter(model);
+      const outline = adapter.createWidget(model, session.desktop) as Outline;
+
+      adapter.onModelEvent(treeHelper.createNodesInsertedEvent(outline, [helper.createModelNode('0_0', 'newChildNode', {
+        nodeType: 'jsPage',
+        jsPageObjectType: 'outlineadapterspec.MyJsPage'
+      })]));
+      const [jsPage, page] = outline.nodes as AdapterTreeNode[]; // new node is inserted at at index 0
+
+      expect(jsPage).toBeInstanceOf(MyJsPage);
+      expect(jsPage.__hybrid).toBeTrue();
+
+      expect(page).toBeInstanceOf(Page);
+      expect(page).not.toBeInstanceOf(MyJsPage);
+      expect(page.__hybrid).toBeFalsy();
     });
   });
 

--- a/eclipse-scout-core/test/tree/TreeAdapterSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeAdapterSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {defaultValues, RemoteEvent, Tree} from '../../src/index';
+import {AdapterTreeNode, defaultValues, RemoteEvent, Tree, TreeAdapter} from '../../src/index';
 import {JQueryTesting, TreeSpecHelper} from '../../src/testing/index';
 
 describe('TreeAdapter', () => {
@@ -660,6 +660,104 @@ describe('TreeAdapter', () => {
         expect(helper.findAllNodes(tree).length).toBe(10);
         expect(node0.childNodes[0].$node).toBeDefined();
       });
+    });
+  });
+
+  describe('events are only sent for remote and hybrid nodes', () => {
+    let adapter: TreeAdapter;
+    let tree: Tree;
+    let remoteNode: AdapterTreeNode;
+    let hybridNode: AdapterTreeNode;
+    let jsNode: AdapterTreeNode;
+
+    beforeEach(() => {
+      const model = helper.createModelFixture(3, 1);
+      adapter = helper.createTreeAdapter(model);
+      tree = adapter.createWidget(model, session.desktop) as Tree;
+      tree.render();
+
+      [remoteNode, hybridNode, jsNode] = tree.nodes as AdapterTreeNode[];
+      // all nodes created by the adapter are marked as remote
+      expect(remoteNode.remote).toBeTrue();
+      expect(remoteNode.__hybrid).toBeFalsy();
+
+      hybridNode.remote = false;
+      hybridNode.__hybrid = true;
+      jsNode.remote = false;
+      jsNode.__hybrid = false;
+    });
+
+    it('nodesSelected', () => {
+      tree.selectNodes([jsNode, hybridNode, remoteNode]);
+
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(1);
+
+      const request = mostRecentJsonRequest();
+      expect(request).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesSelected', {nodeIds: [hybridNode.id, remoteNode.id]})
+      ]);
+    });
+
+    it('nodeClick', () => {
+      JQueryTesting.triggerClick(jsNode.$node);
+      JQueryTesting.triggerClick(hybridNode.$node);
+      JQueryTesting.triggerClick(remoteNode.$node);
+
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(1);
+
+      const request = mostRecentJsonRequest();
+      expect(request).toContainEventsExactly([
+        // no 'nodesSelected' for hybridNode as it is coalesced
+        new RemoteEvent(adapter.id, 'nodeClick', {nodeId: hybridNode.id}),
+        new RemoteEvent(adapter.id, 'nodesSelected', {nodeIds: [remoteNode.id]}),
+        new RemoteEvent(adapter.id, 'nodeClick', {nodeId: remoteNode.id})
+      ]);
+    });
+
+    it('nodeAction', () => {
+      tree.doNodeAction(jsNode, jsNode.expanded);
+      tree.doNodeAction(hybridNode, hybridNode.expanded);
+      tree.doNodeAction(remoteNode, remoteNode.expanded);
+
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(1);
+
+      const request = mostRecentJsonRequest();
+      expect(request).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodeAction', {nodeId: hybridNode.id}),
+        new RemoteEvent(adapter.id, 'nodeAction', {nodeId: remoteNode.id})
+      ]);
+    });
+
+    it('nodeExpanded', () => {
+      tree.expandNode(jsNode);
+      tree.expandNode(hybridNode);
+      tree.expandNode(remoteNode);
+
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(1);
+
+      const request = mostRecentJsonRequest();
+      expect(request).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodeExpanded', {nodeId: hybridNode.id, expanded: true, expandedLazy: false}),
+        new RemoteEvent(adapter.id, 'nodeExpanded', {nodeId: remoteNode.id, expanded: true, expandedLazy: false})
+      ]);
+    });
+
+    it('nodesChecked', () => {
+      tree.checkable = true;
+
+      tree.checkNodes([jsNode, hybridNode, remoteNode]);
+
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(1);
+
+      const request = mostRecentJsonRequest();
+      expect(request).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesChecked', {nodes: [{nodeId: hybridNode.id, checked: true}, {nodeId: remoteNode.id, checked: true}]})
+      ]);
     });
   });
 });


### PR DESCRIPTION
Tree node events sent to the UI server for nodes that do not exist on the UI server create a lot of noise in the log. This may be acceptable if Scout JS expects the UI server to know a tree node but should be avoided when Scout JS knows for sure that a tree node does not exist on the UI server.
Therefore, all tree nodes created by the TreeAdapter are now marked as remote. This flag is used to filter events that are sent back to the UI server. In addition, the filter method introduces hybrid nodes which are nodes created as a wrapper in Java while all their logic is implemented in Scout JS. The only known variant of these hybrid nodes are JsPages and these are marked accordingly by the OutlineAdapter.

427023