### PR TITLE
Improve JavaDoc

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
@@ -341,8 +341,8 @@ public class Application {
   }
 
   /**
-   * Installs the default error handler. This custom implementation doesn't show the servlet and doesn't send any stack
-   *traces to the client. Furthermore, no internal URIs are exposes in error messages.
+   * Installs a custom error handler that omits sensitive information from error messages.
+   * Specifically, it does not expose the servlet name, the internal URI, or stack traces.
    */
   protected void installErrorHandler(Server server) {
     server.setErrorHandler(BEANS.get(ScoutJettyErrorHandler.class));

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/handler/ScoutJettyErrorHandler.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/handler/ScoutJettyErrorHandler.java
@@ -19,7 +19,8 @@ import org.eclipse.scout.rt.platform.Bean;
 import org.json.JSONObject;
 
 /**
- * This custom implementation doesn't show the servlet and doesn't send any stack traces to the client. Furthermore, no internal URIs are exposes in error messages.
+ * This custom implementation omits sensitive information from error messages.
+ * Specifically, it does not expose the servlet name, the internal URI, or stack traces.
  */
 @Bean
 public class ScoutJettyErrorHandler extends ErrorHandler {


### PR DESCRIPTION
- Fix typo: "are exposes"
- Add missing space at start of line
- Make description more concise