### PR TITLE
Calculate checkable column for row icon column

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -447,6 +447,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
 
     // Add gui only row icon column at the beginning
     if (this.rowIconVisible) {
+      this._calculateCheckableColumn();
       this._insertRowIconColumn();
     }
 


### PR DESCRIPTION
- The row icon column is always the first column with one exception: -- if there is a checkable column, then it is the second column
- To correctly insert the gui only column the columns must be calculated

435853