### PR TITLE
Legacy bookmarks: remove warning

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/bookmark/view/BookmarkViewForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/bookmark/view/BookmarkViewForm.java
@@ -236,9 +236,6 @@ public class BookmarkViewForm extends AbstractForm {
               }
               form.setBookmarkRootFolder(getUserBookmarkTreeField().getBookmarkRootFolder());
               form.setBookmark(b);
-              if (form.getBookmarkRootFolder() != form.getBookmarkRootFolder()) {
-                form.setFolder(form.getBookmarkRootFolder());
-              }
               form.startNew();
               form.waitFor();
               if (form.isFormStored()) {


### PR DESCRIPTION
The string is compared to itself and the condition therefore never satisfied.

-> Delete it because obviously nobody noticed a wrong behavior in the last decade and the form is deprecated anyway.

436101