### PR TITLE
Reset Interrupt Status

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/filter/ExceptionFilter.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/filter/ExceptionFilter.java
@@ -62,6 +62,18 @@ public class ExceptionFilter implements Filter {
       }
       throw new JettyQuietExceptionWrapper(e);
     }
+    finally {
+      if (Thread.interrupted()) {
+        HttpServletRequest req = (HttpServletRequest) request;
+        MDC.put(CorrelationIdContextValueProvider.KEY, req.getHeader(CorrelationId.HTTP_HEADER_NAME));
+        try {
+          LOG.debug("Reset interrupted state");
+        }
+        finally {
+          MDC.remove(CorrelationIdContextValueProvider.KEY);
+        }
+      }
+    }
   }
 
   /**
@@ -69,10 +81,6 @@ public class ExceptionFilter implements Filter {
    */
   protected boolean isCausedByQuietException(Throwable t) {
     return BEANS.get(DefaultExceptionTranslator.class).throwableCausesAccept(t, e -> e instanceof QuietException);
-  }
-
-  @Override
-  public void destroy() {
   }
 
   /**

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/filter/ExceptionFilter.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/filter/ExceptionFilter.java
@@ -53,26 +53,25 @@ public class ExceptionFilter implements Filter {
       }
 
       HttpServletRequest req = (HttpServletRequest) request;
-      MDC.put(CorrelationIdContextValueProvider.KEY, req.getHeader(CorrelationId.HTTP_HEADER_NAME));
-      try {
-        LOG.warn(req.getRequestURI(), e);
-      }
-      finally {
-        MDC.remove(CorrelationIdContextValueProvider.KEY);
-      }
+      runWithCorrelationId(req.getHeader(CorrelationId.HTTP_HEADER_NAME), () -> LOG.warn(req.getRequestURI(), e));
+
       throw new JettyQuietExceptionWrapper(e);
     }
     finally {
       if (Thread.interrupted()) {
         HttpServletRequest req = (HttpServletRequest) request;
-        MDC.put(CorrelationIdContextValueProvider.KEY, req.getHeader(CorrelationId.HTTP_HEADER_NAME));
-        try {
-          LOG.debug("Reset interrupted state");
-        }
-        finally {
-          MDC.remove(CorrelationIdContextValueProvider.KEY);
-        }
+        runWithCorrelationId(req.getHeader(CorrelationId.HTTP_HEADER_NAME), () -> LOG.debug("Reset interrupted state - {}", req.getRequestURI()));
       }
+    }
+  }
+
+  protected void runWithCorrelationId(String correlationId, Runnable runnable) {
+    MDC.put(CorrelationIdContextValueProvider.KEY, correlationId);
+    try {
+      runnable.run();
+    }
+    finally {
+      MDC.remove(CorrelationIdContextValueProvider.KEY);
     }
   }
 

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/RunMonitorCancelRegistry.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/RunMonitorCancelRegistry.java
@@ -102,7 +102,7 @@ public class RunMonitorCancelRegistry {
         m_registry.remove(entry);
         if (entry.getRunMonitor().isCancelled() && Thread.interrupted()) {
           // as thread may be used by other operations as well; interrupted state must be reset after previous interruption
-          LOG.trace("Reset interrupted state for cancelled and interrupted run monitor - requestId:{}", requestId);
+          LOG.trace("Reset interrupted state for cancelled and interrupted run monitor - [requestId:{}, sessionId:{}]", requestId, sessionId);
         }
       }
     };

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/RunMonitorCancelRegistry.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/RunMonitorCancelRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,8 @@ import org.eclipse.scout.rt.platform.index.IndexedStore;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CompositeObject;
 import org.eclipse.scout.rt.platform.util.ToStringBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Registry that contains the {@link RunMonitor}s of operations which are currently executing, and which are subject for
@@ -37,6 +39,7 @@ import org.eclipse.scout.rt.platform.util.ToStringBuilder;
  */
 @ApplicationScoped
 public class RunMonitorCancelRegistry {
+  private static final Logger LOG = LoggerFactory.getLogger(RunMonitorCancelRegistry.class);
 
   private boolean m_destroyed;
   protected final IndexedStore<RegistryEntry> m_registry;
@@ -97,6 +100,10 @@ public class RunMonitorCancelRegistry {
     return () -> {
       synchronized (m_registryLock) {
         m_registry.remove(entry);
+        if (entry.getRunMonitor().isCancelled() && Thread.interrupted()) {
+          // as thread may be used by other operations as well; interrupted state must be reset after previous interruption
+          LOG.trace("Reset interrupted state for cancelled and interrupted run monitor - requestId:{}", requestId);
+        }
       }
     };
   }


### PR DESCRIPTION
Ensures that any interrupt flags set during request handling don’t leak back into Jetty’s thread pool.

372827