### PR TITLE
Add child pages to IJsPage

### DIFF
--- a/eclipse-scout-core/src/Extension.ts
+++ b/eclipse-scout-core/src/Extension.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,12 +40,21 @@ export class Extension<E> {
   next: (...args: any[]) => any;
 
   extend(extended: E, funcName: string) {
-    let origFunc = extended[funcName];
-    let extension = this;
+    const funcOrig = extended[funcName];
+    const extension = this;
     extended[funcName] = function(...args) {
+      const extendedOrig = extension.extended;
+      const nextOrig = extension.next;
+
       extension.extended = this;
-      extension.next = origFunc.bind(this);
-      return extension[funcName](...args);
+      extension.next = funcOrig.bind(this);
+
+      try {
+        return extension[funcName](...args);
+      } finally {
+        extension.extended = extendedOrig;
+        extension.next = nextOrig;
+      }
     };
   }
 

--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -516,6 +516,7 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
     let page = row.page;
     page.enabled = row.enabled;
 
+    // keep in sync with token: [5vv7MGGQ5BQY5NXX7CwJ9tmL4]
     const summaryColumns = page._computeSummaryColumns(row);
     page.text = page.computeTextForRow(row, summaryColumns);
 

--- a/eclipse-scout-core/src/desktop/outline/pages/js/JsPageHelper.less
+++ b/eclipse-scout-core/src/desktop/outline/pages/js/JsPageHelper.less
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+// hide icon and text if child page of a js page is loading to prevent flickering (e.g. the child pages text will change from the text given in its model to the summary of its parent table page)
+.tree-node.js-page-child-page-loading {
+  & > .icon,
+  & > .text {
+    .invisible();
+  }
+}

--- a/eclipse-scout-core/src/desktop/outline/pages/js/JsPageHelper.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/js/JsPageHelper.ts
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {
+  arrays, dataObjects, HybridActionContextElement, HybridActionContextElements, HybridManager, InitModelOf, LoadChildPagesHybridActionDo, objects, ObjectWithType, Outline, OutlineAdapter, Page, PageParamDo, PageWithTable, scout,
+  SomeRequired, Table, TableRowsInsertedEvent, TreeAllChildNodesDeletedEvent, TreeNodesDeletedEvent, TreeNodesInsertedEvent, TreeNodesUpdatedEvent, typeName
+} from '../../../../index';
+
+/**
+ * This helper can be used to create child pages for a JsPage on the UI server.
+ * The child pages are created using an id or a {@link PageParamDo}.
+ * The child pages are created by the Java equivalent of the JsPage (see AbstractJsPage.createChildPage) when {@link #callLoadChildPages} is called.
+ * After the returned {@link Promise} is resolved the child pages are available by {@link #findChildPage}.
+ *
+ * To create child pages for a {@link PageWithTable}:
+ * - Call and await {@link #callLoadChildPages} in {@link PageWithTable#_loadTableData} using ids or {@link PageParamDo}s created from the loaded data.
+ * - Implement {@link PageWithTable#_createChildPage} and return the result of {@link #findChildPage} using an id or {@link PageParamDo} created for the given {@link TableRow}.
+ *
+ * To create child pages for a {@link PageWithNodes}:
+ * - Implement {@link PageWithNodes#_createChildPages} and call {@link #callLoadChildPages} using ids or {@link PageParamDo}s.
+ * - After the {@link Promise} is resolved use the same ids or {@link PageParamDo}s to call {@link #findChildPages} and return the resulting child pages.
+ */
+export class JsPageHelper implements JsPageHelperModel, ObjectWithType {
+
+  declare model: JsPageHelperModel;
+  declare initModel: SomeRequired<this['model'], 'page'>;
+
+  objectType: string;
+
+  page: Page;
+
+  protected _replaceChildPages = true;
+  /**
+   * Child pages by id (see {@link #_createChildPageId}).
+   */
+  protected _childPagesById = new Map<string, JsPageChildPage>();
+
+  // general listeners
+
+  protected _nodesUpdatedHandler = this._onNodesUpdated.bind(this);
+  protected _nodesDeletedHandler = this._onNodesDeleted.bind(this);
+  protected _allChildNodesDeletedHandler = this._onAllChildNodesDeleted.bind(this);
+
+  // listeners for PageWithTable
+
+  protected _nodesInsertedHandler = this._onNodesInserted.bind(this);
+  protected _tableRowsInsertHandler = this._onTableRowsInserted.bind(this);
+
+  init(model: InitModelOf<this>) {
+    $.extend(this, model);
+
+    scout.assertInstance(this.page, Page, 'Page not set or has wrong type');
+
+    // do not replace child pages initially
+    // if e.g. the browser is reloaded the previously created child pages already exist on the UI server and therefore childNodes are set in the pages initModel
+    // if the page is a PageWithTable its table will be loaded when the page is selected and this load must not lead to all child pages being replaced
+    this._replaceChildPages = !this.page.childNodes?.length;
+
+    this._installOutlineListeners();
+    this._installPageWithTableListeners();
+  }
+
+  public destroy() {
+    this._uninstallOutlineListeners();
+    this._uninstallPageWithTableListeners();
+    this.page = null;
+  }
+
+  protected _installOutlineListeners() {
+    this.outline.on('nodesUpdated', this._nodesUpdatedHandler);
+    this.outline.on('nodesDeleted', this._nodesDeletedHandler);
+    this.outline.on('allChildNodesDeleted', this._allChildNodesDeletedHandler);
+  }
+
+  protected _uninstallOutlineListeners() {
+    this.outline.off('nodesUpdated', this._nodesUpdatedHandler);
+    this.outline.off('nodesDeleted', this._nodesDeletedHandler);
+    this.outline.off('allChildNodesDeleted', this._allChildNodesDeletedHandler);
+  }
+
+  protected _onNodesUpdated(event: TreeNodesUpdatedEvent) {
+    if (!event.nodes?.length) {
+      return;
+    }
+
+    // filter child pages of page
+    const childPages = event.nodes.filter(node => node.parentNode === this.page) as Page[];
+    if (!childPages.length) {
+      return;
+    }
+
+    // Child pages may have been updated with e.g. a new text. Send a nodesChanged event in order to send this information to the UI server.
+    // This information is needed when the browser is reloaded as the child pages will still be available.
+    (this.outline.modelAdapter as OutlineAdapter).sendNodesChanged(childPages);
+  }
+
+  protected _onNodesDeleted(event: TreeNodesDeletedEvent) {
+    if (!event.nodes?.length) {
+      return;
+    }
+
+    // mark page as childrenLoaded=false if all child pages are deleted
+    if (!this.page.childNodes.length) {
+      this.page.childrenLoaded = false;
+    }
+
+    // clean up _childPagesById map
+    const pages = event.nodes as Page[];
+    this._removeChildPagesFromIdMap(pages);
+
+    if (!this.page.detailTable) {
+      return;
+    }
+
+    // remove corresponding rows, otherwise e.g. double-clicking a row will lead to errors as the page was deleted
+    const rows = pages.map(page => page.row).filter(Boolean);
+    this.page.detailTable.deleteRows(rows);
+  }
+
+  protected _onAllChildNodesDeleted(event: TreeAllChildNodesDeletedEvent) {
+    if (event.parentNode !== this.page) {
+      return;
+    }
+
+    // always mark page as childrenLoaded=false as all child pages are deleted
+    this.page.childrenLoaded = false;
+
+    // clean up _childPagesById map
+    this._childPagesById.clear();
+
+    if (!this.page.detailTable) {
+      return;
+    }
+
+    // remove all rows, otherwise e.g. double-clicking a row will lead to errors as the page was deleted
+    this.page.detailTable.deleteAllRows();
+  }
+
+  protected _installPageWithTableListeners() {
+    if (!(this.page instanceof PageWithTable)) {
+      return;
+    }
+
+    this.outline.on('nodesInserted', this._nodesInsertedHandler);
+
+    // detailTable may change -> install for current and listen on propertyChange
+    this._installPageWithTableDetailTableListeners(this.page?.detailTable);
+    this.page.on('propertyChange:detailTable', e => {
+      this._uninstallPageWithTableDetailTableListeners(e.oldValue);
+      this._installPageWithTableDetailTableListeners(e.newValue);
+    });
+  }
+
+  protected _uninstallPageWithTableListeners() {
+    if (!(this.page instanceof PageWithTable)) {
+      return;
+    }
+
+    this.outline.off('nodesInserted', this._nodesInsertedHandler);
+    this._uninstallPageWithTableDetailTableListeners(this.page?.detailTable);
+  }
+
+  protected _onNodesInserted(event: TreeNodesInsertedEvent) {
+    if (event.parentNode !== this.page) {
+      return;
+    }
+
+    // The event is triggered twice during the load/reload of a PageWithTable that creates its child pages using the JsPageHelper.
+    // 1. When the child pages are inserted on the UI server it is called for the first time.
+    //    In this case e.g. the text may not be correct as the page was not updated from the table row yet.
+    //    If this happens, the PageWithTable is marked with childrenLoaded=false.
+    // 2. The second time this event is triggered is when the PageWithTable replaces its rows.
+    //    Now the child page is ready to be inserted as it was linked to the row and updated from it.
+    //    As the table load/reload is now completed, the PageWithTable is marked with childrenLoaded=true.
+
+    // Mark all child pages loading iff the PageWithTable has not loaded its children.
+    for (const childPage of event.nodes) {
+      childPage.toggleCssClass('js-page-child-page-loading', !this.page.childrenLoaded);
+      childPage._decorate();
+    }
+  }
+
+  protected _installPageWithTableDetailTableListeners(detailTable: Table) {
+    if (!detailTable) {
+      return;
+    }
+    detailTable.on('rowsInserted', this._tableRowsInsertHandler);
+  }
+
+  protected _uninstallPageWithTableDetailTableListeners(detailTable: Table) {
+    if (!detailTable) {
+      return;
+    }
+    detailTable.off('rowsInserted', this._tableRowsInsertHandler);
+  }
+
+  protected _onTableRowsInserted(event: TableRowsInsertedEvent) {
+    // When rows are inserted in a PageWithTable, all child pages are ready, i.e. they are linked to their row and updated from it.
+    // Send a nodesChanged event in order to send summary information from the PageWithTable to the UI server.
+    // This information is needed when the browser is reloaded as the child pages will still be available but the table data won't.
+    const pages = event.rows.map(row => row.page).filter(Boolean);
+    (this.outline.modelAdapter as OutlineAdapter).sendNodesChanged(pages);
+  }
+
+  get outline(): Outline {
+    return this.page.outline;
+  }
+
+  /**
+   * Calls loadChildPages on the UI server for the given ids or {@link PageParamDo}s. The pages are created by the Java equivalent of the JsPage (see AbstractJsPage.createChildPage).
+   * The returned {@link Promise} is resolved when all child pages are created on the UI server.
+   *
+   * @param idsOrPageParams ids or {@link PageParamDo}s that are used to create child pages on the UI server.
+   * @param replace Whether existing child pages shall be replaced or reused. If not specified, the child pages will always be replaced except for the first call in order to keep existing child pages after a browser reload.
+   */
+  async callLoadChildPages(idsOrPageParams: (string | PageParamDo)[], replace?: boolean): Promise<void> {
+    // Ensure pageParams and collect them distinctly.
+    // The given list may contain duplicate pageParams.
+    // Sending these duplicates to the server would result in pages added multiple times to the outline which leads to unexpected behaviour.
+    const childPageIds = new Set<string>();
+    const pageParams: PageParamDo[] = [];
+    arrays.ensure(idsOrPageParams)
+      .map(idOrPageParam => this._createChildPageParam(idOrPageParam))
+      .filter(Boolean)
+      .forEach(pageParam => {
+        // The pageParam is a PageParamDo and a Set only checks "===" and not ".equals()".
+        // Therefore, create the child page id to ensure that duplicate page params are only used once.
+        const childPageId = this._createChildPageId(pageParam);
+        if (childPageIds.has(childPageId)) {
+          return;
+        }
+        childPageIds.add(childPageId);
+
+        pageParams.push(pageParam);
+      });
+    // ensure replace flag
+    replace = scout.nvl(replace, this._replaceChildPages);
+
+    // call load child pages
+    const hybridManager = await HybridManager.get(this.page.session, true);
+    await hybridManager.callActionAndWaitWithContext('scout.LoadChildPages',
+      scout.create(LoadChildPagesHybridActionDo, {pageParams, replace}),
+      scout.create(HybridActionContextElements)
+        .withElement('page', HybridActionContextElement.of(this.outline, this.page))
+    );
+
+    // child pages must be replaced after the first load
+    this._replaceChildPages = true;
+
+    // The LoadChildPagesHybridAction fires the hybridActionEnd-event after the child pages are created and inserted.
+    // The tree and its JsonAdapter may buffer the tree events, but it is ensured that they are contained in the same response from the UI server as the hybridActionEnd-event.
+    // As the session processes all events in the response synchronously the nodesInserted-event is processed before the Promise that is waiting for the hybrid action to complete is resolved.
+    // Therefore, all child pages created on the UI server are already inserted into the tree, and they can be collected into the child pages map.
+    this._addChildPagesToIdMap();
+  }
+
+  /**
+   * Loads the child page for the given id or {@link PageParamDo}.
+   */
+  async loadChildPage(idOrPageParam: string | PageParamDo, replace?: boolean): Promise<Page> {
+    await this.callLoadChildPages([idOrPageParam], replace);
+    return this.findChildPage(idOrPageParam);
+  }
+
+  /**
+   * Loads the child pages for the given ids or {@link PageParamDo}s and returns them in the order of the given ids or {@link PageParamDo}s.
+   */
+  async loadChildPages(idsOrPageParams: (string | PageParamDo)[], replace?: boolean): Promise<Page[]> {
+    await this.callLoadChildPages(idsOrPageParams, replace);
+    return this.findChildPages(idsOrPageParams);
+  }
+
+  /**
+   * Finds the child page for the given id or {@link PageParamDo}.
+   */
+  findChildPage(idOrPageParam: string | PageParamDo): Page {
+    if (!idOrPageParam) {
+      return null;
+    }
+
+    // create id and lookup child page
+    return this._childPagesById.get(this._createChildPageId(idOrPageParam));
+  }
+
+  /**
+   * Finds the child pages for the given ids or {@link PageParamDo}s and returns them in the order of the given ids or {@link PageParamDo}s.
+   */
+  findChildPages(idsOrPageParams: string | PageParamDo | (string | PageParamDo)[]): Page[] {
+    if (!idsOrPageParams) {
+      return [];
+    }
+
+    const idsOrPageParamsArray = arrays.ensure(idsOrPageParams);
+    return idsOrPageParamsArray.map(idsOrPageParam => this.findChildPage(idsOrPageParam));
+  }
+
+  /**
+   * Adds all given child pages to the {@link #_childPagesById}-map. If no child pages are given the child pages of {@link #page} are taken.
+   */
+  protected _addChildPagesToIdMap(childPages?: JsPageChildPage[]) {
+    // use child pages of this.page as default
+    childPages = childPages || this.page.childNodes;
+
+    for (const childPage of childPages) {
+      // get and assert id
+      const id = this._getChildPageId(childPage);
+      if (!id) {
+        continue;
+      }
+
+      // add to map
+      this._childPagesById.set(id, childPage);
+
+      // if the page is linked to a row it may be deleted if the row is replaced -> remove link as it will be created again later on
+      if (childPage.row) {
+        childPage.unlinkWithRow(childPage.row);
+      }
+
+      // the child page must not be shown initially -> hide it until e.g. the PageWithTable inserts all nodes for its rows
+      this.outline.hideNode(childPage, false);
+    }
+
+    // mark page with childrenLoaded=true
+    this.page.childrenLoaded = true;
+  }
+
+  /**
+   * Removes all given child pages from the {@link #_childPagesById}-map. If no child pages are given the child pages of {@link #page} are taken.
+   */
+  protected _removeChildPagesFromIdMap(childPages?: JsPageChildPage[]) {
+    // use child pages of this.page as default
+    childPages = childPages || this.page.childNodes;
+
+    for (const childPage of childPages) {
+      // get and assert id
+      const id = this._getChildPageId(childPage);
+      if (!id) {
+        continue;
+      }
+
+      // remove from map
+      this._childPagesById.delete(id);
+    }
+  }
+
+  /**
+   * Creates a {@link PageParamDo} from the given id or {@link PageParamDo}.
+   * If the given id or param is an id, this id is wrapped in an {@link IdPageParamDo}.
+   * If the given id or param is a {@link PageParamDo} already, it is simply returned.
+   */
+  protected _createChildPageParam(idOrPageParam?: string | PageParamDo): PageParamDo {
+    if (!idOrPageParam) {
+      return null;
+    }
+
+    // wrap id in IdPageParamDo
+    if (objects.isString(idOrPageParam)) {
+      return scout.create(IdPageParamDo, {id: idOrPageParam});
+    }
+
+    // deserialize object literal DO and check whether the result is a PageParamDo
+    idOrPageParam = dataObjects.deserialize(idOrPageParam);
+    if (!(idOrPageParam instanceof PageParamDo)) {
+      return null;
+    }
+    return idOrPageParam;
+  }
+
+  /**
+   * Creates a child page id for the given id or {@link PageParamDo}.
+   * If the given id or param is an id already, it is simply returned.
+   * If the given id or param is a {@link PageParamDo} it is stringified (see {@link dataObjects#stringify}) in order to create a child page id.
+   */
+  protected _createChildPageId(idOrPageParam?: string | PageParamDo): string {
+    if (!idOrPageParam) {
+      return null;
+    }
+
+    // simply return id
+    if (objects.isString(idOrPageParam)) {
+      return idOrPageParam;
+    }
+
+    // deserialize object literal DO and check whether the result is a PageParamDo
+    idOrPageParam = dataObjects.deserialize(idOrPageParam);
+    if (!(idOrPageParam instanceof PageParamDo)) {
+      return null;
+    }
+
+    // stringify PageParamDo
+    return dataObjects.stringify(idOrPageParam);
+  }
+
+  /**
+   * Gets the child page param from the given {@link JsPageChildPage}.
+   */
+  protected _getChildPageParam(childPage?: JsPageChildPage): PageParamDo {
+    if (!childPage?.__jsPageChildPageParam) {
+      return null;
+    }
+
+    // ensure that __jsPageChildPageParam is a PageParamDo
+    this._ensureJsPageChildPage(childPage);
+
+    return childPage.__jsPageChildPageParam;
+  }
+
+  /**
+   * Gets the child page id from the given {@link JsPageChildPage}.
+   */
+  protected _getChildPageId(childPage?: JsPageChildPage): string {
+    // get child page param
+    const pageParam = this._getChildPageParam(childPage);
+    if (!pageParam) {
+      return null;
+    }
+
+    // page param is IdPageParamDo -> use its id (see _createChildPageParam)
+    if (pageParam instanceof IdPageParamDo) {
+      return this._createChildPageId(pageParam.id);
+    }
+
+    return this._createChildPageId(pageParam);
+  }
+
+  /**
+   * Ensures the given {@link JsPageChildPage}, i.e. ensures that its properties are of the correct type.
+   */
+  protected _ensureJsPageChildPage(childPage?: JsPageChildPage) {
+    if (!childPage?.__jsPageChildPageParam) {
+      return;
+    }
+
+    // __jsPageChildPageParam is a PageParamDo already -> return
+    if (childPage.__jsPageChildPageParam instanceof PageParamDo) {
+      return;
+    }
+
+    // deserialize __jsPageChildPageParam as it may be an object literal DO when it comes from the server
+    childPage.__jsPageChildPageParam = dataObjects.deserialize(childPage.__jsPageChildPageParam);
+  }
+}
+
+export interface JsPageHelperModel {
+  page?: Page;
+}
+
+/**
+ * Page param that is used by {@link JsPageHelper} to create child pages if only an id is provided.
+ */
+@typeName('scout.IdPageParam')
+export class IdPageParamDo extends PageParamDo {
+  id: string;
+}
+
+interface JsPageChildPage extends Page {
+  /**
+   * The {@link PageParamDo} sent to the server by the {@link JsPageHelper} in order to create this child page.
+   */
+  __jsPageChildPageParam?: PageParamDo;
+}

--- a/eclipse-scout-core/src/desktop/outline/pages/js/LoadChildPagesHybridActionDo.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/js/LoadChildPagesHybridActionDo.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {BaseDoEntity, PageParamDo, typeName} from '../../../../index';
+
+@typeName('scout.LoadChildPagesHybridAction')
+export class LoadChildPagesHybridActionDo extends BaseDoEntity {
+  pageParams: PageParamDo[];
+  replace: boolean;
+}

--- a/eclipse-scout-core/src/index.less
+++ b/eclipse-scout-core/src/index.less
@@ -42,6 +42,7 @@
 @import "desktop/outline/SearchOutline";
 @import "desktop/outline/navigation/NavigateButton";
 @import "desktop/outline/overview/OutlineOverview";
+@import "desktop/outline/pages/js/JsPageHelper";
 @import "desktop/popupblocker/PopupBlockerDesktopNotification";
 @import "desktop/toolbox/DesktopToolBox";
 @import "desktop/viewbutton/ViewButton";

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -1125,6 +1125,8 @@ export * from './desktop/outline/pages/AutoLeafPageWithNodesModel';
 export * from './desktop/outline/pages/PageDetailMenuContributor';
 export * from './desktop/outline/pages/ParentTablePageMenuContributor';
 export * from './desktop/outline/pages/PageResolver';
+export * from './desktop/outline/pages/js/JsPageHelper';
+export * from './desktop/outline/pages/js/LoadChildPagesHybridActionDo';
 export * from './desktop/outline/DetailTableTreeFilter';
 export * from './desktop/outline/Outline';
 export * from './desktop/outline/OutlineModel';

--- a/eclipse-scout-core/src/tree/TreeAdapter.ts
+++ b/eclipse-scout-core/src/tree/TreeAdapter.ts
@@ -113,6 +113,24 @@ export class TreeAdapter extends ModelAdapter {
     this._send('nodesChecked', data);
   }
 
+  sendNodesChanged(nodes: TreeNode[]) {
+    nodes = arrays.ensure(nodes)
+      .filter(node => TreeAdapter.isRemote(node));
+    if (!nodes.length) {
+      return;
+    }
+
+    this._send('nodesChanged', {
+      nodes: nodes.map(node => ({
+        nodeId: node.id,
+        text: node.text,
+        htmlEnabled: node.htmlEnabled,
+        cssClass: node.cssClass,
+        iconId: node.iconId
+      }))
+    });
+  }
+
   protected override _onWidgetEvent(event: Event<Tree>) {
     if (event.type === 'nodesSelected') {
       this._onWidgetNodesSelected(event as TreeNodesSelectedEvent);

--- a/eclipse-scout-core/src/tree/TreeNode.ts
+++ b/eclipse-scout-core/src/tree/TreeNode.ts
@@ -432,6 +432,46 @@ export class TreeNode implements TreeNodeModel, ObjectWithType, FilterElement {
     this.cssClass = cssClass;
   }
 
+  /**
+   * Adds the given css class to {@link TreeNode#cssClass}.
+   *
+   * @see styles#addCssClass
+   * @param cssClass may contain multiple css classes separated by space.
+   */
+  addCssClass(cssClass: string) {
+    this.setCssClass(styles.addCssClass(this.cssClass, cssClass));
+  }
+
+  /**
+   * Removes the given css class from {@link TreeNode#cssClass}.
+   *
+   * @see styles#removeCssClass
+   * @param cssClass may contain multiple css classes separated by space.
+   */
+  removeCssClass(cssClass: string) {
+    this.setCssClass(styles.removeCssClass(this.cssClass, cssClass));
+  }
+
+  /**
+   * Toggles the given css class in {@link TreeNode#cssClass}.
+   *
+   * @see styles#toggleCssClass
+   * @param cssClass may contain multiple css classes separated by space.
+   */
+  toggleCssClass(cssClass: string, condition: boolean) {
+    this.setCssClass(styles.toggleCssClass(this.cssClass, cssClass, condition));
+  }
+
+  /**
+   * Checks whether the css class is contained in {@link TreeNode#cssClass}.
+   *
+   * @see styles#hasCssClass
+   * @param cssClass may contain multiple css classes separated by space.
+   */
+  hasCssClass(cssClass: string): boolean {
+    return styles.hasCssClass(this.cssClass, cssClass);
+  }
+
   setEnabled(enabled: boolean) {
     this.enabled = enabled;
   }

--- a/eclipse-scout-core/test/ExtensionSpec.ts
+++ b/eclipse-scout-core/test/ExtensionSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Extension, scout, StringField} from '../src/index';
+import {arrays, Extension, scout, StringField, Tree, TreeNode} from '../src/index';
 import {LocaleSpecHelper} from '../src/testing/index';
 import {InitModelOf} from '../src/scout';
 
@@ -118,4 +118,60 @@ describe('Extension', () => {
 
   });
 
+  describe('recursively called extensions', () => {
+
+    let extendedBeforeNextCall: MyTreeNode[];
+    let extendedAfterNextCall: MyTreeNode[];
+
+    beforeEach(() => {
+      extendedBeforeNextCall = [];
+      extendedAfterNextCall = [];
+    });
+
+    class MyTreeNode extends TreeNode {
+    }
+
+    class MyTreeNodeExtension extends Extension<MyTreeNode> {
+      init() {
+        this.extend(MyTreeNode.prototype, '_init');
+      }
+
+      protected _init(model: InitModelOf<MyTreeNode>) {
+        const extended = this.extended;
+        extendedBeforeNextCall.push(extended);
+
+        this.next(model);
+
+        // extension is called for all child nodes during next-call -> expect that this.extended is reset after nested calls
+        expect(extended).toBe(this.extended);
+
+        extendedAfterNextCall.push(extended);
+      }
+    }
+
+    Extension.install(MyTreeNodeExtension);
+
+    it('always run with the correct context', () => {
+      arrays.clear(extendedBeforeNextCall);
+
+      scout.create(Tree, {
+        parent: session.desktop,
+        nodes: [{
+          objectType: MyTreeNode,
+          text: '0',
+          childNodes: [{
+            objectType: MyTreeNode,
+            text: '1',
+            childNodes: [{
+              objectType: MyTreeNode,
+              text: '2'
+            }]
+          }]
+        }]
+      });
+
+      expect(extendedBeforeNextCall.map(node => node.text)).toEqual(['0', '1', '2']);
+      expect(extendedAfterNextCall.map(node => node.text)).toEqual(['2', '1', '0']);
+    });
+  });
 });

--- a/eclipse-scout-core/test/desktop/outline/pages/js/JsPageHelperSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/js/JsPageHelperSpec.ts
@@ -1,0 +1,1057 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {
+  Column, HybridManager, HybridManagerAdapter, InitModelOf, JsPageHelper, Outline, OutlineAdapter, Page, PageParamDo, PageWithTable, RemoteEvent, RemoteRequest, scout, styles, Table, TableRow, TreeNode, TreeNodeModel, typeName, UuidPool
+} from '../../../../../src';
+import {OutlineSpecHelper} from '../../../../../src/testing';
+
+describe('JsPageHelper', () => {
+  let session: SandboxSession;
+  let outlineSpecHelper: OutlineSpecHelper;
+  let outline: Outline;
+  let outlineAdapter: OutlineAdapter;
+  let page: Page;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+
+    session.desktop.addOns.push(
+      scout.create(HybridManager, {parent: session.desktop}),
+      scout.create(UuidPool, {parent: session.desktop})
+    );
+
+    outlineSpecHelper = new OutlineSpecHelper(session);
+    outline = outlineSpecHelper.createOutline(outlineSpecHelper.createModelFixture(1, 0, true));
+
+    linkWidgetAndAdapter(outline, OutlineAdapter);
+    outlineAdapter = outline.modelAdapter as OutlineAdapter;
+
+    page = outline.nodes[0];
+  });
+
+  describe('init', () => {
+
+    it('ensures page is set', () => {
+      expect(() => scout.create(SpecJsPageHelper, {} as InitModelOf<SpecJsPageHelper>)).toThrowError('Page not set or has wrong type');
+      expect(() => scout.create(SpecJsPageHelper, {page: 'Foo' as unknown as Page})).toThrowError('Page not set or has wrong type');
+    });
+
+    it('installs listeners', () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      expect(outline.events.count('nodesUpdated', helper._nodesUpdatedHandler)).toBe(1);
+      expect(outline.events.count('nodesDeleted', helper._nodesDeletedHandler)).toBe(1);
+      expect(outline.events.count('allChildNodesDeleted', helper._allChildNodesDeletedHandler)).toBe(1);
+      expect(outline.events.count('nodesInserted', helper._nodesInsertedHandler)).toBe(0);
+
+      // PageWithTable needs more listeners
+
+      outline.insertNode({
+        ...outlineSpecHelper.createModelNode(null, 'bar'),
+        objectType: MyPageWithTable
+      });
+
+      const myPageWithTable = outline.nodes[1] as MyPageWithTable;
+      expect(myPageWithTable).toBeInstanceOf(MyPageWithTable);
+      myPageWithTable.ensureDetailTable();
+
+      const myPageWithTableHelper = myPageWithTable.jsPageHelper;
+
+      expect(outline.events.count('nodesUpdated', myPageWithTableHelper._nodesUpdatedHandler)).toBe(1);
+      expect(outline.events.count('nodesDeleted', myPageWithTableHelper._nodesDeletedHandler)).toBe(1);
+      expect(outline.events.count('allChildNodesDeleted', myPageWithTableHelper._allChildNodesDeletedHandler)).toBe(1);
+      expect(outline.events.count('nodesInserted', myPageWithTableHelper._nodesInsertedHandler)).toBe(1);
+
+      const table = myPageWithTable.detailTable;
+      expect(table.events.count('rowsInserted', myPageWithTableHelper._tableRowsInsertHandler)).toBe(1);
+
+      myPageWithTable.setDetailTable(scout.create(Table, {
+        parent: outline,
+        columns: [
+          {
+            id: 'PrimaryKeyColumn',
+            objectType: Column,
+            displayable: false,
+            primaryKey: true
+          },
+          {
+            id: 'LabelColumn',
+            objectType: Column,
+            text: 'Label',
+            width: 200,
+            summary: true
+          }
+        ]
+      }));
+
+      expect(myPageWithTable.detailTable).not.toBe(table);
+      expect(table.events.count('rowsInserted', myPageWithTableHelper._tableRowsInsertHandler)).toBe(0);
+      expect(myPageWithTable.detailTable.events.count('rowsInserted', myPageWithTableHelper._tableRowsInsertHandler)).toBe(1);
+    });
+  });
+
+  describe('destroy', () => {
+
+    it('uninstalls listeners', () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+      helper.destroy();
+
+      expect(outline.events.count('nodesUpdated', helper._nodesUpdatedHandler)).toBe(0);
+      expect(outline.events.count('nodesDeleted', helper._nodesDeletedHandler)).toBe(0);
+      expect(outline.events.count('allChildNodesDeleted', helper._allChildNodesDeletedHandler)).toBe(0);
+
+      // PageWithTable
+
+      outline.insertNode({
+        ...outlineSpecHelper.createModelNode(null, 'bar'),
+        objectType: MyPageWithTable
+      });
+
+      const myPageWithTable = outline.nodes[1] as MyPageWithTable;
+      expect(myPageWithTable).toBeInstanceOf(MyPageWithTable);
+      myPageWithTable.ensureDetailTable();
+
+      const myPageWithTableHelper = myPageWithTable.jsPageHelper;
+      myPageWithTableHelper.destroy();
+
+      expect(outline.events.count('nodesUpdated', myPageWithTableHelper._nodesUpdatedHandler)).toBe(0);
+      expect(outline.events.count('nodesDeleted', myPageWithTableHelper._nodesDeletedHandler)).toBe(0);
+      expect(outline.events.count('allChildNodesDeleted', myPageWithTableHelper._allChildNodesDeletedHandler)).toBe(0);
+      expect(outline.events.count('nodesInserted', myPageWithTableHelper._nodesInsertedHandler)).toBe(0);
+      expect(myPageWithTable.detailTable.events.count('rowsInserted', myPageWithTableHelper._tableRowsInsertHandler)).toBe(0);
+    });
+  });
+
+  describe('nodesUpdated', () => {
+
+    it('removes linked rows', async () => {
+      outline.insertNode({
+        ...outlineSpecHelper.createModelNode(null, 'bar'),
+        objectType: MyPageWithTable,
+        childNodes: [
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '1'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '2'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '3'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '4'}}
+        ]
+      });
+
+      const myPageWithTable = outline.nodes[1] as MyPageWithTable;
+      expect(myPageWithTable).toBeInstanceOf(MyPageWithTable);
+      myPageWithTable.ensureDetailTable();
+
+      const helper = myPageWithTable.jsPageHelper;
+      spyOn(helper, 'callLoadChildPages').and.callFake(async (idsOrPageParams: string | PageParamDo | (string | PageParamDo)[], replace?: boolean): Promise<void> => {
+        helper._addChildPagesToIdMap();
+      });
+
+      await myPageWithTable.ensureLoadChildren();
+
+      spyOn(outlineAdapter, 'sendNodesChanged').and.callFake((nodes: TreeNode[]) => undefined);
+
+      const [page1, page2, page3, page4] = myPageWithTable.childNodes;
+
+      outline.updateNodes([page1, page2]);
+      expect(outlineAdapter.sendNodesChanged).toHaveBeenCalledWith([page1, page2]);
+
+      outline.updateNodes([myPageWithTable, page2, page3, page4]);
+      expect(outlineAdapter.sendNodesChanged).toHaveBeenCalledWith([page2, page3, page4]);
+    });
+  });
+
+  describe('nodesDeleted', () => {
+
+    it('removes linked rows', async () => {
+      outline.insertNode({
+        ...outlineSpecHelper.createModelNode(null, 'bar'),
+        objectType: MyPageWithTable,
+        childNodes: [
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '1'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '2'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '3'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '4'}}
+        ]
+      });
+
+      const myPageWithTable = outline.nodes[1] as MyPageWithTable;
+      expect(myPageWithTable).toBeInstanceOf(MyPageWithTable);
+      myPageWithTable.ensureDetailTable();
+
+      const helper = myPageWithTable.jsPageHelper;
+      spyOn(helper, 'callLoadChildPages').and.callFake(async (idsOrPageParams: string | PageParamDo | (string | PageParamDo)[], replace?: boolean): Promise<void> => {
+        helper._addChildPagesToIdMap();
+      });
+
+      await myPageWithTable.ensureLoadChildren();
+
+      const row3 = myPageWithTable.detailTable.rows[2];
+      const row4 = myPageWithTable.detailTable.rows[3];
+
+      expect(myPageWithTable.childrenLoaded).toBeTrue();
+      expect(myPageWithTable.childNodes.length).toBe(4);
+      expect(myPageWithTable.detailTable.rows.length).toBe(4);
+      expect(helper._childPagesById.size).toBe(4);
+
+      const [page1, page2, page3, page4] = myPageWithTable.childNodes;
+
+      outline.deleteNodes([page1, page2]);
+
+      expect(myPageWithTable.childrenLoaded).toBeTrue();
+      expect(myPageWithTable.childNodes).toEqual([page3, page4]);
+      expect(myPageWithTable.detailTable.rows).toEqual([row3, row4]);
+      expect(helper._childPagesById.size).toBe(2);
+
+      outline.deleteNodes([page3, page4]);
+
+      expect(myPageWithTable.childrenLoaded).toBeFalse();
+      expect(myPageWithTable.childNodes.length).toBe(0);
+      expect(myPageWithTable.detailTable.rows.length).toBe(0);
+      expect(helper._childPagesById.size).toBe(0);
+    });
+  });
+
+  describe('allChildNodesDeleted', () => {
+
+    it('removes all rows', async () => {
+      outline.insertNode({
+        ...outlineSpecHelper.createModelNode(null, 'bar'),
+        objectType: MyPageWithTable,
+        childNodes: [
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '1'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '2'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '3'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '4'}}
+        ]
+      });
+
+      const myPageWithTable = outline.nodes[1] as MyPageWithTable;
+      expect(myPageWithTable).toBeInstanceOf(MyPageWithTable);
+      myPageWithTable.ensureDetailTable();
+
+      const helper = myPageWithTable.jsPageHelper;
+      spyOn(helper, 'callLoadChildPages').and.callFake(async (idsOrPageParams: string | PageParamDo | (string | PageParamDo)[], replace?: boolean): Promise<void> => {
+        helper._addChildPagesToIdMap();
+      });
+
+      await myPageWithTable.ensureLoadChildren();
+
+      expect(myPageWithTable.childrenLoaded).toBeTrue();
+      expect(myPageWithTable.childNodes.length).toBe(4);
+      expect(myPageWithTable.detailTable.rows.length).toBe(4);
+      expect(helper._childPagesById.size).toBe(4);
+
+      outline.deleteAllChildNodes(myPageWithTable);
+
+      expect(myPageWithTable.childrenLoaded).toBeFalse();
+      expect(myPageWithTable.childNodes.length).toBe(0);
+      expect(myPageWithTable.detailTable.rows.length).toBe(0);
+      expect(helper._childPagesById.size).toBe(0);
+    });
+  });
+
+  describe('nodesInserted', () => {
+
+    it('toggles css class js-page-child-page-loading', () => {
+      outline.insertNode({
+        ...outlineSpecHelper.createModelNode(null, 'bar'),
+        objectType: MyPageWithTable,
+        childNodes: [
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '1'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '2'}}
+        ]
+      });
+
+      const myPageWithTable = outline.nodes[1] as MyPageWithTable;
+      expect(myPageWithTable).toBeInstanceOf(MyPageWithTable);
+
+      expect(myPageWithTable.childNodes.length).toBe(2);
+      for (const page of myPageWithTable.childNodes) {
+        expect(styles.hasCssClass(page.cssClass, 'js-page-child-page-loading')).toBeFalse();
+      }
+
+      myPageWithTable.childrenLoaded = false;
+      outline.insertNodes(myPageWithTable.childNodes, myPageWithTable);
+      expect(myPageWithTable.childNodes.length).toBe(2);
+      for (const page of myPageWithTable.childNodes) {
+        expect(styles.hasCssClass(page.cssClass, 'js-page-child-page-loading')).toBeTrue();
+      }
+
+      myPageWithTable.childrenLoaded = true;
+      outline.insertNodes(myPageWithTable.childNodes, myPageWithTable);
+      expect(myPageWithTable.childNodes.length).toBe(2);
+      for (const page of myPageWithTable.childNodes) {
+        expect(styles.hasCssClass(page.cssClass, 'js-page-child-page-loading')).toBeFalse();
+      }
+    });
+  });
+
+  describe('rowsInserted', () => {
+
+    it('sends nodesChanged event for linked pages', async () => {
+      outline.insertNode({
+        ...outlineSpecHelper.createModelNode(null, 'bar'),
+        objectType: MyPageWithTable,
+        childNodes: [
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '1'}},
+          {__jsPageChildPageParam: {_type: 'scout.IdPageParam', id: '2'}}
+        ]
+      });
+
+      const myPageWithTable = outline.nodes[1] as MyPageWithTable;
+      expect(myPageWithTable).toBeInstanceOf(MyPageWithTable);
+      myPageWithTable.ensureDetailTable();
+
+      const helper = myPageWithTable.jsPageHelper;
+      spyOn(helper, 'callLoadChildPages').and.callFake(async (idsOrPageParams: string | PageParamDo | (string | PageParamDo)[], replace?: boolean): Promise<void> => {
+        helper._addChildPagesToIdMap();
+      });
+
+      spyOn(outlineAdapter, 'sendNodesChanged').and.callFake((nodes: TreeNode[]) => undefined);
+
+      await myPageWithTable.ensureLoadChildren();
+
+      const [page1, page2] = helper.findChildPages(['1', '2']);
+      expect(outlineAdapter.sendNodesChanged).toHaveBeenCalledWith([page1, page2]);
+    });
+  });
+
+  describe('callLoadChildPages', () => {
+    let hybridManager: HybridManager;
+    let hybridManagerAdapter: HybridManagerAdapter;
+
+    beforeEach(() => {
+      hybridManager = HybridManager.get(session);
+      linkWidgetAndAdapter(hybridManager, HybridManagerAdapter);
+      hybridManagerAdapter = hybridManager.modelAdapter as HybridManagerAdapter;
+
+      jasmine.Ajax.install();
+    });
+
+    afterEach(() => {
+      jasmine.Ajax.uninstall();
+    });
+
+    it('loads child pages using page params', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      // single page param
+
+      const idSingle = '7';
+      UuidPool.get(session).uuids.push(idSingle);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages([scout.create(MyPageParamDo, {id: 'foo'})]);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idSingle,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'jsPageHelper.MyPageParam', id: 'foo'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+
+      // multiple page params
+
+      const idMultiple = '13';
+      UuidPool.get(session).uuids.push(idMultiple);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages([scout.create(MyPageParamDo, {id: 'foo'}), scout.create(MyPageParamDo, {id: 'bar'})]);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idMultiple,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'jsPageHelper.MyPageParam', id: 'foo'},
+            {_type: 'jsPageHelper.MyPageParam', id: 'bar'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+
+      // multiple page params
+
+      const idDuplicate = '42';
+      UuidPool.get(session).uuids.push(idDuplicate);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages([scout.create(MyPageParamDo, {id: 'foo'}), scout.create(MyPageParamDo, {id: 'bar'}), scout.create(MyPageParamDo, {id: 'foo'})]);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idDuplicate,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'jsPageHelper.MyPageParam', id: 'foo'},
+            {_type: 'jsPageHelper.MyPageParam', id: 'bar'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+    });
+
+    it('loads child pages using ids', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      // single id
+
+      const idSingle = '7';
+      UuidPool.get(session).uuids.push(idSingle);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages(['foo']);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idSingle,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'scout.IdPageParam', id: 'foo'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+
+      // multiple ids
+
+      const idMultiple = '13';
+      UuidPool.get(session).uuids.push(idMultiple);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages(['foo', 'bar']);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idMultiple,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'scout.IdPageParam', id: 'foo'},
+            {_type: 'scout.IdPageParam', id: 'bar'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+
+      // duplicate ids
+
+      const idDuplicate = '42';
+      UuidPool.get(session).uuids.push(idDuplicate);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages(['foo', 'bar', 'foo']);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idDuplicate,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'scout.IdPageParam', id: 'foo'},
+            {_type: 'scout.IdPageParam', id: 'bar'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+    });
+
+    it('loads child pages using page params and ids', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      // id and page param mixed
+
+      const idMixed = '42';
+      UuidPool.get(session).uuids.push(idMixed);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages(['foo', scout.create(MyPageParamDo, {id: 'bar'})]);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idMixed,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'scout.IdPageParam', id: 'foo'},
+            {_type: 'jsPageHelper.MyPageParam', id: 'bar'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+    });
+
+    it('loads child pages passing the replace flag', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      // explicitly disable replace
+
+      const idFalse = '13';
+      UuidPool.get(session).uuids.push(idFalse);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages(['foo'], false);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idFalse,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'scout.IdPageParam', id: 'foo'}
+          ],
+          replace: false
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+
+      // explicitly enable replace
+
+      const idTrue = '13';
+      UuidPool.get(session).uuids.push(idTrue);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages(['foo'], true);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idTrue,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'scout.IdPageParam', id: 'foo'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+    });
+
+    it('loads child pages without replace if child pages are present during initialisation', async () => {
+      outline.insertNode({
+        ...outlineSpecHelper.createModelNode(null, 'bar'),
+        __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'bar'}
+      }, page);
+
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      // if there are child pages during initialisation they are not replaced
+
+      const idFirst = '13';
+      UuidPool.get(session).uuids.push(idFirst);
+      const callLoadChildPagesPromise = helper.callLoadChildPages(['foo']);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idFirst,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'scout.IdPageParam', id: 'foo'}
+          ],
+          replace: false
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+
+      // trigger the hybridActionEnd-event to resolve the promise
+      hybridManager.trigger(`hybridActionEnd:${idFirst}`);
+
+      await callLoadChildPagesPromise;
+
+      // every following call will replace child pages
+
+      const idSecond = '42';
+      UuidPool.get(session).uuids.push(idSecond);
+      // noinspection ES6MissingAwait
+      helper.callLoadChildPages(['foo']);
+
+      await hybridManager.when('hybridAction');
+
+      expect(sendQueuedCallsAndGetMostRecentRequest()).toContainEvents(new RemoteEvent(hybridManagerAdapter.id, 'hybridAction', {
+        actionType: 'scout.LoadChildPages',
+        id: idSecond,
+        data: {
+          _type: 'scout.LoadChildPagesHybridAction',
+          pageParams: [
+            {_type: 'scout.IdPageParam', id: 'foo'}
+          ],
+          replace: true
+        },
+        contextElements: {
+          page: [{widget: outlineAdapter.id, element: page.id}]
+        }
+      }));
+    });
+
+    it('collects child pages into map', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      expect(helper._childPagesById.size).toBe(0);
+
+      const id = '42';
+      UuidPool.get(session).uuids.push(id);
+      const callLoadChildPagesPromise = helper.callLoadChildPages(['foo', 'bar']);
+
+      await hybridManager.when('hybridAction');
+
+      sendQueuedCalls();
+      session._processSuccessResponse({
+        events: [
+          {
+            target: hybridManagerAdapter.id,
+            type: 'hybridEvent',
+            id,
+            eventType: 'hybridActionEnd'
+          },
+          {
+            target: outlineAdapter.id,
+            type: 'nodesInserted',
+            commonParentNodeId: page.id,
+            nodes: [
+              {
+                ...outlineSpecHelper.createModelNode(null, 'foo'),
+                __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'foo'}
+              },
+              {
+                ...outlineSpecHelper.createModelNode(null, 'bar'),
+                __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'bar'}
+              }
+            ]
+          }
+        ]
+      });
+
+      await callLoadChildPagesPromise;
+
+      expect(helper._childPagesById.size).toBe(2);
+    });
+  });
+
+  describe('loadChildPages', () => {
+    let hybridManager: HybridManager;
+    let hybridManagerAdapter: HybridManagerAdapter;
+
+    beforeEach(() => {
+      hybridManager = HybridManager.get(session);
+      linkWidgetAndAdapter(hybridManager, HybridManagerAdapter);
+      hybridManagerAdapter = hybridManager.modelAdapter as HybridManagerAdapter;
+
+      jasmine.Ajax.install();
+    });
+
+    afterEach(() => {
+      jasmine.Ajax.uninstall();
+    });
+
+    it('loads and returns pages using page params', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      const id = '42';
+      UuidPool.get(session).uuids.push(id);
+      const loadChildPagesPromise = helper.loadChildPages([scout.create(MyPageParamDo, {id: 'foo'}), scout.create(MyPageParamDo, {id: 'bar'})]);
+
+      await hybridManager.when('hybridAction');
+
+      sendQueuedCalls();
+      session._processSuccessResponse({
+        events: [
+          {
+            target: hybridManagerAdapter.id,
+            type: 'hybridEvent',
+            id,
+            eventType: 'hybridActionEnd'
+          },
+          {
+            target: outlineAdapter.id,
+            type: 'nodesInserted',
+            commonParentNodeId: page.id,
+            nodes: [
+              {
+                ...outlineSpecHelper.createModelNode(null, 'foo'),
+                __jsPageChildPageParam: {_type: 'jsPageHelper.MyPageParam', id: 'foo'}
+              },
+              {
+                ...outlineSpecHelper.createModelNode(null, 'bar'),
+                __jsPageChildPageParam: {_type: 'jsPageHelper.MyPageParam', id: 'bar'}
+              }
+            ]
+          }
+        ]
+      });
+
+      expect((await loadChildPagesPromise)?.map(page => page.text)).toEqual(['foo', 'bar']);
+    });
+
+    it('loads and returns pages using ids', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      const id = '42';
+      UuidPool.get(session).uuids.push(id);
+      const loadChildPagesPromise = helper.loadChildPages(['foo', 'bar']);
+
+      await hybridManager.when('hybridAction');
+
+      sendQueuedCalls();
+      session._processSuccessResponse({
+        events: [
+          {
+            target: hybridManagerAdapter.id,
+            type: 'hybridEvent',
+            id,
+            eventType: 'hybridActionEnd'
+          },
+          {
+            target: outlineAdapter.id,
+            type: 'nodesInserted',
+            commonParentNodeId: page.id,
+            nodes: [
+              {
+                ...outlineSpecHelper.createModelNode(null, 'foo'),
+                __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'foo'}
+              },
+              {
+                ...outlineSpecHelper.createModelNode(null, 'bar'),
+                __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'bar'}
+              }
+            ]
+          }
+        ]
+      });
+
+      expect((await loadChildPagesPromise)?.map(page => page.text)).toEqual(['foo', 'bar']);
+    });
+
+    it('loads and returns pages using page params and ids', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      const id = '42';
+      UuidPool.get(session).uuids.push(id);
+      const loadChildPagesPromise = helper.loadChildPages([scout.create(MyPageParamDo, {id: 'foo'}), 'bar']);
+
+      await hybridManager.when('hybridAction');
+
+      sendQueuedCalls();
+      session._processSuccessResponse({
+        events: [
+          {
+            target: hybridManagerAdapter.id,
+            type: 'hybridEvent',
+            id,
+            eventType: 'hybridActionEnd'
+          },
+          {
+            target: outlineAdapter.id,
+            type: 'nodesInserted',
+            commonParentNodeId: page.id,
+            nodes: [
+              {
+                ...outlineSpecHelper.createModelNode(null, 'foo'),
+                __jsPageChildPageParam: {_type: 'jsPageHelper.MyPageParam', id: 'foo'}
+              },
+              {
+                ...outlineSpecHelper.createModelNode(null, 'bar'),
+                __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'bar'}
+              }
+            ]
+          }
+        ]
+      });
+
+      expect((await loadChildPagesPromise)?.map(page => page.text)).toEqual(['foo', 'bar']);
+    });
+  });
+
+  describe('findChildPages', () => {
+    let hybridManager: HybridManager;
+    let hybridManagerAdapter: HybridManagerAdapter;
+
+    beforeEach(() => {
+      hybridManager = HybridManager.get(session);
+      linkWidgetAndAdapter(hybridManager, HybridManagerAdapter);
+      hybridManagerAdapter = hybridManager.modelAdapter as HybridManagerAdapter;
+
+      jasmine.Ajax.install();
+    });
+
+    afterEach(() => {
+      jasmine.Ajax.uninstall();
+    });
+
+    it('returns pages previously created using page params', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      const id = '42';
+      UuidPool.get(session).uuids.push(id);
+      const callLoadChildPagesPromise = helper.callLoadChildPages([scout.create(MyPageParamDo, {id: 'foo'}), scout.create(MyPageParamDo, {id: 'bar'})]);
+
+      await hybridManager.when('hybridAction');
+
+      sendQueuedCalls();
+      session._processSuccessResponse({
+        events: [
+          {
+            target: hybridManagerAdapter.id,
+            type: 'hybridEvent',
+            id,
+            eventType: 'hybridActionEnd'
+          },
+          {
+            target: outlineAdapter.id,
+            type: 'nodesInserted',
+            commonParentNodeId: page.id,
+            nodes: [
+              {
+                ...outlineSpecHelper.createModelNode(null, 'foo'),
+                __jsPageChildPageParam: {_type: 'jsPageHelper.MyPageParam', id: 'foo'}
+              },
+              {
+                ...outlineSpecHelper.createModelNode(null, 'bar'),
+                __jsPageChildPageParam: {_type: 'jsPageHelper.MyPageParam', id: 'bar'}
+              }
+            ]
+          }
+        ]
+      });
+
+      await callLoadChildPagesPromise;
+
+      expect(helper.findChildPage(scout.create(MyPageParamDo, {id: 'foo'}))?.text).toBe('foo');
+      expect(helper.findChildPages(scout.create(MyPageParamDo, {id: 'bar'}))?.map(page => page.text)).toEqual(['bar']);
+      expect(helper.findChildPages([
+        scout.create(MyPageParamDo, {id: 'bar'}),
+        scout.create(MyPageParamDo, {id: 'foo'})
+      ])?.map(page => page.text)).toEqual(['bar', 'foo']);
+    });
+
+    it('returns pages previously created using ids', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      const id = '42';
+      UuidPool.get(session).uuids.push(id);
+      const callLoadChildPagesPromise = helper.callLoadChildPages(['foo', 'bar']);
+
+      await hybridManager.when('hybridAction');
+
+      sendQueuedCalls();
+      session._processSuccessResponse({
+        events: [
+          {
+            target: hybridManagerAdapter.id,
+            type: 'hybridEvent',
+            id,
+            eventType: 'hybridActionEnd'
+          },
+          {
+            target: outlineAdapter.id,
+            type: 'nodesInserted',
+            commonParentNodeId: page.id,
+            nodes: [
+              {
+                ...outlineSpecHelper.createModelNode(null, 'foo'),
+                __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'foo'}
+              },
+              {
+                ...outlineSpecHelper.createModelNode(null, 'bar'),
+                __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'bar'}
+              }
+            ]
+          }
+        ]
+      });
+
+      await callLoadChildPagesPromise;
+
+      expect(helper.findChildPage('foo')?.text).toBe('foo');
+      expect(helper.findChildPages('bar')?.map(page => page.text)).toEqual(['bar']);
+      expect(helper.findChildPages(['bar', 'foo'])?.map(page => page.text)).toEqual(['bar', 'foo']);
+    });
+
+    it('returns pages previously created using page params and ids', async () => {
+      const helper = scout.create(SpecJsPageHelper, {page});
+
+      const id = '42';
+      UuidPool.get(session).uuids.push(id);
+      const callLoadChildPagesPromise = helper.callLoadChildPages([scout.create(MyPageParamDo, {id: 'foo'}), 'bar']);
+
+      await hybridManager.when('hybridAction');
+
+      sendQueuedCalls();
+      session._processSuccessResponse({
+        events: [
+          {
+            target: hybridManagerAdapter.id,
+            type: 'hybridEvent',
+            id,
+            eventType: 'hybridActionEnd'
+          },
+          {
+            target: outlineAdapter.id,
+            type: 'nodesInserted',
+            commonParentNodeId: page.id,
+            nodes: [
+              {
+                ...outlineSpecHelper.createModelNode(null, 'foo'),
+                __jsPageChildPageParam: {_type: 'jsPageHelper.MyPageParam', id: 'foo'}
+              },
+              {
+                ...outlineSpecHelper.createModelNode(null, 'bar'),
+                __jsPageChildPageParam: {_type: 'scout.IdPageParam', id: 'bar'}
+              }
+            ]
+          }
+        ]
+      });
+
+      await callLoadChildPagesPromise;
+
+      expect(helper.findChildPage(scout.create(MyPageParamDo, {id: 'foo'}))?.text).toBe('foo');
+      expect(helper.findChildPages('bar')?.map(page => page.text)).toEqual(['bar']);
+      expect(helper.findChildPages([
+        'bar',
+        scout.create(MyPageParamDo, {id: 'foo'})
+      ])?.map(page => page.text)).toEqual(['bar', 'foo']);
+    });
+  });
+});
+
+function sendQueuedCalls() {
+  jasmine.clock().install();
+  sendQueuedAjaxCalls();
+  jasmine.clock().uninstall();
+}
+
+function sendQueuedCallsAndGetMostRecentRequest(): RemoteRequest {
+  sendQueuedCalls();
+  return mostRecentJsonRequest();
+}
+
+class SpecJsPageHelper extends JsPageHelper {
+  declare _childPagesById: Map<string, Page>;
+
+  declare _nodesUpdatedHandler: typeof this._onNodesUpdated;
+  declare _nodesDeletedHandler: typeof this._onNodesDeleted;
+  declare _allChildNodesDeletedHandler: typeof this._onAllChildNodesDeleted;
+  declare _nodesInsertedHandler: typeof this._onNodesInserted;
+  declare _tableRowsInsertHandler: typeof this._onTableRowsInserted;
+
+  override _addChildPagesToIdMap(childPages?: Page[]) {
+    super._addChildPagesToIdMap(childPages);
+  }
+}
+
+class MyPageWithTable extends PageWithTable {
+
+  jsPageHelper: SpecJsPageHelper;
+
+  protected override _jsonModel(): TreeNodeModel {
+    return {
+      lazyExpandingEnabled: true,
+      detailTable: {
+        objectType: Table,
+        columns: [
+          {
+            id: 'IdColumn',
+            objectType: Column,
+            displayable: false,
+            primaryKey: true
+          },
+          {
+            id: 'TextColumn',
+            objectType: Column,
+            text: 'Text',
+            width: 200,
+            summary: true
+          }
+        ]
+      }
+    };
+  }
+
+  protected override _init(model: InitModelOf<this>) {
+    super._init(model);
+    this.jsPageHelper = scout.create(SpecJsPageHelper, {page: this});
+  }
+
+  override destroy() {
+    super.destroy();
+    this.jsPageHelper.destroy();
+  }
+
+  protected override _loadTableData(searchFilter: any): JQuery.Promise<any> {
+    return $.when(this._loadTableDataAsync(searchFilter));
+  }
+
+  protected async _loadTableDataAsync(searchFilter: any): Promise<any> {
+    await this.jsPageHelper.callLoadChildPages(['1', '2', '3', '4']);
+    return [
+      {cells: ['1', 'one']},
+      {cells: ['2', 'two']},
+      {cells: ['3', 'three']},
+      {cells: ['4', 'four']}
+    ];
+  }
+
+  protected override _createChildPage(row: TableRow): Page {
+    const id = this.detailTable.columnById('IdColumn').cellValue(row);
+    return this.jsPageHelper.findChildPage(id);
+  }
+}
+
+@typeName('jsPageHelper.MyPageParam')
+export class MyPageParamDo extends PageParamDo {
+  id: string;
+}

--- a/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/page/IdPageParamDo.java
+++ b/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/page/IdPageParamDo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.api.data.page;
+
+import jakarta.annotation.Generated;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.ScoutTypeVersions.Scout_26_1_001;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.TypeVersion;
+import org.eclipse.scout.rt.dataobject.id.IId;
+
+/**
+ * Page param that is used by JsPageHelper to create child pages if only an {@link IId} is provided.
+ */
+@TypeName("scout.IdPageParam")
+@TypeVersion(Scout_26_1_001.class)
+public class IdPageParamDo extends DoEntity implements IPageParamDo {
+
+  public DoValue<IId> id() {
+    return doValue("id");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IdPageParamDo withId(IId id) {
+    id().set(id);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public IId getId() {
+    return id().get();
+  }
+}

--- a/org.eclipse.scout.rt.api.data/src/test/resources/org/eclipse/scout/rt/api/data/scout-api-data-dataobject-signature.json
+++ b/org.eclipse.scout.rt.api.data/src/test/resources/org/eclipse/scout/rt/api/data/scout-api-data-dataobject-signature.json
@@ -109,6 +109,15 @@
     "_type" : "scout.EntityDataObjectSignature",
     "attributes" : [ {
       "_type" : "scout.AttributeDataObjectSignature",
+      "name" : "id",
+      "valueType" : "IDI[org.eclipse.scout.rt.dataobject.id.IId]"
+    } ],
+    "typeName" : "scout.IdPageParam",
+    "typeVersion" : "scout-26.1.001"
+  }, {
+    "_type" : "scout.EntityDataObjectSignature",
+    "attributes" : [ {
+      "_type" : "scout.AttributeDataObjectSignature",
       "name" : "displayText",
       "valueType" : "CLASS[java.lang.String]"
     }, {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
@@ -51,6 +51,7 @@ import org.eclipse.scout.rt.client.ui.action.menu.MenuUtility;
 import org.eclipse.scout.rt.client.ui.action.menu.root.ITreeContextMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.root.internal.TreeContextMenu;
 import org.eclipse.scout.rt.client.ui.basic.cell.Cell;
+import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
 import org.eclipse.scout.rt.client.ui.basic.userfilter.IUserFilter;
 import org.eclipse.scout.rt.client.ui.dnd.IDNDSupport;
 import org.eclipse.scout.rt.client.ui.dnd.TransferObject;
@@ -2763,6 +2764,11 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
     m_flags = FLAGS_BIT_HELPER.changeBit(SAVE_AND_RESTORE_SCROLLBARS, b, m_flags);
   }
 
+  @Override
+  public void changeNode(ITreeNode node, ICell cell) {
+    node.getCellForUpdate().updateFrom(cell);
+  }
+
   private abstract static class P_AbstractCountingTreeVisitor extends DepthFirstTreeVisitor<ITreeNode> {
 
     private int m_count;
@@ -3030,6 +3036,23 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
     @Override
     public void setDisplayStyleFromUI(String style) {
       setDisplayStyle(style);
+    }
+
+    @Override
+    public void changeNodesFromUI(Collection<NodeCellTuple> nodeCellTuples) {
+      try {
+        pushUIProcessor();
+        try {
+          setTreeChanging(true);
+          nodeCellTuples.forEach(tuple -> changeNode(tuple.node(), tuple.cell()));
+        }
+        finally {
+          setTreeChanging(false);
+        }
+      }
+      finally {
+        popUIProcessor();
+      }
     }
   }// end private class
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITree.java
@@ -22,6 +22,7 @@ import org.eclipse.scout.rt.client.ui.IWidget;
 import org.eclipse.scout.rt.client.ui.action.keystroke.IKeyStroke;
 import org.eclipse.scout.rt.client.ui.action.menu.root.IContextMenuOwner;
 import org.eclipse.scout.rt.client.ui.action.menu.root.ITreeContextMenu;
+import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
 import org.eclipse.scout.rt.client.ui.dnd.IDNDSupport;
 import org.eclipse.scout.rt.platform.util.visitor.IDepthFirstTreeVisitor;
 import org.eclipse.scout.rt.platform.util.visitor.TreeVisitResult;
@@ -550,4 +551,6 @@ public interface ITree extends IWidget, IDNDSupport, IStyleable, IAppLinkCapable
    * color...) but no structural changes occurred.
    */
   void fireNodeChanged(ITreeNode treeNode);
+
+  void changeNode(ITreeNode node, ICell cell);
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeUIFacade.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeUIFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,9 +9,11 @@
  */
 package org.eclipse.scout.rt.client.ui.basic.tree;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.scout.rt.client.ui.MouseButton;
+import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
 import org.eclipse.scout.rt.client.ui.dnd.TransferObject;
 
 public interface ITreeUIFacade {
@@ -57,4 +59,9 @@ public interface ITreeUIFacade {
   void fireAppLinkActionFromUI(String ref);
 
   void setDisplayStyleFromUI(String style);
+
+  void changeNodesFromUI(Collection<NodeCellTuple> nodeCellTuples);
+
+  record NodeCellTuple(ITreeNode node, ICell cell) {
+  }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/AbstractOutline.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/AbstractOutline.java
@@ -30,6 +30,7 @@ import org.eclipse.scout.rt.client.ui.IWidget;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.TableMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.TreeMenuType;
+import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.basic.table.ITableRow;
 import org.eclipse.scout.rt.client.ui.basic.tree.AbstractTree;
@@ -43,6 +44,7 @@ import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPageWithNodes;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPageWithTable;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.ISearchForm;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.js.IJsPage;
 import org.eclipse.scout.rt.client.ui.dnd.TransferObject;
 import org.eclipse.scout.rt.client.ui.form.FormEvent;
 import org.eclipse.scout.rt.client.ui.form.FormListener;
@@ -1102,5 +1104,13 @@ public abstract class AbstractOutline extends AbstractTree implements IOutline {
       BEANS.get(ExceptionHandler.class).handle(e);
     }
     super.disposeTreeInternal();
+  }
+
+  @Override
+  public void changeNode(ITreeNode node, ICell cell) {
+    super.changeNode(node, cell);
+    if (node instanceof IJsPage jsPage) {
+      jsPage.changeNode(cell);
+    }
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/AbstractSearchOutline.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/AbstractSearchOutline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/AbstractJsPage.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/AbstractJsPage.java
@@ -9,16 +9,31 @@
  */
 package org.eclipse.scout.rt.client.ui.desktop.outline.pages.js;
 
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.eclipse.scout.rt.api.data.page.IPageParamDo;
+import org.eclipse.scout.rt.api.data.page.IdPageParamDo;
+import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.AbstractPage;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
+import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
+import org.eclipse.scout.rt.dataobject.id.IId;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.annotations.ConfigProperty;
 import org.eclipse.scout.rt.platform.classid.ClassId;
 import org.eclipse.scout.rt.platform.reflect.ConfigurationUtility;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 
 @ClassId("3ad642d8-4858-43af-bf4c-f5aa7fab4ba1")
-public class AbstractJsPage extends AbstractPage<ITable> implements IJsPage {
+public abstract class AbstractJsPage extends AbstractPage<ITable> implements IJsPage {
 
   private String m_jsPageObjectType;
   private IDoEntity m_jsPageModel;
@@ -86,5 +101,108 @@ public class AbstractJsPage extends AbstractPage<ITable> implements IJsPage {
     // If there is no classId annotation, null is returned
     // If there is a classId annotation, it must match the uuid of the JavaScript page
     return ConfigurationUtility.getAnnotatedClass(getClass());
+  }
+
+  @Override
+  public void loadChildPages(List<IPageParamDo> pageParams, boolean replace) {
+    try {
+      getOutline().setTreeChanging(true);
+      setChildrenLoaded(false);
+      fireBeforeDataLoaded();
+      try {
+        if (replace) {
+          getOutline().removeAllChildNodes(this);
+          getOutline().addChildNodes(this, createChildPages(pageParams));
+        }
+        else {
+          List<IPage<?>> childPages = createChildPages(pageParams);
+
+          List<IPage<?>> childPagesToRemove = getChildPages();
+          childPagesToRemove.removeAll(childPages);
+          getOutline().removeChildNodes(this, childPagesToRemove);
+
+          List<IPage<?>> childPagesToAdd = CollectionUtility.arrayList(childPages);
+          childPagesToAdd.removeAll(getChildPages());
+          getOutline().addChildNodes(this, childPagesToAdd);
+
+          getOutline().updateChildNodeOrder(this, childPages);
+        }
+      }
+      finally {
+        fireAfterDataLoaded();
+      }
+      setChildrenLoaded(true);
+      setChildrenDirty(false);
+    }
+    finally {
+      getOutline().setTreeChanging(false);
+    }
+  }
+
+  protected List<IPage<?>> createChildPages(List<IPageParamDo> pageParams) {
+    if (!CollectionUtility.hasElements(pageParams)) {
+      return emptyList();
+    }
+    return pageParams.stream()
+        .map(this::getOrCreateChildPage)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  protected IPage<?> getOrCreateChildPage(IPageParamDo pageParam) {
+    IPage<?> existingPage = findExistingPage(pageParam);
+    if (existingPage != null) {
+      return existingPage;
+    }
+    IPage<?> childPage = createChildPage(pageParam);
+    if (childPage != null) {
+      childPage.setPrimaryKey(pageParam);
+    }
+    return childPage;
+  }
+
+  protected IPage<?> findExistingPage(IPageParamDo pageParam) {
+    return getChildPages().stream()
+        .filter(p -> ObjectUtility.equals(pageParam, p.getPrimaryKey()))
+        .findAny()
+        .orElse(null);
+  }
+
+  /**
+   * Override this method to create a child page using an {@link IPageParamDo} given by the Scout JS equivalent of this page.
+   */
+  protected IPage<?> createChildPage(IPageParamDo pageParam) {
+    if (pageParam instanceof IdPageParamDo idPageParam) {
+      return createChildPage(idPageParam.getId());
+    }
+    return null;
+  }
+
+  /**
+   * Override this method to create a child page using an {@link IId} given by the Scout JS equivalent of this page.
+   */
+  protected IPage<?> createChildPage(IId id) {
+    return null;
+  }
+
+  @Override
+  public void changeNode(ICell cell) {
+    if (cell == null) {
+      return;
+    }
+
+    IDoEntity jsPageModel = getJsPageModel();
+    if (jsPageModel == null) {
+      jsPageModel = BEANS.get(DoEntity.class);
+    }
+
+    // properties come from a summary column from a parent PageWithTable, transfer them to jsPageModel so that they are still available after a browser reload
+    // keep in sync with token: [5vv7MGGQ5BQY5NXX7CwJ9tmL4]
+    jsPageModel.put("text", cell.getText());
+    jsPageModel.put("htmlEnabled", cell.isHtmlEnabled());
+    jsPageModel.put("cssClass", cell.getCssClass());
+    jsPageModel.put("iconId", cell.getIconId());
+
+    setJsPageModel(jsPageModel);
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/IJsPage.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/IJsPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,10 @@
  */
 package org.eclipse.scout.rt.client.ui.desktop.outline.pages.js;
 
+import java.util.List;
+
+import org.eclipse.scout.rt.api.data.page.IPageParamDo;
+import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
@@ -34,4 +38,8 @@ public interface IJsPage extends IPage<ITable> {
   IDoEntity getJsPageModel();
 
   void setJsPageModel(IDoEntity jsPageModel);
+
+  void loadChildPages(List<IPageParamDo> pageParams, boolean replace);
+
+  void changeNode(ICell cell);
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/LoadChildPagesHybridAction.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/LoadChildPagesHybridAction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.desktop.outline.pages.js;
+
+import org.eclipse.scout.rt.client.ui.desktop.hybrid.AbstractHybridAction;
+import org.eclipse.scout.rt.client.ui.desktop.hybrid.HybridActionType;
+
+@HybridActionType(LoadChildPagesHybridAction.TYPE)
+public class LoadChildPagesHybridAction extends AbstractHybridAction<LoadChildPagesHybridActionDo> {
+
+  protected static final String TYPE = "scout.LoadChildPages";
+
+  @Override
+  public void execute(LoadChildPagesHybridActionDo data) {
+    try {
+      var jsPage = getContextElement("page").getElement(IJsPage.class);
+      jsPage.loadChildPages(data.getPageParams(), data.isReplace());
+    }
+    finally { // always signal the end of the action to the UI, even in the case of an error on the server
+      fireHybridActionEndEvent();
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/LoadChildPagesHybridActionDo.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/LoadChildPagesHybridActionDo.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.desktop.outline.pages.js;
+
+import java.util.Collection;
+import java.util.List;
+
+import jakarta.annotation.Generated;
+
+import org.eclipse.scout.rt.api.data.page.IPageParamDo;
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoList;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.TypeName;
+
+@TypeName("scout.LoadChildPagesHybridAction")
+public class LoadChildPagesHybridActionDo extends DoEntity {
+
+  public DoList<IPageParamDo> pageParams() {
+    return doList("pageParams");
+  }
+
+  public DoValue<Boolean> replace() {
+    return doValue("replace");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public LoadChildPagesHybridActionDo withPageParams(Collection<? extends IPageParamDo> pageParams) {
+    pageParams().updateAll(pageParams);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public LoadChildPagesHybridActionDo withPageParams(IPageParamDo... pageParams) {
+    pageParams().updateAll(pageParams);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<IPageParamDo> getPageParams() {
+    return pageParams().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public LoadChildPagesHybridActionDo withReplace(Boolean replace) {
+    replace().set(replace);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public Boolean getReplace() {
+    return replace().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public boolean isReplace() {
+    return nvl(getReplace());
+  }
+}

--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/AbstractSeleniumTest.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/junit/AbstractSeleniumTest.java
@@ -391,6 +391,14 @@ public abstract class AbstractSeleniumTest {
     return waitUntilTableCellClickable(null, cellText);
   }
 
+  public WebElement waitUntilTableRowClickable(WebElement cell) {
+    return waitUntilElementClickable(cell, By.xpath(".//ancestor::div[contains(@class, 'table-row')]"));
+  }
+
+  public WebElement waitUntilTableRowClickable(String cellText) {
+    return waitUntilTableRowClickable(waitUntilTableCellClickable(cellText));
+  }
+
   /**
    * Waits for all pending server calls to finish.
    */

--- a/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumUtil.java
+++ b/org.eclipse.scout.rt.ui.html.selenium/src/main/java/org/eclipse/scout/rt/ui/html/selenium/util/SeleniumUtil.java
@@ -34,6 +34,7 @@ public final class SeleniumUtil {
    * DOM attribute used by Scout widgets to identify the Scout Java model class.
    */
   private static final String ATTR_DATA_MODELCLASS = "data-modelclass";
+  private static final String ATTR_DATA_UUID = "data-uuid";
 
   private SeleniumUtil() {
   }
@@ -88,7 +89,7 @@ public final class SeleniumUtil {
    * This query solves the problem that we don't want to find partial matches for a CSS class-name when we query 'class'
    * attribute in the DOM. See
    * <a href="https://stackoverflow.com/questions/1604471/how-can-i-find-an-element-by-css-class-with-xpath">
-   *   how-can-i-find-an-element-by-css-class-with-xpath</a>
+   * how-can-i-find-an-element-by-css-class-with-xpath</a>
    */
   private static String cssClassQuery(String cssClass) {
     return "contains(concat(' ', normalize-space(@class), ' '), ' " + cssClass + " ')";
@@ -191,6 +192,14 @@ public final class SeleniumUtil {
   public static By byModelClassAttributeContainsNot(Class<?> modelClass, String attribute, String value) {
     return By.xpath(String.format("//*[@" + ATTR_DATA_MODELCLASS + "='%s' and contains(@%s, '%s') = false]",
         modelClass.getName(), attribute, value));
+  }
+
+  public static By byUuid(String uuid) {
+    return byUuid(uuid, null);
+  }
+
+  public static By byUuid(String uuid, String xPathIndex) {
+    return byAttributeValue(ATTR_DATA_UUID, uuid, xPathIndex);
   }
 
   /**

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/desktop/outline/pages/js/JsonLoadChildPagesHybridActionTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/desktop/outline/pages/js/JsonLoadChildPagesHybridActionTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html.json.desktop.outline.pages.js;
+
+import static org.junit.Assert.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+
+import org.eclipse.scout.rt.api.data.page.IPageParamDo;
+import org.eclipse.scout.rt.api.data.page.IdPageParamDo;
+import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
+import org.eclipse.scout.rt.client.ui.desktop.hybrid.HybridEvent;
+import org.eclipse.scout.rt.client.ui.desktop.hybrid.HybridManager;
+import org.eclipse.scout.rt.client.ui.desktop.outline.IOutline;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.js.AbstractJsPage;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.js.IJsPage;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.js.LoadChildPagesHybridActionDo;
+import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
+import org.eclipse.scout.rt.dataobject.IIdSignatureDataObjectMapper;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureIntegerId;
+import org.eclipse.scout.rt.dataobject.id.IdCodec;
+import org.eclipse.scout.rt.dataobject.id.IdCodec.IdCodecFlag;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.eclipse.scout.rt.ui.html.UiSession;
+import org.eclipse.scout.rt.ui.html.UiSessionTestUtility;
+import org.eclipse.scout.rt.ui.html.json.JsonEvent;
+import org.eclipse.scout.rt.ui.html.json.desktop.JsPageChildPageToJsonContributor;
+import org.eclipse.scout.rt.ui.html.json.desktop.JsonOutline;
+import org.eclipse.scout.rt.ui.html.json.desktop.fixtures.Outline;
+import org.eclipse.scout.rt.ui.html.json.desktop.hybrid.JsonHybridManager;
+import org.eclipse.scout.rt.ui.html.json.fixtures.UiSessionMock;
+import org.eclipse.scout.rt.ui.html.json.testing.JsonTestUtility;
+import org.eclipse.scout.rt.ui.html.json.tree.JsonTree;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(TestEnvironmentClientSession.class)
+public class JsonLoadChildPagesHybridActionTest {
+
+  private HybridManager m_oldHybridManager;
+
+  private UiSessionMock m_uiSession;
+  private HybridManager m_hybridManager;
+  private JsonHybridManager<HybridManager> m_jsonHybridManager;
+  private JsonOutline<IOutline> m_jsonOutline;
+  private IOutline m_outline;
+
+  private static List<IBean<?>> s_beans;
+
+  @BeforeClass
+  public static void beforeClass() {
+    s_beans = BeanTestingHelper.get().registerBeans(new BeanMetaData(P_IdCodec.class).withReplace(true));
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    BeanTestingHelper.get().unregisterBeans(s_beans);
+    s_beans = null;
+  }
+
+  @Before
+  public void setUp() {
+    m_oldHybridManager = HybridManager.get();
+    IDesktop.CURRENT.get().removeAddOn(m_oldHybridManager);
+
+    m_uiSession = new UiSessionMock();
+
+    m_hybridManager = BEANS.get(HybridManager.class);
+    IDesktop.CURRENT.get().addAddOn(getHybridManager());
+    m_jsonHybridManager = UiSessionTestUtility.newJsonAdapter(getUiSession(), getHybridManager());
+
+    m_outline = new Outline(List.of());
+    m_jsonOutline = UiSessionTestUtility.newJsonAdapter(getUiSession(), getOutline());
+  }
+
+  @After
+  public void tearDown() {
+    UiSessionTestUtility.getJsonAdapterRegistry(getUiSession()).disposeAdapters();
+
+    IDesktop.CURRENT.get().removeAddOn(getHybridManager());
+    IDesktop.CURRENT.get().addAddOn(m_oldHybridManager);
+  }
+
+  private UiSession getUiSession() {
+    return m_uiSession;
+  }
+
+  private HybridManager getHybridManager() {
+    return m_hybridManager;
+  }
+
+  private JsonHybridManager<HybridManager> getJsonHybridManager() {
+    return m_jsonHybridManager;
+  }
+
+  private IOutline getOutline() {
+    return m_outline;
+  }
+
+  private JsonOutline<IOutline> getJsonOutline() {
+    return m_jsonOutline;
+  }
+
+  private String createId() {
+    return UUID.randomUUID().toString();
+  }
+
+  private String callLoadChildPages(String pageId, boolean replace, FixtureIntegerId... fictureIntegerIds) {
+    var id = createId();
+    var data = new JSONObject(BEANS.get(IIdSignatureDataObjectMapper.class).writeValue(BEANS.get(DoEntityBuilder.class)
+        .put("id", id)
+        .put("actionType", "scout.LoadChildPages")
+        .put("data", BEANS.get(LoadChildPagesHybridActionDo.class)
+            .withPageParams(
+                Arrays.stream(fictureIntegerIds).map(fictureIntegerId -> BEANS.get(IdPageParamDo.class).withId(fictureIntegerId)).toList()
+            )
+            .withReplace(replace))
+        .put("contextElements", BEANS.get(DoEntityBuilder.class)
+            .put("page", List.of(BEANS.get(DoEntityBuilder.class)
+                .put("widget", getJsonOutline().getId())
+                .put("element", pageId)
+                .build()))
+            .build())
+        .build()));
+
+    getJsonHybridManager().handleUiEvent(new JsonEvent(getJsonHybridManager().getId(), "hybridAction", data));
+
+    return id;
+  }
+
+  @Test
+  public void testHybridAction() {
+    var myJsTablePage = new MyJsTablePage();
+    getOutline().addChildNode(getOutline().getRootPage(), myJsTablePage);
+
+    getUiSession().currentJsonResponse().fireProcessBufferedEvents();
+    JsonTestUtility.endRequest(m_uiSession);
+
+    var myJsTablePageId = getJsonOutline().getOrCreateNodeId(myJsTablePage);
+
+    // initially insert pages 7 and 13
+
+    var create7And13Id = callLoadChildPages(myJsTablePageId, true, FixtureIntegerId.of(7), FixtureIntegerId.of(13));
+
+    assertEquals(2, myJsTablePage.getChildNodeCount());
+    var createJsPage7 = myJsTablePage.getChildNode(0);
+    var createJsPage13 = myJsTablePage.getChildNode(1);
+
+    assertEquals(BEANS.get(IdPageParamDo.class).withId(FixtureIntegerId.of(7)), createJsPage7.getPrimaryKey());
+    assertEquals(BEANS.get(IdPageParamDo.class).withId(FixtureIntegerId.of(13)), createJsPage13.getPrimaryKey());
+
+    var response = getUiSession().currentJsonResponse();
+    response.fireProcessBufferedEvents();
+
+    var createJsPage7Id = getJsonOutline().getOrCreateNodeId(createJsPage7);
+    var createJsPage13Id = getJsonOutline().getOrCreateNodeId(createJsPage13);
+
+    // corresponding hybridActionEnd-event
+    assertTrue(response.getEventList().stream().anyMatch(hybridActionEndPredicate(create7And13Id)));
+    // nodesInserted-event
+    assertTrue(response.getEventList().stream().anyMatch(nodesInsertedPredicate(
+        myJsTablePageId,
+        new NodesInsertedChildPageInfo(createJsPage7Id, 0, "MyJsPage", FixtureIntegerId.of(7)),
+        new NodesInsertedChildPageInfo(createJsPage13Id, 1, "MyJsPage", FixtureIntegerId.of(13))
+    )));
+
+    JsonTestUtility.endRequest(m_uiSession);
+
+    // replace with pages 13 and 42
+
+    var replace13And42Id = callLoadChildPages(myJsTablePageId, true, FixtureIntegerId.of(13), FixtureIntegerId.of(42));
+
+    assertEquals(2, myJsTablePage.getChildNodeCount());
+    var replaceJsPage13 = myJsTablePage.getChildNode(0);
+    var replaceJsPage42 = myJsTablePage.getChildNode(1);
+
+    // page 13 was replaced
+    assertNotEquals(createJsPage13, replaceJsPage13);
+
+    assertEquals(BEANS.get(IdPageParamDo.class).withId(FixtureIntegerId.of(13)), replaceJsPage13.getPrimaryKey());
+    assertEquals(BEANS.get(IdPageParamDo.class).withId(FixtureIntegerId.of(42)), replaceJsPage42.getPrimaryKey());
+
+    response = getUiSession().currentJsonResponse();
+    response.fireProcessBufferedEvents();
+
+    var replaceJsPage13Id = getJsonOutline().getOrCreateNodeId(replaceJsPage13);
+    var replaceJsPage42Id = getJsonOutline().getOrCreateNodeId(replaceJsPage42);
+
+    // corresponding hybridActionEnd-event
+    assertTrue(response.getEventList().stream().anyMatch(hybridActionEndPredicate(replace13And42Id)));
+    // allChildNodesDeleted-event
+    assertTrue(response.getEventList().stream().anyMatch(allChildNodesDeletedPredicate(myJsTablePageId)));
+    // nodesInserted-event
+    assertTrue(response.getEventList().stream().anyMatch(nodesInsertedPredicate(
+        myJsTablePageId,
+        new NodesInsertedChildPageInfo(replaceJsPage13Id, 0, "MyJsPage", FixtureIntegerId.of(13)),
+        new NodesInsertedChildPageInfo(replaceJsPage42Id, 1, "MyJsPage", FixtureIntegerId.of(42))
+    )));
+
+    JsonTestUtility.endRequest(m_uiSession);
+
+    // create 7 and 42 without replace
+
+    var noReplace7And42Id = callLoadChildPages(myJsTablePageId, false, FixtureIntegerId.of(7), FixtureIntegerId.of(42));
+
+    assertEquals(2, myJsTablePage.getChildNodeCount());
+    var noReplaceJsPage7 = myJsTablePage.getChildNode(0);
+    var noReplaceJsPage42 = myJsTablePage.getChildNode(1);
+
+    // page 42 was NOT replaced
+    assertSame(replaceJsPage42, noReplaceJsPage42);
+
+    assertEquals(BEANS.get(IdPageParamDo.class).withId(FixtureIntegerId.of(7)), noReplaceJsPage7.getPrimaryKey());
+    assertEquals(BEANS.get(IdPageParamDo.class).withId(FixtureIntegerId.of(42)), noReplaceJsPage42.getPrimaryKey());
+
+    response = getUiSession().currentJsonResponse();
+    response.fireProcessBufferedEvents();
+
+    var noReplaceJsPage7Id = getJsonOutline().getOrCreateNodeId(noReplaceJsPage7);
+    var noReplaceJsPage42Id = getJsonOutline().getOrCreateNodeId(noReplaceJsPage42);
+
+    // corresponding hybridActionEnd-event
+    assertTrue(response.getEventList().stream().anyMatch(hybridActionEndPredicate(noReplace7And42Id)));
+    // nodesDeleted-event
+    assertTrue(response.getEventList().stream().anyMatch(nodesDeletedPredicate(myJsTablePageId, replaceJsPage13Id)));
+    // nodesInserted-event
+    assertTrue(response.getEventList().stream().anyMatch(nodesInsertedPredicate(myJsTablePageId, new NodesInsertedChildPageInfo(noReplaceJsPage7Id, 0, "MyJsPage", FixtureIntegerId.of(7)))));
+    // childNodeOrderChanged-event
+    assertTrue(response.getEventList().stream().anyMatch(childNodeOrderChangedPredicate(myJsTablePageId, noReplaceJsPage7Id, noReplaceJsPage42Id)));
+  }
+
+  private Predicate<JsonEvent> hybridActionEndPredicate(String id) {
+    return event -> getJsonHybridManager().getId().equals(event.getTarget()) &&
+        "hybridEvent".equals(event.getType()) &&
+        event.getData() instanceof JSONObject data &&
+        id.equals(data.getString("id")) &&
+        HybridEvent.HYBRID_ACTION_END.equals(data.getString("eventType"));
+  }
+
+  private Predicate<JsonEvent> nodesInsertedPredicate(String pageId, NodesInsertedChildPageInfo... childPages) {
+    return event -> getJsonOutline().getId().equals(event.getTarget()) &&
+        JsonTree.EVENT_NODES_INSERTED.equals(event.getType()) &&
+        event.getData() instanceof JSONObject data &&
+        pageId.equals(data.getString(JsonTree.PROP_COMMON_PARENT_NODE_ID)) &&
+        data.getJSONArray("nodes") instanceof JSONArray nodes &&
+        childPages.length == nodes.length() &&
+        IntStream.range(0, childPages.length).allMatch(i -> nodes.getJSONObject(i) instanceof JSONObject node &&
+            childPages[i].id().equals(node.getString("id")) &&
+            childPages[i].childNodeIndex() == node.getInt("childNodeIndex") &&
+            childPages[i].jsPageObjectType().equals(node.getString(IJsPage.PROP_JS_PAGE_OBJECT_TYPE)) &&
+            node.getJSONObject(IJsPage.PROP_JS_PAGE_MODEL).getJSONObject(JsPageChildPageToJsonContributor.PROP_JS_PAGE_CHILD_PAGE_PARAM) instanceof JSONObject childPageParam &&
+            BEANS.get(IdCodec.class).toQualified(childPages[i].fixtureIntegerId(), IdCodecFlag.SIGNATURE).equals(childPageParam.get("id"))
+        );
+  }
+
+  private Predicate<JsonEvent> nodesDeletedPredicate(String pageId, String... childPageIds) {
+    return event -> getJsonOutline().getId().equals(event.getTarget()) &&
+        JsonTree.EVENT_NODES_DELETED.equals(event.getType()) &&
+        event.getData() instanceof JSONObject data &&
+        pageId.equals(data.getString(JsonTree.PROP_COMMON_PARENT_NODE_ID)) &&
+        data.getJSONArray(JsonTree.PROP_NODE_IDS) instanceof JSONArray nodeIds &&
+        childPageIds.length == nodeIds.length() &&
+        IntStream.range(0, childPageIds.length).allMatch(i -> childPageIds[i].equals(nodeIds.getString(i)));
+  }
+
+  private Predicate<JsonEvent> allChildNodesDeletedPredicate(String pageId) {
+    return event -> getJsonOutline().getId().equals(event.getTarget()) &&
+        JsonTree.EVENT_ALL_CHILD_NODES_DELETED.equals(event.getType()) &&
+        event.getData() instanceof JSONObject data &&
+        pageId.equals(data.getString(JsonTree.PROP_COMMON_PARENT_NODE_ID));
+  }
+
+  private Predicate<JsonEvent> childNodeOrderChangedPredicate(String pageId, String... childPageIds) {
+    return event -> getJsonOutline().getId().equals(event.getTarget()) &&
+        JsonTree.EVENT_CHILD_NODE_ORDER_CHANGED.equals(event.getType()) &&
+        event.getData() instanceof JSONObject data &&
+        pageId.equals(data.getString("parentNodeId")) &&
+        data.getJSONArray("childNodeIds") instanceof JSONArray childNodeIds &&
+        childPageIds.length == childNodeIds.length() &&
+        IntStream.range(0, childPageIds.length).allMatch(i -> childPageIds[i].equals(childNodeIds.getString(i)));
+  }
+
+  private static class MyJsTablePage extends AbstractJsPage {
+
+    @Override
+    public String getConfiguredJsPageObjectType() {
+      return "MyJsTablePage";
+    }
+
+    @Override
+    protected IPage<?> createChildPage(IPageParamDo pageParam) {
+      return new MyJsPage();
+    }
+  }
+
+  private static class MyJsPage extends AbstractJsPage {
+
+    @Override
+    public String getConfiguredJsPageObjectType() {
+      return "MyJsPage";
+    }
+
+    @Override
+    protected IPage<?> createChildPage(IPageParamDo pageParam) {
+      return new MyJsTablePage();
+    }
+  }
+
+  private static class P_IdCodec extends IdCodec {
+
+    @Override
+    protected byte[] getIdSignaturePassword() {
+      return "42".getBytes(StandardCharsets.UTF_8);
+    }
+  }
+
+  private record NodesInsertedChildPageInfo(String id, int childNodeIndex, String jsPageObjectType, FixtureIntegerId fixtureIntegerId) {
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsPageChildPageToJsonContributor.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsPageChildPageToJsonContributor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html.json.desktop;
+
+import org.eclipse.scout.rt.api.data.page.IPageParamDo;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.js.IJsPage;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
+import org.eclipse.scout.rt.ui.html.json.JsonDataObjectHelper;
+import org.json.JSONObject;
+
+/**
+ * The creation of child pages of an {@link IJsPage} is triggered by the JsPageHelper.
+ * The helper sends an {@link IPageParamDo} that is used to create the page.
+ * The {@link IPageParamDo} is set on the child page as {@link IPage#getPrimaryKey()}.
+ * This {@link IPageToJsonContributor} adds the {@link IPageParamDo} to the {@link JSONObject} so the JsPageHelper can identify the created child pages.
+ */
+public class JsPageChildPageToJsonContributor implements IPageToJsonContributor {
+
+  public static final String PROP_JS_PAGE_CHILD_PAGE_PARAM = "__jsPageChildPageParam";
+
+  private final JsonDataObjectHelper m_jsonDoHelper = BEANS.get(JsonDataObjectHelper.class); // cached instance
+
+  protected JsonDataObjectHelper jsonDoHelper() {
+    return m_jsonDoHelper;
+  }
+
+  @Override
+  public void contribute(JSONObject json, IPage<?> page) {
+    // check if parent is an IJsPage
+    if (page == null || !(page.getParentPage() instanceof IJsPage)) {
+      return;
+    }
+
+    // check if primaryKey is an IPageParamDo
+    if (!(page.getPrimaryKey() instanceof IPageParamDo pageParam)) {
+      return;
+    }
+
+    JSONObject jsPageChildPageParam = jsonDoHelper().dataObjectToJson(pageParam);
+
+    // simply add the pageParam to the JSONObject if the page is NOT an IJsPage
+    if (!(page instanceof IJsPage)) {
+      json.put(PROP_JS_PAGE_CHILD_PAGE_PARAM, jsPageChildPageParam);
+      return;
+    }
+
+    // add the pageParam to the jsPageModel if the page is an IJsPage to ensure the property is set on the created Scout JS page
+    JSONObject jsPageModel = ObjectUtility.nvl(json.optJSONObject(IJsPage.PROP_JS_PAGE_MODEL), new JSONObject());
+    jsPageModel.put(PROP_JS_PAGE_CHILD_PAGE_PARAM, jsPageChildPageParam);
+
+    json.put(IJsPage.PROP_JS_PAGE_MODEL, jsPageModel);
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutline.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/desktop/JsonOutline.java
@@ -40,6 +40,7 @@ import org.eclipse.scout.rt.ui.html.json.menu.JsonContextMenu;
 import org.eclipse.scout.rt.ui.html.json.table.JsonOutlineTable;
 import org.eclipse.scout.rt.ui.html.json.tree.IChildNodeIndexLookup;
 import org.eclipse.scout.rt.ui.html.json.tree.JsonTree;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class JsonOutline<OUTLINE extends IOutline> extends JsonTree<OUTLINE> {
@@ -247,10 +248,23 @@ public class JsonOutline<OUTLINE extends IOutline> extends JsonTree<OUTLINE> {
       JSONObject jsPageModel = ObjectUtility.nvl(json.optJSONObject(IJsPage.PROP_JS_PAGE_MODEL), new JSONObject());
 
       // Send the properties which might come from a summary column from a parent PageWithTable
-      jsPageModel.put("text", jsPage.getCell().getText());
-      jsPageModel.put("htmlEnabled", jsPage.getCell().isHtmlEnabled());
-      jsPageModel.put("cssClass", jsPage.getCell().getCssClass());
-      jsPageModel.put("iconId", jsPage.getCell().getIconId());
+      // keep in sync with token: [5vv7MGGQ5BQY5NXX7CwJ9tmL4]
+      putProperty(jsPageModel, "text", jsPage.getCell().getText());
+      putProperty(jsPageModel, "htmlEnabled", jsPage.getCell().isHtmlEnabled());
+      putProperty(jsPageModel, "cssClass", jsPage.getCell().getCssClass());
+      putProperty(jsPageModel, "iconId", jsPage.getCell().getIconId());
+
+      putProperty(json, IJsPage.PROP_JS_PAGE_MODEL, jsPageModel);
+    }
+
+    JSONArray childNodes = json.optJSONArray("childNodes");
+    if (childNodes != null && childNodes.length() > 0) {
+      JSONObject jsPageModel = ObjectUtility.nvl(json.optJSONObject(IJsPage.PROP_JS_PAGE_MODEL), new JSONObject());
+
+      // send child nodes and expanded state if js page has child nodes
+      putProperty(jsPageModel, "childNodes", childNodes);
+      putProperty(jsPageModel, "expanded", json.opt("expanded"));
+      putProperty(jsPageModel, "expandedLazy", json.opt("expandedLazy"));
 
       putProperty(json, IJsPage.PROP_JS_PAGE_MODEL, jsPageModel);
     }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/tree/JsonTree.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/tree/JsonTree.java
@@ -18,7 +18,9 @@ import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import org.eclipse.scout.rt.client.job.ModelJobs;
 import org.eclipse.scout.rt.client.ui.AbstractEventBuffer;
@@ -26,11 +28,13 @@ import org.eclipse.scout.rt.client.ui.IEventHistory;
 import org.eclipse.scout.rt.client.ui.MouseButton;
 import org.eclipse.scout.rt.client.ui.action.keystroke.IKeyStroke;
 import org.eclipse.scout.rt.client.ui.action.menu.root.IContextMenu;
+import org.eclipse.scout.rt.client.ui.basic.cell.Cell;
 import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
 import org.eclipse.scout.rt.client.ui.basic.tree.AutoCheckStyle;
 import org.eclipse.scout.rt.client.ui.basic.tree.CheckableStyle;
 import org.eclipse.scout.rt.client.ui.basic.tree.ITree;
 import org.eclipse.scout.rt.client.ui.basic.tree.ITreeNode;
+import org.eclipse.scout.rt.client.ui.basic.tree.ITreeUIFacade.NodeCellTuple;
 import org.eclipse.scout.rt.client.ui.basic.tree.TreeAdapter;
 import org.eclipse.scout.rt.client.ui.basic.tree.TreeEvent;
 import org.eclipse.scout.rt.client.ui.basic.tree.TreeListener;
@@ -77,6 +81,7 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
   public static final String EVENT_NODE_ACTION = "nodeAction";
   public static final String EVENT_NODE_EXPANDED = "nodeExpanded";
   public static final String EVENT_NODE_CHANGED = "nodeChanged";
+  public static final String EVENT_NODES_CHANGED = "nodesChanged";
   public static final String EVENT_CHILD_NODE_ORDER_CHANGED = "childNodeOrderChanged";
   public static final String EVENT_NODES_CHECKED = "nodesChecked";
   public static final String EVENT_REQUEST_FOCUS = "requestFocus";
@@ -1040,6 +1045,9 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
     else if (EVENT_NODES_CHECKED.equals(event.getType())) {
       handleUiNodesChecked(event);
     }
+    else if (EVENT_NODES_CHANGED.equals(event.getType())) {
+      handleUiNodesChanged(event);
+    }
     else {
       super.handleUiEvent(event);
     }
@@ -1101,6 +1109,34 @@ public class JsonTree<TREE extends ITree> extends AbstractJsonWidget<TREE> imple
     int eventType = expanded ? TreeEvent.TYPE_NODE_EXPANDED : TreeEvent.TYPE_NODE_COLLAPSED;
     addTreeEventFilterCondition(eventType).setNodes(CollectionUtility.arrayList(node));
     getModel().getUIFacade().setNodeExpandedFromUI(node, expanded, lazy);
+  }
+
+  protected void handleUiNodesChanged(JsonEvent event) {
+    JSONArray nodes = event.getData().getJSONArray(PROP_NODES);
+    List<NodeCellTuple> nodeCellTuples = IntStream.range(0, nodes.length())
+        .mapToObj(nodes::getJSONObject)
+        .map(json -> {
+          String nodeId = json.getString(PROP_NODE_ID);
+          ITreeNode node = optTreeNodeForNodeId(nodeId);
+          if (node == null) {
+            LOG.info("Requested tree-node with ID {} doesn't exist. Skip nodeChanged event", nodeId);
+            return null;
+          }
+          var cell = new Cell(node.getCell());
+          // keep in sync with token: [5vv7MGGQ5BQY5NXX7CwJ9tmL4]
+          cell.setText(json.optString("text"));
+          cell.setHtmlEnabled(json.optBoolean("htmlEnabled"));
+          cell.setCssClass(json.optString("cssClass"));
+          cell.setIconId(json.optString("iconId"));
+
+          return new NodeCellTuple(node, cell);
+        })
+        .filter(Objects::nonNull)
+        .toList();
+
+    // ignore all future node-changed-events by the model while processing this json event
+    addTreeEventFilterCondition(TreeEvent.TYPE_NODE_CHANGED).setNodes(nodeCellTuples.stream().map(NodeCellTuple::node).toList());
+    getModel().getUIFacade().changeNodesFromUI(nodeCellTuples);
   }
 
   @Override


### PR DESCRIPTION
An IJsPage is a page created in Java as a wrapper while all its logic is
implemented in Scout JS. As this page lives in a Scout Classic Outline
all its child pages need to be known to the Outline in Java as well.
Therefore, the implementation in Scout JS can use the new JsPageHelper
and call the server to create its child pages for a list of IIds or
IPageParamDos. The creation of the child pages is then delegated to the
IJsPage wrapper in Java. Afterward, the JsPageHelper holds references to
the created child pages that can be used by the Scout JS page again.
The created child pages will be identified by an IPageParamDo and they
are inserted into the Outline directly on the server. The JsPageHelper
ensures that necessary information is synchronized, like e.g. summary
information from a parent table page.
The TreeAdapter may now send nodesChanged events back to the server in
order to update text, htmlEnabled, cssClass and iconId if it was changed
e.g. by a parent PageWithTable.
If there are childNodes present on the server for an IJsPage these
childNodes and the properties expanded and expandedLazy are added to the
jsPageModel. This ensures the outline state being correct even after a
browser reload.

427023