### PR TITLE
REST: Normalize URI for requests (force US-ASCII syntax)

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/mock/MockConfigPropertyRule.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/mock/MockConfigPropertyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,11 +18,11 @@ import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.config.IConfigProperty;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
-import org.junit.rules.TestRule;
+import org.eclipse.scout.rt.testing.platform.util.AbstractScoutTestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-public class MockConfigPropertyRule<DATA_TYPE> implements TestRule {
+public class MockConfigPropertyRule<DATA_TYPE> extends AbstractScoutTestRule {
 
   private final Class<? extends IConfigProperty<DATA_TYPE>> m_configPropertyClazz;
   private DATA_TYPE m_initialValue;

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/mock/RegisterBeanTestRule.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/mock/RegisterBeanTestRule.java
@@ -1,6 +1,5 @@
 /*
-<<<<<<< HEAD
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,14 +14,14 @@ import java.util.function.Supplier;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
-import org.junit.rules.TestRule;
+import org.eclipse.scout.rt.testing.platform.util.AbstractScoutTestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
  * Shortcut to replace a application scoped bean within a test.
  */
-public class RegisterBeanTestRule<BEAN> implements TestRule {
+public class RegisterBeanTestRule<BEAN> extends AbstractScoutTestRule {
 
   private final Class<? super BEAN> m_beanClazz;
   private final Supplier<BEAN> m_mockSupplier;

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/AbstractScoutTestRule.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/AbstractScoutTestRule.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.testing.platform.util;
+
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.util.concurrent.IRunnable;
+import org.eclipse.scout.rt.testing.platform.mock.MockConfigPropertyRule;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+
+public abstract class AbstractScoutTestRule implements TestRule {
+
+  /**
+   * Regularly a {@link TestRule} can only be applied for the whole class, this method may be used to apply it just for a certain {@link IRunnable} (e.g. use it only within one method).
+   * <p>
+   * Example usage for {@link MockConfigPropertyRule}:
+   * <pre>
+   * &commat;Test
+   * public void testLorem() {
+   *   MockConfigPropertyRule&lt;Integer&gt; rule = new MockConfigPropertyRule&lt;&gt;(LoremConfigProperty.class, 42);
+   *   rule.run(() -> {
+   *     assertEquals(73, BEANS.get(LoremService.class).doSomething());
+   *
+   *     // manipulate the config property
+   *     rule.setValue(43);
+   *
+   *     assertEquals(97, BEANS.get(LoremService.class).doSomething());
+   *   });
+   * }
+   * </pre>
+   * <p>
+   */
+  public void run(IRunnable runnable) {
+    try {
+      apply(new Statement() {
+        @Override
+        public void evaluate() throws Exception {
+          runnable.run();
+        }
+      }, null).evaluate();
+    }
+    catch (RuntimeException | Error e) {
+      throw e; // re-throw immediately
+    }
+    catch (Throwable throwable) {
+      throw new ProcessingException("Error during runnable", throwable);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/LocaleTestRule.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/LocaleTestRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,14 +13,13 @@ import java.util.Locale;
 
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.testing.platform.runner.SafeStatementInvoker;
-import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
  * Test rule to use a fixed locale.
  */
-public class LocaleTestRule implements TestRule {
+public class LocaleTestRule extends AbstractScoutTestRule {
 
   private Locale m_locale;
 

--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,6 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
-import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.core.Configuration;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -75,10 +75,12 @@ import org.apache.hc.core5.http.io.entity.BufferedHttpEntity;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.config.AbstractBooleanConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractIntegerConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractLongConfigProperty;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.context.RunMonitor;
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.platform.util.BooleanUtility;
 import org.eclipse.scout.rt.platform.util.IRegistrationHandle;
@@ -486,7 +488,14 @@ public class ScoutApacheConnector implements Connector {
     boolean bufferingEnabled = BooleanUtility.nvl(clientRequest.resolveProperty(RestClientProperties.DISABLE_CHUNKED_TRANSFER_ENCODING, Boolean.class));
     HttpEntity entity = getHttpEntity(clientRequest, bufferingEnabled);
 
-    HttpUriRequestBase request = new HttpUriRequestBase(clientRequest.getMethod(), clientRequest.getUri());
+    HttpUriRequestBase request = null;
+    try {
+      boolean encodeUriForRequest = CONFIG.getPropertyValue(RestForceEncodeUriForRequestProperty.class);
+      request = new HttpUriRequestBase(clientRequest.getMethod(), encodeUriForRequest ? new URI(clientRequest.getUri().toASCIIString()) : clientRequest.getUri());
+    }
+    catch (URISyntaxException e) {
+      throw new ProcessingException("Invalid URI for request: {}", clientRequest.getUri(), e);
+    }
     request.setEntity(entity);
     request.setConfig(requestConfigBuilder.build());
     return request;
@@ -853,6 +862,24 @@ public class ScoutApacheConnector implements Connector {
     @Override
     public String getKey() {
       return "scout.rest.client.http.connectionTimeToLive";
+    }
+  }
+
+  public static class RestForceEncodeUriForRequestProperty extends AbstractBooleanConfigProperty {
+
+    @Override
+    public Boolean getDefaultValue() {
+      return true;
+    }
+
+    @Override
+    public String description() {
+      return "Specifies whether the URI should be re-encoded to force US-ASCII encoding (strict RFC 2396 compliance), default: " + getDefaultValue();
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.rest.client.http.forceEncodeUriForRequest";
     }
   }
 }

--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnectorTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ScoutApacheConnectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.stream.IntStream;
 
 import javax.net.ssl.SSLContext;
 
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.RedirectionException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -41,6 +43,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -64,6 +67,7 @@ import org.eclipse.scout.rt.rest.jersey.ProxyServletParameters;
 import org.eclipse.scout.rt.rest.jersey.RestClientHttpProxyServlet;
 import org.eclipse.scout.rt.rest.jersey.RestClientTestEchoResponse;
 import org.eclipse.scout.rt.rest.jersey.RestClientTestEchoServlet;
+import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestForceEncodeUriForRequestProperty;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportConnectionKeepAliveProperty;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportConnectionTimeToLiveProperty;
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportMaxConnectionsPerRouteProperty;
@@ -71,6 +75,7 @@ import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTran
 import org.eclipse.scout.rt.rest.jersey.client.ScoutApacheConnector.RestHttpTransportValidateAfterInactivityProperty;
 import org.eclipse.scout.rt.shared.http.HttpClientMetricsHelper;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.eclipse.scout.rt.testing.platform.mock.MockConfigPropertyRule;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientRequest;
@@ -771,5 +776,35 @@ public class ScoutApacheConnectorTest {
     clientRequestConsumer.accept(clientRequest);
     connector.initKeepAliveTimeout(clientRequest, requestConfigBuilder);
     assertEquals(expected >= 0 ? Timeout.ofMilliseconds(expected) : Timeout.of(BEANS.get(RestHttpTransportConnectionKeepAliveProperty.class).getDefaultValue(), TimeUnit.MILLISECONDS), requestConfigBuilder.build().getConnectionKeepAlive());
+  }
+
+  @Test
+  public void testForceEncodeUriForRequest_true() {
+    MockConfigPropertyRule<Boolean> rule = new MockConfigPropertyRule<>(RestForceEncodeUriForRequestProperty.class, true);
+    rule.run(() -> {
+      runTestForceEncodeUriForRequest(new URI("http://127.0.0.1/%C3%A4"), new URI("http://127.0.0.1/ä")); // umlaut must be encoded properly
+      runTestForceEncodeUriForRequest(new URI("http://127.0.0.1/%C3%A4"), new URI("http://127.0.0.1/%C3%A4")); // already properly encoded URL should be kept intact
+    });
+  }
+
+  @Test
+  public void testForceEncodeUriForRequest_false() {
+    MockConfigPropertyRule<Boolean> rule = new MockConfigPropertyRule<>(RestForceEncodeUriForRequestProperty.class, false);
+    rule.run(() -> {
+      for (URI uri : new URI[]{new URI("http://127.0.0.1/ä"), new URI("http://127.0.0.1/%C3%A4")}) {
+        runTestForceEncodeUriForRequest(uri, uri); // no re-encoding expected, request URI should always match inputUri
+      }
+    });
+  }
+
+  protected void runTestForceEncodeUriForRequest(URI expectedUriForRequest, URI inputUri) throws URISyntaxException {
+    Client client = Mockito.mock(Client.class);
+    Configuration configuration = Mockito.mock(Configuration.class);
+    ScoutApacheConnector connector = new ScoutApacheConnector(client, configuration);
+    ClientRequest clientRequest = Mockito.mock(ClientRequest.class);
+    when(clientRequest.getMethod()).thenReturn(HttpMethod.OPTIONS);
+    when(clientRequest.getUri()).thenReturn(inputUri);
+    HttpUriRequestBase uriHttpRequest = connector.getUriHttpRequest(clientRequest);
+    assertEquals(expectedUriForRequest, uriHttpRequest.getUri());
   }
 }


### PR DESCRIPTION
Starting with Apache HTTP client 5 the URI was not re-encoded/normalized
 by the HTTP client anymore (previously the HTTP client did this); see
 migration guide to HttpClient 5.x classic APIs.