### PR TITLE
Reset Interrupt Status

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/filter/ExceptionFilter.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/filter/ExceptionFilter.java
@@ -53,14 +53,25 @@ public class ExceptionFilter implements Filter {
       }
 
       HttpServletRequest req = (HttpServletRequest) request;
-      MDC.put(CorrelationIdContextValueProvider.KEY, req.getHeader(CorrelationId.HTTP_HEADER_NAME));
-      try {
-        LOG.warn(req.getRequestURI(), e);
-      }
-      finally {
-        MDC.remove(CorrelationIdContextValueProvider.KEY);
-      }
+      runWithCorrelationId(req.getHeader(CorrelationId.HTTP_HEADER_NAME), () -> LOG.warn(req.getRequestURI(), e));
+
       throw new JettyQuietExceptionWrapper(e);
+    }
+    finally {
+      if (Thread.interrupted()) {
+        HttpServletRequest req = (HttpServletRequest) request;
+        runWithCorrelationId(req.getHeader(CorrelationId.HTTP_HEADER_NAME), () -> LOG.debug("Reset interrupted state - {}", req.getRequestURI()));
+      }
+    }
+  }
+
+  protected void runWithCorrelationId(String correlationId, Runnable runnable) {
+    MDC.put(CorrelationIdContextValueProvider.KEY, correlationId);
+    try {
+      runnable.run();
+    }
+    finally {
+      MDC.remove(CorrelationIdContextValueProvider.KEY);
     }
   }
 
@@ -69,10 +80,6 @@ public class ExceptionFilter implements Filter {
    */
   protected boolean isCausedByQuietException(Throwable t) {
     return BEANS.get(DefaultExceptionTranslator.class).throwableCausesAccept(t, e -> e instanceof QuietException);
-  }
-
-  @Override
-  public void destroy() {
   }
 
   /**


### PR DESCRIPTION
Ensures that any interrupt flags set during request handling don’t leak back into Jetty’s thread pool.

372827