### PR TITLE
Correction for validation message on a pair of from/to fields

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/form/fields/sequencebox/SequenceValidationHelperTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/form/fields/sequencebox/SequenceValidationHelperTest.java
@@ -72,7 +72,7 @@ public class SequenceValidationHelperTest {
     from.setValue(3L);
     m_helper.checkFromTo(from, to);
     assertEquals(InvalidSequenceStatus.ERROR, from.getErrorStatus().getSeverity());
-    assertEquals("'from-label' must be greater than or equal to 'to-label'", from.getErrorStatus().getMessage());
+    assertEquals("'to-label' must be greater than or equal to 'from-label'", from.getErrorStatus().getMessage());
     assertNull(to.getErrorStatus());
 
     // start null -> no error

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/sequencebox/SequenceValidationHelper.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/sequencebox/SequenceValidationHelper.java
@@ -48,7 +48,7 @@ public class SequenceValidationHelper {
       if (endField.isValueChanging() && !StringUtility.isNullOrEmpty(endField.getLabel())) {
         errorField = endField;
       }
-      InvalidSequenceStatus errorStatus = new InvalidSequenceStatus(TEXTS.get("XMustBeGreaterThanOrEqualY", startField.getLabel(), endField.getLabel()));
+      InvalidSequenceStatus errorStatus = new InvalidSequenceStatus(TEXTS.get("XMustBeGreaterThanOrEqualY", endField.getLabel(), startField.getLabel()));
       errorField.addErrorStatus(errorStatus);
       return;
     }


### PR DESCRIPTION
If start field is greater than end field, the current modified field gets an error status.

Before this correction the error status message was wrong, saying that the start field must be greater than the end field.

Now the message says that the end field must be greater than the start field.

436156