### PR TITLE
New test for the correct naming of concrete type version classes

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/AbstractDataObjectTestCompletenessTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/AbstractDataObjectTestCompletenessTest.java
@@ -43,6 +43,14 @@ public abstract class AbstractDataObjectTestCompletenessTest {
     support.failOnError();
   }
 
+  @Test
+  public void testTypeVersionClassNamingTestCompleteness() throws IOException {
+    TypeVersionClassNamingTestSupport support = createTypeVersionClassNamingTestSupport();
+    getPathExclusions().forEach(support::addPathExclusion);
+    support.doTest();
+    support.failOnError();
+  }
+
   protected DataObjectSignatureTestSupport createSignatureTestSupport() {
     return BEANS.get(DataObjectSignatureTestSupport.class);
   }
@@ -53,6 +61,10 @@ public abstract class AbstractDataObjectTestCompletenessTest {
 
   protected IdStructureTestSupport createIdStructureTestSupport() {
     return BEANS.get(IdStructureTestSupport.class);
+  }
+
+  protected TypeVersionClassNamingTestSupport createTypeVersionClassNamingTestSupport() {
+    return BEANS.get(TypeVersionClassNamingTestSupport.class);
   }
 
   protected List<Path> getPathExclusions() {

--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/AbstractTypeVersionClassNamingTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/AbstractTypeVersionClassNamingTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.testing;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+import org.eclipse.scout.rt.dataobject.AbstractTypeVersion;
+import org.eclipse.scout.rt.dataobject.ITypeVersion;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PlatformTestRunner.class)
+public abstract class AbstractTypeVersionClassNamingTest {
+
+  @Test
+  public final void testTypeVersions() {
+    List<String> malformedTypeVersionClassNames = collectMalformedTypeVersionClassNames();
+    if (!malformedTypeVersionClassNames.isEmpty()) {
+      Assert.fail("Malformed type version class names found.\nType version class names must follow the following pattern: "
+          + "<Namespace>_<version1>[_<version2>[_<versionN>]][__<comment>] where <Namespace> must be called after the respective scout namespace with all "
+          + "letters in lower case except for the first letter, which must be capitalized.\n- " + String.join("\n- ", malformedTypeVersionClassNames));
+    }
+  }
+
+  protected abstract String getPackageNamePrefix();
+
+  protected Set<Class<ITypeVersion>> getExclusionList() {
+    return CollectionUtility.emptyHashSet();
+  }
+
+  protected List<String> collectMalformedTypeVersionClassNames() {
+    String packagePrefix = getPackageNamePrefix();
+
+    Set<Class<ITypeVersion>> excludedTypeVersions = getExclusionList();
+
+    return BEANS.all(ITypeVersion.class).stream()
+        .map(Object::getClass)
+        .filter(typeVersionClass -> !excludedTypeVersions.contains(typeVersionClass))
+        .filter(typeVersionClass -> typeVersionClass.getPackageName().startsWith(packagePrefix))
+        .map(Class::getSimpleName)
+        .filter(this::isMalformedTypeVersionClassName)
+        .toList();
+  }
+
+  protected boolean isMalformedTypeVersionClassName(String className) {
+    Matcher matcher = AbstractTypeVersion.CLASS_NAME_PATTERN.matcher(className);
+    if (!matcher.matches()) {
+      return false;
+    }
+
+    String actualNamespaceIdString = matcher.group(1);
+    String expectedNamespaceIdString = StringUtility.uppercaseFirst(actualNamespaceIdString.toLowerCase());
+
+    return !actualNamespaceIdString.equals(expectedNamespaceIdString);
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/AbstractTypeVersionClassNamingTestSupportTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/AbstractTypeVersionClassNamingTestSupportTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.testing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.util.regex.Pattern;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.junit.Test;
+
+public abstract class AbstractTypeVersionClassNamingTestSupportTest {
+
+  @Test
+  public void testFilePattern() {
+    Pattern filePattern = BEANS.get(TypeVersionClassNamingTestSupport.class).getFilePattern();
+
+    assertThat(filePattern.matcher("class MyVersion extends AbstractTypeVersion {}").find(), is(true));
+    assertThat(filePattern.matcher("public class MyVersion extends AbstractTypeVersion {}").find(), is(true));
+    assertThat(filePattern.matcher("final class MyVersion extends AbstractTypeVersion {}").find(), is(true));
+    assertThat(filePattern.matcher("public final class MyVersion extends AbstractTypeVersion {}").find(), is(true));
+    assertThat(filePattern.matcher("class MyVersion extends AbstractTypeVersionTest {}").find(), is(false));
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/TypeVersionClassNamingTestSupport.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/main/java/org/eclipse/scout/rt/dataobject/testing/TypeVersionClassNamingTestSupport.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.testing;
+
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+public class TypeVersionClassNamingTestSupport extends AbstractDataObjectTestSupport {
+
+  @Override
+  protected Pattern createFilePattern() {
+    return Pattern.compile("class \\w+ extends AbstractTypeVersion\\b");
+  }
+
+  @Override
+  protected Pattern createTestFilePattern() {
+    return Pattern.compile("\\bextends AbstractTypeVersionClassNamingTest\\b");
+  }
+
+  @Override
+  protected Pattern createPackageNamePrefixPattern() {
+    return Pattern.compile("String getPackageNamePrefix\\(\\)\\s*\\{\\s*return \\s*\"(.+?)\";\\s*}");
+  }
+
+  @Override
+  protected boolean acceptFile(Path path, String content) {
+    return !path.toString().contains(Path.of("src/test").toString()) && !path.getFileName().toString().endsWith("Test.java") && getFilePattern().matcher(content).find();
+  }
+
+  @Override
+  protected boolean acceptTestFile(Path path, String content) {
+    return path.getFileName().toString().endsWith("TypeVersionClassNamingTest.java") && getTestFilePattern().matcher(content).find();
+  }
+
+  @Override
+  protected String getErrorTitle() {
+    return "No TypeVersionClassNamingTest found for the following files:";
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/AbstractTypeVersionTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/AbstractTypeVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,13 +13,13 @@ import static org.eclipse.scout.rt.dataobject.AbstractTypeVersion.fromClassName;
 import static org.eclipse.scout.rt.platform.util.Assertions.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_002__suffix;
 import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_0__123456;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_0__loremIpsumDolor_3;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_0__lorem_ipsum;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_3_0__suffix;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectProjectFixtureTypeVersions.DataObjectProjectFixture_1_2_3_004;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_3_002__suffix;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_3_0__loremIpsumDolor_3;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_3_0__lorem_ipsum;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_3_0__suffix;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectProjectFixtureTypeVersions.Dataobjectprojectfixture_1_2_3_004;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,14 +34,14 @@ public class AbstractTypeVersionTest {
     assertNull(fromClassName(null));
     Assert.assertThrows(IllegalArgumentException.class, () -> fromClassName(AbstractTypeVersion.class));
 
-    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.0.0"), fromClassName(DataObjectFixture_1_0_0.class));
-    assertEquals(NamespaceVersion.of("dataObjectProjectFixture", "1.2.3.004"), fromClassName(DataObjectProjectFixture_1_2_3_004.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.0.0"), fromClassName(Dataobjectfixture_1_0_0.class));
+    assertEquals(NamespaceVersion.of("dataObjectProjectFixture", "1.2.3.004"), fromClassName(Dataobjectprojectfixture_1_2_3_004.class));
 
     // with suffix
-    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(DataObjectFixture_1_3_0__suffix.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(Dataobjectfixture_1_3_0__suffix.class));
     assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(DataObjectFixture_1_3_0__123456.class));
-    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(DataObjectFixture_1_3_0__lorem_ipsum.class));
-    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(DataObjectFixture_1_3_0__loremIpsumDolor_3.class));
-    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.002"), fromClassName(DataObjectFixture_1_3_002__suffix.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(Dataobjectfixture_1_3_0__lorem_ipsum.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.0"), fromClassName(Dataobjectfixture_1_3_0__loremIpsumDolor_3.class));
+    assertEquals(NamespaceVersion.of("dataObjectFixture", "1.3.002"), fromClassName(Dataobjectfixture_1_3_002__suffix.class));
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectInventoryTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectInventoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,12 +22,12 @@ import org.eclipse.scout.rt.dataobject.fixture.AbstractLoremFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.BiCompositeFixtureObject;
 import org.eclipse.scout.rt.dataobject.fixture.BiCompositeFixtureObjectDataObjectVisitorExtension;
 import org.eclipse.scout.rt.dataobject.fixture.CollectionFixtureDo;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0_034;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0_Duplicate;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_No_Version;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.NonRegisteredNamespaceFixture_1_0_0;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectProjectFixtureTypeVersions.DataObjectProjectFixture_1_2_3_004;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0_034;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0_Duplicate;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_No_Version;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Nonregisterednamespacefixture_1_0_0;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectProjectFixtureTypeVersions.Dataobjectprojectfixture_1_2_3_004;
 import org.eclipse.scout.rt.dataobject.fixture.DateFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.EntityFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.EntityFixtureInvalidTypeNameDo;
@@ -113,7 +113,7 @@ public class DataObjectInventoryTest {
     m_inventory.validateTypeVersionImplementors(); // no exception
 
     BeanTestingHelper beanTestingHelper = BEANS.get(BeanTestingHelper.class);
-    IBean<Object> fixtureNoVersionBean = beanTestingHelper.registerBean(new BeanMetaData(DataObjectFixture_No_Version.class));
+    IBean<Object> fixtureNoVersionBean = beanTestingHelper.registerBean(new BeanMetaData(Dataobjectfixture_No_Version.class));
     try {
       assertThrows(AssertionException.class, () -> m_inventory.validateTypeVersionImplementors());
     }
@@ -121,7 +121,7 @@ public class DataObjectInventoryTest {
       beanTestingHelper.unregisterBean(fixtureNoVersionBean);
     }
 
-    IBean<Object> fixtureNoRegisteredNamespaceBean = beanTestingHelper.registerBean(new BeanMetaData(NonRegisteredNamespaceFixture_1_0_0.class));
+    IBean<Object> fixtureNoRegisteredNamespaceBean = beanTestingHelper.registerBean(new BeanMetaData(Nonregisterednamespacefixture_1_0_0.class));
     try {
       assertThrows(AssertionException.class, () -> m_inventory.validateTypeVersionImplementors());
     }
@@ -129,7 +129,7 @@ public class DataObjectInventoryTest {
       beanTestingHelper.unregisterBean(fixtureNoRegisteredNamespaceBean);
     }
 
-    IBean<Object> fixtureDuplicateVersionBean = beanTestingHelper.registerBean(new BeanMetaData(DataObjectFixture_1_0_0_Duplicate.class));
+    IBean<Object> fixtureDuplicateVersionBean = beanTestingHelper.registerBean(new BeanMetaData(Dataobjectfixture_1_0_0_Duplicate.class));
     try {
       assertThrows(AssertionException.class, () -> m_inventory.validateTypeVersionImplementors());
     }
@@ -342,14 +342,14 @@ public class DataObjectInventoryTest {
   @Test
   public void testResolveTypeVersionClass() {
     assertNull(m_inventory.resolveTypeVersionClass(EntityFixtureDo.class));
-    assertEquals(DataObjectFixture_1_0_0.class, m_inventory.resolveTypeVersionClass(OtherEntityFixtureDo.class));
+    assertEquals(Dataobjectfixture_1_0_0.class, m_inventory.resolveTypeVersionClass(OtherEntityFixtureDo.class));
     assertNull(m_inventory.resolveTypeVersionClass(Object.class));
 
     m_inventory.registerClassByTypeVersion(ScoutFixtureDo.class);
-    assertEquals(DataObjectFixture_1_0_0_034.VERSION, m_inventory.getTypeVersion(ScoutFixtureDo.class));
+    assertEquals(Dataobjectfixture_1_0_0_034.VERSION, m_inventory.getTypeVersion(ScoutFixtureDo.class));
 
     m_inventory.registerClassByTypeVersion(ProjectFixtureDo.class);
-    assertEquals(DataObjectProjectFixture_1_2_3_004.VERSION, m_inventory.getTypeVersion(ProjectFixtureDo.class));
+    assertEquals(Dataobjectprojectfixture_1_2_3_004.VERSION, m_inventory.getTypeVersion(ProjectFixtureDo.class));
     assertNull(m_inventory.getTypeVersion(ProjectSubFixtureDo.class));
   }
 
@@ -369,8 +369,8 @@ public class DataObjectInventoryTest {
     assertEquals("ScoutFixture", inv.toTypeName(ProjectFixtureDo.class));
     assertEquals("ScoutFixture", inv.toTypeName(ProjectSubFixtureDo.class));
 
-    assertEquals(DataObjectFixture_1_0_0_034.VERSION, inv.getTypeVersion(ScoutFixtureDo.class));
-    assertEquals(DataObjectProjectFixture_1_2_3_004.VERSION, inv.getTypeVersion(ProjectFixtureDo.class));
+    assertEquals(Dataobjectfixture_1_0_0_034.VERSION, inv.getTypeVersion(ScoutFixtureDo.class));
+    assertEquals(Dataobjectprojectfixture_1_2_3_004.VERSION, inv.getTypeVersion(ProjectFixtureDo.class));
 
     assertNull(inv.getTypeVersion(ProjectSubFixtureDo.class));
 

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/ScoutDataObjectTypeVersionClassNamingTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/ScoutDataObjectTypeVersionClassNamingTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject;
+
+import org.eclipse.scout.rt.dataobject.testing.AbstractTypeVersionClassNamingTest;
+
+public class ScoutDataObjectTypeVersionClassNamingTest extends AbstractTypeVersionClassNamingTest {
+  @Override
+  protected String getPackageNamePrefix() {
+    return "org.eclipse.scout.rt.dataobject";
+  }
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/DataObjectFixtureTypeVersions.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/DataObjectFixtureTypeVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,20 +21,20 @@ import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 
 public final class DataObjectFixtureTypeVersions {
 
-  public static final class DataObjectFixture_1_0_0 extends AbstractTypeVersion {
+  public static final class Dataobjectfixture_1_0_0 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(DataObjectFixtureNamespace.ID, "1.0.0");
 
-    public DataObjectFixture_1_0_0() {
+    public Dataobjectfixture_1_0_0() {
       super(VERSION);
     }
   }
 
-  public static final class DataObjectFixture_1_0_0_034 extends AbstractTypeVersion {
+  public static final class Dataobjectfixture_1_0_0_034 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(DataObjectFixtureNamespace.ID, "1.0.0.034");
 
-    public DataObjectFixture_1_0_0_034() {
+    public Dataobjectfixture_1_0_0_034() {
       super(VERSION);
     }
   }
@@ -43,7 +43,7 @@ public final class DataObjectFixtureTypeVersions {
    * Manually registered in {@link DataObjectInventoryTest}.
    */
   @IgnoreBean
-  public static final class DataObjectFixture_No_Version implements ITypeVersion {
+  public static final class Dataobjectfixture_No_Version implements ITypeVersion {
 
     @Override
     public NamespaceVersion getVersion() {
@@ -60,7 +60,7 @@ public final class DataObjectFixtureTypeVersions {
    * Manually registered in {@link DataObjectInventoryTest}.
    */
   @IgnoreBean
-  public static final class NonRegisteredNamespaceFixture_1_0_0 implements ITypeVersion {
+  public static final class Nonregisterednamespacefixture_1_0_0 implements ITypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of("noRegisteredNamespace", "1.0.0");
 
@@ -79,11 +79,11 @@ public final class DataObjectFixtureTypeVersions {
    * Manually registered in {@link DataObjectInventoryTest}.
    */
   @IgnoreBean
-  public static final class DataObjectFixture_1_0_0_Duplicate implements ITypeVersion {
+  public static final class Dataobjectfixture_1_0_0_Duplicate implements ITypeVersion {
 
     @Override
     public NamespaceVersion getVersion() {
-      return DataObjectFixture_1_0_0.VERSION;
+      return Dataobjectfixture_1_0_0.VERSION;
     }
 
     @Override
@@ -96,7 +96,7 @@ public final class DataObjectFixtureTypeVersions {
    * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
    */
   @IgnoreBean
-  public static final class DataObjectFixture_1_3_0__suffix extends AbstractTypeVersion {
+  public static final class Dataobjectfixture_1_3_0__suffix extends AbstractTypeVersion {
   }
 
   /**
@@ -110,20 +110,20 @@ public final class DataObjectFixtureTypeVersions {
    * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
    */
   @IgnoreBean
-  public static final class DataObjectFixture_1_3_0__lorem_ipsum extends AbstractTypeVersion {
+  public static final class Dataobjectfixture_1_3_0__lorem_ipsum extends AbstractTypeVersion {
   }
 
   /**
    * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
    */
   @IgnoreBean
-  public static final class DataObjectFixture_1_3_0__loremIpsumDolor_3 extends AbstractTypeVersion {
+  public static final class Dataobjectfixture_1_3_0__loremIpsumDolor_3 extends AbstractTypeVersion {
   }
 
   /**
    * Only used for {@link AbstractTypeVersionTest#testFromClassName()}.
    */
   @IgnoreBean
-  public static final class DataObjectFixture_1_3_002__suffix extends AbstractTypeVersion {
+  public static final class Dataobjectfixture_1_3_002__suffix extends AbstractTypeVersion {
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/DataObjectProjectFixtureTypeVersions.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/DataObjectProjectFixtureTypeVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,11 +17,11 @@ public final class DataObjectProjectFixtureTypeVersions {
   private DataObjectProjectFixtureTypeVersions() {
   }
 
-  public static final class DataObjectProjectFixture_1_2_3_004 extends AbstractTypeVersion {
+  public static final class Dataobjectprojectfixture_1_2_3_004 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(DataObjectProjectFixtureNamespace.ID, "1.2.3.004");
 
-    public DataObjectProjectFixture_1_2_3_004() {
+    public Dataobjectprojectfixture_1_2_3_004() {
       super(VERSION);
     }
   }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/OtherEntityFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/OtherEntityFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,10 +19,10 @@ import org.eclipse.scout.rt.dataobject.DoList;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0;
 
 @TypeName("OtherEntityFixture")
-@TypeVersion(DataObjectFixture_1_0_0.class)
+@TypeVersion(Dataobjectfixture_1_0_0.class)
 public class OtherEntityFixtureDo extends DoEntity implements IInterfaceFixtureDo {
 
   public DoValue<String> id() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/OtherEntityMapperFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/OtherEntityMapperFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,10 +15,10 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0;
 
 @TypeName("OtherEntityMapperFixture")
-@TypeVersion(DataObjectFixture_1_0_0.class)
+@TypeVersion(Dataobjectfixture_1_0_0.class)
 public class OtherEntityMapperFixtureDo extends DoEntity {
 
   public DoValue<String> id() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/ProjectFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/ProjectFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,11 +13,11 @@ import jakarta.annotation.Generated;
 
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectProjectFixtureTypeVersions.DataObjectProjectFixture_1_2_3_004;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectProjectFixtureTypeVersions.Dataobjectprojectfixture_1_2_3_004;
 import org.eclipse.scout.rt.platform.Replace;
 
 @Replace
-@TypeVersion(DataObjectProjectFixture_1_2_3_004.class)
+@TypeVersion(Dataobjectprojectfixture_1_2_3_004.class)
 public class ProjectFixtureDo extends ScoutFixtureDo {
 
   public DoValue<Integer> count() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/ScoutFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/fixture/ScoutFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,10 +15,10 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0_034;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0_034;
 
 @TypeName("ScoutFixture")
-@TypeVersion(DataObjectFixture_1_0_0_034.class)
+@TypeVersion(Dataobjectfixture_1_0_0_034.class)
 public class ScoutFixtureDo extends DoEntity {
 
   public DoValue<String> name() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandlerTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/AbstractRemoveDoEntityContributionValueMigrationHandlerTest.java
@@ -21,8 +21,8 @@ import org.eclipse.scout.rt.dataobject.fixture.FirstSimpleContributionFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.SecondSimpleContributionFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.SimpleFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrator.DataObjectMigratorResult;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.junit.Test;
@@ -95,13 +95,13 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
     // Unknown contribution 1 - should not be removed because of different type version
     IDoEntity expectedUnknownContribution1 = BEANS.get(DoEntity.class);
     expectedUnknownContribution1.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
-    expectedUnknownContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_2.VERSION.unwrap());
+    expectedUnknownContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, Alfafixture_2.VERSION.unwrap());
     expectedUnknownContribution1.put("testValue", "myTestValue");
 
     // Unknown contribution 2 - should not be removed because there is no migration handler to remove the contribution
     IDoEntity expectedUnknownContribution2 = BEANS.get(DoEntity.class);
     expectedUnknownContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyOtherTestContribution");
-    expectedUnknownContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    expectedUnknownContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, Alfafixture_1.VERSION.unwrap());
     expectedUnknownContribution2.put("otherTestValue", "myOtherTestValue");
 
     SimpleFixtureDo expected = createSimpleFixtureDo();
@@ -146,7 +146,7 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
     // Unknown contribution
     IDoEntity contribution = BEANS.get(DoEntity.class);
     contribution.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
-    contribution.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    contribution.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, Alfafixture_1.VERSION.unwrap());
     contribution.put("testValue", "myTestValue");
 
     SimpleFixtureDo dataObject = createSimpleFixtureDo();
@@ -165,19 +165,19 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
     // Unknown contribution 1
     IDoEntity nonExistingContribution1 = BEANS.get(DoEntity.class);
     nonExistingContribution1.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
-    nonExistingContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    nonExistingContribution1.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, Alfafixture_1.VERSION.unwrap());
     nonExistingContribution1.put("testValue", "myTestValue");
 
     // Unknown contribution 2 with different type version
     IDoEntity nonExistingContribution2 = BEANS.get(DoEntity.class);
     nonExistingContribution2.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyTestContribution");
-    nonExistingContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_2.VERSION.unwrap());
+    nonExistingContribution2.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, Alfafixture_2.VERSION.unwrap());
     nonExistingContribution2.put("testValue", "myTestValue");
 
     // Unknown contribution 3
     IDoEntity nonExistingContribution3 = BEANS.get(DoEntity.class);
     nonExistingContribution3.put(DoStructureMigrationHelper.TYPE_ATTRIBUTE_NAME, "scout.MyOtherTestContribution");
-    nonExistingContribution3.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, AlfaFixture_1.VERSION.unwrap());
+    nonExistingContribution3.put(DoStructureMigrationHelper.TYPE_VERSION_ATTRIBUTE_NAME, Alfafixture_1.VERSION.unwrap());
     nonExistingContribution3.put("otherTestValue", "myOtherTestValue");
 
     SimpleFixtureDo dataObject = createSimpleFixtureDo();
@@ -211,7 +211,7 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
 
     @Override
     public Class<? extends ITypeVersion> typeVersionClass() {
-      return AlfaFixture_1.class;
+      return Alfafixture_1.class;
     }
 
     @Override
@@ -221,7 +221,7 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
 
     @Override
     protected Class<? extends ITypeVersion> getContributionTypeVersionClass() {
-      return AlfaFixture_1.class;
+      return Alfafixture_1.class;
     }
   }
 
@@ -239,7 +239,7 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
 
     @Override
     public Class<? extends ITypeVersion> typeVersionClass() {
-      return AlfaFixture_1.class;
+      return Alfafixture_1.class;
     }
 
     @Override
@@ -249,7 +249,7 @@ public class AbstractRemoveDoEntityContributionValueMigrationHandlerTest {
 
     @Override
     protected Class<? extends ITypeVersion> getContributionTypeVersionClass() {
-      return AlfaFixture_1.class;
+      return Alfafixture_1.class;
     }
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventoryTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationInventoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,24 +40,24 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStru
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomSizeFixtureDoValueMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomTypeFixtureDoValueMigrationHandler_2;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_6;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_7;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_6;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_7;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_4;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_4;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_5;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.Deltafixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.Deltafixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.exception.PlatformException;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
@@ -79,10 +79,10 @@ public class DataObjectMigrationInventoryTest {
     s_inventory = new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace()),
         Arrays.asList(
-            new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(), // AlfaFixture_7 is explicitly not registered
-            new BravoFixture_1(), new BravoFixture_2(), new BravoFixture_3(),
-            new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5(),
-            new DeltaFixture_1(), new DeltaFixture_2()),
+            new Alfafixture_1(), new Alfafixture_2(), new Alfafixture_3(), new Alfafixture_6(), // Alfafixture_7 is explicitly not registered
+            new Bravofixture_1(), new Bravofixture_2(), new Bravofixture_3(),
+            new Charliefixture_1(), new Charliefixture_2(), new Charliefixture_3(), new Charliefixture_4(), new Charliefixture_5(),
+            new Deltafixture_1(), new Deltafixture_2()),
         Arrays.asList(
             HouseFixtureStructureMigrationTargetContextData.class,
             HouseFixtureRawOnlyStructureMigrationTargetContextData.class,
@@ -112,9 +112,9 @@ public class DataObjectMigrationInventoryTest {
     TestDataObjectMigrationInventory inventory = new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace()),
         Arrays.asList(
-            new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(),
-            new BravoFixture_1(), new BravoFixture_2(), new BravoFixture_3(),
-            new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5()),
+            new Alfafixture_1(), new Alfafixture_2(), new Alfafixture_3(), new Alfafixture_6(),
+            new Bravofixture_1(), new Bravofixture_2(), new Bravofixture_3(),
+            new Charliefixture_1(), new Charliefixture_2(), new Charliefixture_3(), new Charliefixture_4(), new Charliefixture_5()),
         Collections.emptyList(),
         Arrays.asList(new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3()),
         Collections.emptyList());
@@ -124,9 +124,9 @@ public class DataObjectMigrationInventoryTest {
     assertThrows(PlatformException.class, () -> new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace()),
         Arrays.asList(
-            new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(),
-            new BravoFixture_1(), new BravoFixture_2(), new BravoFixture_3(),
-            new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5()),
+            new Alfafixture_1(), new Alfafixture_2(), new Alfafixture_3(), new Alfafixture_6(),
+            new Bravofixture_1(), new Bravofixture_2(), new Bravofixture_3(),
+            new Charliefixture_1(), new Charliefixture_2(), new Charliefixture_3(), new Charliefixture_4(), new Charliefixture_5()),
         Collections.emptyList(),
         Arrays.asList(
             new PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3(),
@@ -141,12 +141,12 @@ public class DataObjectMigrationInventoryTest {
   public void testOrderedVersions() {
     assertEquals(
         Arrays.asList(
-            AlfaFixture_1.VERSION, BravoFixture_1.VERSION, CharlieFixture_1.VERSION, DeltaFixture_1.VERSION,
-            AlfaFixture_2.VERSION, BravoFixture_2.VERSION, CharlieFixture_2.VERSION, DeltaFixture_2.VERSION,
-            AlfaFixture_3.VERSION, BravoFixture_3.VERSION, CharlieFixture_3.VERSION,
-            CharlieFixture_4.VERSION,
-            AlfaFixture_6.VERSION,
-            CharlieFixture_5.VERSION // after charlieFixture-4, must not necessarily be after alfaFixture-6
+            Alfafixture_1.VERSION, Bravofixture_1.VERSION, Charliefixture_1.VERSION, Deltafixture_1.VERSION,
+            Alfafixture_2.VERSION, Bravofixture_2.VERSION, Charliefixture_2.VERSION, Deltafixture_2.VERSION,
+            Alfafixture_3.VERSION, Bravofixture_3.VERSION, Charliefixture_3.VERSION,
+            Charliefixture_4.VERSION,
+            Alfafixture_6.VERSION,
+            Charliefixture_5.VERSION // after charlieFixture-4, must not necessarily be after alfaFixture-6
         ),
         new ArrayList<>(s_inventory.m_orderedVersions));
   }
@@ -158,17 +158,17 @@ public class DataObjectMigrationInventoryTest {
   public void testTypeNameVersions() {
     assertEquals(
         CollectionUtility.hashMap(
-            new ImmutablePair<>("charlieFixture.BuildingFixture", Arrays.asList(CharlieFixture_2.VERSION)),
-            new ImmutablePair<>("charlieFixture.RoomFixture", Arrays.asList(CharlieFixture_2.VERSION, CharlieFixture_3.VERSION, CharlieFixture_4.VERSION, CharlieFixture_5.VERSION)),
-            new ImmutablePair<>("bravoFixture.PetFixture", Arrays.asList(BravoFixture_3.VERSION))),
+            new ImmutablePair<>("charlieFixture.BuildingFixture", Arrays.asList(Charliefixture_2.VERSION)),
+            new ImmutablePair<>("charlieFixture.RoomFixture", Arrays.asList(Charliefixture_2.VERSION, Charliefixture_3.VERSION, Charliefixture_4.VERSION, Charliefixture_5.VERSION)),
+            new ImmutablePair<>("bravoFixture.PetFixture", Arrays.asList(Bravofixture_3.VERSION))),
         s_inventory.m_typeNameVersions);
   }
 
   @Test
   public void testTypeNameToCurrentTypeVersion() {
-    assertEquals(CharlieFixture_3.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.HouseFixture"));
-    assertEquals(CharlieFixture_5.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.RoomFixture"));
-    assertEquals(CharlieFixture_2.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.PostalAddressFixture"));
+    assertEquals(Charliefixture_3.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.HouseFixture"));
+    assertEquals(Charliefixture_5.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.RoomFixture"));
+    assertEquals(Charliefixture_2.VERSION, s_inventory.m_typeNameToCurrentTypeVersion.get("charlieFixture.PostalAddressFixture"));
   }
 
   @Test
@@ -195,160 +195,160 @@ public class DataObjectMigrationInventoryTest {
   public void testIsUpToDateOrMigrationAvailable() {
     // Non-existing type names
     assertFalse(s_inventory.isUpToDateOrMigrationAvailable("lorem.Ipsum", null));
-    assertFalse(s_inventory.isUpToDateOrMigrationAvailable("lorem.Dolor", CharlieFixture_1.VERSION));
+    assertFalse(s_inventory.isUpToDateOrMigrationAvailable("lorem.Dolor", Charliefixture_1.VERSION));
 
     // Missing migration handler from charlieFixture-1 to -2 [lorem.Migrationless].
-    assertFalse(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.PostalAddressFixture", CharlieFixture_1.VERSION));
+    assertFalse(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.PostalAddressFixture", Charliefixture_1.VERSION));
 
     // Regular case [lorem.Example]
     assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", null));
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", CharlieFixture_1.VERSION));
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", CharlieFixture_2.VERSION));
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", CharlieFixture_3.VERSION));
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", CharlieFixture_4.VERSION));
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", CharlieFixture_5.VERSION)); // current type version
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", Charliefixture_1.VERSION));
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", Charliefixture_2.VERSION));
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", Charliefixture_3.VERSION));
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", Charliefixture_4.VERSION));
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", Charliefixture_5.VERSION)); // current type version
 
     // invalid, unknown type version
-    assertFalse(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", AlfaFixture_7.VERSION));
+    assertFalse(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.RoomFixture", Alfafixture_7.VERSION));
 
     //  [lorem.One/lorem.Two]
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.BuildingFixture", CharlieFixture_1.VERSION));
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.BuildingFixture", Charliefixture_1.VERSION));
 
     // invalid, BuildingFixture not available for this type version (next version from full list is returned due to possible renamings)
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.BuildingFixture", CharlieFixture_3.VERSION));
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.BuildingFixture", Charliefixture_3.VERSION));
 
-    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.HouseFixture", CharlieFixture_3.VERSION)); // current type version
+    assertTrue(s_inventory.isUpToDateOrMigrationAvailable("charlieFixture.HouseFixture", Charliefixture_3.VERSION)); // current type version
   }
 
   @Test
   public void testFindNextMigrationHandlerVersion() {
     // Missing migration handler from charlieFixture-1 to -2 [lorem.Migrationless].
     assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.NO_MIGRATION_HANDLERS, null),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.PostalAddressFixture", CharlieFixture_1.VERSION));
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.PostalAddressFixture", Charliefixture_1.VERSION));
 
     // Regular case [lorem.Example]
-    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.NO_TYPE_VERSION_YET, CharlieFixture_2.VERSION),
+    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.NO_TYPE_VERSION_YET, Charliefixture_2.VERSION),
         s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", null));
 
-    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, CharlieFixture_2.VERSION),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", CharlieFixture_1.VERSION));
+    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, Charliefixture_2.VERSION),
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", Charliefixture_1.VERSION));
 
-    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, CharlieFixture_3.VERSION),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", CharlieFixture_2.VERSION));
+    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, Charliefixture_3.VERSION),
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", Charliefixture_2.VERSION));
 
-    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, CharlieFixture_4.VERSION),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", CharlieFixture_3.VERSION));
+    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, Charliefixture_4.VERSION),
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", Charliefixture_3.VERSION));
 
-    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, CharlieFixture_5.VERSION),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", CharlieFixture_4.VERSION));
+    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, Charliefixture_5.VERSION),
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", Charliefixture_4.VERSION));
 
     assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.UP_TO_DATE, null),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", CharlieFixture_5.VERSION)); // current type version
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", Charliefixture_5.VERSION)); // current type version
 
     assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.UNKNOWN_TYPE_VERSION, null),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", AlfaFixture_7.VERSION)); // invalid, unknown type version
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.RoomFixture", Alfafixture_7.VERSION)); // invalid, unknown type version
 
     //  [lorem.One/lorem.Two]
-    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, CharlieFixture_2.VERSION),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.BuildingFixture", CharlieFixture_1.VERSION));
+    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, Charliefixture_2.VERSION),
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.BuildingFixture", Charliefixture_1.VERSION));
 
     // invalid, BuildingFixture not available for this type version (next version from full list is returned due to possible renamings)
-    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, CharlieFixture_4.VERSION),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.BuildingFixture", CharlieFixture_3.VERSION));
+    assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.MIGRATION_HANDLER_FOUND, Charliefixture_4.VERSION),
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.BuildingFixture", Charliefixture_3.VERSION));
 
     assertEquals(ImmutablePair.of(FindNextMigrationHandlerVersionStatus.UP_TO_DATE, null),
-        s_inventory.findNextMigrationHandlerVersion("charlieFixture.HouseFixture", CharlieFixture_3.VERSION)); // current type version
+        s_inventory.findNextMigrationHandlerVersion("charlieFixture.HouseFixture", Charliefixture_3.VERSION)); // current type version
   }
 
   @Test
   public void testGetVersions() {
-    assertThrows(AssertionException.class, () -> s_inventory.getVersions(CollectionUtility.emptyHashMap(), AlfaFixture_7.VERSION)); // alfaFixture-7 is unknown
+    assertThrows(AssertionException.class, () -> s_inventory.getVersions(CollectionUtility.emptyHashMap(), Alfafixture_7.VERSION)); // alfaFixture-7 is unknown
 
     assertEquals(CollectionUtility.emptyArrayList(), s_inventory.getVersions(CollectionUtility.emptyHashMap(), null));
-    assertEquals(CollectionUtility.emptyArrayList(), s_inventory.getVersions(CollectionUtility.emptyHashMap(), CharlieFixture_2.VERSION));
+    assertEquals(CollectionUtility.emptyArrayList(), s_inventory.getVersions(CollectionUtility.emptyHashMap(), Charliefixture_2.VERSION));
 
     // Only versions with handlers are returned
 
-    assertEquals(Arrays.asList(CharlieFixture_2.VERSION, BravoFixture_3.VERSION, CharlieFixture_3.VERSION, CharlieFixture_4.VERSION, CharlieFixture_5.VERSION),
+    assertEquals(Arrays.asList(Charliefixture_2.VERSION, Bravofixture_3.VERSION, Charliefixture_3.VERSION, Charliefixture_4.VERSION, Charliefixture_5.VERSION),
         s_inventory.getVersions(CollectionUtility.hashMap(
-                new ImmutablePair<>("charlieFixture.BuildingFixture", CharlieFixture_1.VERSION),
-                new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_1.VERSION)),
+                new ImmutablePair<>("charlieFixture.BuildingFixture", Charliefixture_1.VERSION),
+                new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_1.VERSION)),
             null));
 
-    assertEquals(Arrays.asList(CharlieFixture_3.VERSION, CharlieFixture_4.VERSION, CharlieFixture_5.VERSION),
+    assertEquals(Arrays.asList(Charliefixture_3.VERSION, Charliefixture_4.VERSION, Charliefixture_5.VERSION),
         s_inventory.getVersions(CollectionUtility.hashMap(
-                new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-                new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_2.VERSION)),
+                new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+                new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_2.VERSION)),
             null));
 
-    assertEquals(Arrays.asList(CharlieFixture_4.VERSION, CharlieFixture_5.VERSION),
+    assertEquals(Arrays.asList(Charliefixture_4.VERSION, Charliefixture_5.VERSION),
         s_inventory.getVersions(CollectionUtility.hashMap(
-                new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-                new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_3.VERSION)),
+                new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+                new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_3.VERSION)),
             null));
 
-    assertEquals(Arrays.asList(CharlieFixture_5.VERSION),
+    assertEquals(Arrays.asList(Charliefixture_5.VERSION),
         s_inventory.getVersions(CollectionUtility.hashMap(
-                new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-                new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_4.VERSION)),
+                new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+                new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_4.VERSION)),
             null));
 
     assertEquals(CollectionUtility.emptyArrayList(),
         s_inventory.getVersions(CollectionUtility.hashMap(
-                new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-                new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_5.VERSION)),
+                new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+                new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_5.VERSION)),
             null));
 
     // With limit of toVersion
-    assertEquals(Arrays.asList(CharlieFixture_3.VERSION),
+    assertEquals(Arrays.asList(Charliefixture_3.VERSION),
         s_inventory.getVersions(CollectionUtility.hashMap(
-                new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-                new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_2.VERSION)),
-            CharlieFixture_3.VERSION));
+                new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+                new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_2.VERSION)),
+            Charliefixture_3.VERSION));
 
-    // With limit of toVersion (lower than first returned version CharlieFixture_3)
+    // With limit of toVersion (lower than first returned version Charliefixture_3)
     assertEquals(Collections.emptyList(),
         s_inventory.getVersions(CollectionUtility.hashMap(
-                new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-                new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_2.VERSION)),
-            CharlieFixture_2.VERSION));
+                new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+                new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_2.VERSION)),
+            Charliefixture_2.VERSION));
   }
 
   @Test
   public void testGetStructureMigrationHandlers() {
     assertThrows(AssertionException.class, () -> s_inventory.getStructureMigrationHandlers(null));
-    assertThrows(AssertionException.class, () -> s_inventory.getStructureMigrationHandlers(AlfaFixture_7.VERSION)); // no registered
+    assertThrows(AssertionException.class, () -> s_inventory.getStructureMigrationHandlers(Alfafixture_7.VERSION)); // no registered
 
     // alfaFixture-1
-    assertTrue(s_inventory.getStructureMigrationHandlers(AlfaFixture_1.VERSION).isEmpty()); // no handlers
+    assertTrue(s_inventory.getStructureMigrationHandlers(Alfafixture_1.VERSION).isEmpty()); // no handlers
 
     Map<String, IDoStructureMigrationHandler> migrationHandlers;
 
     // charlieFixture-2
-    migrationHandlers = s_inventory.getStructureMigrationHandlers(CharlieFixture_2.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(Charliefixture_2.VERSION);
     assertEquals(2, migrationHandlers.size());
 
     assertTrue(migrationHandlers.get("charlieFixture.BuildingFixture") instanceof HouseFixtureDoStructureMigrationHandler_2);
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_2);
 
     // bravoFixture-3
-    migrationHandlers = s_inventory.getStructureMigrationHandlers(BravoFixture_3.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(Bravofixture_3.VERSION);
     assertEquals(1, migrationHandlers.size());
 
     assertTrue(migrationHandlers.get("bravoFixture.PetFixture") instanceof PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3);
 
     // charlieFixture-3
-    migrationHandlers = s_inventory.getStructureMigrationHandlers(CharlieFixture_3.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(Charliefixture_3.VERSION);
     assertEquals(1, migrationHandlers.size());
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_3);
 
     // charlieFixture-4
-    migrationHandlers = s_inventory.getStructureMigrationHandlers(CharlieFixture_4.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(Charliefixture_4.VERSION);
     assertEquals(1, migrationHandlers.size());
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_4);
 
     // charlieFixture-5
-    migrationHandlers = s_inventory.getStructureMigrationHandlers(CharlieFixture_5.VERSION);
+    migrationHandlers = s_inventory.getStructureMigrationHandlers(Charliefixture_5.VERSION);
     assertEquals(1, migrationHandlers.size());
     assertTrue(migrationHandlers.get("charlieFixture.RoomFixture") instanceof RoomFixtureDoStructureMigrationHandler_5);
   }
@@ -381,10 +381,10 @@ public class DataObjectMigrationInventoryTest {
     PlatformException exception = assertThrows(PlatformException.class, () -> new TestDataObjectMigrationInventory(
         Arrays.asList(new AlfaFixtureNamespace(), new BravoFixtureNamespace(), new CharlieFixtureNamespace(), new DeltaFixtureNamespace()),
         Arrays.asList(
-            new AlfaFixture_1(), new AlfaFixture_2(),
-            new BravoFixture_1(), new BravoFixture_2(),
-            new CharlieFixture_1(), new CharlieFixture_2(),
-            new DeltaFixture_1(), new DeltaFixture_2()),
+            new Alfafixture_1(), new Alfafixture_2(),
+            new Bravofixture_1(), new Bravofixture_2(),
+            new Charliefixture_1(), new Charliefixture_2(),
+            new Deltafixture_1(), new Deltafixture_2()),
         Collections.emptyList(),
         Collections.emptyList(),
         Arrays.asList(

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationTestHelper.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigrationTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,24 +19,24 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureStruc
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureTypedOnlyStructureMigrationTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.PersonFixtureTargetContextData;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_6;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_7;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_6;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_7;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_4;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_4;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_5;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.Deltafixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.Deltafixture_2;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.namespace.INamespace;
 
@@ -52,10 +52,10 @@ public class DataObjectMigrationTestHelper {
 
   public Collection<ITypeVersion> getFixtureTypeVersions() {
     return Arrays.asList(
-        new AlfaFixture_1(), new AlfaFixture_2(), new AlfaFixture_3(), new AlfaFixture_6(), new AlfaFixture_7(),
-        new BravoFixture_1(), new BravoFixture_2(), new BravoFixture_3(),
-        new CharlieFixture_1(), new CharlieFixture_2(), new CharlieFixture_3(), new CharlieFixture_4(), new CharlieFixture_5(),
-        new DeltaFixture_1(), new DeltaFixture_2());
+        new Alfafixture_1(), new Alfafixture_2(), new Alfafixture_3(), new Alfafixture_6(), new Alfafixture_7(),
+        new Bravofixture_1(), new Bravofixture_2(), new Bravofixture_3(),
+        new Charliefixture_1(), new Charliefixture_2(), new Charliefixture_3(), new Charliefixture_4(), new Charliefixture_5(),
+        new Deltafixture_1(), new Deltafixture_2());
   }
 
   public Collection<Class<? extends IDoStructureMigrationTargetContextData>> getFixtureContextDataClasses() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorStructureMigrationTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorStructureMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,14 +36,14 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStru
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStructureMigrationHandler_3;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStructureMigrationHandler_4;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDoStructureMigrationHandler_5;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_5;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
@@ -106,11 +106,11 @@ public class DataObjectMigratorStructureMigrationTest {
         .build();
 
     // stop at bravoFixture-2, otherwise namespace will change too
-    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, BravoFixture_2.VERSION));
+    assertTrue(s_migrator.applyStructureMigration(s_migrationContext, actual, Bravofixture_2.VERSION));
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "bravoFixture.PetFixture")
-        .put("_typeVersion", BravoFixture_2.VERSION.unwrap())
+        .put("_typeVersion", Bravofixture_2.VERSION.unwrap())
         .put("name", "Charlie")
         .build();
 
@@ -134,7 +134,7 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PostalAddressFixture")
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
         .put("street", "Main street 12")
         .build();
 
@@ -151,7 +151,7 @@ public class DataObjectMigratorStructureMigrationTest {
   public void testUpdateVersionWithPreviousTypeVersion() {
     IDoEntity actual = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PostalAddressFixture")
-        .put("_typeVersion", CharlieFixture_1.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_1.VERSION.unwrap())
         .put("street", "Main street 12")
         .build();
 
@@ -159,7 +159,7 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PostalAddressFixture")
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
         .put("street", "Main street 12")
         .build();
 
@@ -176,7 +176,7 @@ public class DataObjectMigratorStructureMigrationTest {
   public void testNamespaceChange() {
     IDoEntity actual = BEANS.get(DoEntityBuilder.class)
         .put("_type", "bravoFixture.PetFixture")
-        .put("_typeVersion", BravoFixture_1.VERSION.unwrap())
+        .put("_typeVersion", Bravofixture_1.VERSION.unwrap())
         .put("name", "JOHN")
         .build();
 
@@ -184,7 +184,7 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.PetFixture")
-        .put("_typeVersion", AlfaFixture_3.VERSION.unwrap())
+        .put("_typeVersion", Alfafixture_3.VERSION.unwrap())
         .put("name", "John")
         .put("familyFriendly", true)
         .build();
@@ -199,7 +199,7 @@ public class DataObjectMigratorStructureMigrationTest {
   public void testMigrationHandlerForOriginalDataObject() {
     IDoEntity actual = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.CustomerFixture")
-        .put("_typeVersion", AlfaFixture_1.VERSION.unwrap())
+        .put("_typeVersion", Alfafixture_1.VERSION.unwrap())
         .put("firstName", "John")
         .build();
 
@@ -207,7 +207,7 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.CustomerFixture")
-        .put("_typeVersion", AlfaFixture_3.VERSION.unwrap())
+        .put("_typeVersion", Alfafixture_3.VERSION.unwrap())
         .put("firstName", "JOHN") // uppercase due to CustomerFixtureMigrationHandler_3
         .build();
 
@@ -225,7 +225,7 @@ public class DataObjectMigratorStructureMigrationTest {
   public void testMigrationHandlerForSubclassedDataObject() {
     IDoEntity actual = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.CustomerFixture")
-        .put("_typeVersion", CharlieFixture_1.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_1.VERSION.unwrap())
         .put("firstName", "John")
         .build();
 
@@ -233,7 +233,7 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.CustomerFixture")
-        .put("_typeVersion", CharlieFixture_3.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_3.VERSION.unwrap())
         .put("firstName", "john") // lowercase due to CharlieCustomerFixtureMigrationHandler_3
         .build();
 
@@ -244,11 +244,11 @@ public class DataObjectMigratorStructureMigrationTest {
   public void testHouseFixtureMigration_1_to_5() {
     IDoEntity actual = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.BuildingFixture")
-        .put("_typeVersion", CharlieFixture_1.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_1.VERSION.unwrap())
         .put("name", "Family Doe")
         .putList("rooms", BEANS.get(DoEntityBuilder.class)
             .put("_type", "charlieFixture.RoomFixture")
-            .put("_typeVersion", CharlieFixture_1.VERSION.unwrap())
+            .put("_typeVersion", Charliefixture_1.VERSION.unwrap())
             .put("roomName", "Kitchen")
             .build())
         .build();
@@ -257,11 +257,11 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.HouseFixture") // BuildingFixture -> HouseFixture
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap()) // updated version
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap()) // updated version
         .put("name", "Family Doe")
         .putList("rooms", BEANS.get(DoEntityBuilder.class)
             .put("_type", "charlieFixture.RoomFixture")
-            .put("_typeVersion", CharlieFixture_5.VERSION.unwrap()) // updated version
+            .put("_typeVersion", Charliefixture_5.VERSION.unwrap()) // updated version
             .put("name", "Kitchen") // roomName -> name
             .put("displayText", "Family Doe: Kitchen") // display text was calculated based on name of house and room
             .build())
@@ -274,11 +274,11 @@ public class DataObjectMigratorStructureMigrationTest {
   public void testHouseFixtureMigration_3_to_5() {
     IDoEntity actual = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.HouseFixture")
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
         .put("name", "Family Doe")
         .putList("rooms", BEANS.get(DoEntityBuilder.class)
             .put("_type", "charlieFixture.RoomFixture")
-            .put("_typeVersion", CharlieFixture_3.VERSION.unwrap())
+            .put("_typeVersion", Charliefixture_3.VERSION.unwrap())
             .put("name", "Kitchen")
             .put("areaInSquareFoot", 10764)
             .build())
@@ -288,11 +288,11 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.HouseFixture")
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
         .put("name", "Family Doe")
         .putList("rooms", BEANS.get(DoEntityBuilder.class)
             .put("_type", "charlieFixture.RoomFixture")
-            .put("_typeVersion", CharlieFixture_5.VERSION.unwrap()) // updated version
+            .put("_typeVersion", Charliefixture_5.VERSION.unwrap()) // updated version
             .put("name", "Kitchen")
             .put("displayText", "Family Doe: Kitchen (1000m2)") // display text was calculated based on areaInSquareMeter and name of house and room
             .put("areaInSquareMeter", 1000) // areaInSquareFoot -> areaInSquareMeter
@@ -313,15 +313,15 @@ public class DataObjectMigratorStructureMigrationTest {
   public void testStackedLocalContextData() {
     IDoEntity actual = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PersonFixture")
-        .put("_typeVersion", CharlieFixture_1.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_1.VERSION.unwrap())
         .put("name", "John Doe")
         .putList("children", BEANS.get(DoEntityBuilder.class)
             .put("_type", "charlieFixture.PersonFixture")
-            .put("_typeVersion", CharlieFixture_1.VERSION.unwrap())
+            .put("_typeVersion", Charliefixture_1.VERSION.unwrap())
             .put("name", "John Doe Junior")
             .putList("children", BEANS.get(DoEntityBuilder.class)
                 .put("_type", "charlieFixture.PersonFixture")
-                .put("_typeVersion", CharlieFixture_1.VERSION.unwrap())
+                .put("_typeVersion", Charliefixture_1.VERSION.unwrap())
                 .put("name", "John Doe Junior 2. Gen")
                 .build())
             .build())
@@ -331,17 +331,17 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PersonFixture")
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap()) // updated version
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap()) // updated version
         .put("name", "John Doe")
         .put("relation", "(none)") // add relation
         .putList("children", BEANS.get(DoEntityBuilder.class)
             .put("_type", "charlieFixture.PersonFixture")
-            .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())// updated version
+            .put("_typeVersion", Charliefixture_2.VERSION.unwrap())// updated version
             .put("name", "John Doe Junior")
             .put("relation", "Child of John Doe") // added relation
             .putList("children", BEANS.get(DoEntityBuilder.class)
                 .put("_type", "charlieFixture.PersonFixture")
-                .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())// updated version
+                .put("_typeVersion", Charliefixture_2.VERSION.unwrap())// updated version
                 .put("name", "John Doe Junior 2. Gen")
                 .put("relation", "Child of John Doe Junior") // added relation
                 .build())
@@ -359,7 +359,7 @@ public class DataObjectMigratorStructureMigrationTest {
   public void testListManipulationViaMigrationHandler() {
     IDoEntity actual = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PersonFixture")
-        .put("_typeVersion", CharlieFixture_1.VERSION.unwrap())
+        .put("_typeVersion", Charliefixture_1.VERSION.unwrap())
         .put("name", "example")
         .build();
 
@@ -367,12 +367,12 @@ public class DataObjectMigratorStructureMigrationTest {
 
     IDoEntity expected = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.PersonFixture")
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap()) // updated version
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap()) // updated version
         .put("name", "example")
         .put("relation", "(none)") // added relation
         .putList("children", BEANS.get(DoEntityBuilder.class) // added child
             .put("_type", "charlieFixture.PersonFixture")
-            .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+            .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
             .put("name", "Jane Doe")
             .put("relation", "(undefined)")
             .build())

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorValueMigrationTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DataObjectMigratorValueMigrationTest.java
@@ -54,8 +54,8 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.house.StreetNameStringI
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.StreetNameStringIdValueMigrationHandlerByMap_1;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.StreetNameWrapperDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.StreetNamesFixture;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
@@ -282,7 +282,7 @@ public class DataObjectMigratorValueMigrationTest {
     // raw DoEntity data object
     IDoEntity original = BEANS.get(DoEntityBuilder.class)
         .put("_type", "alfaFixture.CustomerFixture")
-        .put("_typeVersion", AlfaFixture_3.VERSION.unwrap())
+        .put("_typeVersion", Alfafixture_3.VERSION.unwrap())
         .put("firstName", "John")
         .put("lastName", "Doe")
         .put("gender", "m")
@@ -317,7 +317,7 @@ public class DataObjectMigratorValueMigrationTest {
     // raw DoEntity data object
     IDoEntity original = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.HouseFixture")
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap()) // will be updated by HouseFixtureDoStructureMigrationHandler_3
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap()) // will be updated by HouseFixtureDoStructureMigrationHandler_3
         .build();
 
     DataObjectMigratorResult<IDoEntity> result = s_migrator.migrateDataObject(s_migrationContext, original, IDoEntity.class);
@@ -344,7 +344,7 @@ public class DataObjectMigratorValueMigrationTest {
     // raw DoEntity data object
     IDoEntity original = BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.HouseFixture")
-        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap()) // will be updated by HouseFixtureDoStructureMigrationHandler_3
+        .put("_typeVersion", Charliefixture_2.VERSION.unwrap()) // will be updated by HouseFixtureDoStructureMigrationHandler_3
         .build();
 
     DataObjectMigrationContext ctx = s_migrationContext.copy();

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationHelperTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/DoStructureMigrationHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,13 +16,13 @@ import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.HouseFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.RoomFixtureDo;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_5;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -66,25 +66,25 @@ public class DoStructureMigrationHelperTest {
   @Test
   public void testGetTypeVersion() {
     assertNull(s_helper.getTypeVersion(BEANS.get(DoEntityBuilder.class).build()));
-    assertEquals(AlfaFixture_1.VERSION, s_helper.getTypeVersion(BEANS.get(DoEntityBuilder.class).put("_typeVersion", "alfaFixture-1").build()));
+    assertEquals(Alfafixture_1.VERSION, s_helper.getTypeVersion(BEANS.get(DoEntityBuilder.class).put("_typeVersion", "alfaFixture-1").build()));
   }
 
   @Test
   public void testSetTypeVersion() {
     IDoEntity doEntity = BEANS.get(DoEntityBuilder.class).build();
-    s_helper.setTypeVersion(doEntity, AlfaFixture_1.VERSION);
-    assertEquals(AlfaFixture_1.VERSION, s_helper.getTypeVersion(doEntity));
-    assertEquals(AlfaFixture_1.VERSION.unwrap(), doEntity.getString("_typeVersion"));
+    s_helper.setTypeVersion(doEntity, Alfafixture_1.VERSION);
+    assertEquals(Alfafixture_1.VERSION, s_helper.getTypeVersion(doEntity));
+    assertEquals(Alfafixture_1.VERSION.unwrap(), doEntity.getString("_typeVersion"));
   }
 
   @Test
   public void testUpdateTypeVersion() {
     IDoEntity doEntity = BEANS.get(DoEntityBuilder.class).build();
-    s_helper.setTypeVersion(doEntity, AlfaFixture_1.VERSION);
-    assertFalse(s_helper.updateTypeVersion(doEntity, AlfaFixture_1.VERSION)); // already up-to-date
-    assertTrue(s_helper.updateTypeVersion(doEntity, AlfaFixture_2.VERSION)); // changed
-    assertEquals(AlfaFixture_2.VERSION.unwrap(), doEntity.getString("_typeVersion")); // verify
-    assertFalse(s_helper.updateTypeVersion(doEntity, AlfaFixture_2.VERSION)); // already up-to-date
+    s_helper.setTypeVersion(doEntity, Alfafixture_1.VERSION);
+    assertFalse(s_helper.updateTypeVersion(doEntity, Alfafixture_1.VERSION)); // already up-to-date
+    assertTrue(s_helper.updateTypeVersion(doEntity, Alfafixture_2.VERSION)); // changed
+    assertEquals(Alfafixture_2.VERSION.unwrap(), doEntity.getString("_typeVersion")); // verify
+    assertFalse(s_helper.updateTypeVersion(doEntity, Alfafixture_2.VERSION)); // already up-to-date
   }
 
   @Test
@@ -93,62 +93,62 @@ public class DoStructureMigrationHelperTest {
 
     // Single data object
     Assert.assertEquals(CollectionUtility.hashMap(
-            new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION)),
+            new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION)),
         helper.collectRawDataObjectTypeVersions(
             BEANS.get(DoEntityBuilder.class)
                 .put("_type", "charlieFixture.HouseFixture")
-                .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+                .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
                 .build()));
 
     // Data object containing another data objects (house owner attribute not set here)
     Assert.assertEquals(CollectionUtility.hashMap(
-            new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-            new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_5.VERSION),
-            new ImmutablePair<>("charlieFixture.PostalAddressFixture", CharlieFixture_2.VERSION)),
+            new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+            new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_5.VERSION),
+            new ImmutablePair<>("charlieFixture.PostalAddressFixture", Charliefixture_2.VERSION)),
         helper.collectRawDataObjectTypeVersions(
             BEANS.get(DoEntityBuilder.class)
                 .put("_type", "charlieFixture.HouseFixture")
-                .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+                .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
                 .putList("rooms",
                     BEANS.get(DoEntityBuilder.class)
                         .put("_type", "charlieFixture.RoomFixture")
-                        .put("_typeVersion", CharlieFixture_5.VERSION.unwrap())
+                        .put("_typeVersion", Charliefixture_5.VERSION.unwrap())
                         .build())
                 .put("postalAddress",
                     BEANS.get(DoEntityBuilder.class)
                         .put("_type", "charlieFixture.PostalAddressFixture")
-                        .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+                        .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
                         .build())
                 .build()));
 
     // Data object with a subclass but using origin class (different type version) [not a real case]
     Assert.assertEquals(CollectionUtility.hashMap(
-            new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-            new ImmutablePair<>("alfaFixture.CustomerFixture", AlfaFixture_3.VERSION)),
+            new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+            new ImmutablePair<>("alfaFixture.CustomerFixture", Alfafixture_3.VERSION)),
         helper.collectRawDataObjectTypeVersions(
             BEANS.get(DoEntityBuilder.class)
                 .put("_type", "charlieFixture.HouseFixture")
-                .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+                .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
                 .put("owner",
                     BEANS.get(DoEntityBuilder.class)
                         .put("_type", "alfaFixture.CustomerFixture")
-                        .put("_typeVersion", AlfaFixture_3.VERSION.unwrap()) // CustomerFixtureDo
+                        .put("_typeVersion", Alfafixture_3.VERSION.unwrap()) // CustomerFixtureDo
                         .build())
                 .build()));
 
     // Data object with a subclass using replaced class
     Assert.assertEquals(CollectionUtility.hashMap(
-            new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION),
-            new ImmutablePair<>("alfaFixture.CustomerFixture", CharlieFixture_3.VERSION)),
+            new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION),
+            new ImmutablePair<>("alfaFixture.CustomerFixture", Charliefixture_3.VERSION)),
 
         helper.collectRawDataObjectTypeVersions(
             BEANS.get(DoEntityBuilder.class)
                 .put("_type", "charlieFixture.HouseFixture")
-                .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+                .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
                 .put("owner",
                     BEANS.get(DoEntityBuilder.class)
                         .put("_type", "alfaFixture.CustomerFixture")
-                        .put("_typeVersion", CharlieFixture_3.VERSION.unwrap()) // CharlieCustomerFixtureDo
+                        .put("_typeVersion", Charliefixture_3.VERSION.unwrap()) // CharlieCustomerFixtureDo
                         .build())
                 .build()));
 
@@ -159,52 +159,52 @@ public class DoStructureMigrationHelperTest {
 
   @Test
   public void testIsMigrationApplicable() {
-    assertFalse(s_helper.isMigrationApplicable(BEANS.get(RoomFixtureDo.class), CharlieFixture_2.VERSION)); // typed data object (not raw)
-    assertTrue(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").build(), CharlieFixture_2.VERSION)); // no type version (yet)
-    assertFalse(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").put("_typeVersion", AlfaFixture_1.VERSION.unwrap()).build(), CharlieFixture_2.VERSION)); // different namespace
-    assertFalse(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").put("_typeVersion", CharlieFixture_2.VERSION.unwrap()).build(), CharlieFixture_2.VERSION)); // same version
-    assertTrue(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").put("_typeVersion", CharlieFixture_1.VERSION.unwrap()).build(), CharlieFixture_2.VERSION)); // lower version
-    assertFalse(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").put("_typeVersion", CharlieFixture_3.VERSION.unwrap()).build(), CharlieFixture_2.VERSION)); // higher version (invalid)
+    assertFalse(s_helper.isMigrationApplicable(BEANS.get(RoomFixtureDo.class), Charliefixture_2.VERSION)); // typed data object (not raw)
+    assertTrue(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").build(), Charliefixture_2.VERSION)); // no type version (yet)
+    assertFalse(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").put("_typeVersion", Alfafixture_1.VERSION.unwrap()).build(), Charliefixture_2.VERSION)); // different namespace
+    assertFalse(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").put("_typeVersion", Charliefixture_2.VERSION.unwrap()).build(), Charliefixture_2.VERSION)); // same version
+    assertTrue(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").put("_typeVersion", Charliefixture_1.VERSION.unwrap()).build(), Charliefixture_2.VERSION)); // lower version
+    assertFalse(s_helper.isMigrationApplicable(BEANS.get(DoEntityBuilder.class).put("_type", "charlieFixture.RoomFixture").put("_typeVersion", Charliefixture_3.VERSION.unwrap()).build(), Charliefixture_2.VERSION)); // higher version (invalid)
   }
 
   /**
-   * References {@link HouseFixtureDo} with type version {@link CharlieFixture_2} and {@link RoomFixtureDo} with type
-   * version {@link CharlieFixture_5}.
+   * References {@link HouseFixtureDo} with type version {@link Charliefixture_2} and {@link RoomFixtureDo} with type
+   * version {@link Charliefixture_5}.
    */
   @Test
   public void testIsAnyMigrationRequired() {
     assertFalse(s_helper.isAnyMigrationRequired(CollectionUtility.emptyHashMap())); // no versions at all -> not outdated
 
     assertTrue(s_helper.isAnyMigrationRequired(CollectionUtility.hashMap(
-        new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_1.VERSION.unwrap()),
-        new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_1.VERSION.unwrap()))));
+        new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_1.VERSION.unwrap()),
+        new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_1.VERSION.unwrap()))));
 
     // invalid constellation, all data objects within a persisted data object have a consistent type version
     assertTrue(s_helper.isAnyMigrationRequired(CollectionUtility.hashMap(
-        new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_2.VERSION.unwrap()),
-        new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_1.VERSION.unwrap()))));
+        new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_2.VERSION.unwrap()),
+        new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_1.VERSION.unwrap()))));
 
     // invalid constellation, all data objects within a persisted data object have a consistent type version
     assertTrue(s_helper.isAnyMigrationRequired(CollectionUtility.hashMap(
-        new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_1.VERSION.unwrap()),
-        new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_5.VERSION.unwrap()))));
+        new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_1.VERSION.unwrap()),
+        new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_5.VERSION.unwrap()))));
 
     assertFalse(s_helper.isAnyMigrationRequired(CollectionUtility.hashMap(
-        new ImmutablePair<>("charlieFixture.HouseFixture", CharlieFixture_3.VERSION.unwrap()),
-        new ImmutablePair<>("charlieFixture.RoomFixture", CharlieFixture_5.VERSION.unwrap()))));
+        new ImmutablePair<>("charlieFixture.HouseFixture", Charliefixture_3.VERSION.unwrap()),
+        new ImmutablePair<>("charlieFixture.RoomFixture", Charliefixture_5.VERSION.unwrap()))));
   }
 
   /**
-   * References {@link HouseFixtureDo} that has type version {@link CharlieFixture_3}.
+   * References {@link HouseFixtureDo} that has type version {@link Charliefixture_3}.
    */
   @Test
   public void testIsMigrationRequired() {
     assertTrue(s_helper.isMigrationRequired("charlieFixture.HouseFixture", null)); // no type version
     assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", NamespaceVersion.of("unknown", "1.0.0"))); // unknown type version
-    assertTrue(s_helper.isMigrationRequired("charlieFixture.BuildingFixture", CharlieFixture_1.VERSION)); // unknown type name (e.g. renamed)
-    assertTrue(s_helper.isMigrationRequired("charlieFixture.HouseFixture", CharlieFixture_1.VERSION)); // lower type version
-    assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", CharlieFixture_3.VERSION)); // same type version
-    assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", CharlieFixture_5.VERSION)); // newer type version (invalid)
+    assertTrue(s_helper.isMigrationRequired("charlieFixture.BuildingFixture", Charliefixture_1.VERSION)); // unknown type name (e.g. renamed)
+    assertTrue(s_helper.isMigrationRequired("charlieFixture.HouseFixture", Charliefixture_1.VERSION)); // lower type version
+    assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", Charliefixture_3.VERSION)); // same type version
+    assertFalse(s_helper.isMigrationRequired("charlieFixture.HouseFixture", Charliefixture_5.VERSION)); // newer type version (invalid)
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CharlieCustomerFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CharlieCustomerFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureNamespace;
 import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureNamespace;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
 import org.eclipse.scout.rt.platform.Replace;
 
 /**
@@ -37,7 +37,7 @@ import org.eclipse.scout.rt.platform.Replace;
  *
  * @since charlieFixture-2
  */
-@TypeVersion(CharlieFixture_3.class)
+@TypeVersion(Charliefixture_3.class)
 @Replace
 public class CharlieCustomerFixtureDo extends CustomerFixtureDo {
 

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CharlieCustomerFixtureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CharlieCustomerFixtureMigrationHandler_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
@@ -26,7 +26,7 @@ public class CharlieCustomerFixtureMigrationHandler_3 extends AbstractDoStructur
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_3.class;
+    return Charliefixture_3.class;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
 
 /**
  * Changes:
@@ -26,7 +26,7 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureType
  * @since alfaFixture-1
  */
 @TypeName("alfaFixture.CustomerFixture")
-@TypeVersion(AlfaFixture_3.class)
+@TypeVersion(Alfafixture_3.class)
 public class CustomerFixtureDo extends DoEntity {
 
   public DoValue<String> firstName() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerFixtureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerFixtureMigrationHandler_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
@@ -26,7 +26,7 @@ public class CustomerFixtureMigrationHandler_3 extends AbstractDoStructureMigrat
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return AlfaFixture_3.class;
+    return Alfafixture_3.class;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerGenderFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/CustomerGenderFixtureDoValueMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 
@@ -35,7 +35,7 @@ public class CustomerGenderFixtureDoValueMigrationHandler_2 extends AbstractDoVa
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return CharlieFixture_2.class;
+    return Charliefixture_2.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/DuplicateIdFixtureDoValueMigrationHandler_1.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/DuplicateIdFixtureDoValueMigrationHandler_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.Deltafixture_1;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 
 @IgnoreBean
@@ -30,7 +30,7 @@ public class DuplicateIdFixtureDoValueMigrationHandler_1 extends AbstractDoValue
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return DeltaFixture_1.class;
+    return Deltafixture_1.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ import org.eclipse.scout.rt.dataobject.DoList;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
 
 /**
  * Change history:
@@ -32,7 +32,7 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureT
  * @since charlieFixture-1
  */
 @TypeName("charlieFixture.HouseFixture")
-@TypeVersion(CharlieFixture_3.class)
+@TypeVersion(Charliefixture_3.class)
 public class HouseFixtureDo extends DoEntity {
 
   public DoValue<String> name() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoStructureMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoStructureMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@ import java.util.Map;
 
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureRenameMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 
 /**
@@ -24,7 +24,7 @@ public class HouseFixtureDoStructureMigrationHandler_2 extends AbstractDoStructu
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_2.class;
+    return Charliefixture_2.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoStructureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoStructureMigrationHandler_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,8 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_5;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -32,7 +32,7 @@ public class HouseFixtureDoStructureMigrationHandler_3 extends AbstractDoStructu
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_3.class;
+    return Charliefixture_3.class;
   }
 
   @Override
@@ -46,14 +46,14 @@ public class HouseFixtureDoStructureMigrationHandler_3 extends AbstractDoStructu
 
     rooms.add(BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.RoomFixture")
-        .put("_typeVersion", CharlieFixture_5.VERSION.unwrap()) // latest version, no structure migration will be applied
+        .put("_typeVersion", Charliefixture_5.VERSION.unwrap()) // latest version, no structure migration will be applied
         .put("name", "example room 1")
         .put("roomType", "room") // valid room type (already migrated), will not be migrated by RoomTypeFixtureDoValueMigrationHandler_2
         .build());
 
     rooms.add(BEANS.get(DoEntityBuilder.class)
         .put("_type", "charlieFixture.RoomFixture")
-        .put("_typeVersion", CharlieFixture_5.VERSION.unwrap()) // latest version, no structure migration will be applied
+        .put("_typeVersion", Charliefixture_5.VERSION.unwrap()) // latest version, no structure migration will be applied
         .put("name", "example room 2")
         .put("roomType", "standard-room") // old room type value, will be migrated by RoomTypeFixtureDoValueMigrationHandler_2
         .build());

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoValueMigrationHandler_1.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseFixtureDoValueMigrationHandler_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -34,7 +34,7 @@ public class HouseFixtureDoValueMigrationHandler_1 extends AbstractDoValueMigrat
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return CharlieFixture_1.class;
+    return Charliefixture_1.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/HouseTypeFixtureDoValueMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 
 /**
@@ -31,7 +31,7 @@ public class HouseTypeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMi
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return CharlieFixture_2.class;
+    return Charliefixture_2.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ import org.eclipse.scout.rt.dataobject.id.UnknownId;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueUntypedMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.Deltafixture_2;
 
 /**
  * Migration handler migrating former OldHouseTypeFixtureStringId instances to {@link HouseTypeFixtureStringId}.
@@ -30,9 +30,9 @@ public class OldHouseTypeFixtureStringIdTypeNameRenameMigrationHandler_2 extends
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    // Type version DeltaFixture_2 is after CharlieFixture_2 and therefore HouseTypeFixtureDoValueMigrationHandler_2.
+    // Type version Deltafixture_2 is after Charliefixture_2 and therefore HouseTypeFixtureDoValueMigrationHandler_2.
     // But untyped value migrations will always be applied before regular value migrations, based on the primary sort order.
-    return DeltaFixture_2.class;
+    return Deltafixture_2.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ import org.eclipse.scout.rt.dataobject.DoList;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 
 /**
  * Changes:
@@ -28,7 +28,7 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureT
  * </ul>
  */
 @TypeName("charlieFixture.PersonFixture")
-@TypeVersion(CharlieFixture_2.class)
+@TypeVersion(Charliefixture_2.class)
 public class PersonFixtureDo extends DoEntity {
 
   public DoValue<String> name() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureDoStructureMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureDoStructureMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
@@ -30,7 +30,7 @@ public class PersonFixtureDoStructureMigrationHandler_2 extends AbstractDoStruct
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_2.class;
+    return Charliefixture_2.class;
   }
 
   /**
@@ -56,7 +56,7 @@ public class PersonFixtureDoStructureMigrationHandler_2 extends AbstractDoStruct
       children.add(BEANS.get(DoEntityBuilder.class)
           .put("_type", "charlieFixture.PersonFixture")
           // when no type version is added or charlieFixture-1 is used, this migration handler would be called for the added child too
-          .put("_typeVersion", CharlieFixture_2.VERSION.unwrap())
+          .put("_typeVersion", Charliefixture_2.VERSION.unwrap())
           .put("name", "Jane Doe")
           .put("relation", "(undefined)")
           .build());

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureTargetContextData.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PersonFixtureTargetContextData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationContextDataTarget;
 import org.eclipse.scout.rt.dataobject.migration.IDoStructureMigrationTargetContextData;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 
 @DoStructureMigrationContextDataTarget(typeNames = {"charlieFixture.PersonFixture"})
@@ -33,7 +33,7 @@ public class PersonFixtureTargetContextData implements IDoStructureMigrationTarg
     // A context data must only be initialized with an already migrated data object for a certain version.
     // The data object itself must be migrated as well as the correct type version must be set (in case type version switches are used within context)
     assertNotNull(doEntity.getString("relation")); // created by PersonFixtureDoStructureMigrationHandler_2
-    assertEquals(CharlieFixture_2.VERSION, NamespaceVersion.of(doEntity.getString("_typeVersion"))); // version must be updated before context data is initialized
+    assertEquals(Charliefixture_2.VERSION, NamespaceVersion.of(doEntity.getString("_typeVersion"))); // version must be updated before context data is initialized
 
     m_name = doEntity.getString("name");
     return true;

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,8 +16,8 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationHelper;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_3;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
@@ -34,11 +34,11 @@ public class PetFixtureAlfaNamespaceFamilyFriendlyMigrationHandler_3 extends Abs
   public Class<? extends ITypeVersion> toTypeVersionClass() {
     // The target type version must be in the same namespace to trigger the migration handler correctly.
     // The namespace is then migrated as part of the handler execution.
-    return BravoFixture_3.class;
+    return Bravofixture_3.class;
   }
 
   protected NamespaceVersion typeVersionToUpdate() {
-    return AlfaFixture_3.VERSION;
+    return Alfafixture_3.VERSION;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureAlwaysAcceptDoValueMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureAlwaysAcceptDoValueMigrationHandler_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.StringUtility;
@@ -36,7 +36,7 @@ public class PetFixtureAlwaysAcceptDoValueMigrationHandler_3 extends AbstractDoV
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return AlfaFixture_3.class;
+    return Alfafixture_3.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureCaseSensitiveNameMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureCaseSensitiveNameMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
@@ -26,7 +26,7 @@ public class PetFixtureCaseSensitiveNameMigrationHandler_2 extends AbstractDoStr
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return BravoFixture_2.class;
+    return Bravofixture_2.class;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
 
 /**
  * Introduced in namespace bravo with type version bravo-1, attribute name. Changes:
@@ -26,7 +26,7 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureType
  * </ul>
  */
 @TypeName("alfaFixture.PetFixture")
-@TypeVersion(AlfaFixture_3.class)
+@TypeVersion(Alfafixture_3.class)
 public class PetFixtureDo extends DoEntity {
 
   public DoValue<String> name() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureDoValueMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureDoValueMigrationHandler_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.StringUtility;
@@ -36,7 +36,7 @@ public class PetFixtureDoValueMigrationHandler_3 extends AbstractDoValueMigratio
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return AlfaFixture_3.class;
+    return Alfafixture_3.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,15 +17,15 @@ import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHan
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationInventoryTest;
 import org.eclipse.scout.rt.dataobject.migration.DoStructureMigrationHelper;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_3;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
 /**
- * A second migration handler for type version {@link BravoFixture_3} for the type name 'bravoFixture.PetFixture', only
+ * A second migration handler for type version {@link Bravofixture_3} for the type name 'bravoFixture.PetFixture', only
  * used within {@link DataObjectMigrationInventoryTest#testValidateMigrationHandlerUniqueness()}.
  */
 @IgnoreBean
@@ -35,11 +35,11 @@ public class PetFixtureFamilyFriendlyMigrationHandlerInvalidTypeVersionToUpdate_
   public Class<? extends ITypeVersion> toTypeVersionClass() {
     // The target type version must be in the same namespace to trigger the migration handler correctly.
     // The namespace is then migrated as part of the handler execution.
-    return BravoFixture_3.class;
+    return Bravofixture_3.class;
   }
 
   protected NamespaceVersion typeVersionToUpdate() {
-    return AlfaFixture_3.VERSION;
+    return Alfafixture_3.VERSION;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PostalAddressFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PostalAddressFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 
 /**
  * No changes.
@@ -23,7 +23,7 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureT
  * @since charlieFixture-2 but introduced and persisted without a type version first.
  */
 @TypeName("charlieFixture.PostalAddressFixture")
-@TypeVersion(CharlieFixture_2.class)
+@TypeVersion(Charliefixture_2.class)
 public class PostalAddressFixtureDo extends DoEntity {
 
   public DoValue<String> street() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PostalAddressFixtureUpdateVersionOnlyMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/PostalAddressFixtureUpdateVersionOnlyMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
@@ -24,7 +24,7 @@ public class PostalAddressFixtureUpdateVersionOnlyMigrationHandler_2 extends Abs
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_2.class;
+    return Charliefixture_2.class;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,7 @@ import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_5;
 
 /**
  * Change history:
@@ -31,7 +31,7 @@ import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureT
  * @since charlieFixture-1
  */
 @TypeName("charlieFixture.RoomFixture")
-@TypeVersion(CharlieFixture_5.class)
+@TypeVersion(Charliefixture_5.class)
 public class RoomFixtureDo extends DoEntity {
 
   public DoValue<String> name() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@ import java.util.Map;
 
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureRenameMigrationHandler;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.ImmutablePair;
@@ -26,7 +26,7 @@ public class RoomFixtureDoStructureMigrationHandler_2 extends AbstractDoStructur
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_2.class;
+    return Charliefixture_2.class;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_3.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_3;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
@@ -24,7 +24,7 @@ public class RoomFixtureDoStructureMigrationHandler_3 extends AbstractDoStructur
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_3.class;
+    return Charliefixture_3.class;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_4.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_4;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_4;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 
@@ -24,7 +24,7 @@ public class RoomFixtureDoStructureMigrationHandler_4 extends AbstractDoStructur
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_4.class;
+    return Charliefixture_4.class;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_5.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomFixtureDoStructureMigrationHandler_5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoStructureMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_5;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_5;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
@@ -25,7 +25,7 @@ public class RoomFixtureDoStructureMigrationHandler_5 extends AbstractDoStructur
 
   @Override
   public Class<? extends ITypeVersion> toTypeVersionClass() {
-    return CharlieFixture_5.class;
+    return Charliefixture_5.class;
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomSizeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomSizeFixtureDoValueMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.DeltaFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.DeltaFixtureTypeVersions.Deltafixture_2;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.util.NumberUtility;
@@ -36,7 +36,7 @@ public class RoomSizeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMig
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return DeltaFixture_2.class; // after RoomTypeValueMigrationHandler
+    return Deltafixture_2.class; // after RoomTypeValueMigrationHandler
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeCompositeFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeCompositeFixtureDo.java
@@ -1,12 +1,11 @@
 /*
- * Copyright (c) 2010-2021 BSI Business Systems Integration AG.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
- * Contributors:
- *     BSI Business Systems Integration AG - initial API and implementation
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.scout.rt.dataobject.migration.fixture.house;
 
@@ -16,14 +15,14 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
 
 /**
  * Used for value migration tests for composite objects handled by
  * {@link RoomTypeCompositeFixtureDataObjectVisitorExtension}.
  */
 @TypeName("charlieFixture.RoomTypeCompositeFixture")
-@TypeVersion(CharlieFixture_1.class)
+@TypeVersion(Charliefixture_1.class)
 public class RoomTypeCompositeFixtureDo extends DoEntity {
 
   public DoValue<RoomTypeCompositeFixture> roomTypeComposite() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeFixtureDoValueMigrationHandler_2.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypeFixtureDoValueMigrationHandler_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@ import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandler;
 import org.eclipse.scout.rt.dataobject.migration.DataObjectMigrationContext;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 
 /**
@@ -31,7 +31,7 @@ public class RoomTypeFixtureDoValueMigrationHandler_2 extends AbstractDoValueMig
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return CharlieFixture_2.class;
+    return Charliefixture_2.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypesCollectionFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/RoomTypesCollectionFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,13 +22,13 @@ import org.eclipse.scout.rt.dataobject.DoSet;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
 
 /**
  * Used for value migration tests for lists, sets and maps.
  */
 @TypeName("charlieFixture.RoomTypesCollectionFixture")
-@TypeVersion(CharlieFixture_1.class)
+@TypeVersion(Charliefixture_1.class)
 public class RoomTypesCollectionFixtureDo extends DoEntity {
 
   public DoList<RoomTypeFixtureStringId> roomTypesList() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/StreetNameStringIdValueMigrationHandlerByMap_1.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/house/StreetNameStringIdValueMigrationHandlerByMap_1.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
 import org.eclipse.scout.rt.dataobject.migration.AbstractDoValueMigrationHandlerByMap;
 import org.eclipse.scout.rt.dataobject.migration.DoValueMigrationId;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 
 @IgnoreBean
@@ -27,7 +27,7 @@ public class StreetNameStringIdValueMigrationHandlerByMap_1 extends AbstractDoVa
 
   @Override
   public Class<? extends ITypeVersion> typeVersionClass() {
-    return CharlieFixture_1.class;
+    return Charliefixture_1.class;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/AlfaFixtureTypeVersions.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/AlfaFixtureTypeVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,47 +14,47 @@ import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 
 public final class AlfaFixtureTypeVersions {
 
-  public static final class AlfaFixture_1 extends AbstractTypeVersion {
+  public static final class Alfafixture_1 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(AlfaFixtureNamespace.ID, "1");
 
-    public AlfaFixture_1() {
+    public Alfafixture_1() {
       super(VERSION);
     }
   }
 
-  public static final class AlfaFixture_2 extends AbstractTypeVersion {
+  public static final class Alfafixture_2 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(AlfaFixtureNamespace.ID, "2");
 
-    public AlfaFixture_2() {
+    public Alfafixture_2() {
       super(VERSION);
     }
   }
 
-  public static final class AlfaFixture_3 extends AbstractTypeVersion {
+  public static final class Alfafixture_3 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(AlfaFixtureNamespace.ID, "3");
 
-    public AlfaFixture_3() {
+    public Alfafixture_3() {
       super(VERSION);
     }
   }
 
-  public static final class AlfaFixture_6 extends AbstractTypeVersion {
+  public static final class Alfafixture_6 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(AlfaFixtureNamespace.ID, "6");
 
-    public AlfaFixture_6() {
+    public Alfafixture_6() {
       super(VERSION);
     }
   }
 
-  public static final class AlfaFixture_7 extends AbstractTypeVersion {
+  public static final class Alfafixture_7 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(AlfaFixtureNamespace.ID, "7");
 
-    public AlfaFixture_7() {
+    public Alfafixture_7() {
       super(VERSION);
     }
   }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/BravoFixtureTypeVersions.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/BravoFixtureTypeVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,52 +14,52 @@ import java.util.Collection;
 
 import org.eclipse.scout.rt.dataobject.AbstractTypeVersion;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.AlfaFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.AlfaFixtureTypeVersions.Alfafixture_3;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 
 public final class BravoFixtureTypeVersions {
 
-  public static final class BravoFixture_1 extends AbstractTypeVersion {
+  public static final class Bravofixture_1 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(BravoFixtureNamespace.ID, "1");
 
-    public BravoFixture_1() {
+    public Bravofixture_1() {
       super(VERSION);
     }
 
     @Override
     protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
-      return Arrays.asList(AlfaFixture_1.class);
+      return Arrays.asList(Alfafixture_1.class);
     }
   }
 
-  public static final class BravoFixture_2 extends AbstractTypeVersion {
+  public static final class Bravofixture_2 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(BravoFixtureNamespace.ID, "2");
 
-    public BravoFixture_2() {
+    public Bravofixture_2() {
       super(VERSION);
     }
 
     @Override
     protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
-      return Arrays.asList(AlfaFixture_2.class);
+      return Arrays.asList(Alfafixture_2.class);
     }
   }
 
-  public static final class BravoFixture_3 extends AbstractTypeVersion {
+  public static final class Bravofixture_3 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(BravoFixtureNamespace.ID, "3");
 
-    public BravoFixture_3() {
+    public Bravofixture_3() {
       super(VERSION);
     }
 
     @Override
     protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
-      return Arrays.asList(AlfaFixture_3.class);
+      return Arrays.asList(Alfafixture_3.class);
     }
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/CharlieFixtureTypeVersions.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/CharlieFixtureTypeVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,69 +14,69 @@ import java.util.Collection;
 
 import org.eclipse.scout.rt.dataobject.AbstractTypeVersion;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_2;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.BravoFixture_3;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.BravoFixtureTypeVersions.Bravofixture_3;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 
 public final class CharlieFixtureTypeVersions {
 
-  public static final class CharlieFixture_1 extends AbstractTypeVersion {
+  public static final class Charliefixture_1 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(CharlieFixtureNamespace.ID, "1");
 
-    public CharlieFixture_1() {
+    public Charliefixture_1() {
       super(VERSION);
     }
 
     @Override
     protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
-      return Arrays.asList(BravoFixture_1.class);
+      return Arrays.asList(Bravofixture_1.class);
     }
   }
 
-  public static final class CharlieFixture_2 extends AbstractTypeVersion {
+  public static final class Charliefixture_2 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(CharlieFixtureNamespace.ID, "2");
 
-    public CharlieFixture_2() {
+    public Charliefixture_2() {
       super(VERSION);
     }
 
     @Override
     protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
-      return Arrays.asList(BravoFixture_2.class);
+      return Arrays.asList(Bravofixture_2.class);
     }
   }
 
-  public static final class CharlieFixture_3 extends AbstractTypeVersion {
+  public static final class Charliefixture_3 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(CharlieFixtureNamespace.ID, "3");
 
-    public CharlieFixture_3() {
+    public Charliefixture_3() {
       super(VERSION);
     }
 
     @Override
     protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
-      return Arrays.asList(BravoFixture_3.class);
+      return Arrays.asList(Bravofixture_3.class);
     }
   }
 
-  public static final class CharlieFixture_4 extends AbstractTypeVersion {
+  public static final class Charliefixture_4 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(CharlieFixtureNamespace.ID, "4");
 
-    public CharlieFixture_4() {
+    public Charliefixture_4() {
       super(VERSION);
     }
   }
 
-  public static final class CharlieFixture_5 extends AbstractTypeVersion {
+  public static final class Charliefixture_5 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(CharlieFixtureNamespace.ID, "5");
 
-    public CharlieFixture_5() {
+    public Charliefixture_5() {
       super(VERSION);
     }
   }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/DeltaFixtureTypeVersions.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/migration/fixture/version/DeltaFixtureTypeVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,37 +14,37 @@ import java.util.Collection;
 
 import org.eclipse.scout.rt.dataobject.AbstractTypeVersion;
 import org.eclipse.scout.rt.dataobject.ITypeVersion;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_1;
-import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.CharlieFixture_2;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_1;
+import org.eclipse.scout.rt.dataobject.migration.fixture.version.CharlieFixtureTypeVersions.Charliefixture_2;
 import org.eclipse.scout.rt.platform.namespace.NamespaceVersion;
 
 public final class DeltaFixtureTypeVersions {
 
-  public static final class DeltaFixture_1 extends AbstractTypeVersion {
+  public static final class Deltafixture_1 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(DeltaFixtureNamespace.ID, "1");
 
-    public DeltaFixture_1() {
+    public Deltafixture_1() {
       super(VERSION);
     }
 
     @Override
     protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
-      return Arrays.asList(CharlieFixture_1.class);
+      return Arrays.asList(Charliefixture_1.class);
     }
   }
 
-  public static final class DeltaFixture_2 extends AbstractTypeVersion {
+  public static final class Deltafixture_2 extends AbstractTypeVersion {
 
     public static final NamespaceVersion VERSION = NamespaceVersion.of(DeltaFixtureNamespace.ID, "2");
 
-    public DeltaFixture_2() {
+    public Deltafixture_2() {
       super(VERSION);
     }
 
     @Override
     protected Collection<Class<? extends ITypeVersion>> getDependencyClasses() {
-      return Arrays.asList(CharlieFixture_2.class);
+      return Arrays.asList(Charliefixture_2.class);
     }
   }
 }

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/testing/TypeVersionClassNamingTestSupportTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/testing/TypeVersionClassNamingTestSupportTest.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.testing;
+
+public class TypeVersionClassNamingTestSupportTest extends AbstractTypeVersionClassNamingTestSupportTest {
+}

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/testing/signature/fixture/SignatureFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/testing/signature/fixture/SignatureFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,13 +19,13 @@ import org.eclipse.scout.rt.dataobject.DoList;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0;
 import org.eclipse.scout.rt.dataobject.fixture.FixtureEnum;
 import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
 import org.eclipse.scout.rt.dataobject.id.AbstractStringId;
 
 @TypeName("dataObjectFixture.SignatureFixture")
-@TypeVersion(DataObjectFixture_1_0_0.class)
+@TypeVersion(Dataobjectfixture_1_0_0.class)
 public class SignatureFixtureDo extends DoEntity {
 
   public DoList<FixtureStringId> idAttribute() {

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/testing/signature/fixture/SignatureSubFixtureDo.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/testing/signature/fixture/SignatureSubFixtureDo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,10 +15,10 @@ import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.dataobject.TypeVersion;
-import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.DataObjectFixture_1_0_0_034;
+import org.eclipse.scout.rt.dataobject.fixture.DataObjectFixtureTypeVersions.Dataobjectfixture_1_0_0_034;
 
 @TypeName("dataObjectFixture.SignatureSubFixture")
-@TypeVersion(DataObjectFixture_1_0_0_034.class)
+@TypeVersion(Dataobjectfixture_1_0_0_034.class)
 public class SignatureSubFixtureDo extends DoEntity {
 
   public DoValue<String> text() {

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractTypeVersion.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/AbstractTypeVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -80,7 +80,7 @@ public abstract class AbstractTypeVersion implements ITypeVersion {
   /**
    * Optional suffix (class name only) starting with __ followed by any word characters.
    */
-  private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("(\\w+?)_(\\d+(?:_\\d+)*)(?:__\\w+)?");
+  public static final Pattern CLASS_NAME_PATTERN = Pattern.compile("(\\w+?)_(\\d+(?:_\\d+)*)(?:__\\w+)?");
 
   static NamespaceVersion fromClassName(Class<? extends ITypeVersion> typeVersionClass) {
     if (typeVersionClass == null) {


### PR DESCRIPTION
When creating a new NamespaceVersion from a type version class name, the name of the class (up until the first underscore) is converted to the namespace id with the first letter being transformed to lower case (the rest of the classname is left as-is). As all namespace ids only consist of lowercase letters, this assumes that the type version class name only consists of lowercase letters (except the first one). When this assumption is not true, problems arise when trying to resolve namespaces by the created NamespaceVersion as the contained namespace id (with incorrect casing) does not match any known namespace id. The problems that can arise are hard to debug because there's no hint at the wrong casing, every class seems to be present and have the right name. This is why we chose to contribute a test case that checks for the correct naming of ITypeVersion implementations. In addition, a test was added to the AbstractDataObjectTestCompletenessTest as a reminder to add the mentioned test class.