### PR TITLE
JsPage: childNodeIndex is not set

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
@@ -306,7 +306,8 @@ export class OutlineAdapter extends TreeAdapter {
       objectType: pageModel.jsPageObjectType,
       pageParam: pageParam,
       classId: pageModel.classId,
-      modelClass: pageModel.modelClass
+      modelClass: pageModel.modelClass,
+      childNodeIndex: pageModel.childNodeIndex
     };
   }
 

--- a/eclipse-scout-core/test/desktop/outline/OutlineAdapterSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineAdapterSpec.ts
@@ -391,6 +391,28 @@ describe('OutlineAdapter', () => {
       expect(objects.isPojo(legacyDataObject)).toBe(true);
       expect(legacyDataObject.prop).toBe(5);
     });
+
+    it('has childNodeIndex set', () => {
+      const treeHelper = new TreeSpecHelper(session);
+      let model = helper.createModelFixture(1);
+      let adapter = helper.createOutlineAdapter(model);
+      let outline = adapter.createWidget(model, session.desktop) as Outline;
+
+      let nodes = [helper.createModelNode('0_0', 'newChildNode1', {
+        nodeType: 'jsPage',
+        jsPageObjectType: 'outlineadapterspec.MyJsPage'
+      }), helper.createModelNode('1_0', 'newChildNode2', {
+        nodeType: 'jsPage',
+        jsPageObjectType: 'outlineadapterspec.MyJsPage'
+      })];
+      adapter.onModelEvent(treeHelper.createNodesInsertedEvent(outline, nodes));
+      expect(outline.nodes[0].childNodeIndex).toBe(0);
+      expect(outline.nodes[0]).not.toBeInstanceOf(MyJsPage);
+      expect(outline.nodes[1]).toBeInstanceOf(MyJsPage);
+      expect(outline.nodes[1].childNodeIndex).toBe(1);
+      expect(outline.nodes[2]).toBeInstanceOf(MyJsPage);
+      expect(outline.nodes[2].childNodeIndex).toBe(2);
+    });
   });
 
   describe('pageParam', () => {


### PR DESCRIPTION
Each tree node in the tree should have a child node index set. This is not the case for hybrid pages (JsPage).

385169