### PR TITLE
Stop propagating clicks on chart area

### DIFF
--- a/eclipse-scout-chart/src/chart/AbstractSvgChartRenderer.ts
+++ b/eclipse-scout-chart/src/chart/AbstractSvgChartRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,8 @@ export class AbstractSvgChartRenderer extends AbstractChartRenderer {
 
   $svg: JQuery<SVGElement>;
 
+  protected _nonValueClickHandler: (event: JQuery.ClickEvent) => void;
+
   constructor(chart: Chart) {
     super(chart);
     this.chartBox = null;
@@ -33,6 +35,8 @@ export class AbstractSvgChartRenderer extends AbstractChartRenderer {
     this.maskId = 'Mask-' + ObjectFactory.get().createUniqueId();
 
     this.suppressLegendBox = false;
+
+    this._nonValueClickHandler = this._onNonValueClick.bind(this);
   }
 
   static FONT_SIZE_SMALLEST = 'smallestFont';
@@ -46,6 +50,7 @@ export class AbstractSvgChartRenderer extends AbstractChartRenderer {
       aria.role(this.$svg, 'img');
       // labeling has to be done here because otherwise the svg is ignored
       this.linkChartWithFieldLabel(this.$svg);
+      this.$svg.on('click', this._nonValueClickHandler);
     }
     this.firstOpaqueBackgroundColor = styles.getFirstOpaqueBackgroundColor(this.$svg);
     // This works, because CSS specifies 100% width/height
@@ -139,6 +144,16 @@ export class AbstractSvgChartRenderer extends AbstractChartRenderer {
       dataIndex: xIndex,
       datasetIndex: datasetIndex
     };
+  }
+
+  protected _onChartValueClick(event: JQuery.ClickEvent) {
+    this.chart.handleValueClick(event.data, event.originalEvent);
+    event.stopPropagation();
+  }
+
+  protected _onNonValueClick(event: JQuery.ClickEvent) {
+    this.chart.handleNonValueClick(event.originalEvent);
+    event.stopPropagation();
   }
 
   protected _measureText(text: string, legendLabelClass?: string): { height: number; width: number } {

--- a/eclipse-scout-chart/src/chart/Chart.ts
+++ b/eclipse-scout-chart/src/chart/Chart.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -397,6 +397,19 @@ export class Chart extends Widget implements ChartModel {
     this.trigger('valueClick', {
       data: clickedItem,
       originalEvent
+    });
+  }
+
+  handleNonValueClick(originalEvent?: Event) {
+    this.trigger('nonValueClick', {
+      originalEvent
+    });
+  }
+
+  handleLegendClick(legentItemIndex: number, originalEvent?: Event) {
+    this.trigger('legendItemClick', {
+      legendItemIndex: legentItemIndex,
+      originalEvent: originalEvent
     });
   }
 }

--- a/eclipse-scout-chart/src/chart/ChartEventMap.ts
+++ b/eclipse-scout-chart/src/chart/ChartEventMap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,20 @@ export interface ChartValueClickEvent<C = Chart> extends ScoutEvent<C> {
   originalEvent?: Event;
 }
 
+export interface ChartNonValueClickEvent<C = Chart> extends ScoutEvent<C> {
+  originalEvent?: Event;
+}
+
+export interface ChartLegendItemClickEvent<C = Chart> extends ScoutEvent<C> {
+  legendItemIndex?: number;
+  originalEvent?: Event;
+}
+
 export interface ChartEventMap extends WidgetEventMap {
   'chartRender': ScoutEvent<Chart>;
   'valueClick': ChartValueClickEvent;
+  'nonValueClick': ChartNonValueClickEvent;
+  'legendItemClick': ChartLegendItemClickEvent;
   'propertyChange:chartRenderer': PropertyChangeEvent<AbstractChartRenderer>;
   'propertyChange:checkedItems': PropertyChangeEvent<ClickObject[]>;
   'propertyChange:config': PropertyChangeEvent<ChartConfig>;

--- a/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
+++ b/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
@@ -121,6 +121,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
   protected _tooltip: Tooltip;
   protected _tooltipTimeoutId: number;
   protected _updatingDatalabels: boolean;
+  protected _hoveringClickableElement: boolean;
 
   constructor(chart: Chart) {
     super(chart);
@@ -239,6 +240,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
   protected override _render() {
     if (!this.$canvas) {
       this.$canvas = this.chart.$container.appendElement('<canvas>') as JQuery<HTMLCanvasElement>;
+      this.$canvas.on('click', this._onCanvasClick.bind(this));
       aria.hidden(this.$canvas, true); // aria not supported yet
     }
     this.firstOpaqueBackgroundColor = styles.getFirstOpaqueBackgroundColor(this.$canvas);
@@ -2254,13 +2256,26 @@ export class ChartJsRenderer extends AbstractChartRenderer {
     }
   }
 
+  protected _onCanvasClick(event: JQuery.ClickEvent) {
+    // Clicks on e.g. the axes don't trigger the onClickHandler of the chartJs Chart.
+    // To register additional actions depending on the area clicked and to cover the whole canvas, the clicks outside an element must already be processed here.
+    // If no item is present, a click in the chart but outside an element was made and a corresponding event gets triggered.
+    // Clicks on elements are handled in a separate method (see this#_onClick)
+    if (!this._hoveringClickableElement) {
+      this.chart.handleNonValueClick(event.originalEvent);
+    }
+    event.originalEvent.stopPropagation();
+  }
+
   protected _onClick(event: ChartEvent, items: ActiveElement[]) {
     if (!items.length) {
+      this.chart.handleNonValueClick(event.native);
       return;
     }
     let relevantItem = this._selectRelevantItem(items);
 
     if (this._isMaxSegmentsExceeded(this.chartJs.config, relevantItem.index)) {
+      this.chart.handleNonValueClick(event.native);
       return;
     }
 
@@ -2336,14 +2351,17 @@ export class ChartJsRenderer extends AbstractChartRenderer {
       return;
     }
     if (items.length && !this._isMaxSegmentsExceeded(this.chartJs.config, items[0].index)) {
+      this._hoveringClickableElement = true;
       this.$canvas.css('cursor', 'pointer');
     } else {
+      this._hoveringClickableElement = false;
       this.$canvas.css('cursor', 'default');
     }
   }
 
   protected _onLegendClick(e: ChartEvent, legendItem: LegendItem, legend: LegendElement<any>) {
     if (!this.chartJs.config || !this.chartJs.config.type) {
+      this.chart.handleNonValueClick(e.native);
       return;
     }
 
@@ -2356,6 +2374,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
     defaultLegendClick.call(this.chartJs, e, legendItem, legend);
     this._onLegendLeave(e, legendItem, legend);
     this._onLegendHoverPointer(e, legendItem, legend);
+    this.chart.handleLegendClick(legendItem.datasetIndex, e.native);
   }
 
   protected _onLegendHover(e: ChartEvent, legendItem: LegendItem, legend: LegendElement<any>) {
@@ -2386,6 +2405,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
     if (!this.rendered || this.removing) {
       return;
     }
+    this._hoveringClickableElement = true;
     this.$canvas.css('cursor', 'pointer');
   }
 
@@ -2448,6 +2468,7 @@ export class ChartJsRenderer extends AbstractChartRenderer {
     if (!this.rendered || this.removing) {
       return;
     }
+    this._hoveringClickableElement = false;
     this.$canvas.css('cursor', 'default');
   }
 

--- a/eclipse-scout-chart/src/chart/FulfillmentChartRenderer.ts
+++ b/eclipse-scout-chart/src/chart/FulfillmentChartRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -106,7 +106,7 @@ export class FulfillmentChartRenderer extends AbstractSvgChartRenderer {
       .text(percentage + '%');
 
     if (this.chart.config.options.clickable) {
-      $arc.on('click', this._createClickObject(null, null), e => this.chart.handleValueClick(e.data));
+      $arc.on('click', this._createClickObject(null, null), this._onChartValueClick.bind(this));
     }
     if (!this.chart.config.options.autoColor && !chartGroupCss) {
       $arc.attr('fill', color);

--- a/eclipse-scout-chart/src/chart/SalesfunnelChartRenderer.ts
+++ b/eclipse-scout-chart/src/chart/SalesfunnelChartRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -274,7 +274,7 @@ export class SalesfunnelChartRenderer extends AbstractSvgChartRenderer {
       }, this._createAnimationObjectWithTabIndexRemoval(expandFunc, this.animationDuration));
     }
     if (this.chart.config.options.clickable) {
-      $poly.on('click', renderPolyOptions.clickObject, e => this.chart.handleValueClick(e.data));
+      $poly.on('click', renderPolyOptions.clickObject, this._onChartValueClick.bind(this));
     }
     if (renderPolyOptions.fill) {
       $poly.attr('fill', renderPolyOptions.fill);

--- a/eclipse-scout-chart/src/chart/SpeedoChartRenderer.ts
+++ b/eclipse-scout-chart/src/chart/SpeedoChartRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -127,7 +127,8 @@ export class SpeedoChartRenderer extends AbstractSvgChartRenderer {
 
     this.$svg.addClass('speedo-chart-svg');
     if (this.chart.config.options.clickable) {
-      this.$svg.on('click', this._createClickObject(null, null), e => this.chart.handleValueClick(e.data));
+      this.$svg.off('click', this._nonValueClickHandler);
+      this.$svg.on('click', this._createClickObject(null, null), this._onChartValueClick.bind(this));
     }
   }
 

--- a/eclipse-scout-chart/src/chart/VennChartRenderer.ts
+++ b/eclipse-scout-chart/src/chart/VennChartRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -387,7 +387,7 @@ export class VennChartRenderer extends AbstractSvgChartRenderer {
     }
 
     if (this.chart.config.options.clickable) {
-      $circle.on('click', this._createClickObject(null, circleIndex), e => this.chart.handleValueClick(e.data));
+      $circle.on('click', this._createClickObject(null, circleIndex), this._onChartValueClick.bind(this));
     }
 
     return $circle;


### PR DESCRIPTION
Clicks on the chart area are no longer bubbling up. Instead, an event is triggered when a click is made within the chart area but outside an element. This allows additional actions to be registered in a more targeted manner.

430441