### PR TITLE
Fix Group Body

### DIFF
--- a/eclipse-scout-core/src/group/Group.ts
+++ b/eclipse-scout-core/src/group/Group.ts
@@ -312,6 +312,9 @@ export class Group<TBody extends Widget = Widget> extends Widget implements Grou
   }
 
   protected _renderBody() {
+    if (this.collapsed) {
+      return;
+    }
     this.body.render();
     this.body.$container.insertAfter(this.$header);
     this.body.$container.addClass('group-body');


### PR DESCRIPTION
If the group gets expanded it renders its body. If the body is already rendered when this happens an 'Already rendered'-error is thrown. Therefore, prevent the body from being rendered when it is changed while the group is collapsed.