### PR TITLE
UploadRequestHandler: Support resource sanitation

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/XmlUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/XmlUtilityTest.java
@@ -39,12 +39,24 @@ public class XmlUtilityTest {
   private static final String XML_PROLOG = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
   private static final String EMPTY_XML = XML_PROLOG + "<root/>";
   private static final String SIMPLE_XML = XML_PROLOG + "<root><element/></root>";
+  private static final String SIMPLE_XML_WITH_TEST_NAMESPACE = XML_PROLOG + "<root xmlns=\"test-namespace\"><element/></root>";
   private static final String NESTED_XML = XML_PROLOG + "<root><otherElement><element nested=\"true\" attrib=\"value\"/></otherElement><element nested=\"false\" attrib=\"value\"/></root>";
 
   @Test
   public void testDocumentBuilderSimple() throws Exception {
     Document doc = XmlUtility.newDocumentBuilder().parse(new ByteArrayInputStream(SIMPLE_XML.getBytes(StandardCharsets.UTF_8)));
     assertEquals("root", doc.getDocumentElement().getNodeName());
+  }
+
+  @Test
+  public void testDocumentBuilderNamespaceAware() throws Exception {
+    Document doc = XmlUtility.newDocumentBuilder(false).parse(new ByteArrayInputStream(SIMPLE_XML_WITH_TEST_NAMESPACE.getBytes(StandardCharsets.UTF_8)));
+    assertEquals("root", doc.getDocumentElement().getNodeName());
+    assertNull(doc.getDocumentElement().getNamespaceURI());
+
+    doc = XmlUtility.newDocumentBuilder(true).parse(new ByteArrayInputStream(SIMPLE_XML_WITH_TEST_NAMESPACE.getBytes(StandardCharsets.UTF_8)));
+    assertEquals("root", doc.getDocumentElement().getNodeName());
+    assertEquals("test-namespace", doc.getDocumentElement().getNamespaceURI());
   }
 
   @Test
@@ -171,5 +183,16 @@ public class XmlUtilityTest {
     children = XmlUtility.getChildElementsWithAttributes(otherElement, "element", "attrib", "value");
     assertEquals(1, children.size());
     assertEquals("true", CollectionUtility.firstElement(children).getAttribute("nested"));
+  }
+
+  @Test
+  public void testGetXmlDocumentNamespaceAware() {
+    Element root = XmlUtility.getXmlDocument(SIMPLE_XML_WITH_TEST_NAMESPACE, false).getDocumentElement();
+    assertEquals("root", root.getNodeName());
+    assertNull(root.getNamespaceURI());
+
+    root = XmlUtility.getXmlDocument(SIMPLE_XML_WITH_TEST_NAMESPACE, true).getDocumentElement();
+    assertEquals("root", root.getNodeName());
+    assertEquals("test-namespace", root.getNamespaceURI());
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/IResourceSanitizerImplementor.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/IResourceSanitizerImplementor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.security;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.resource.BinaryResource;
+
+@ApplicationScoped
+public interface IResourceSanitizerImplementor {
+
+  /**
+   * Sanitizes the given {@code res}
+   *
+   * @return a new, sanitized {@link BinaryResource}
+   * @throws RejectedResourceException
+   *     if the implementor is unable to perform the sanitation
+   */
+  BinaryResource sanitize(BinaryResource res);
+
+  /**
+   * @return {@code true} if the sanitizer accepts the given {@code res}
+   */
+  boolean accepts(BinaryResource res);
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/ResourceSanitizer.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/ResourceSanitizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.security;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.resource.BinaryResource;
+
+@ApplicationScoped
+public class ResourceSanitizer {
+
+  /**
+   * If there exists an {@link IResourceSanitizerImplementor} that accepts the given {@code res}
+   * it will be used to sanitize it
+   *
+   * @return a new, sanitized {@link BinaryResource} if there exists a corresponding implementor,
+   * the provided {@code res} otherwise
+   * @throws RejectedResourceException
+   *     if the implementor is unable to perform the sanitation
+   */
+  public BinaryResource sanitize(BinaryResource res) {
+    for (IResourceSanitizerImplementor sanitizer : BEANS.all(IResourceSanitizerImplementor.class)) {
+      if (sanitizer.accepts(res)) {
+        return sanitizer.sanitize(res);
+      }
+    }
+    return res;
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/XmlUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/XmlUtility.java
@@ -92,6 +92,18 @@ public final class XmlUtility {
    * @throws ParserConfigurationException
    */
   public static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+    return newDocumentBuilder(false);
+  }
+
+  /**
+   * @param namespaceAware
+   *        If set to {@code true}, the parser used to parse the input will provide support for XML namespaces,
+   *        {@code false} otherwise
+   *
+   * @return a new secure {@link DocumentBuilder} with disabled xml-external-entity
+   * @throws ParserConfigurationException
+   */
+  public static DocumentBuilder newDocumentBuilder(boolean namespaceAware) throws ParserConfigurationException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
     for (Entry<String, Boolean> a : getXmlFeaturesMap().entrySet()) {
@@ -122,6 +134,7 @@ public final class XmlUtility {
     factory.setXIncludeAware(false);
     factory.setExpandEntityReferences(false);
     factory.setIgnoringComments(true);
+    factory.setNamespaceAware(namespaceAware);
     return factory.newDocumentBuilder();
   }
 
@@ -299,7 +312,7 @@ public final class XmlUtility {
   }
 
   /**
-   * Wellforms the given xml {@link Document} and flushes the result into the given output stream.
+   * Wellforms the given XML {@link Document} and flushes the result into the given output stream.
    *
    * @param document
    *     The document to wellform.
@@ -314,12 +327,12 @@ public final class XmlUtility {
       out.flush();
     }
     catch (IOException e) {
-      throw new ProcessingException("unable to flush xml document to output.", e);
+      throw new ProcessingException("unable to flush XML document to output.", e);
     }
   }
 
   /**
-   * Wellforms the given xml {@link Document} and flushes the result into the given {@link File}.
+   * Wellforms the given XML {@link Document} and flushes the result into the given {@link File}.
    *
    * @param document
    *     The document to wellform.
@@ -340,12 +353,12 @@ public final class XmlUtility {
       wellformDocument(document, out);
     }
     catch (IOException e) {
-      throw new ProcessingException("Exception writing xml file: '" + f.getAbsolutePath() + "'.", e);
+      throw new ProcessingException("Exception writing XML file: '" + f.getAbsolutePath() + "'.", e);
     }
   }
 
   /**
-   * Wellforms the given xml {@link Document} and flushes the result into the given {@link Writer}
+   * Wellforms the given XML {@link Document} and flushes the result into the given {@link Writer}
    *
    * @param document
    *     The document to wellform.
@@ -360,7 +373,7 @@ public final class XmlUtility {
       writer.flush();
     }
     catch (IOException e) {
-      throw new ProcessingException("unable to flush xml document to writer.", e);
+      throw new ProcessingException("unable to flush XML document to writer.", e);
     }
   }
 
@@ -375,16 +388,16 @@ public final class XmlUtility {
       transformer.transform(new DOMSource(document), result);
     }
     catch (TransformerException e) {
-      throw new ProcessingException("Unable to wellform xml.", e);
+      throw new ProcessingException("Unable to wellform XML.", e);
     }
   }
 
   /**
-   * Wellforms the given xml {@link Document} and returns the result as {@link String}.
+   * Wellforms the given XML {@link Document} and returns the result as {@link String}.
    *
    * @param document
    *     The document to wellform
-   * @return A {@link String} containing the xml {@link Document} content.
+   * @return A {@link String} containing the XML {@link Document} content.
    * @throws ProcessingException
    *     if there is an exception wellforming the document.
    */
@@ -395,13 +408,13 @@ public final class XmlUtility {
   }
 
   /**
-   * Takes the given xml input, creates an xml {@link Document} and returnes it as wellformed {@link String}.
+   * Takes the given XML input, creates an XML {@link Document} and returnes it as wellformed {@link String}.
    *
    * @param rawXml
-   *     The xml input.
-   * @return A {@link String} containing the wellformed xml.
+   *     The XML input.
+   * @return A {@link String} containing the wellformed XML.
    * @throws ProcessingException
-   *     if there is an exception wellforming the input xml.
+   *     if there is an exception wellforming the input XML.
    */
   public static String wellformXml(String rawXml) {
     return wellformDocument(getXmlDocument(rawXml));
@@ -423,17 +436,17 @@ public final class XmlUtility {
       return document;
     }
     catch (ParserConfigurationException e) {
-      LOG.debug("Could not create new xml document", e);
+      LOG.debug("Could not create new XML document", e);
     }
     return null;
   }
 
   /**
-   * Creates an xml {@link Document} filled with the given {@link InputStream}.
+   * Creates an XML {@link Document} filled with the given {@link InputStream}.
    *
    * @param is
    *     The input stream to use as data source.
-   * @return A xml {@link Document} containing the data of the given {@link InputStream}.
+   * @return An XML {@link Document} containing the data of the given {@link InputStream}.
    * @throws ProcessingException
    *     if there is an error reading from the {@link InputStream} or parsing the content.
    */
@@ -442,16 +455,16 @@ public final class XmlUtility {
       return newDocumentBuilder().parse(is);
     }
     catch (IOException | SAXException | ParserConfigurationException e) {
-      throw new ProcessingException("Unable to load xml document.", e);
+      throw new ProcessingException("Unable to load XML document.", e);
     }
   }
 
   /**
-   * Creates an xml {@link Document} filled with the content of the given {@link File}.
+   * Creates an XML {@link Document} filled with the content of the given {@link File}.
    *
    * @param f
    *     The {@link File} to use as data source.
-   * @return A xml {@link Document} containing the data of the given {@link File}.
+   * @return An XML {@link Document} containing the data of the given {@link File}.
    * @throws ProcessingException
    *     if there is an error reading from the {@link File} or parsing the content.
    */
@@ -460,16 +473,16 @@ public final class XmlUtility {
       return newDocumentBuilder().parse(f);
     }
     catch (IOException | SAXException | ParserConfigurationException e) {
-      throw new ProcessingException("Unable to load xml document.", e);
+      throw new ProcessingException("Unable to load XML document.", e);
     }
   }
 
   /**
-   * Creates an xml {@link Document} filled with the content of the given {@link URL}.
+   * Creates an XML {@link Document} filled with the content of the given {@link URL}.
    *
    * @param url
    *     The {@link URL} to use as data source.
-   * @return A xml {@link Document} containing the data of the given {@link URL}.
+   * @return An XML {@link Document} containing the data of the given {@link URL}.
    * @throws ProcessingException
    *     if there is an error reading from the {@link URL} or parsing the content.
    */
@@ -483,20 +496,36 @@ public final class XmlUtility {
   }
 
   /**
-   * Creates an xml {@link Document} filled with the content of the given {@link String}.
+   * Creates an XML {@link Document} filled with the content of the given {@link String}.
    *
    * @param rawXml
-   *     The {@link String} holding the xml content.
-   * @return A xml {@link Document} containing the data of the given {@link String}.
+   *     The {@link String} holding the XML content.
+   * @return An XML {@link Document} containing the data of the given {@link String}.
    * @throws ProcessingException
    *     if there is an error parsing the content of the {@link String} into a {@link Document}.
    */
   public static Document getXmlDocument(String rawXml) {
+    return getXmlDocument(rawXml, false);
+  }
+
+  /**
+   * Creates an XML {@link Document} filled with the content of the given {@link String}.
+   *
+   * @param rawXml
+   *     The {@link String} holding the XML content.
+   * @param namespaceAware
+   *     If set to {@code true}, the parser used to parse the input will provide support for XML namespaces,
+   *     {@code false} otherwise
+   * @return An XML {@link Document} containing the data of the given {@link String}.
+   * @throws ProcessingException
+   *     if there is an error parsing the content of the {@link String} into a {@link Document}.
+   */
+  public static Document getXmlDocument(String rawXml, boolean namespaceAware) {
     try {
-      return newDocumentBuilder().parse(new InputSource(new StringReader(rawXml)));
+      return newDocumentBuilder(namespaceAware).parse(new InputSource(new StringReader(rawXml)));
     }
     catch (IOException | SAXException | ParserConfigurationException e) {
-      throw new ProcessingException("Unable to load xml document.", e);
+      throw new ProcessingException("Unable to load XML document.", e);
     }
   }
 

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/UploadRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/UploadRequestHandler.java
@@ -43,8 +43,10 @@ import org.eclipse.scout.rt.platform.exception.PlatformException;
 import org.eclipse.scout.rt.platform.resource.BinaryResource;
 import org.eclipse.scout.rt.platform.resource.BinaryResources;
 import org.eclipse.scout.rt.platform.resource.MimeTypes;
+import org.eclipse.scout.rt.platform.security.IResourceSanitizerImplementor;
 import org.eclipse.scout.rt.platform.security.MalwareScanner;
 import org.eclipse.scout.rt.platform.security.RejectedResourceException;
+import org.eclipse.scout.rt.platform.security.ResourceSanitizer;
 import org.eclipse.scout.rt.platform.security.UnsafeResourceException;
 import org.eclipse.scout.rt.platform.util.FileUtility;
 import org.eclipse.scout.rt.platform.util.HexUtility;
@@ -259,6 +261,7 @@ public class UploadRequestHandler extends AbstractUiServletRequestHandler {
           .build();
       verifyFileSafety(res);
       verifyFileIntegrity(res);
+      res = sanitizeResource(res);
 
       // properties are sent as form fields without file name by UI (see Session.ts)
       if (StringUtility.isNullOrEmpty(part.getSubmittedFileName())) {
@@ -400,5 +403,15 @@ public class UploadRequestHandler extends AbstractUiServletRequestHandler {
       LOG.info(message, res.getFilename(), header);
       throw new RejectedResourceException(message, res.getFilename(), header);
     }
+  }
+
+  /**
+   * If there exists an {@link IResourceSanitizerImplementor} that accepts the given {@code res}
+   * it will be used to sanitize it
+   *
+   * @return a sanitized {@link BinaryResource}
+   */
+  protected BinaryResource sanitizeResource(BinaryResource res) {
+    return BEANS.get(ResourceSanitizer.class).sanitize(res);
   }
 }


### PR DESCRIPTION
By providing corresponding implementations of
IResourceSanitizerImplementor, files uploaded
via the UploadRequestHandler can be sanitized.

The XmlUtility provides now a method to create
a namespace aware xml document from a raw string
representation of a xml.

434705

(cherry picked from commits 13551db1c76c5f0b87f666d5e14febdf0e627f43 be5ad41f07ac06958cf95aac238f51e13231d1f9)