### PR TITLE
Support for chunked data for REST resources and REST clients

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/testing/signature/ScoutDataObjectTestCompletenessTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/testing/signature/ScoutDataObjectTestCompletenessTest.java
@@ -30,6 +30,7 @@ public class ScoutDataObjectTestCompletenessTest extends AbstractDataObjectTestC
         Path.of("karma-jasmine-scout"),
         Path.of("scout-hellojs-app"),
         Path.of("scout-helloworld-app"),
-        Path.of("scout-jaxws-module"));
+        Path.of("scout-jaxws-module"),
+        Path.of("org/eclipse/scout/rt/rest/jersey/fixture"));
   }
 }

--- a/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ChunkedDataReader.java
+++ b/org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ChunkedDataReader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.client;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.*;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.rest.client.chunked.IChunkedDataReader;
+import org.glassfish.jersey.client.ChunkedInput;
+
+/**
+ * Scout REST API wrapper around Jersey {@link ChunkedInput} instance.
+ * <p>
+ * See documentation
+ * <a href="https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/user-guide.html#d0e10936">Jersey chunked input</a>
+ */
+public class ChunkedDataReader<T> implements IChunkedDataReader<T> {
+
+  protected ChunkedInput<T> m_input;
+
+  @Override
+  public void init(Response response, Class<T> type, String delimiter) {
+    assertNull(m_input, "already initialized");
+
+    m_input = response.readEntity(new GenericType<>(new ParameterizedType() {
+      @Override
+      public Type[] getActualTypeArguments() {
+        return new Type[]{type};
+      }
+
+      @Override
+      public Type getRawType() {
+        return ChunkedInput.class;
+      }
+
+      @Override
+      public Type getOwnerType() {
+        return null;
+      }
+    }));
+
+    // Use default parser if no custom delimiter was specified.
+    // See org.glassfish.jersey.client.ChunkedInput.parser (uses default delimiter "\r\n")
+    if (!StringUtility.isNullOrEmpty(delimiter)) {
+      m_input.setParser(ChunkedInput.createParser(delimiter));
+    }
+  }
+
+  @Override
+  public T read() {
+    return m_input.read();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return m_input.isClosed();
+  }
+
+  @Override
+  public void close() throws IOException {
+    m_input.close();
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.server/pom.xml
+++ b/org.eclipse.scout.rt.rest.jersey.server/pom.xml
@@ -35,5 +35,9 @@
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/org.eclipse.scout.rt.rest.jersey.server/src/main/java/org/eclipse/scout/rt/rest/jersey/server/chunked/ChunkedDataWriter.java
+++ b/org.eclipse.scout.rt.rest.jersey.server/src/main/java/org/eclipse/scout/rt/rest/jersey/server/chunked/ChunkedDataWriter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.server.chunked;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.assertNull;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.core.GenericType;
+
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.rest.chunked.IChunkedDataWriter;
+import org.glassfish.jersey.server.ChunkedOutput;
+
+/**
+ * Scout REST API wrapper around Jersey {@link ChunkedOutput} instance.
+ * <p>
+ * See documentation
+ * <a href="https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/user-guide.html#chunked-output">Jersey chunked output</a>
+ */
+public class ChunkedDataWriter<T> implements IChunkedDataWriter<T> {
+
+  protected ChunkedOutput<T> m_output;
+
+  @Override
+  public void init(Class<T> type, String delimiter, int queueCapacity) {
+    assertNull(m_output, "already initialized");
+
+    // Use delimiter specified by org.glassfish.jersey.client.ChunkedInput.parser (e.g. "\r\n") if no custom delimiter was specified.
+    // Providing a null or empty delimiter to ChunkedOutput leads to no delimiter at all which cannot be parsed by ChunkedInput later on.
+    // See https://stackoverflow.com/questions/40429196/chunkedoutput-response-from-jersey-rest-services
+    byte[] delimiterBytes = (StringUtility.isNullOrEmpty(delimiter) ? "\r\n" : delimiter).getBytes();
+
+    m_output = ChunkedOutput.<T>builder(type)
+        .chunkDelimiter(delimiterBytes)
+        .queueCapacity(queueCapacity)
+        .build();
+  }
+
+  @Override
+  public GenericType<T> toEntity() {
+    return m_output;
+  }
+
+  @Override
+  public void write(T chunk) throws IOException {
+    m_output.write(chunk);
+  }
+
+  @Override
+  public boolean isClosed() {
+    return m_output.isClosed();
+  }
+
+  @Override
+  public void close() throws IOException {
+    m_output.close();
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/ChunkedDataResource.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/ChunkedDataResource.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.fixture;
+
+import static org.junit.Assert.*;
+
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.scout.rt.dataobject.fixture.FixtureDateId;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureUuId;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.job.Jobs;
+import org.eclipse.scout.rt.platform.util.SleepUtil;
+import org.eclipse.scout.rt.rest.IRestResource;
+import org.eclipse.scout.rt.rest.chunked.IChunkedDataWriter;
+import org.glassfish.jersey.server.ChunkedOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("chunked")
+public class ChunkedDataResource implements IRestResource {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ChunkedDataResource.class);
+
+  /**
+   * Implementation example based on JAX-RS API and Scout API
+   *
+   * @see org.eclipse.scout.rt.rest.chunked.IChunkedDataWriter
+   */
+  @GET
+  @Path("string-scout")
+  @Produces(MediaType.TEXT_PLAIN)
+  public GenericType<String> getStringsScout() {
+    IChunkedDataWriter<String> writer = IChunkedDataWriter.create(String.class, "\n\n", 100);
+    writeAsyncDataScout(writer, Integer::toString);
+    return writer.toEntity();
+  }
+
+  /**
+   * Implementation example based on Jersey API
+   *
+   * @see org.glassfish.jersey.server.ChunkedOutput
+   */
+  @GET
+  @Path("string-jersey")
+  @Produces(MediaType.TEXT_PLAIN)
+  public ChunkedOutput<String> getStringsJersey() {
+    ChunkedOutput<String> output = new ChunkedOutput<>(String.class, "\n\n");
+    writeAsyncDataJersey(output, Integer::toString);
+    return output;
+  }
+
+  /**
+   * Implementation example based on JAX-RS API and Scout API
+   *
+   * @see org.eclipse.scout.rt.rest.chunked.IChunkedDataWriter
+   */
+  @GET
+  @Path("dataobject-scout")
+  @Produces(MediaType.APPLICATION_JSON)
+  public GenericType<FixtureDo> getDataObjectsScout() {
+    IChunkedDataWriter<FixtureDo> writer = IChunkedDataWriter.create(FixtureDo.class, "\n\n", 100);
+    writeAsyncDataScout(writer, this::createFixtureDo);
+    return writer.toEntity();
+  }
+
+  /**
+   * Implementation example based on Jersey API
+   *
+   * @see org.glassfish.jersey.server.ChunkedOutput
+   */
+  @GET
+  @Path("dataobject-jersey")
+  @Produces(MediaType.APPLICATION_JSON)
+  public ChunkedOutput<FixtureDo> getDataobjectsJersey() {
+    ChunkedOutput<FixtureDo> output = new ChunkedOutput<>(FixtureDo.class, "\n\n");
+    writeAsyncDataJersey(output, this::createFixtureDo);
+    return output;
+  }
+
+  /**
+   * Implementation example based on JAX-RS API and Scout API.<br>
+   * Returning {@link Response} including header 'X-Mock' with value {@code headerValue}.
+   */
+  @GET
+  @Path("dataobject-scout/header")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getDataObjectsScout(@QueryParam("headerValue") String headerValue) {
+    IChunkedDataWriter<FixtureDo> writer = IChunkedDataWriter.create(FixtureDo.class, "\n\n", 100);
+    writeAsyncDataScout(writer, this::createFixtureDo);
+    return Response.ok(writer.toEntity())
+        .header("X-Mock", headerValue)
+        .build();
+  }
+
+  /**
+   * Implementation example based on JAX-RS API and Scout API and using default jersey-defined delimiter.
+   */
+  @GET
+  @Path("dataobject-scout/default-delimiter")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getDataObjectsScoutDefaultDelimiter() {
+    IChunkedDataWriter<FixtureDo> writer = IChunkedDataWriter.create(FixtureDo.class);
+    writeAsyncDataScout(writer, this::createFixtureDo);
+    return Response.ok(writer.toEntity()).build();
+  }
+
+  /**
+   * Implementation example based on JAX-RS API and Scout API and using "" as delimiter (resulting in default jersey-defined delimiter).
+   */
+  @GET
+  @Path("dataobject-scout/default-delimiter-empty-string")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getDataObjectsScoutDefaultDelimiterEmptyString() {
+    IChunkedDataWriter<FixtureDo> writer = IChunkedDataWriter.create(FixtureDo.class, "", 100);
+    writeAsyncDataScout(writer, this::createFixtureDo);
+    return Response.ok(writer.toEntity()).build();
+  }
+
+  /**
+   * Implementation example based on JAX-RS API and Scout API and using null as delimiter (resulting in default jersey-defined delimiter).
+   */
+  @GET
+  @Path("dataobject-scout/default-delimiter-null")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getDataObjectsScoutDefaultDelimiterNull() {
+    IChunkedDataWriter<FixtureDo> writer = IChunkedDataWriter.create(FixtureDo.class, null, 100);
+    writeAsyncDataScout(writer, this::createFixtureDo);
+    return Response.ok(writer.toEntity()).build();
+  }
+
+  public FixtureDo createFixtureDo(int id) {
+    return BEANS.get(FixtureDo.class)
+        .withId(FixtureStringId.of(Integer.toString(id)))
+        .withUuid(FixtureUuId.of(UUID.fromString("00000000-0000-0000-0000-000000000000")))
+        .withDates(FixtureDateId.of(new Date(id)), FixtureDateId.of(new Date(id + 1)));
+  }
+
+  protected <W extends IChunkedDataWriter<T>, T> void writeAsyncDataScout(W writer, IntFunction<T> writeSupplier) {
+    Jobs.schedule(() -> {
+      try (writer) {
+        for (int i = 1; i <= 3; i++) {
+          writer.write(writeSupplier.apply(i));
+          LOG.debug("Wrote chunk '{}'", i);
+          SleepUtil.sleepSafe(10, TimeUnit.MILLISECONDS);
+          assertFalse(writer.isClosed());
+        }
+      }
+      assertTrue(writer.isClosed());
+    }, Jobs.newInput());
+  }
+
+  protected <W extends ChunkedOutput<T>, T> void writeAsyncDataJersey(W writer, IntFunction<T> writeSupplier) {
+    Jobs.schedule(() -> {
+      try (writer) {
+        for (int i = 1; i <= 3; i++) {
+          writer.write(writeSupplier.apply(i));
+          LOG.debug("Wrote chunk '{}'", i);
+          SleepUtil.sleepSafe(10, TimeUnit.MILLISECONDS);
+          assertFalse(writer.isClosed());
+        }
+      }
+      assertTrue(writer.isClosed());
+    }, Jobs.newInput());
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/FixtureDo.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/FixtureDo.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.fixture;
+
+import java.util.Collection;
+import java.util.List;
+
+import jakarta.annotation.Generated;
+
+import org.eclipse.scout.rt.dataobject.DoEntity;
+import org.eclipse.scout.rt.dataobject.DoList;
+import org.eclipse.scout.rt.dataobject.DoValue;
+import org.eclipse.scout.rt.dataobject.ScoutTypeVersions.Scout_25_2_001;
+import org.eclipse.scout.rt.dataobject.TypeName;
+import org.eclipse.scout.rt.dataobject.TypeVersion;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureDateId;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureStringId;
+import org.eclipse.scout.rt.dataobject.fixture.FixtureUuId;
+
+@TypeName("scout.Fixture")
+@TypeVersion(Scout_25_2_001.class)
+public class FixtureDo extends DoEntity {
+
+  public DoValue<FixtureStringId> id() {
+    return doValue("id");
+  }
+
+  public DoValue<FixtureUuId> uuid() {
+    return doValue("uuid");
+  }
+
+  public DoList<FixtureDateId> dates() {
+    return doList("dates");
+  }
+
+  /* **************************************************************************
+   * GENERATED CONVENIENCE METHODS
+   * *************************************************************************/
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureDo withId(FixtureStringId id) {
+    id().set(id);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureStringId getId() {
+    return id().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureDo withUuid(FixtureUuId uuid) {
+    uuid().set(uuid);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureUuId getUuid() {
+    return uuid().get();
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureDo withDates(Collection<? extends FixtureDateId> dates) {
+    dates().updateAll(dates);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public FixtureDo withDates(FixtureDateId... dates) {
+    dates().updateAll(dates);
+    return this;
+  }
+
+  @Generated("DoConvenienceMethodsGenerator")
+  public List<FixtureDateId> getDates() {
+    return dates().get();
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ChunkedDataTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/client/ChunkedDataTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.client;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
+import org.eclipse.scout.rt.rest.chunked.IChunkedDataWriter;
+import org.eclipse.scout.rt.rest.client.chunked.IChunkedDataReader;
+import org.eclipse.scout.rt.rest.jersey.JerseyTestApplication;
+import org.eclipse.scout.rt.rest.jersey.JerseyTestRestClientHelper;
+import org.eclipse.scout.rt.rest.jersey.fixture.ChunkedDataResource;
+import org.eclipse.scout.rt.rest.jersey.fixture.FixtureDo;
+import org.glassfish.jersey.client.ChunkParser;
+import org.glassfish.jersey.client.ChunkedInput;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test cases for REST using chunked data.
+ */
+public class ChunkedDataTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ChunkedDataTest.class);
+
+  private WebTarget m_target;
+
+  @BeforeClass
+  public static void beforeClass() {
+    BEANS.get(JerseyTestApplication.class).ensureStarted();
+  }
+
+  @Before
+  public void before() {
+    m_target = BEANS.get(JerseyTestRestClientHelper.class).target("api/chunked");
+  }
+
+  @Test
+  public void testGetStringsScout() {
+    Response response = m_target
+        .path("string-scout")
+        .request()
+        .accept(MediaType.TEXT_PLAIN)
+        .get();
+
+    IChunkedDataReader<String> reader = IChunkedDataReader.create(response, String.class, "\n\n");
+    assertFalse(reader.isClosed());
+
+    String chunk;
+    List<String> chunks = new ArrayList<>();
+    while ((chunk = reader.read()) != null) {
+      chunks.add(chunk);
+      LOG.debug("Received chunk {}", chunk);
+    }
+    assertEquals(List.of("1", "2", "3"), chunks);
+    assertTrue(reader.isClosed());
+  }
+
+  @Test
+  public void testGetStringsJersey() {
+    Response response = m_target
+        .path("string-jersey")
+        .request()
+        .accept(MediaType.TEXT_PLAIN)
+        .get();
+
+    ChunkedInput<String> chunkedInput = response.readEntity(new GenericType<>() {
+    });
+    ChunkParser p = ChunkedInput.createParser("\n\n");
+    chunkedInput.setParser(p);
+    assertFalse(chunkedInput.isClosed());
+
+    String chunk;
+    List<String> chunks = new ArrayList<>();
+    while ((chunk = chunkedInput.read()) != null) {
+      chunks.add(chunk);
+      LOG.debug("Received chunk {}", chunk);
+    }
+    assertEquals(List.of("1", "2", "3"), chunks);
+    assertTrue(chunkedInput.isClosed());
+  }
+
+  @Test
+  public void testGetDataObjectsScout() {
+    Response response = m_target
+        .path("dataobject-scout")
+        .request()
+        .accept(MediaType.APPLICATION_JSON)
+        .get();
+
+    IChunkedDataReader<FixtureDo> reader = IChunkedDataReader.create(response, FixtureDo.class, "\n\n");
+    assertFalse(reader.isClosed());
+
+    FixtureDo chunk;
+    List<FixtureDo> chunks = new ArrayList<>();
+    while ((chunk = reader.read()) != null) {
+      chunks.add(chunk);
+      LOG.debug("Received chunk {}", chunk);
+    }
+    assertChunks(chunks);
+    assertTrue(reader.isClosed());
+  }
+
+  @Test
+  public void testGetDataobjectsJersey() {
+    Response response = m_target
+        .path("dataobject-jersey")
+        .request()
+        .accept(MediaType.APPLICATION_JSON)
+        .get();
+
+    ChunkedInput<FixtureDo> chunkedInput = response.readEntity(new GenericType<>() {
+    });
+    ChunkParser p = ChunkedInput.createParser("\n\n");
+    chunkedInput.setParser(p);
+    assertFalse(chunkedInput.isClosed());
+
+    FixtureDo chunk;
+    List<FixtureDo> chunks = new ArrayList<>();
+    while ((chunk = chunkedInput.read()) != null) {
+      chunks.add(chunk);
+      LOG.debug("Received chunk {}", chunk);
+    }
+    assertChunks(chunks);
+    assertTrue(chunkedInput.isClosed());
+  }
+
+  @Test
+  public void testGetDataObjectsScout_withHeader() {
+    Response response = m_target
+        .path("dataobject-scout/header")
+        .queryParam("headerValue", "foo")
+        .request()
+        .accept(MediaType.APPLICATION_JSON)
+        .get();
+
+    assertEquals("foo", response.getHeaderString("X-Mock"));
+
+    IChunkedDataReader<FixtureDo> reader = IChunkedDataReader.create(response, FixtureDo.class, "\n\n");
+    assertFalse(reader.isClosed());
+
+    FixtureDo chunk;
+    List<FixtureDo> chunks = new ArrayList<>();
+    while ((chunk = reader.read()) != null) {
+      chunks.add(chunk);
+      LOG.debug("Received chunk {}", chunk);
+    }
+    assertChunks(chunks);
+    assertTrue(reader.isClosed());
+  }
+
+  @Test
+  public void testGetDataObjectsScout_earlyAbort() throws IOException {
+    Response response = m_target
+        .path("dataobject-scout")
+        .request()
+        .accept(MediaType.APPLICATION_JSON)
+        .get();
+
+    IChunkedDataReader<FixtureDo> reader = IChunkedDataReader.create(response, FixtureDo.class, "\n\n");
+    assertFalse(reader.isClosed());
+
+    FixtureDo chunk = reader.read();
+    reader.close();
+    assertEquals(BEANS.get(ChunkedDataResource.class).createFixtureDo(1), chunk);
+    assertTrue(reader.isClosed());
+    assertThrows(IllegalStateException.class, () -> reader.read());
+  }
+
+  @Test
+  public void testGetDataObjectsScout_defaultDelimiter() {
+    testGetDataObjectsScout_defaultDelimiter("default-delimiter", response -> IChunkedDataReader.create(response, FixtureDo.class));
+  }
+
+  @Test
+  public void testGetDataObjectsScout_defaultDelimiterEmptyString() {
+    testGetDataObjectsScout_defaultDelimiter( "default-delimiter-empty-string", response -> IChunkedDataReader.create(response, FixtureDo.class, ""));
+  }
+
+  @Test
+  public void testGetDataObjectsScout_defaultDelimiterNull() {
+    testGetDataObjectsScout_defaultDelimiter( "default-delimiter-null", response -> IChunkedDataReader.create(response, FixtureDo.class, null));
+  }
+
+  protected void testGetDataObjectsScout_defaultDelimiter( String contextPath, Function<Response, IChunkedDataReader<FixtureDo>> chunkedReaderCreator) {
+    Response response = m_target
+        .path("dataobject-scout/" + contextPath)
+        .request()
+        .accept(MediaType.APPLICATION_JSON)
+        .get();
+
+    IChunkedDataReader<FixtureDo> reader = chunkedReaderCreator.apply(response);
+    assertFalse(reader.isClosed());
+
+    FixtureDo chunk;
+    List<FixtureDo> chunks = new ArrayList<>();
+    while ((chunk = reader.read()) != null) {
+      chunks.add(chunk);
+      LOG.debug("Received chunk {}", chunk);
+    }
+    assertChunks(chunks);
+    assertTrue(reader.isClosed());
+  }
+
+  protected void assertChunks(List<FixtureDo> chunks) {
+    ChunkedDataResource resource = BEANS.get(ChunkedDataResource.class);
+    assertEquals(List.of(resource.createFixtureDo(1), resource.createFixtureDo(2), resource.createFixtureDo(3)), chunks);
+  }
+
+  protected static class FixtureDoChunkedInputMock extends ChunkedInput<FixtureDo> {
+    protected FixtureDoChunkedInputMock() {
+      super(FixtureDo.class, null, null, null, null, null, null);
+    }
+  }
+
+  @Test
+  public void testInitReaderAlreadyInitialized() {
+    Response response = Mockito.mock(Response.class);
+    //noinspection unchecked
+    when(response.readEntity(any(GenericType.class))).thenReturn(new FixtureDoChunkedInputMock());
+    IChunkedDataReader<FixtureDo> reader = IChunkedDataReader.create(response, FixtureDo.class, "");
+    assertThrows(AssertionException.class, () -> reader.init(response, FixtureDo.class, ""));
+  }
+
+  @Test
+  public void testInitWriterAlreadyInitialized() {
+    @SuppressWarnings("resource")
+    IChunkedDataWriter<FixtureDo> writer = IChunkedDataWriter.create(FixtureDo.class, "", -1);
+    assertThrows(AssertionException.class, () -> writer.init(FixtureDo.class, "", -1));
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/chunked/IChunkedDataWriter.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/chunked/IChunkedDataWriter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.chunked;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
+import org.eclipse.scout.rt.rest.IRestResource;
+
+/**
+ * Writer for a stream of chunked data of type {@code T} within a {@link IRestResource}.
+ * <p>
+ * Example:
+ *
+ * <pre>
+ * &#064;GET
+ * &#064;Path("chunked")
+ * &#064;Produces(MediaType.APPLICATION_JSON)
+ * public Response load() {
+ *   IChunkedDataWriter&#060;ExampleDo&#062; writer = IChunkedDataWriter.create(ExampleDo.class, "\r\n", 100);
+ *   Jobs.schedule(() -> {
+ *     try (writer) {
+ *       // write all ExampleDo instances to writer
+ *       writer.write(...);
+ *     }
+ *   }, Jobs.newInput());
+ *   return Response.ok(writer.toEntity()).build();
+ * }
+ * </pre>
+ */
+@Bean
+public interface IChunkedDataWriter<T> extends Closeable {
+
+  /**
+   * @return IChunkedDataWriter for chunks of type {@code type}, using the default delimiter {@code \r\n} and a queue capacity of 100 chunks.
+   */
+  static <T> IChunkedDataWriter<T> create(Class<T> type) {
+    return create(type, null, 100);
+  }
+
+  /**
+   * @return IChunkedDataWriter for chunks of type {@code type}, using the given {@code delimiter} and the given {@code queueCapacity}.
+   * Provide {@code null} as delimiter to use the default delimiter {@code \r\n}.
+   * If the queue capacity (e.g. enqueued chunks) is greater than 0, the queue is bounded and will block writing when full. Use {@code -1} for an unbounded queue.
+   * Caution: the queue is hold in memory until reader consumes the stream.
+   */
+  static <T> IChunkedDataWriter<T> create(Class<T> type, String delimiter, int queueCapacity) {
+    //noinspection unchecked
+    IChunkedDataWriter<T> writer = BEANS.get(IChunkedDataWriter.class);
+    writer.init(type, delimiter, queueCapacity);
+    return writer;
+  }
+
+  /**
+   * Initialize writer for chunks of type {@code type}, using the given {@code delimiter} and the given {@code queueCapacity}.
+   * Provide {@code null} as delimiter to use the default delimiter {@code \r\n}.
+   * If the queue capacity (e.g. enqueued chunks) is greater than 0, the queue is bounded and will block writing when full. Use {@code -1} for an unbounded queue.
+   * Caution: the queue is hold in memory until reader consumes the stream.
+   *
+   * @throws AssertionException
+   *     if already initialized
+   */
+  void init(Class<T> type, String delimiter, int queueCapacity);
+
+  /**
+   * @return writer as entity to be used as response payload, see {@code Response#ok(entity)}
+   */
+  GenericType<T> toEntity();
+
+  /**
+   * Writes given {@code chunk} into the wrapped {@link Response}.
+   */
+  void write(T chunk) throws IOException;
+
+  /**
+   * @return {@code true} if stream was closed, otherwise {@code false}.
+   */
+  boolean isClosed();
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/chunked/IChunkedDataReader.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/chunked/IChunkedDataReader.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.client.chunked;
+
+import java.io.Closeable;
+
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
+import org.eclipse.scout.rt.rest.client.IRestClientHelper;
+
+/**
+ * Reader for a stream of chunked data of type {@code T} e.g. by using a {@link IRestClientHelper}.
+ * <p>
+ * Example:
+ *
+ * <pre>
+ * Example:
+ *
+ * Response response = helper()
+ *     .target("chunked")
+ *     .request()
+ *     .accept(MediaType.APPLICATION_JSON)
+ *     .get();
+ *
+ * IChunkedDataReader&#060;ExampleDo&#062; reader = IChunkedDataReader.create(response, ExampleDo.class, "\r\n");
+ * ExampleDo chunk;
+ * while ((chunk = reader.read()) != null) {
+ *   // process chunk
+ * }
+ * </pre>
+ */
+@Bean
+public interface IChunkedDataReader<T> extends Closeable {
+
+  /**
+   * @return IChunkedDataReader for given {@code response} providing chunks of type {@code type}, the default delimiter {@code \r\n}.
+   */
+  static <T> IChunkedDataReader<T> create(Response response, Class<T> type) {
+    return create(response, type, null);
+  }
+
+  /**
+   * @return IChunkedDataReader for given {@code response} providing chunks of type {@code type}, using given {@code delimiter}.
+   * Provide {@code null} as delimiter to use the default delimiter {@code \r\n}.
+   */
+  static <T> IChunkedDataReader<T> create(Response response, Class<T> type, String delimiter) {
+    //noinspection unchecked
+    IChunkedDataReader<T> reader = BEANS.get(IChunkedDataReader.class);
+    reader.init(response, type, delimiter);
+    return reader;
+  }
+
+  /**
+   * Initialize reader for given {@code response} providing chunks of type {@code type}, using given {@code delimiter}.
+   * Provide {@code null} as delimiter to use the default delimiter {@code \r\n}.
+   *
+   * @throws AssertionException
+   *     if already initialized
+   */
+  void init(Response response, Class<T> type, String delimiter);
+
+  /**
+   * @return next chunk of data or {@code null} if no more data available.
+   */
+  T read();
+
+  /**
+   * @return {@code true} if stream was closed, otherwise {@code false}.
+   */
+  boolean isClosed();
+}


### PR DESCRIPTION
Added support chunked data resources and resource clients as Scout API using Jersey ChunkedInput and ChunkedOutput internally.

Update org.eclipse.scout.rt.rest.jersey.client/src/main/java/org/eclipse/scout/rt/rest/jersey/client/ChunkedDataReader.java
Update org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/ChunkedDataResource.java

Co-authored-by: matthiaso <matthias.otterbach@bsi-software.com>

423389