### PR TITLE
MalwareScanner: Add support for RemoteSystemUnavailableException

### DIFF
--- a/eclipse-scout-core/src/session/Session.ts
+++ b/eclipse-scout-core/src/session/Session.ts
@@ -163,7 +163,8 @@ export class Session extends EventEmitter implements SessionModel, ModelAdapterL
     UI_PROCESSING: 20,
     UNSAFE_UPLOAD: 30,
     REJECTED_UPLOAD: 31,
-    VERSION_MISMATCH: 40
+    VERSION_MISMATCH: 40,
+    REMOTE_SYSTEM_UNAVAILABLE: 50
   } as const;
 
   // Placeholder string for an empty filename
@@ -1087,6 +1088,14 @@ export class Session extends EventEmitter implements SessionModel, ModelAdapterL
       boxOptions.yesButtonText = this.optText('ui.Ok', 'Ok');
       boxOptions.yesButtonAction = null; // NOP
       isFatalError = false; // unsafe upload allows the application to continue
+    } else if (jsonError.code === Session.JsonResponseError.REMOTE_SYSTEM_UNAVAILABLE) {
+      boxOptions.header = this.optText('NetErrorTitle', boxOptions.header);
+      boxOptions.body = this.optText('NetSystemsNotAvailable', 'The system is partially unavailable at the moment.')
+        + '\n\n'
+        + this.optText('PleaseTryAgainLater', 'Please try again later.');
+      boxOptions.yesButtonText = this.optText('ui.Ok', 'Ok');
+      boxOptions.yesButtonAction = null; // NOP
+      isFatalError = false; // remote system unavailable allows the application to continue
     } else if (jsonError.code === Session.JsonResponseError.REJECTED_UPLOAD) {
       boxOptions.header = this.optText('ui.RejectedUpload', boxOptions.header);
       boxOptions.body = this.optText('ui.RejectedUploadMsg', boxOptions.body);

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/IMalwareScannerImplementor.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/IMalwareScannerImplementor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,8 @@ package org.eclipse.scout.rt.platform.security;
 import java.nio.file.Path;
 
 import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.exception.RemoteSystemUnavailableException;
 import org.eclipse.scout.rt.platform.resource.BinaryResource;
 
 @ApplicationScoped
@@ -21,7 +23,11 @@ public interface IMalwareScannerImplementor {
    * Scans given {@code res} for malware content.
    *
    * @throws UnsafeResourceException
-   *     if implementor is unable to perform a scan for malware or actually detects malware.
+   *     if implementor detects malware.
+   * @throws RemoteSystemUnavailableException
+   *     if implementor is not available.
+   * @throws ProcessingException
+   *     if a technical error occurs when performing malware scan.
    */
   void scan(BinaryResource res);
 
@@ -29,7 +35,11 @@ public interface IMalwareScannerImplementor {
    * Scans given {@code path} for malware content.
    *
    * @throws UnsafeResourceException
-   *           if implementor is unable to perform a scan for malware or actually detects malware.
+   *     if implementor detects malware.
+   * @throws RemoteSystemUnavailableException
+   *     if implementor is not available.
+   * @throws ProcessingException
+   *     if a technical error occurs when performing malware scan.
    */
   void scan(Path path);
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/MalwareScanner.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/MalwareScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,8 @@ import java.nio.file.Path;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
+import org.eclipse.scout.rt.platform.exception.RemoteSystemUnavailableException;
 import org.eclipse.scout.rt.platform.resource.BinaryResource;
 
 /**
@@ -29,9 +31,12 @@ public class MalwareScanner {
   /**
    * Scans given {@code res} for malware content.
    *
-   * @throws PlatformException
-   *     if the resource is valid and the scanner did not find any issues
-   * @since 10.x
+   * @throws UnsafeResourceException
+   *     if implementor detects malware.
+   * @throws RemoteSystemUnavailableException
+   *     if implementor is not available.
+   * @throws ProcessingException
+   *     if a technical error occurs when performing malware scan.
    */
   public void scan(BinaryResource res) {
     BEANS.get(IMalwareScannerImplementor.class).scan(res);
@@ -41,7 +46,11 @@ public class MalwareScanner {
    * Scans given {@code path} for malware content.
    *
    * @throws UnsafeResourceException
-   *           if implementor is unable to perform a scan for malware or actually detects malware.
+   *     if implementor detects malware.
+   * @throws RemoteSystemUnavailableException
+   *     if implementor is not available.
+   * @throws ProcessingException
+   *     if a technical error occurs when performing malware scan.
    */
   public void scan(Path path) {
     BEANS.get(IMalwareScannerImplementor.class).scan(path);

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiTextContributor.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/UiTextContributor.java
@@ -66,6 +66,7 @@ public class UiTextContributor implements IUiTextContributor {
         "InvalidNumberMessageX",
         "InvalidValueMessageX",
         "NavigationBackward",
+        "NetErrorTitle",
         "NetSystemsNotAvailable",
         "No",
         "NoButton",

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonRequestHelper.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonRequestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -67,8 +67,6 @@ public class JsonRequestHelper {
   }
 
   /**
-   * UI Text <code>ui.UnsafeUpload</code>
-   *
    * @return {@link JSONObject} to indicate that the file upload is unsafe.
    */
   public JSONObject createUnsafeUploadResponse() {
@@ -78,8 +76,6 @@ public class JsonRequestHelper {
   }
 
   /**
-   * UI Text <code>ui.RejectedUpload</code>
-   *
    * @return {@link JSONObject} to indicate that the file upload was rejected.
    */
   public JSONObject createRejectedUploadResponse() {
@@ -115,6 +111,15 @@ public class JsonRequestHelper {
   public JSONObject createVersionMismatchResponse() {
     final JsonResponse response = new JsonResponse();
     response.markAsError(JsonResponse.ERR_VERSION_MISMATCH, "Version mismatch");
+    return response.toJson();
+  }
+
+  /**
+   * @return {@link JSONObject} to indicate that a remote system is not available and therefore the request could not be completed.
+   */
+  public JSONObject createRemoteSystemUnavailableResponse() {
+    final JsonResponse response = new JsonResponse();
+    response.markAsError(JsonResponse.ERR_REMOTE_SYSTEM_UNAVAILABLE, "Remote system unavailable.");
     return response.toJson();
   }
 

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonResponse.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/JsonResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,7 @@ public class JsonResponse {
   public static final int ERR_UNSAFE_UPLOAD = 30;
   public static final int ERR_REJECTED_UPLOAD = 31;
   public static final int ERR_VERSION_MISMATCH = 40;
+  public static final int ERR_REMOTE_SYSTEM_UNAVAILABLE = 50;
 
   public static final String PROP_SEQUENCE_NO = "#";
   public static final String PROP_COMBINED = "combined";

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/UploadRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/UploadRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,6 +40,7 @@ import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.exception.DefaultExceptionTranslator;
 import org.eclipse.scout.rt.platform.exception.PlatformException;
+import org.eclipse.scout.rt.platform.exception.RemoteSystemUnavailableException;
 import org.eclipse.scout.rt.platform.resource.BinaryResource;
 import org.eclipse.scout.rt.platform.resource.BinaryResources;
 import org.eclipse.scout.rt.platform.resource.MimeTypes;
@@ -178,6 +179,11 @@ public class UploadRequestHandler extends AbstractUiServletRequestHandler {
       catch (UnsafeResourceException e) { // NOSONAR
         // LOG is done in MalwareScanner, verifyFileSafety is the only method throwing this exception
         writeJsonResponse(httpServletResponse, m_jsonRequestHelper.createUnsafeUploadResponse());
+        return;
+      }
+      catch (RemoteSystemUnavailableException e) {
+        // A remote system required for file upload is not available (e.g. malware scanner)
+        writeJsonResponse(httpServletResponse, m_jsonRequestHelper.createRemoteSystemUnavailableResponse());
         return;
       }
       catch (RejectedResourceException e) { // NOSONAR


### PR DESCRIPTION
When the MalwareScanner is not available a
RemoteSystemUnavailableException can be thrown to adress this case. This allows a more detailed error handling.

422721