### PR TITLE
Simple tab box: add support for vertical tabs

### DIFF
--- a/eclipse-scout-core/src/desktop/header/DesktopHeaderLayout.ts
+++ b/eclipse-scout-core/src/desktop/header/DesktopHeaderLayout.ts
@@ -89,7 +89,7 @@ export class DesktopHeaderLayout extends AbstractLayout {
     }
     // Ensure minimum width for the the overflow menu - expect if there are no tabs at all (in that case ensure min width of 0)
     let layout = tabArea.htmlComp.layout as DesktopTabAreaLayout;
-    let overflowTabItemWidth = layout.overflowTabItemWidth;
+    let overflowTabItemWidth = layout.overflowTabItemSize;
     tabsWidth = Math.max(tabsWidth, (tabArea.tabs.length ? overflowTabItemWidth : 0));
     setTabsSize();
 

--- a/eclipse-scout-core/src/tabbox/SimpleTab.less
+++ b/eclipse-scout-core/src/tabbox/SimpleTab.less
@@ -13,10 +13,22 @@
   vertical-align: top;
   padding: @simple-tab-padding;
   background-color: @simple-tab-background-color;
-  border-right: 1px solid @border-color;
   cursor: pointer;
   width: 120px;
   min-width: 60px;
+  height: @desktop-header-height;
+
+  .position-top > &,
+  .position-bottom > & {
+    border-right: 1px solid @border-color;
+  }
+
+  .position-right > &,
+  .position-left > & {
+    border-bottom: 1px solid @border-color;
+    min-width: 120px;
+    min-height: @desktop-header-height;
+  }
 
   & > .title-line {
     display: flex;

--- a/eclipse-scout-core/src/tabbox/SimpleTabArea.less
+++ b/eclipse-scout-core/src/tabbox/SimpleTabArea.less
@@ -13,12 +13,28 @@
   white-space: nowrap;
   display: flex;
 
+  &.position-top,
+  &.position-bottom {
+    flex-direction: row;
+
+    & > .simple-overflow-tab-item {
+      min-width: 30px;
+    }
+  }
+
+  &.position-right,
+  &.position-left {
+    flex-direction: column;
+
+    & > .simple-overflow-tab-item {
+      min-height: 40px;
+    }
+  }
+
   & > .simple-overflow-tab-item {
-    border-right: 1px solid @border-color;
     display: inline-flex;
     flex-direction: column;
     justify-content: center;
-    min-width: 30px;
     background-color: @simple-tab-background-color;
     text-align: center;
     cursor: pointer;
@@ -30,18 +46,22 @@
   }
 
   &.spread-even {
-    &:not(.overflown) {
-      & > .simple-tab {
-        flex-grow: 1;
+    & > .simple-tab {
+      flex-grow: 1;
+    }
 
-        &.last {
-          border-right-width: 0;
-        }
+    &.position-top,
+    &.position-bottom {
+      &:not(.overflown) > .simple-tab.last {
+        border-right-width: 0;
       }
     }
 
-    & > .simple-overflow-tab-item {
-      border-right-width: 0;
+    &.position-right,
+    &.position-left {
+      &:not(.overflown) > .simple-tab.last {
+        border-bottom-width: 0;
+      }
     }
   }
 }

--- a/eclipse-scout-core/src/tabbox/SimpleTabArea.ts
+++ b/eclipse-scout-core/src/tabbox/SimpleTabArea.ts
@@ -9,6 +9,7 @@
  */
 import {AbstractLayout, EnumObject, Event, EventHandler, HtmlComponent, InitModelOf, SimpleTab, SimpleTabAreaEventMap, SimpleTabAreaLayout, SimpleTabAreaModel, SimpleTabView, Widget, widgets} from '../index';
 
+export type SimpleTabAreaPosition = EnumObject<typeof SimpleTabArea.Position>;
 export type SimpleTabAreaDisplayStyle = EnumObject<typeof SimpleTabArea.DisplayStyle>;
 
 export class SimpleTabArea<TView extends SimpleTabView = SimpleTabView> extends Widget implements SimpleTabAreaModel<TView> {
@@ -16,11 +17,19 @@ export class SimpleTabArea<TView extends SimpleTabView = SimpleTabView> extends 
   declare eventMap: SimpleTabAreaEventMap<TView>;
   declare self: SimpleTabArea<any>;
 
+  static Position = {
+    TOP: 'top',
+    BOTTOM: 'bottom',
+    RIGHT: 'right',
+    LEFT: 'left'
+  } as const;
+
   static DisplayStyle = {
     DEFAULT: 'default',
     SPREAD_EVEN: 'spreadEven'
   } as const;
 
+  position: SimpleTabAreaPosition;
   displayStyle: SimpleTabAreaDisplayStyle;
   tabs: SimpleTab<TView>[];
 
@@ -29,6 +38,7 @@ export class SimpleTabArea<TView extends SimpleTabView = SimpleTabView> extends 
 
   constructor() {
     super();
+    this.position = SimpleTabArea.Position.TOP;
     this.displayStyle = SimpleTabArea.DisplayStyle.DEFAULT;
     this.tabs = [];
     this._selectedViewTab = null;
@@ -53,8 +63,23 @@ export class SimpleTabArea<TView extends SimpleTabView = SimpleTabView> extends 
 
   protected override _renderProperties() {
     super._renderProperties();
+    this._renderPosition();
     this._renderDisplayStyle();
     this._renderTabs();
+  }
+
+  setPosition(position: SimpleTabAreaPosition) {
+    this.setProperty('position', position);
+  }
+
+  protected _renderPosition() {
+    const positions: SimpleTabAreaPosition[] = [SimpleTabArea.Position.TOP, SimpleTabArea.Position.BOTTOM, SimpleTabArea.Position.LEFT, SimpleTabArea.Position.RIGHT];
+    positions.forEach(position => this.$container.toggleClass(this._cssClassForPosition(position), this.position === position));
+    this.invalidateLayoutTree();
+  }
+
+  protected _cssClassForPosition(position: SimpleTabAreaPosition) {
+    return 'position-' + position;
   }
 
   setDisplayStyle(displayStyle: SimpleTabAreaDisplayStyle) {

--- a/eclipse-scout-core/src/tabbox/SimpleTabAreaLayout.ts
+++ b/eclipse-scout-core/src/tabbox/SimpleTabAreaLayout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,24 +12,27 @@ import $ from 'jquery';
 
 export class SimpleTabAreaLayout extends AbstractLayout {
   tabArea: SimpleTabArea;
-  tabWidth: number;
-  tabMinWidth: number;
-  overflowTabItemWidth: number;
+  tabSize: number;
+  tabMinSize: number;
+  overflowTabItemSize: number;
+  protected _horizontalTabs: boolean;
   protected _$overflowTab: JQuery;
   protected _overflowTabsIndizes: number[];
 
   constructor(tabArea: SimpleTabArea) {
     super();
     this.tabArea = tabArea;
+    this.tabSize = null;
+    this.tabMinSize = null;
+    this.overflowTabItemSize = null;
+    this._horizontalTabs = null;
     this._$overflowTab = null;
     this._overflowTabsIndizes = [];
-
-    this.tabWidth = null;
-    this.tabMinWidth = null;
-    this.overflowTabItemWidth = null;
   }
 
   override layout($container: JQuery) {
+    this._initSizes();
+
     let htmlContainer = this.tabArea.htmlComp,
       containerSize = htmlContainer.size({
         exact: true
@@ -40,8 +43,6 @@ export class SimpleTabAreaLayout extends AbstractLayout {
 
     containerSize = containerSize.subtract(htmlContainer.insets());
 
-    this._initSizes();
-
     // Reset tabs
     if (this._$overflowTab) {
       this._$overflowTab.remove();
@@ -51,17 +52,17 @@ export class SimpleTabAreaLayout extends AbstractLayout {
     widgets.updateFirstLastMarker(this.tabArea.getTabs());
 
     // All tabs fit in container -> no overflow menu necessary
-    if (smallPrefSize.width <= containerSize.width) {
+    if (this._getSize(smallPrefSize) <= this._getSize(containerSize)) {
       $container.removeClass('overflown');
       return;
     }
 
     // Not all tabs fit in container -> put tabs into overflow menu
     $container.addClass('overflown');
-    containerSize.width -= this.overflowTabItemWidth;
+    this._setSize(containerSize, this._getSize(containerSize) - this.overflowTabItemSize);
 
-    // check how many tabs fit into remaining containerSize.width
-    let numVisibleTabs = Math.floor(containerSize.width / this.tabMinWidth);
+    // check how many tabs fit into remaining containerSize.width or containerSize.height
+    let numVisibleTabs = Math.floor(this._getSize(containerSize) / this.tabMinSize);
     let numOverflowTabs = numTabs - numVisibleTabs;
 
     let selectedIndex = 0;
@@ -99,31 +100,52 @@ export class SimpleTabAreaLayout extends AbstractLayout {
     widgets.updateFirstLastMarker(this.tabArea.getVisibleTabs());
   }
 
-  smallPrefSize(options: PrefSizeOptions & { minTabWidth?: number } = {}): Dimension {
+  protected _getSize(dimension: Dimension): number {
+    return this._horizontalTabs ? dimension.width : dimension.height;
+  }
+
+  protected _setSize(dimension: Dimension, size: number) {
+    if (this._horizontalTabs) {
+      dimension.width = size;
+    } else {
+      dimension.height = size;
+    }
+  }
+
+  smallPrefSize(options: PrefSizeOptions & { tabMinSize?: number } = {}): Dimension {
     this._initSizes();
-    options = $.extend({minTabWidth: this.tabMinWidth}, options);
+    options = $.extend({tabMinSize: this.tabMinSize}, options);
     return this.preferredLayoutSize(this.tabArea.$container, options);
   }
 
-  override preferredLayoutSize($container: JQuery, options?: PrefSizeOptions & { minTabWidth?: number }): Dimension {
+  override preferredLayoutSize($container: JQuery, options?: PrefSizeOptions & { tabMinSize?: number }): Dimension {
     this._initSizes();
-    let minTabWidth = scout.nvl(options.minTabWidth, 0) || scout.nvl(this.tabWidth, 0);
+    let tabMinSize = scout.nvl(options.tabMinSize, 0) || scout.nvl(this.tabSize, 0);
     let numTabs = this.tabArea.getTabs().length;
-    let minWidth = numTabs * minTabWidth;
+    let minSize = numTabs * tabMinSize;
     options = $.extend({useCssSize: true}, options);
     let prefSize = graphics.prefSize(this.tabArea.$container, options);
-    if (options.widthHint && this.tabArea.displayStyle === SimpleTabArea.DisplayStyle.SPREAD_EVEN) {
-      minWidth = Math.max(options.widthHint, minWidth);
+    let sizeHint = this._horizontalTabs ? options.widthHint : options.heightHint;
+    if (sizeHint && this.tabArea.displayStyle === SimpleTabArea.DisplayStyle.SPREAD_EVEN) {
+      minSize = Math.max(sizeHint, minSize);
     }
-    return new Dimension(minWidth, prefSize.height);
+    return this._horizontalTabs ? new Dimension(minSize, prefSize.height) : new Dimension(prefSize.width, minSize);
   }
 
   /**
-   * Reads the default sizes from CSS -> the tabs need to specify a width and a min-width.
+   * Reads the default sizes from CSS -> the tabs need to specify a width and a min-width or a height and a min-height.
    * The layout expects all tabs to have the same width.
    */
   protected _initSizes() {
-    if (this.tabWidth != null && this.tabMinWidth != null && this.overflowTabItemWidth != null) {
+    // in case the orientation has changed, the cached sizes must be updated
+    const horizontalTabs = this.tabArea.position === SimpleTabArea.Position.TOP || this.tabArea.position === SimpleTabArea.Position.BOTTOM;
+    if (this._horizontalTabs !== horizontalTabs) {
+      this.tabSize = null;
+      this.tabMinSize = null;
+      this.overflowTabItemSize = null;
+      this._horizontalTabs = horizontalTabs;
+    }
+    if (this.tabSize != null && this.tabMinSize != null && this.overflowTabItemSize != null) {
       return;
     }
     let $tab = this.tabArea.$container.children('.simple-tab').eq(0);
@@ -133,17 +155,32 @@ export class SimpleTabAreaLayout extends AbstractLayout {
     $tab = $tab.clone().addClass('selected'); // Non selected items have a margin, selected ones don't -> we need to get the width incl. margin
     let tabAreaClasses = this.tabArea.$container.attr('class');
     let tabItemClasses = $tab.attr('class');
-    if (this.tabWidth === null) {
-      this.tabWidth = styles.getSize([tabAreaClasses, tabItemClasses], 'width', 'width', 0);
+    this._initTabSize([tabAreaClasses, tabItemClasses], this._horizontalTabs);
+    this._initTabMinSize([tabAreaClasses, tabItemClasses], this._horizontalTabs);
+    this._initOverflowTabItemSize([tabAreaClasses, 'simple-overflow-tab-item'], this._horizontalTabs);
+  }
+
+  protected _initTabSize(cssClasses: string[], horizontal: boolean) {
+    if (this.tabSize !== null) {
+      return;
     }
-    if (this.tabMinWidth === null) {
-      this.tabMinWidth = styles.getSize([tabAreaClasses, tabItemClasses], 'min-width', 'minWidth');
+    this.tabSize = horizontal ? styles.getSize(cssClasses, 'width', 'width', 0) : styles.getSize(cssClasses, 'height', 'height', 0);
+  }
+
+  protected _initTabMinSize(cssClasses: string[], horizontal: boolean) {
+    if (this.tabMinSize !== null) {
+      return;
     }
-    if (this.overflowTabItemWidth === null) {
-      this.overflowTabItemWidth = styles.getSize([tabAreaClasses, 'simple-overflow-tab-item'], 'min-width', 'minWidth');
-      this.overflowTabItemWidth += styles.getSize([tabAreaClasses, 'simple-overflow-tab-item'], 'margin-left', 'marginLeft');
-      this.overflowTabItemWidth += styles.getSize([tabAreaClasses, 'simple-overflow-tab-item'], 'margin-right', 'marginRight');
+    this.tabMinSize = horizontal ? styles.getSize(cssClasses, 'min-width', 'minWidth') : styles.getSize(cssClasses, 'min-height', 'minHeight');
+  }
+
+  protected _initOverflowTabItemSize(cssClasses: string[], horizontal: boolean) {
+    if (this.overflowTabItemSize !== null) {
+      return;
     }
+    this.overflowTabItemSize = horizontal
+      ? styles.getSize(cssClasses, 'min-width', 'minWidth') + styles.getSize(cssClasses, 'margin-left', 'marginLeft') + styles.getSize(cssClasses, 'margin-right', 'marginRight')
+      : styles.getSize(cssClasses, 'min-height', 'minHeight') + styles.getSize(cssClasses, 'margin-top', 'marginTop') + styles.getSize(cssClasses, 'margin-bottom', 'marginBottom');
   }
 
   protected _onOverflowTabItemMouseDown(event: JQuery.MouseDownEvent) {

--- a/eclipse-scout-core/src/tabbox/SimpleTabAreaModel.ts
+++ b/eclipse-scout-core/src/tabbox/SimpleTabAreaModel.ts
@@ -7,9 +7,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ObjectOrModel, SimpleTab, SimpleTabAreaDisplayStyle, SimpleTabView, WidgetModel} from '../index';
+import {ObjectOrModel, SimpleTab, SimpleTabAreaDisplayStyle, SimpleTabAreaPosition, SimpleTabView, WidgetModel} from '../index';
 
 export interface SimpleTabAreaModel<TView extends SimpleTabView = SimpleTabView> extends WidgetModel {
+  position?: SimpleTabAreaPosition;
   displayStyle?: SimpleTabAreaDisplayStyle;
   tabs?: ObjectOrModel<SimpleTab<TView>>[];
 }

--- a/eclipse-scout-core/src/tabbox/SimpleTabBox.less
+++ b/eclipse-scout-core/src/tabbox/SimpleTabBox.less
@@ -13,8 +13,7 @@
   min-height: @bench-view-min-height;
 
   & > .simple-tab-area {
-    position: relative;
-    height: @desktop-header-height;
+    position: absolute;
 
     /* Has the same effect as "border-bottom: 1px solid @border-color", but is over-drawable by child */
     /* elements (such as the selected view-tab). The border would not be, because of "overflow: hidden". */
@@ -22,16 +21,42 @@
     &::before {
       content: '';
       background-color: @border-color;
+      position: absolute;
+    }
+
+    &.position-top::before,
+    &.position-bottom::before {
       width: 100%;
       height: 1px;
-      position: absolute;
-      top: calc(~'100% - 1px');
       left: 0;
+    }
+
+    &.position-top::before {
+      top: calc(~'100% - 1px');
+    }
+
+    &.position-bottom::before {
+      bottom: calc(~'100% - 1px');
+    }
+
+    &.position-right::before,
+    &.position-left::before {
+      width: 1px;
+      height: 100%;
+      top: 0;
+    }
+
+    &.position-right::before {
+      right: calc(~'100% - 1px');
+    }
+
+    &.position-left::before {
+      left: calc(~'100% - 1px');
     }
   }
 
   & > .tab-content {
-    height: 100%;
+    position: absolute;
     background-color: @background-color;
   }
 }

--- a/eclipse-scout-core/src/tabbox/SimpleTabBoxLayout.ts
+++ b/eclipse-scout-core/src/tabbox/SimpleTabBoxLayout.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AbstractLayout, Dimension, HtmlComponent, HtmlCompPrefSizeOptions, SimpleTabBox} from '../index';
+import {AbstractLayout, Dimension, HtmlComponent, HtmlCompPrefSizeOptions, Rectangle, SimpleTabArea, SimpleTabBox} from '../index';
 
 export class SimpleTabBoxLayout extends AbstractLayout {
   tabBox: SimpleTabBox;
@@ -18,30 +18,51 @@ export class SimpleTabBoxLayout extends AbstractLayout {
   }
 
   override layout($container: JQuery) {
-    let htmlContainer = HtmlComponent.get($container),
-      htmlViewContent = HtmlComponent.get(this.tabBox.$viewContent);
+    const htmlContainer = HtmlComponent.get($container);
+    const containerSize = htmlContainer.availableSize({exact: true}).subtract(htmlContainer.insets());
 
-    let containerSize = htmlContainer.availableSize({exact: true}).subtract(htmlContainer.insets());
-    let tabAreaSize = this._layoutTabArea(containerSize);
-    let viewContentSize = containerSize.subtract(htmlViewContent.margins());
-    viewContentSize.height -= tabAreaSize.height;
-    htmlViewContent.setSize(viewContentSize);
-  }
+    const htmlTabArea = HtmlComponent.get(this.tabBox.$tabArea);
+    const htmlViewContent = HtmlComponent.get(this.tabBox.$viewContent);
 
-  /**
-   * @returns used of the tab area
-   */
-  protected _layoutTabArea(containerSize: Dimension): Dimension {
-    if (!this.tabBox.rendered) {
-      return new Dimension(0, 0);
+    const tabAreaPosition = this.tabBox.tabArea.position;
+    const tabAreaPrefSize = htmlTabArea.prefSize();
+    const tabAreaMargins = htmlTabArea.margins();
+
+    let tabAreaSize: Dimension;
+    let viewContentSize: Dimension;
+
+    if (tabAreaPosition === SimpleTabArea.Position.TOP || tabAreaPosition === SimpleTabArea.Position.BOTTOM) {
+      tabAreaSize = new Dimension(containerSize.width, tabAreaPrefSize.height + tabAreaMargins.top + tabAreaMargins.bottom);
+      viewContentSize = new Dimension(containerSize.width, containerSize.height - tabAreaSize.height).subtract(htmlViewContent.margins());
+    } else if (tabAreaPosition === SimpleTabArea.Position.RIGHT || tabAreaPosition === SimpleTabArea.Position.LEFT) {
+      tabAreaSize = new Dimension(tabAreaPrefSize.width + tabAreaMargins.left + tabAreaMargins.right, containerSize.height);
+      viewContentSize = new Dimension(containerSize.width - tabAreaSize.width, containerSize.height).subtract(htmlViewContent.margins());
     }
-    // expected the tab area is layouted dynamically only
-    let htmlViewTabs = HtmlComponent.get(this.tabBox.$tabArea),
-      prefSize = htmlViewTabs.prefSize(),
-      margins = htmlViewTabs.margins();
-    let size = new Dimension(containerSize.width, prefSize.height + margins.top + margins.bottom);
-    htmlViewTabs.setSize(size);
-    return size;
+
+    let tabAreaBounds: Rectangle;
+    let viewContentBounds: Rectangle;
+
+    switch (tabAreaPosition) {
+      case SimpleTabArea.Position.TOP:
+        tabAreaBounds = new Rectangle(0, 0, tabAreaSize.width, tabAreaSize.height);
+        viewContentBounds = new Rectangle(0, tabAreaSize.height, viewContentSize.width, viewContentSize.height);
+        break;
+      case SimpleTabArea.Position.BOTTOM:
+        tabAreaBounds = new Rectangle(0, viewContentSize.height, tabAreaSize.width, tabAreaSize.height);
+        viewContentBounds = new Rectangle(0, 0, viewContentSize.width, viewContentSize.height);
+        break;
+      case SimpleTabArea.Position.RIGHT:
+        tabAreaBounds = new Rectangle(viewContentSize.width, 0, tabAreaSize.width, tabAreaSize.height);
+        viewContentBounds = new Rectangle(0, 0, viewContentSize.width, viewContentSize.height);
+        break;
+      case SimpleTabArea.Position.LEFT:
+        tabAreaBounds = new Rectangle(0, 0, tabAreaSize.width, tabAreaSize.height);
+        viewContentBounds = new Rectangle(tabAreaSize.width, 0, viewContentSize.width, viewContentSize.height);
+        break;
+    }
+
+    htmlTabArea.setBounds(tabAreaBounds);
+    htmlViewContent.setBounds(viewContentBounds);
   }
 
   /**
@@ -67,8 +88,16 @@ export class SimpleTabBoxLayout extends AbstractLayout {
       .add(htmlContainer.insets())
       .add(htmlViewContent.margins());
 
-    return new Dimension(
-      Math.max(viewTabsSize.width, viewContentSize.width),
-      viewContentSize.height + viewTabsSize.height);
+    const tabAreaPosition = this.tabBox.tabArea.position;
+    let prefWidth, prefHeight;
+    if (tabAreaPosition === SimpleTabArea.Position.TOP || tabAreaPosition === SimpleTabArea.Position.BOTTOM) {
+      prefWidth = Math.max(viewTabsSize.width, viewContentSize.width);
+      prefHeight = viewContentSize.height + viewTabsSize.height;
+    } else if (tabAreaPosition === SimpleTabArea.Position.RIGHT || tabAreaPosition === SimpleTabArea.Position.LEFT) {
+      prefWidth = viewTabsSize.width + viewContentSize.width;
+      prefHeight = Math.max(viewContentSize.height, viewTabsSize.height);
+    }
+
+    return new Dimension(prefWidth, prefHeight);
   }
 }


### PR DESCRIPTION
So far, the box could only display the tabs at the top. Now, the tabs can be positioned on either side of the box.

By default, the tabs are displayed at the top, but with the new attribute position, the alignment of the tabs can be controlled as desired.