### PR TITLE
ProposalField: lookupOnAcceptByText does not work in touchMode

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/ProposalField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/ProposalField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,13 +16,6 @@ export class ProposalField extends SmartField<string> implements ProposalFieldMo
   declare self: ProposalField;
 
   trimText: boolean;
-
-  /**
-   * If this flag is set to true the proposal field performs a lookup by text when
-   * accept proposal is called. The behavior is similar to what the smart-field does
-   * in that case, but without the need to have a valid single match as the result
-   * from the lookup.
-   */
   lookupOnAcceptByText: boolean;
 
   constructor() {
@@ -32,6 +25,8 @@ export class ProposalField extends SmartField<string> implements ProposalFieldMo
     this.trimText = true;
 
     this.lookupOnAcceptByText = false;
+
+    this._addCloneProperties(['lookupOnAcceptByText']);
   }
 
   protected override _getValueFromLookupRow(lookupRow: LookupRow<string>): string {
@@ -57,8 +52,10 @@ export class ProposalField extends SmartField<string> implements ProposalFieldMo
     // stop propagation (e.g. to avoid calls of other registered enter key-shortcuts, like the default
     // button on a form). See Widget.js for details about removing with or without CSS animations.
     let hasPopup = !!this.popup;
-    this.acceptInput();
-    if (this.popup) {
+    let promise = this.acceptInput();
+    if (promise) {
+      promise.always(this.closePopup.bind(this));
+    } else {
       this.closePopup();
     }
     if (hasPopup) {
@@ -133,6 +130,10 @@ export class ProposalField extends SmartField<string> implements ProposalFieldMo
     this._userWasTyping = false;
     this._extendResult(result);
 
+    if (this.isPopupOpen()) {
+      this.popup.setLookupResult(result);
+    }
+
     // when there's exactly one result, we accept that lookup row
     if (result.uniqueMatch) {
       let lookupRow = result.uniqueMatch;
@@ -169,6 +170,7 @@ export class ProposalField extends SmartField<string> implements ProposalFieldMo
    * the value is set and the lookup-row is null.
    */
   protected override _copyValuesFromField(otherField: ProposalField) {
+    this.lookupSeqNo = otherField.lookupSeqNo;
     if (this.lookupRow !== otherField.lookupRow) {
       this._setLookupRow(otherField.lookupRow); // only set property lookup
     }
@@ -180,7 +182,9 @@ export class ProposalField extends SmartField<string> implements ProposalFieldMo
   protected override _acceptInput(sync: boolean, searchText: string, searchTextEmpty: boolean, searchTextChanged: boolean, selectedLookupRow: LookupRow<string>): JQuery.Promise<void> | void {
     if (this.touchMode) {
       $.log.isDebugEnabled() && $.log.debug('(ProposalField#_acceptInput) Always send acceptInput for touch field');
-      this._inputAccepted(true, !!selectedLookupRow);
+      // When the lookup is accepted by text (e.g. when lookupOnAcceptByText = true), the SmartField#acceptInput cannot
+      // detect the selectedLookupRow, because it just takes the selected row of the Proposal chooser
+      this._inputAccepted(true, !!this.lookupRow);
       return;
     }
 

--- a/eclipse-scout-core/src/form/fields/smartfield/ProposalFieldModel.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/ProposalFieldModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,4 +17,13 @@ export interface ProposalFieldModel extends SmartFieldModel<string> {
    * Default is true.
    */
   trimText?: boolean;
+  /**
+   * If this flag is set to true the proposal field performs a lookup by text when
+   * accept proposal is called. The behavior is similar to what the smart-field does
+   * in that case, but without the need to have a valid single match as the result
+   * from the lookup.
+   *
+   * Default is false
+   */
+  lookupOnAcceptByText?: boolean;
 }

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
@@ -103,7 +103,7 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
 
     this._addCloneProperties(['lookupRow', 'codeType', 'lookupCall', 'activeFilter', 'activeFilterEnabled', 'activeFilterLabels',
       'browseHierarchy', 'browseMaxRowCount', 'browseAutoExpandAll', 'browseLoadIncremental', 'searchRequired', 'columnDescriptors',
-      'displayStyle'
+      'displayStyle', 'lookupSeqNo'
     ]);
 
     this.$screenReaderStatus = null;
@@ -542,6 +542,10 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
     this._userWasTyping = false;
     this._extendResult(result);
     this._notUnique = result.numLookupRows > 1;
+
+    if (this.isPopupOpen()) {
+      this.popup.setLookupResult(result);
+    }
 
     // when there's exactly one result, we accept that lookup row
     if (result.uniqueMatch) {

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldPopup.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldPopup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,9 @@ import {
   SmartFieldPopupEventMap, SmartFieldPopupLayout, SmartFieldPopupModel, SomeRequired, StatusOrModel
 } from '../../../index';
 
+/**
+ * IMPORTANT: this popup logic is partially also implemented in <code>SmartFieldTouchPopup</code>. If you make changes here, also check the touch popup.
+ */
 export class SmartFieldPopup<TValue> extends Popup implements SmartFieldPopupModel<TValue> {
   declare model: SmartFieldPopupModel<TValue>;
   declare initModel: SomeRequired<this['model'], 'parent' | 'field'>;
@@ -76,7 +79,7 @@ export class SmartFieldPopup<TValue> extends Popup implements SmartFieldPopupMod
    */
   getSelectedLookupRow(): LookupRow<TValue> {
     let lookupRow = this.proposalChooser.getSelectedLookupRow();
-    if (lookupRow && lookupRow.enabled) {
+    if (lookupRow?.enabled) {
       return lookupRow;
     }
     return null;

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldTouchPopup.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldTouchPopup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -94,7 +94,11 @@ export class SmartFieldTouchPopup<TValue> extends TouchPopup implements SmartFie
   }
 
   getSelectedLookupRow(): LookupRow<TValue> {
-    return this._widget.getSelectedLookupRow();
+    let lookupRow = this._widget.getSelectedLookupRow();
+    if (lookupRow?.enabled) {
+      return lookupRow;
+    }
+    return null;
   }
 
   protected _triggerEvent(event: ProposalChooserActiveFilterSelectedEvent<TValue> | ProposalChooserLookupRowSelectedEvent<TValue>) {
@@ -102,6 +106,7 @@ export class SmartFieldTouchPopup<TValue> extends TouchPopup implements SmartFie
   }
 
   setLookupResult(result: SmartFieldLookupResult<TValue>) {
+    this._setProperty('lookupResult', result);
     this._widget.setLookupResult(result);
   }
 

--- a/eclipse-scout-core/src/testing/form/fields/smartfield/proposalFieldSpecHelper.ts
+++ b/eclipse-scout-core/src/testing/form/fields/smartfield/proposalFieldSpecHelper.ts
@@ -8,12 +8,12 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {LookupRow, ProposalChooser, ProposalField, SmartFieldLookupResult, SmartFieldPopup, SmartFieldTouchPopup} from '../../../../index';
+import {keys, LookupRow, ProposalChooser, ProposalField, SmartFieldLookupResult, SmartFieldPopup, SmartFieldTouchPopup, Table} from '../../../../index';
 import {JQueryTesting} from '../../../jquery-testing';
 
 export const proposalFieldSpecHelper = {
 
-  async testProposalFieldInputs(field: ProposalField, inputs: (ProposalFieldSpecHelperInput | string)[], touchMode?: boolean, callbacks?: ProposalFieldSpecHelperCallbacks) {
+  async testProposalFieldInputs(field: ProposalField, inputs: (ProposalFieldSpecHelperInput | string)[], touchMode?: boolean, callbacks?: ProposalFieldSpecHelperCallbacks, selectionStrategy?: LookupRowSelectionStrategy) {
     field.touchMode = touchMode;
     field.render();
 
@@ -34,8 +34,8 @@ export const proposalFieldSpecHelper = {
 
       callbacks.beforeInput(input);
 
-      if (lookup) {
-        const lookupRow = await proposalFieldSpecHelper.selectLookupRow(field, text);
+      if (lookup || selectionStrategy === LookupRowSelectionStrategy.EXACT_TEXT) {
+        const lookupRow = await proposalFieldSpecHelper.selectLookupRow(field, text, selectionStrategy);
         callbacks.afterSelectLookupRow(text, lookupRow);
       } else {
         await proposalFieldSpecHelper.acceptCustomText(field, text);
@@ -59,20 +59,37 @@ export const proposalFieldSpecHelper = {
       popup.doneAction.doAction();
     } else {
       field.$field.val(text);
-      field.acceptInput();
+      await field.acceptInput();
     }
   },
 
-  async selectLookupRow(field: ProposalField, text: string): Promise<LookupRow<string>> {
+  async selectLookupRow(field: ProposalField, text: string, strategy = LookupRowSelectionStrategy.CLICK): Promise<LookupRow<string>> {
     // find row for text
     const popup = await proposalFieldSpecHelper.openPopup(field);
+    const smartField = field.touchMode ? (popup as SpecSmartFieldTouchPopup<string>)._field : (popup as SmartFieldPopup<string>).smartField;
     const proposalChooser = field.touchMode ? (popup as SpecSmartFieldTouchPopup<string>)._widget : (popup as SmartFieldPopup<string>).proposalChooser;
-    const table = proposalChooser.content;
+    const table = proposalChooser.content as Table;
     const row = table.rows.find(r => r.cells[0].text === text);
 
-    // trigger row mousedown and mouseup
-    JQueryTesting.triggerMouseDown(row.$row);
-    JQueryTesting.triggerMouseUp(row.$row);
+    switch (strategy) {
+      case LookupRowSelectionStrategy.CLICK: {
+        JQueryTesting.triggerMouseDown(row.$row);
+        JQueryTesting.triggerMouseUp(row.$row);
+        break;
+      }
+      case LookupRowSelectionStrategy.ENTER: {
+        table.selectRow(row);
+        JQueryTesting.triggerKeyDownCapture(smartField.$field, keys.ENTER);
+        break;
+      }
+      case LookupRowSelectionStrategy.EXACT_TEXT: {
+        smartField.$field.val(text);
+        let closePromise = popup.when('close');
+        JQueryTesting.triggerKeyDownCapture(smartField.$field, keys.ENTER);
+        await closePromise;
+        return smartField.lookupRow;
+      }
+    }
 
     return row.lookupRow;
   },
@@ -117,4 +134,10 @@ export class SpecProposalField extends ProposalField {
 
 export class SpecSmartFieldTouchPopup<TValue> extends SmartFieldTouchPopup<TValue> {
   declare _widget: ProposalChooser<TValue, any, any>;
+}
+
+export enum LookupRowSelectionStrategy {
+  CLICK, // The desired row is clicked on
+  ENTER, // The desired row is selected using arrow keys and then enter is pressed
+  EXACT_TEXT // The exact value is typed into the smart field. In combination with the flag lookupOnAcceptByText, the row is selected
 }

--- a/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldAdapterSpec.ts
+++ b/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldAdapterSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {LookupRow, ModelAdapterSendOptions, ProposalFieldAdapter, scout, SmartFieldAcceptInputEvent, SmartFieldTouchPopup, StaticLookupCall, Status} from '../../../../src/index';
-import {proposalFieldSpecHelper, ProposalFieldSpecHelperCallbacks, ProposalFieldSpecHelperInput, SpecProposalField} from '../../../../src/testing';
+import {LookupRowSelectionStrategy, proposalFieldSpecHelper, ProposalFieldSpecHelperCallbacks, ProposalFieldSpecHelperInput, SpecProposalField} from '../../../../src/testing';
 
 describe('ProposalFieldAdapter', () => {
 
@@ -244,7 +244,97 @@ describe('ProposalFieldAdapter', () => {
         true);
     });
 
-    async function testProposalFieldInputs(inputs: (ProposalFieldSpecHelperInput | string)[], touchMode?: boolean, withErrorStatus?: boolean) {
+    describe('when lookupRowSelectionStrategy ENTER is selected', () => {
+
+      // foo > bar > foo > bar
+      it('lookup \'foo\' > lookup \'bar\' > write \'foo\' > write \'bar\' (touchMode: false, withErrorStatus: false)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'foo', 'bar'],
+          false,
+          false,
+          LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'foo\' > lookup \'bar\' > write \'foo\' > write \'bar\' (touchMode: true, withErrorStatus: false)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'foo', 'bar'],
+          true,
+          false,
+          LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'foo\' > lookup \'bar\' > write \'foo\' > write \'bar\' (touchMode: false, withErrorStatus: true)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'foo', 'bar'],
+          false,
+          true,
+          LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'foo\' > lookup \'bar\' > write \'foo\' > write \'bar\' (touchMode: true, withErrorStatus: true)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'foo', lookup: true}, {text: 'bar', lookup: true}, 'foo', 'bar'],
+          true,
+          true,
+          LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'foo\' > write \'bar\' > lookup \'foo\' > lookup \'bar\' (touchMode: false, withErrorStatus: false)', async () => {
+        await testProposalFieldInputs(
+          ['foo', 'bar', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+          false,
+          false,
+          LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'foo\' > write \'bar\' > lookup \'foo\' > lookup \'bar\' (touchMode: true, withErrorStatus: false)', async () => {
+        await testProposalFieldInputs(
+          ['foo', 'bar', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+          true,
+          false,
+          LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'foo\' > write \'bar\' > lookup \'foo\' > lookup \'bar\' (touchMode: false, withErrorStatus: true)', async () => {
+        await testProposalFieldInputs(
+          ['foo', 'bar', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+          false,
+          true,
+          LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'foo\' > write \'bar\' > lookup \'foo\' > lookup \'bar\' (touchMode: true, withErrorStatus: true)', async () => {
+        await testProposalFieldInputs(
+          ['foo', 'bar', {text: 'foo', lookup: true}, {text: 'bar', lookup: true}],
+          true,
+          true,
+          LookupRowSelectionStrategy.ENTER);
+      });
+    });
+
+    describe('when LookupRowSelectionStrategy EXACT_TEXT is used', () => {
+      beforeEach(() => {
+        field.lookupOnAcceptByText = true;
+      });
+
+      it('write \'foo\' > write \'bar\' > write \'some\' (touchMode: false, withErrorStatus: true)', async () => {
+        await testProposalFieldInputs(
+          ['foo', 'bar', 'some'],
+          false,
+          true,
+          LookupRowSelectionStrategy.EXACT_TEXT);
+      });
+
+      it('write \'foo\' > write \'bar\' > write \'some\' (touchMode: true, withErrorStatus: true)', async () => {
+        await testProposalFieldInputs(
+          ['foo', 'bar', 'some'],
+          true,
+          true,
+          LookupRowSelectionStrategy.EXACT_TEXT);
+      });
+    });
+
+    async function testProposalFieldInputs(inputs: (ProposalFieldSpecHelperInput | string)[], touchMode?: boolean, withErrorStatus?: boolean, selectionStrategy?: LookupRowSelectionStrategy) {
       const callbacks: ProposalFieldSpecHelperCallbacks = {
         afterInput: (input: ProposalFieldSpecHelperInput) => {
           const {text} = input;
@@ -259,7 +349,7 @@ describe('ProposalFieldAdapter', () => {
         callbacks.beforeInput = (input: ProposalFieldSpecHelperInput) => field.setErrorStatus(Status.warning('I am a WARNING!'));
       }
 
-      await proposalFieldSpecHelper.testProposalFieldInputs(field, inputs, touchMode, callbacks);
+      await proposalFieldSpecHelper.testProposalFieldInputs(field, inputs, touchMode, callbacks, selectionStrategy);
     }
 
     function expectAcceptInputEvent(text: string, lookupRow?: LookupRow<string>) {

--- a/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/smartfield/ProposalFieldSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {keys, LookupRow, ProposalField, QueryBy, scout, SmartFieldTouchPopup, StaticLookupCall, Status} from '../../../../src/index';
-import {JQueryTesting, proposalFieldSpecHelper, ProposalFieldSpecHelperInput, SpecProposalField} from '../../../../src/testing';
+import {JQueryTesting, LookupRowSelectionStrategy, proposalFieldSpecHelper, ProposalFieldSpecHelperInput, SpecProposalField} from '../../../../src/testing';
 
 describe('ProposalField', () => {
 
@@ -145,6 +145,59 @@ describe('ProposalField', () => {
     jasmine.clock().tick(300);
     expect(field.displayText).toBe('Foo');
     expect(field.$field.val()).toBe('Foo');
+  });
+
+  describe('when lookupOnAcceptByText=true', () => {
+    let expectedLookupRow;
+
+    beforeEach(() => {
+      jasmine.clock().uninstall();
+      field.render();
+      field.lookupOnAcceptByText = true;
+
+      expectedLookupRow = scout.create((LookupRow<number>), {
+        key: 1,
+        text: 'Foo'
+      });
+    });
+
+    it('should select the lookupRow when a unique result is returned (touchMode = false)', async () => {
+      field.$field.focus();
+      field.$field.val('Foo');
+      await field.acceptInput();
+
+      expect(field.lookupRow.key).toBe(expectedLookupRow.key);
+    });
+
+    describe('and touchMode = true', () => {
+      beforeEach(() => {
+        field.touchMode = true;
+      });
+
+      it('should select the lookupRow when a unique result is returned and the touch popup is closed with OK', async () => {
+        field.$field.focus();
+        await field.openPopup(true);
+        let popup = field.popup as SmartFieldTouchPopup<any>;
+        popup._field.$field.val('Foo');
+
+        let closePromise = popup.when('close');
+        popup.doneAction.doAction();
+        await closePromise;
+        expect(field.lookupRow.key).toBe(expectedLookupRow.key);
+      });
+
+      it('should select the lookupRow when a unique result is returned and the touch popup is closed with ENTER', async () => {
+        field.$field.focus();
+        await field.openPopup(true);
+        let popup = field.popup as SmartFieldTouchPopup<any>;
+        popup._field.$field.val('Foo');
+
+        let closePromise = popup.when('close');
+        JQueryTesting.triggerKeyDownCapture(popup._field.$field, keys.ENTER);
+        await closePromise;
+        expect(field.lookupRow.key).toBe(expectedLookupRow.key);
+      });
+    });
   });
 
   it('should return value for last search-text', () => {
@@ -658,7 +711,124 @@ describe('ProposalField', () => {
         true);
     });
 
-    async function testProposalFieldInputs(inputs: (ProposalFieldSpecHelperInput | string)[], touchMode?: boolean) {
+    describe('when LookupRowSelectionStrategy ENTER is used', () => {
+      // ok > throw > warning
+      it('write \'ok\' > write \'throw\' > write \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          ['ok', 'throw', 'warning'],
+          false, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'ok\' > write \'throw\' > write \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          ['ok', 'throw', 'warning'],
+          true, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'ok\' > write \'throw\' > lookup \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          ['ok', 'throw', {text: 'warning', lookup: true}],
+          false, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'ok\' > write \'throw\' > lookup \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          ['ok', 'throw', {text: 'warning', lookup: true}],
+          true, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'ok\' > lookup \'throw\' > write \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          ['ok', {text: 'throw', lookup: true}, 'warning'],
+          false, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'ok\' > lookup \'throw\' > write \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          ['ok', {text: 'throw', lookup: true}, 'warning'],
+          true, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'ok\' > lookup \'throw\' > lookup \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          ['ok', {text: 'throw', lookup: true}, {text: 'warning', lookup: true}],
+          false, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('write \'ok\' > lookup \'throw\' > lookup \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          ['ok', {text: 'throw', lookup: true}, {text: 'warning', lookup: true}],
+          true, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'ok\' > write \'throw\' > write \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'ok', lookup: true}, 'throw', 'warning'],
+          false, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'ok\' > write \'throw\' > write \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'ok', lookup: true}, 'throw', 'warning'],
+          true, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'ok\' > write \'throw\' > lookup \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'ok', lookup: true}, 'throw', {text: 'warning', lookup: true}],
+          false, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'ok\' > write \'throw\' > lookup \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'ok', lookup: true}, 'throw', {text: 'warning', lookup: true}],
+          true, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'ok\' > lookup \'throw\' > write \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, 'warning'],
+          false, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'ok\' > lookup \'throw\' > write \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, 'warning'],
+          true, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'ok\' > lookup \'throw\' > lookup \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, {text: 'warning', lookup: true}],
+          false, LookupRowSelectionStrategy.ENTER);
+      });
+
+      it('lookup \'ok\' > lookup \'throw\' > lookup \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          [{text: 'ok', lookup: true}, {text: 'throw', lookup: true}, {text: 'warning', lookup: true}],
+          true, LookupRowSelectionStrategy.ENTER);
+      });
+    });
+
+    describe('when LookupRowSelectionStrategy EXACT_TEXT is used', () => {
+      beforeEach(() => {
+        field.lookupOnAcceptByText = true;
+      });
+
+      it('write \'ok\' > write \'throw\' > write \'warning\' (touchMode: false)', async () => {
+        await testProposalFieldInputs(
+          ['ok', 'throw', 'warning'],
+          false, LookupRowSelectionStrategy.EXACT_TEXT);
+      });
+
+      it('write \'ok\' > write \'throw\' > write \'warning\' (touchMode: true)', async () => {
+        await testProposalFieldInputs(
+          ['ok', 'throw', 'warning'],
+          true, LookupRowSelectionStrategy.EXACT_TEXT);
+      });
+    });
+
+    async function testProposalFieldInputs(inputs: (ProposalFieldSpecHelperInput | string)[], touchMode?: boolean, selectionStrategy?: LookupRowSelectionStrategy) {
       await proposalFieldSpecHelper.testProposalFieldInputs(field, inputs, touchMode, {
         afterInput: (input: ProposalFieldSpecHelperInput) => {
           const {text, lookup} = input;
@@ -691,7 +861,7 @@ describe('ProposalField', () => {
           }
 
           // lookupRow is set and contains the correct values iff a lookupRow was selected
-          if (lookup) {
+          if (lookup || selectionStrategy === LookupRowSelectionStrategy.EXACT_TEXT) {
             expect(field.lookupRow).not.toBeNull();
             expect(field.lookupRow.text).toBe(text);
             expect(field.lookupRow.key).toBe(text);
@@ -699,7 +869,7 @@ describe('ProposalField', () => {
             expect(field.lookupRow).toBeNull();
           }
         }
-      });
+      }, selectionStrategy);
     }
 
     // select a value, then open and close the touch popup multiple times


### PR DESCRIPTION
When a ProposalField is in touchMode, a popup is opened to handle the input selection. This popup clones the original field and needs also to copy the lookupOnAcceptByText flag, to handle the input identically as original field.

When the OK button of the popup is clicked, the popup waits until the lookup is completed. This is now also the case when the Enter key is pressed.

440147