### PR TITLE
Deprecate FileSystemMalwareScannerImplementor

### DIFF
--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/FileSystemMalwareScannerImplementor.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/FileSystemMalwareScannerImplementor.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.config.PlatformConfigProperties.MalwareScannerDelayProperty;
 import org.eclipse.scout.rt.platform.config.PlatformConfigProperties.MalwareScannerPathProperty;
@@ -35,7 +36,12 @@ import org.slf4j.LoggerFactory;
  * This default scanner assumes that an appropriate malware scanner is in place and scans a special folder using a
  * realtime filesystem scan strategy. Malware should therefore immediately be removed or blocked by the malware
  * implementation.
+ *
+ * @deprecated This scanner is unsafe and has lots of preconditions. Furthermore, it has issues with large files and is hard to configure correctly (timeout) to ensure no malware is missed. Consider switching to a custom implementation
+ * directly using a malware scanner API.
  */
+@Deprecated(since = "26.1")
+@Order(5050) // after IBean.DEFAULT_BEAN_ORDER so that a custom implementation without order wins over this deprecated class.
 public class FileSystemMalwareScannerImplementor implements IMalwareScannerImplementor {
 
   private static final Logger LOG = LoggerFactory.getLogger(FileSystemMalwareScannerImplementor.class);
@@ -118,7 +124,7 @@ public class FileSystemMalwareScannerImplementor implements IMalwareScannerImple
 
   protected long compareFiles(Path path1, Path path2) throws IOException {
     try (BufferedInputStream fis1 = new BufferedInputStream(new FileInputStream(path1.toFile()));
-        BufferedInputStream fis2 = new BufferedInputStream(new FileInputStream(path2.toFile()))) {
+         BufferedInputStream fis2 = new BufferedInputStream(new FileInputStream(path2.toFile()))) {
 
       int ch = 0;
       long pos = 1;


### PR DESCRIPTION
This scanner is unsafe and has lots of preconditions. Furthermore, it has issues with large files and is hard to configure correctly (timeout) to ensure no malware is missed.

436096