### PR TITLE
Remove user id from server session

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/context/ClientRunContextChainTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/context/ClientRunContextChainTest.java
@@ -31,6 +31,7 @@ import org.eclipse.scout.rt.platform.transaction.TransactionProcessor;
 import org.eclipse.scout.rt.platform.util.ThreadLocalProcessor;
 import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.opentelemetry.OpenTelemetrySpanAttributeProcessor;
+import org.eclipse.scout.rt.shared.session.SessionId;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
 import org.eclipse.scout.rt.shared.user.UserId;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
@@ -113,46 +114,51 @@ public class ClientRunContextChainTest {
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(ISession.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 13. ThreadLocalProcessor for Users.CURRENT
+    // 13. ThreadLocalProcessor for SessionId.CURRENT
+    c = chainIterator.next();
+    assertEquals(ThreadLocalProcessor.class, c.getClass());
+    assertSame(SessionId.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
+
+    // 14. ThreadLocalProcessor for Users.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(UserId.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 14. DiagnosticContextValueProcessor
+    // 15. DiagnosticContextValueProcessor
     c = chainIterator.next();
     assertEquals(DiagnosticContextValueProcessor.class, c.getClass());
     assertEquals("scout.user.name", ((DiagnosticContextValueProcessor) c).getMdcKey());
 
-    // 15. DiagnosticContextValueProcessor
+    // 16. DiagnosticContextValueProcessor
     c = chainIterator.next();
     assertEquals(DiagnosticContextValueProcessor.class, c.getClass());
     assertEquals("scout.session.id", ((DiagnosticContextValueProcessor) c).getMdcKey());
 
-    // 16. OpenTelemetrySpanAttributeProcessor
+    // 17. OpenTelemetrySpanAttributeProcessor
     c = chainIterator.next();
     assertEquals(OpenTelemetrySpanAttributeProcessor.class, c.getClass());
 
-    // 17. ThreadLocalProcessor for UserAgent.CURRENT
+    // 18. ThreadLocalProcessor for UserAgent.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(UserAgent.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 18. ThreadLocalProcessor for IDesktop.CURRENT
+    // 19. ThreadLocalProcessor for IDesktop.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(IDesktop.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 19. ThreadLocalProcessor for IOutline.CURRENT
+    // 20. ThreadLocalProcessor for IOutline.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(IOutline.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 20. ThreadLocalProcessor for IForm.CURRENT
+    // 21. ThreadLocalProcessor for IForm.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(IForm.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 21. TransactionProcessor
+    // 22. TransactionProcessor
     c = chainIterator.next();
     assertEquals(TransactionProcessor.class, c.getClass());
     assertFalse(chainIterator.hasNext());

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/context/ClientRunContextChainTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/context/ClientRunContextChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ import org.eclipse.scout.rt.platform.util.ThreadLocalProcessor;
 import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.opentelemetry.OpenTelemetrySpanAttributeProcessor;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -112,41 +113,46 @@ public class ClientRunContextChainTest {
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(ISession.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 13. DiagnosticContextValueProcessor
+    // 13. ThreadLocalProcessor for Users.CURRENT
     c = chainIterator.next();
-    assertEquals(DiagnosticContextValueProcessor.class, c.getClass());
-    assertEquals("scout.user.name", ((DiagnosticContextValueProcessor) c).getMdcKey());
+    assertEquals(ThreadLocalProcessor.class, c.getClass());
+    assertSame(UserId.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
     // 14. DiagnosticContextValueProcessor
     c = chainIterator.next();
     assertEquals(DiagnosticContextValueProcessor.class, c.getClass());
+    assertEquals("scout.user.name", ((DiagnosticContextValueProcessor) c).getMdcKey());
+
+    // 15. DiagnosticContextValueProcessor
+    c = chainIterator.next();
+    assertEquals(DiagnosticContextValueProcessor.class, c.getClass());
     assertEquals("scout.session.id", ((DiagnosticContextValueProcessor) c).getMdcKey());
 
-    // 15. OpenTelemetrySpanAttributeProcessor
+    // 16. OpenTelemetrySpanAttributeProcessor
     c = chainIterator.next();
     assertEquals(OpenTelemetrySpanAttributeProcessor.class, c.getClass());
 
-    // 16. ThreadLocalProcessor for UserAgent.CURRENT
+    // 17. ThreadLocalProcessor for UserAgent.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(UserAgent.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 17. ThreadLocalProcessor for IDesktop.CURRENT
+    // 18. ThreadLocalProcessor for IDesktop.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(IDesktop.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 18. ThreadLocalProcessor for IOutline.CURRENT
+    // 19. ThreadLocalProcessor for IOutline.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(IOutline.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 19. ThreadLocalProcessor for IForm.CURRENT
+    // 20. ThreadLocalProcessor for IForm.CURRENT
     c = chainIterator.next();
     assertEquals(ThreadLocalProcessor.class, c.getClass());
     assertSame(IForm.CURRENT, ((ThreadLocalProcessor) c).getThreadLocal());
 
-    // 20. TransactionProcessor
+    // 21. TransactionProcessor
     c = chainIterator.next();
     assertEquals(TransactionProcessor.class, c.getClass());
     assertFalse(chainIterator.hasNext());

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/IClientSession.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/IClientSession.java
@@ -20,6 +20,7 @@ import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
 import org.eclipse.scout.rt.platform.job.IExecutionSemaphore;
 import org.eclipse.scout.rt.platform.nls.NlsLocale;
 import org.eclipse.scout.rt.platform.reflect.IPropertyObserver;
+import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
 
@@ -95,6 +96,11 @@ public interface IClientSession extends ISession, IPropertyObserver {
   Subject getSubject();
 
   void setSubject(Subject subject);
+
+  /**
+   * Authenticated userId, extracted by {@link IAccessControlService#getUserIdOfCurrentSubject()} on server
+   */
+  String getUserId();
 
   /**
    * @return the desktop model associated with this client session

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/context/ClientRunContext.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/context/ClientRunContext.java
@@ -37,6 +37,7 @@ import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.logging.UserIdContextValueProvider;
 import org.eclipse.scout.rt.shared.opentelemetry.OpenTelemetrySpanAttributeProcessor;
 import org.eclipse.scout.rt.shared.session.ScoutSessionIdContextValueProvider;
+import org.eclipse.scout.rt.shared.session.SessionId;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
 import org.eclipse.scout.rt.shared.user.UserId;
 
@@ -63,6 +64,7 @@ public class ClientRunContext extends RunContext {
   protected <RESULT> void interceptCallableChain(final CallableChain<RESULT> callableChain) {
     callableChain
         .add(new ThreadLocalProcessor<>(ISession.CURRENT, m_session))
+        .add(new ThreadLocalProcessor<>(SessionId.CURRENT, getSession() != null ? getSession().getId() : null))
         .add(new ThreadLocalProcessor<>(UserId.CURRENT, getSession() != null ? getSession().getUserId() : null))
         .add(new DiagnosticContextValueProcessor(BEANS.get(UserIdContextValueProvider.class)))
         .add(new DiagnosticContextValueProcessor(BEANS.get(ScoutSessionIdContextValueProvider.class)))

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/context/ClientRunContext.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/context/ClientRunContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,6 +38,7 @@ import org.eclipse.scout.rt.shared.logging.UserIdContextValueProvider;
 import org.eclipse.scout.rt.shared.opentelemetry.OpenTelemetrySpanAttributeProcessor;
 import org.eclipse.scout.rt.shared.session.ScoutSessionIdContextValueProvider;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 /**
  * Use this class to propagate client-side context.
@@ -62,6 +63,7 @@ public class ClientRunContext extends RunContext {
   protected <RESULT> void interceptCallableChain(final CallableChain<RESULT> callableChain) {
     callableChain
         .add(new ThreadLocalProcessor<>(ISession.CURRENT, m_session))
+        .add(new ThreadLocalProcessor<>(UserId.CURRENT, getSession() != null ? getSession().getUserId() : null))
         .add(new DiagnosticContextValueProcessor(BEANS.get(UserIdContextValueProvider.class)))
         .add(new DiagnosticContextValueProcessor(BEANS.get(ScoutSessionIdContextValueProvider.class)))
         .add(new OpenTelemetrySpanAttributeProcessor())

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/rest/ScoutBackendRestClientHelper.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/rest/ScoutBackendRestClientHelper.java
@@ -46,6 +46,7 @@ public class ScoutBackendRestClientHelper extends AbstractRestClientHelper {
     filters.add(new RestRequestCancellationClientRequestFilter(BEANS.get(CancellationResourceClient.class)::cancel));
     // no classic IdSignatureClientRequestFilter; process resource will determine on its own if header should be added
     filters.add(BEANS.get(ServiceTunnelIdSignatureClientRequestFilter.class));
+    filters.add(BEANS.get(SessionIdClientRequestFilter.class));
     return filters;
   }
 
@@ -60,7 +61,6 @@ public class ScoutBackendRestClientHelper extends AbstractRestClientHelper {
   protected RuntimeException transformException(RuntimeException e, Response response) {
     return BEANS.get(ErrorDoRestClientExceptionTransformer.class).transform(e, response);
   }
-
 
   @Bean
   public interface IScoutBackendRestClientBuilderContributor {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/rest/SessionIdClientRequestFilter.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/rest/SessionIdClientRequestFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.rest;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+
+import org.eclipse.scout.rt.client.IClientSession;
+import org.eclipse.scout.rt.client.session.ClientSessionProvider;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.shared.session.SessionId;
+
+@ApplicationScoped
+public class SessionIdClientRequestFilter implements ClientRequestFilter {
+
+  @Override
+  public void filter(ClientRequestContext requestContext) throws IOException {
+    addSessionIdHeader(requestContext);
+  }
+
+  protected void addSessionIdHeader(ClientRequestContext requestContext) {
+    IClientSession session = ClientSessionProvider.currentSession();
+    if (session != null) {
+      requestContext.getHeaders().add(SessionId.HTTP_HEADER_NAME, session.getId());
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/servicetunnel/HttpServiceTunnel.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/servicetunnel/HttpServiceTunnel.java
@@ -40,7 +40,6 @@ import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.concurrent.FutureCancelledError;
 import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruptedError;
-import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
 import org.eclipse.scout.rt.shared.opentelemetry.HttpServiceTunnelInstrumenterFactory;
 import org.eclipse.scout.rt.shared.servicetunnel.BinaryServiceTunnelContentHandler;
@@ -159,11 +158,6 @@ public class HttpServiceTunnel {
       userAgent = UserAgents.createDefault();
     }
     request.setUserAgent(userAgent.createIdentifier());
-
-    ISession session = ISession.CURRENT.get();
-    if (session != null) {
-      request.setSessionId(session.getId());
-    }
     request.setClientNodeId(NodeId.current());
   }
 

--- a/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/context/HttpRunContextProducerTest.java
+++ b/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/context/HttpRunContextProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,10 +25,13 @@ import org.eclipse.scout.rt.platform.context.CorrelationId;
 import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.platform.security.SimplePrincipalProducer;
 import org.eclipse.scout.rt.platform.transaction.TransactionScope;
+import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.server.commons.authentication.ServletFilterHelper;
 import org.eclipse.scout.rt.server.commons.servlet.IHttpServletRoundtrip;
+import org.eclipse.scout.rt.testing.platform.mock.BeanMock;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,6 +42,14 @@ public class HttpRunContextProducerTest {
   static final String TEST_CID = "abc";
   static final Locale TEST_LOCALE = Locale.CANADA_FRENCH;
   static final Subject TEST_SUBJECT = BEANS.get(ServletFilterHelper.class).createSubject(BEANS.get(SimplePrincipalProducer.class).produce(TEST_SUBJECT_NAME));
+
+  @BeanMock
+  protected IAccessControlService m_mockAccessControlService;
+
+  @Before
+  public void before() {
+    when(m_mockAccessControlService.getUserIdOfCurrentSubject()).thenReturn(TEST_SUBJECT_NAME);
+  }
 
   @Test
   public void testCreateRunContextWithCid() {

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/context/HttpRunContextProducer.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/context/HttpRunContextProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,8 +21,10 @@ import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.transaction.TransactionScope;
 import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.server.commons.servlet.IHttpServletRoundtrip;
 import org.eclipse.scout.rt.server.commons.servlet.logging.ServletDiagnosticsProviderFactory;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 /**
  * Creates a {@link RunContext} based on a {@link HttpServletRequest} and the current JAAS context.
@@ -62,6 +64,7 @@ public class HttpRunContextProducer {
 
     return contextToFill
         .withSubject(Subject.current())
+        .withThreadLocal(UserId.CURRENT, BEANS.get(IAccessControlService.class).getUserId(Subject.current()))
         .withCorrelationId(currentCorrelationId(req))
         .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST, req)
         .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_RESPONSE, resp)

--- a/org.eclipse.scout.rt.server.jdbc.test/src/test/java/org/eclipse/scout/rt/server/jdbc/internal/exec/StatementProcessorTest.java
+++ b/org.eclipse.scout.rt.server.jdbc.test/src/test/java/org/eclipse/scout/rt/server/jdbc/internal/exec/StatementProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -72,10 +72,10 @@ public class StatementProcessorTest {
   public void testDuplicateBindNames() {
     final String bind1Name = "bind1";
     final String bind2Name = "bind2";
-    final String bindSessionName = "userId";
+    final String bindUserId = "userId";
     final String stmtWithInBinds = "select :" + bind1Name + ", :" + bind2Name + " from dual";
     final String stmtWithOutBinds = "select 1, 2 from dual into :" + bind1Name + ", :" + bind2Name;
-    final String stmtWithSessionProperty = "select :" + bindSessionName + ", :" + bind1Name + " from dual";
+    final String stmtWithUserId = "select :" + bindUserId + ", :" + bind1Name + " from dual";
 
     // test in binds
     assertArrayEquals(new String[]{}, exec(true, stmtWithInBinds, new NVPair(bind1Name, null), new NVPair(bind2Name, null)));
@@ -85,8 +85,8 @@ public class StatementProcessorTest {
     assertArrayEquals(new String[]{}, exec(true, stmtWithOutBinds, new NVPair(bind1Name, new IntegerHolder()), new NVPair(bind2Name, new IntegerHolder())));
     assertArrayEquals(new String[]{bind1Name}, exec(true, stmtWithOutBinds, new NVPair(bind1Name, new IntegerHolder()), new NVPair(bind2Name, new IntegerHolder()), new NVPair(bind1Name, new IntegerHolder())));
 
-    // test duplicate with property from session
-    assertArrayEquals(new String[]{bindSessionName}, exec(true, stmtWithSessionProperty, new NVPair(bindSessionName, null), new NVPair(bind1Name, null)));
+    // test duplicate with userId
+    assertArrayEquals(new String[]{bindUserId}, exec(true, stmtWithUserId, new NVPair(bindUserId, null), new NVPair(bind1Name, null)));
 
     // test with duplicate check disabled
     assertArrayEquals(new String[]{}, exec(false, stmtWithInBinds, new NVPair(bind1Name, null), new NVPair(bind2Name, null), new NVPair(bind1Name, null)));

--- a/org.eclipse.scout.rt.server.jdbc/src/main/java/org/eclipse/scout/rt/server/jdbc/internal/exec/StatementProcessor.java
+++ b/org.eclipse.scout.rt.server.jdbc/src/main/java/org/eclipse/scout/rt/server/jdbc/internal/exec/StatementProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,7 +42,6 @@ import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.platform.transaction.ITransactionMember;
 import org.eclipse.scout.rt.platform.util.BeanUtility;
 import org.eclipse.scout.rt.platform.util.TriState;
-import org.eclipse.scout.rt.server.IServerSession;
 import org.eclipse.scout.rt.server.jdbc.AbstractSqlService;
 import org.eclipse.scout.rt.server.jdbc.AbstractSqlTransactionMember;
 import org.eclipse.scout.rt.server.jdbc.ISelectStreamHandler;
@@ -63,12 +62,14 @@ import org.eclipse.scout.rt.server.jdbc.parsers.token.IToken;
 import org.eclipse.scout.rt.server.jdbc.parsers.token.ValueInputToken;
 import org.eclipse.scout.rt.server.jdbc.parsers.token.ValueOutputToken;
 import org.eclipse.scout.rt.server.jdbc.style.ISqlStyle;
-import org.eclipse.scout.rt.server.session.ServerSessionProvider;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("squid:S1166")
 public class StatementProcessor implements IStatementProcessor {
+  public static final String USER_ID_BIND_NAME = "userId";
+
   private static final Logger LOG = LoggerFactory.getLogger(StatementProcessor.class);
   private static final Pattern REGEX_DOT = Pattern.compile("[.]");
 
@@ -114,16 +115,17 @@ public class StatementProcessor implements IStatementProcessor {
       m_originalStm = stm;
       m_maxRowCount = maxRowCount;
       m_maxFetchMemorySize = maxFetchMemorySize;
-      // add session to binds if available
-      final IServerSession session = ServerSessionProvider.currentSession();
-      if (session != null) {
+      // add userId to binds if available
+      final String userId = UserId.CURRENT.get();
+      if (userId != null) {
+        NVPair userIdBindBase = new NVPair(USER_ID_BIND_NAME, userId);
         if (bindBases == null) {
-          m_bindBases = new Object[]{session};
+          m_bindBases = new Object[]{userIdBindBase};
         }
         else {
           m_bindBases = new Object[bindBases.length + 1];
           System.arraycopy(bindBases, 0, m_bindBases, 0, bindBases.length);
-          m_bindBases[m_bindBases.length - 1] = session;
+          m_bindBases[m_bindBases.length - 1] = userIdBindBase;
         }
       }
       else {
@@ -1131,7 +1133,7 @@ public class StatementProcessor implements IStatementProcessor {
         }
       }
       if (input == null) {
-        // strict search without dereferncing holder objects
+        // strict search without dereferencing holder objects
         input = createInputRec(bindToken, newPath, o, nullType);
       }
       return input;

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/runner/ServerTestRunner.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/runner/ServerTestRunner.java
@@ -11,6 +11,7 @@ package org.eclipse.scout.rt.testing.server.runner;
 
 import java.lang.reflect.Method;
 
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.platform.reflect.ReflectionUtility;
 import org.eclipse.scout.rt.server.context.ServerRunContexts;
@@ -18,7 +19,7 @@ import org.eclipse.scout.rt.server.session.ServerSessionProvider;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
 import org.eclipse.scout.rt.testing.server.runner.statement.ClientNotificationsStatement;
-import org.eclipse.scout.rt.testing.server.runner.statement.ServerRunContextStatement;
+import org.eclipse.scout.rt.testing.server.runner.statement.ServerRunContextStatementFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class ServerTestRunner extends PlatformTestRunner {
 
   @Override
   protected Statement interceptClassLevelStatement(final Statement next, final Class<?> testClass) {
-    final Statement s3 = new ServerRunContextStatement(next, ReflectionUtility.getAnnotation(RunWithServerSession.class, testClass));
+    final Statement s3 = BEANS.get(ServerRunContextStatementFactory.class).createServerRunContextStatement(next, ReflectionUtility.getAnnotation(RunWithServerSession.class, testClass));
     final Statement s2 = new ClientNotificationsStatement(s3, ReflectionUtility.getAnnotation(RunWithClientNotifications.class, testClass));
     final Statement s1 = super.interceptClassLevelStatement(s2, testClass);
 
@@ -84,7 +85,7 @@ public class ServerTestRunner extends PlatformTestRunner {
 
   @Override
   protected Statement interceptMethodLevelStatement(final Statement next, final Class<?> testClass, final Method testMethod) {
-    final Statement s3 = new ServerRunContextStatement(next, ReflectionUtility.getAnnotation(RunWithServerSession.class, testMethod, testClass));
+    final Statement s3 = BEANS.get(ServerRunContextStatementFactory.class).createServerRunContextStatement(next, ReflectionUtility.getAnnotation(RunWithServerSession.class, testMethod, testClass));
     final Statement s2 = new ClientNotificationsStatement(s3, ReflectionUtility.getAnnotation(RunWithClientNotifications.class, testClass));
     final Statement s1 = super.interceptMethodLevelStatement(s2, testClass, testMethod);
 

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/runner/statement/ServerRunContextStatement.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/runner/statement/ServerRunContextStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/runner/statement/ServerRunContextStatement.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/runner/statement/ServerRunContextStatement.java
@@ -15,11 +15,13 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.server.IServerSession;
 import org.eclipse.scout.rt.server.context.ServerRunContexts;
 import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
 import org.eclipse.scout.rt.shared.ui.UserAgents;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
 import org.eclipse.scout.rt.testing.platform.runner.SafeStatementInvoker;
 import org.eclipse.scout.rt.testing.server.runner.RunWithServerSession;
@@ -41,6 +43,14 @@ public class ServerRunContextStatement extends Statement {
     m_serverSessionAnnotation = serverSessionAnnotation;
   }
 
+  protected Statement getNext() {
+    return m_next;
+  }
+
+  protected RunWithServerSession getServerSessionAnnotation() {
+    return m_serverSessionAnnotation;
+  }
+
   @Override
   public void evaluate() throws Throwable {
     if (m_serverSessionAnnotation == null) {
@@ -51,7 +61,7 @@ public class ServerRunContextStatement extends Statement {
     }
   }
 
-  private void evaluateWithServerRunContext() throws Throwable {
+  protected void evaluateWithServerRunContext() throws Throwable {
     final Subject currentSubject = Subject.current();
     if (currentSubject == null) {
       Assertions.fail("Subject must not be null. Use the annotation '{}' to execute your test under a particular user. ", RunWithSubject.class.getSimpleName());
@@ -77,6 +87,7 @@ public class ServerRunContextStatement extends Statement {
       ServerRunContexts.copyCurrent()
           .withSession(serverSession)
           .withSubject(currentSubject) // set the test subject explicitly in case it is different to the session subject
+          .withThreadLocal(UserId.CURRENT, BEANS.get(IAccessControlService.class).getUserId(currentSubject))
           .withUserAgent(userAgent)
           .run(invoker);
       invoker.throwOnError();

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/runner/statement/ServerRunContextStatementFactory.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/testing/server/runner/statement/ServerRunContextStatementFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.testing.server.runner.statement;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.testing.server.runner.RunWithServerSession;
+import org.junit.runners.model.Statement;
+
+@ApplicationScoped
+public class ServerRunContextStatementFactory {
+
+  public ServerRunContextStatement createServerRunContextStatement(Statement next, RunWithServerSession serverSessionAnnotation) {
+    return new ServerRunContextStatement(next, serverSessionAnnotation);
+  }
+}

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/AbstractServerSessionTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/AbstractServerSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -62,6 +62,5 @@ public class AbstractServerSessionTest {
 
   private void assertSessionsEquals(IServerSession expected, IServerSession actual) {
     assertEquals(expected.getId(), actual.getId());
-    assertEquals(expected.getUserId(), actual.getUserId());
   }
 }

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/HttpServerRunContextProducerTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/HttpServerRunContextProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import org.eclipse.scout.rt.server.IServerSession;
+import org.eclipse.scout.rt.shared.session.SessionId;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +33,7 @@ public class HttpServerRunContextProducerTest {
     HttpServerRunContextProducer producer = new HttpServerRunContextProducer();
     assertTrue(producer.hasSessionSupport());
 
-    HttpServletRequest req = createRequestMock(null);
+    HttpServletRequest req = createRequestMock(null, null);
     HttpServletResponse resp = mock(HttpServletResponse.class);
 
     ServerRunContext serverRunContextForSessionStart = (ServerRunContext) producer.getInnerRunContextProducer().produce(req, resp);
@@ -52,7 +53,8 @@ public class HttpServerRunContextProducerTest {
     HttpServerRunContextProducer producer = new HttpServerRunContextProducer();
     assertTrue(producer.hasSessionSupport());
 
-    HttpServletRequest req = createRequestMock(null);
+    String clientSessionId = "testClientSessionId";
+    HttpServletRequest req = createRequestMock(null, clientSessionId);
     HttpServletResponse resp = mock(HttpServletResponse.class);
 
     ServerRunContext context = producer.produce(req, resp);
@@ -60,6 +62,7 @@ public class HttpServerRunContextProducerTest {
     try {
       assertNotNull(session);
       assertNotNull(session.getId());
+      assertEquals(clientSessionId, context.call(SessionId.CURRENT::get));
     }
     finally {
       session.stop();
@@ -71,29 +74,32 @@ public class HttpServerRunContextProducerTest {
     HttpServerRunContextProducer producer = new HttpServerRunContextProducer();
     assertTrue(producer.hasSessionSupport());
 
-    String existingScoutSessionId = "testId";
-    HttpServletRequest req = createRequestMock(existingScoutSessionId);
+    String existingServerSessionId = "testServerSessionId";
+    String clientSessionId = "testClientSessionId";
+    HttpServletRequest req = createRequestMock(existingServerSessionId, clientSessionId);
     HttpServletResponse resp = mock(HttpServletResponse.class);
 
     ServerRunContext context = producer.produce(req, resp);
     IServerSession session = context.getSession();
     try {
       assertNotNull(session);
-      assertEquals(existingScoutSessionId, session.getId());
+      assertEquals(existingServerSessionId, session.getId());
+      assertEquals(clientSessionId, context.call(SessionId.CURRENT::get));
     }
     finally {
       session.stop();
     }
   }
 
-  protected HttpServletRequest createRequestMock(String scoutSessionId) {
+  protected HttpServletRequest createRequestMock(String serverSessionId, String clientSessionId) {
     HttpSession httpSession = mock(HttpSession.class);
-    when(httpSession.getAttribute(eq(HttpServerRunContextProducer.SCOUT_SESSION_ID_KEY))).thenReturn(scoutSessionId);
+    when(httpSession.getAttribute(eq(HttpServerRunContextProducer.SCOUT_SESSION_ID_KEY))).thenReturn(serverSessionId);
 
     HttpServletRequest req = mock(HttpServletRequest.class);
     when(req.getHeader(eq("User-Agent"))).thenReturn(TEST_USER_AGENT_STRING);
     when(req.getSession()).thenReturn(httpSession);
     when(req.getSession(anyBoolean())).thenReturn(httpSession);
+    when(req.getHeader(SessionId.HTTP_HEADER_NAME)).thenReturn(clientSessionId);
     return req;
   }
 }

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/ServerRunContextProducerTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/ServerRunContextProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.security.SimplePrincipal;
 import org.eclipse.scout.rt.platform.util.concurrent.IRunnable;
 import org.eclipse.scout.rt.server.IServerSession;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,8 +33,7 @@ public class ServerRunContextProducerTest {
     assertNull((((ServerRunContext) RunContext.CURRENT.get()).getSession())); // ensure no previous session
     ServerRunContextProducer producer = BEANS.get(ServerRunContextProducer.class);
     ServerRunContext context = producer.produce(getSubjectForPrincipalName(username));
-    IServerSession session = context.getSession();
-    assertEquals(username, session.getUserId());
+    assertEquals(username, context.call(UserId.CURRENT::get));
   }
 
   @Test
@@ -47,7 +47,7 @@ public class ServerRunContextProducerTest {
       ServerRunContext context = producer.produce(getSubjectForPrincipalName(secondUsername));
       IServerSession session = context.getSession();
       assertNotEquals(previousSession, session);
-      assertEquals(secondUsername, session.getUserId());
+      assertEquals(secondUsername, context.call(UserId.CURRENT::get));
     });
   }
 
@@ -62,7 +62,7 @@ public class ServerRunContextProducerTest {
       ServerRunContext context = producer.produce(getSubjectForPrincipalName(secondUsername));
       IServerSession session = context.getSession();
       assertEquals(previousSession, session);
-      assertEquals(secondUsername, session.getUserId());
+      assertEquals(secondUsername, context.call(UserId.CURRENT::get));
     });
   }
 
@@ -70,8 +70,7 @@ public class ServerRunContextProducerTest {
     assertNull((((ServerRunContext) RunContext.CURRENT.get()).getSession())); // ensure no previous session
     ServerRunContextProducer producer = BEANS.get(ServerRunContextProducer.class);
     ServerRunContext context = producer.produce(getSubjectForPrincipalName(principalName));
-    IServerSession session = context.getSession();
-    assertEquals(principalName, session.getUserId());
+    assertEquals(principalName, context.call(UserId.CURRENT::get));
     Jobs.schedule(runnable, Jobs.newInput().withRunContext(context)).awaitDoneAndGet();
   }
 

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/ServerRunContextUserIdTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/ServerRunContextUserIdTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.context;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.assertEquals;
+
+import org.eclipse.scout.rt.server.IServerSession;
+import org.eclipse.scout.rt.shared.user.UserId;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.eclipse.scout.rt.testing.server.runner.RunWithServerSession;
+import org.eclipse.scout.rt.testing.server.runner.ServerTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ServerTestRunner.class)
+@RunWithSubject("john")
+@RunWithServerSession(IServerSession.class)
+public class ServerRunContextUserIdTest {
+
+  @Test
+  public void testBasic() {
+    assertUserId("john");
+  }
+
+  @Test
+  public void testNested() {
+    ServerRunContexts.copyCurrent()
+        .run(() -> assertUserId("john"));
+  }
+
+  @Test
+  public void testChangingUser() {
+    String otherUserId = "anna";
+    ServerRunContexts.copyCurrent()
+        .withThreadLocal(UserId.CURRENT, otherUserId)
+        .run(() -> assertUserId(otherUserId));
+  }
+
+  @Test
+  public void testChangingUserNested() {
+    String otherUserId = "anna";
+    ServerRunContexts.copyCurrent()
+        .withThreadLocal(UserId.CURRENT, otherUserId)
+        .run(() -> ServerRunContexts.copyCurrent()
+            .run(() -> assertUserId(otherUserId)));
+  }
+
+  protected void assertUserId(String expectedUserId) {
+    assertEquals(expectedUserId, UserId.CURRENT.get());
+  }
+}

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/security/AccessControlServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/security/AccessControlServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,7 +34,6 @@ import org.eclipse.scout.rt.server.services.common.security.fixture.TestPermissi
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
 import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationService;
 import org.eclipse.scout.rt.shared.security.RemoteServiceAccessPermission;
-import org.eclipse.scout.rt.shared.session.Sessions;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
 import org.eclipse.scout.rt.testing.server.runner.RunWithServerSession;
@@ -123,7 +122,7 @@ public class AccessControlServiceTest {
 
     @Override
     protected String getCurrentUserCacheKey() {
-      return Sessions.getCurrentUserId();
+      return getUserIdOfCurrentSubject();
     }
 
     @Override

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/PiggyBackClientNotificationTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/PiggyBackClientNotificationTest.java
@@ -11,11 +11,17 @@ package org.eclipse.scout.rt.server.servicetunnel;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.server.clientnotification.ClientNotificationRegistry;
+import org.eclipse.scout.rt.server.commons.servlet.IHttpServletRoundtrip;
 import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationService;
 import org.eclipse.scout.rt.shared.services.common.ping.IPingService;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
@@ -25,6 +31,7 @@ import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -50,15 +57,25 @@ public class PiggyBackClientNotificationTest {
 
   @Test
   public void testPiggyBack() {
-    ServiceTunnelService s = new ServiceTunnelService();
-    Class[] parameterTypes = new Class[]{String.class};
-    Object[] args = new Object[]{"test"};
-    ServiceTunnelRequest req = new ServiceTunnelRequest(IPingService.class.getName(), "ping", parameterTypes, args);
-    req.setClientNodeId(NodeId.of("testNodeId"));
-    ServiceTunnelResponse res = s.evaluate(req);
-    assertEquals("pong", res.getData());
-    assertNull(res.getException());
-    assertEquals(1, res.getNotifications().size());
-    assertEquals("testNotification", res.getNotifications().get(0).getNotification());
+    HttpSession session = Mockito.mock(HttpSession.class);
+    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(req.getSession()).thenReturn(session);
+    Mockito.when(req.getSession(false)).thenReturn(session);
+
+    RunContexts.copyCurrent()
+        .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST, req)
+        .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_RESPONSE, mock(HttpServletResponse.class))
+        .run(() -> {
+          ServiceTunnelService s = new ServiceTunnelService();
+          Class[] parameterTypes = new Class[]{String.class};
+          Object[] args = new Object[]{"test"};
+          ServiceTunnelRequest serviceTunnelRequest = new ServiceTunnelRequest(IPingService.class.getName(), "ping", parameterTypes, args);
+          serviceTunnelRequest.setClientNodeId(NodeId.of("testNodeId"));
+          ServiceTunnelResponse res = s.evaluate(serviceTunnelRequest);
+          assertEquals("pong", res.getData());
+          assertNull(res.getException());
+          assertEquals(1, res.getNotifications().size());
+          assertEquals("testNotification", res.getNotifications().get(0).getNotification());
+        });
   }
 }

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelIdSignatureTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelIdSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,7 @@ import org.eclipse.scout.rt.shared.servicetunnel.BinaryServiceTunnelContentHandl
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelOptions;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelResponse;
+import org.eclipse.scout.rt.shared.session.SessionId;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
 import org.eclipse.scout.rt.testing.server.TestHttpSession;
@@ -101,7 +102,6 @@ public class ServiceTunnelIdSignatureTest {
     // create service tunnel request
     var serviceTunnelRequest = new ServiceTunnelRequest(IEchoService.class.getName(), "echo", new Class[]{Object.class}, new Object[]{o});
     serviceTunnelRequest.setUserAgent("UNKNOWN|UNKNOWN|UNKNOWN|UNKNOWN|UNKNOWN");
-    serviceTunnelRequest.setSessionId("4242");
 
     var serviceTunnelContentHandler = BEANS.get(BinaryServiceTunnelContentHandler.class);
 
@@ -120,6 +120,7 @@ public class ServiceTunnelIdSignatureTest {
     Mockito.when(request.getSession()).thenReturn(httpSession);
     Mockito.when(request.getSession(false)).thenReturn(httpSession);
     Mockito.when(request.getHeader(IdSignatureClientRequestFilter.ID_SIGNATURE_HTTP_HEADER)).thenReturn("" + idSignature);
+    Mockito.when(request.getHeader(SessionId.HTTP_HEADER_NAME)).thenReturn("4242");
 
     // create servlet output stream and response to collect service tunnel response
     var servletOutputStream = new BufferedServletOutputStream();

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -54,6 +54,7 @@ import org.eclipse.scout.rt.server.session.ServerSessionProvider;
 import org.eclipse.scout.rt.shared.services.common.ping.IPingService;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelResponse;
+import org.eclipse.scout.rt.shared.session.SessionId;
 import org.eclipse.scout.rt.shared.ui.UserAgents;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
@@ -96,6 +97,7 @@ public class ServiceTunnelServiceTest {
     m_testHttpSession = mock(HttpSession.class);
     when(m_requestMock.getSession()).thenReturn(m_testHttpSession);
     when(m_requestMock.getSession(true)).thenReturn(m_testHttpSession);
+    when(m_requestMock.getHeader(SessionId.HTTP_HEADER_NAME)).thenReturn("testId");
   }
 
   @After
@@ -167,7 +169,7 @@ public class ServiceTunnelServiceTest {
 
   @Test
   public void testPostSuccessful() {
-    verifyTestResponse(new ServiceTunnelService().evaluate(prepareTestRequest()));
+    verifyTestResponse(createServletRunContext(m_requestMock, m_responseMock).call(() -> new ServiceTunnelService().evaluate(prepareTestRequest())));
   }
 
   @Test
@@ -187,6 +189,16 @@ public class ServiceTunnelServiceTest {
       IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST.remove();
       IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_RESPONSE.remove();
     }
+  }
+
+  @Test
+  public void testCreateServiceTunnelContext() {
+    createServletRunContext(m_requestMock, m_responseMock).run(() -> {
+      ServiceTunnelService s = BEANS.get(ServiceTunnelService.class);
+      ServiceTunnelRequest serviceRequest = prepareTestRequest();
+      ServerRunContext context = s.createServiceTunnelRunContext(serviceRequest);
+      assertEquals("testId", context.call(SessionId.CURRENT::get));
+    });
   }
 
   private ServiceTunnelRequest prepareTestRequest() {

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/session/ServerSessionProviderWithCacheTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/session/ServerSessionProviderWithCacheTest.java
@@ -107,7 +107,6 @@ public class ServerSessionProviderWithCacheTest {
     assertTrue(session.isActive());
     assertFalse(session.isStopping());
     assertFalse(session.isStopped());
-    assertEquals("anna", session.getUserId());
 
     // invoke provide again results in the same instance
     assertSame(session, provideSession(null, "anna"));
@@ -139,7 +138,6 @@ public class ServerSessionProviderWithCacheTest {
     assertTrue(session.isActive());
     assertFalse(session.isStopping());
     assertFalse(session.isStopped());
-    assertEquals("anna", session.getUserId());
 
     long sleepMillis = System.currentTimeMillis() - sessionCreatedMillis // time elapsed since session was created
         + FixtureServerSessionProviderWithCache.s_fixedCacheTimeToLiveMillis
@@ -157,7 +155,6 @@ public class ServerSessionProviderWithCacheTest {
     assertTrue(otherSession.isActive());
     assertFalse(otherSession.isStopping());
     assertFalse(otherSession.isStopped());
-    assertEquals("anna", otherSession.getUserId());
 
     // old session is stopped
     assertTrue(session.isStarted());

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/testing/server/runner/ServerTestRunnerDifferentSessionTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/testing/server/runner/ServerTestRunnerDifferentSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import org.eclipse.scout.rt.server.AbstractServerSession;
 import org.eclipse.scout.rt.server.IServerSession;
 import org.eclipse.scout.rt.server.session.ServerSessionProvider;
 import org.eclipse.scout.rt.shared.ISession;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
 import org.eclipse.scout.rt.testing.server.runner.ServerTestRunnerDifferentSessionTest.JUnitServerSession1;
 import org.junit.AfterClass;
@@ -40,7 +41,7 @@ public class ServerTestRunnerDifferentSessionTest {
     m_serverSessions = new HashSet<>();
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession1);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     m_transactions = new HashSet<>();
@@ -53,7 +54,7 @@ public class ServerTestRunnerDifferentSessionTest {
   public void test1() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession1);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();
@@ -65,7 +66,7 @@ public class ServerTestRunnerDifferentSessionTest {
   public void test2() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession1);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();
@@ -78,7 +79,7 @@ public class ServerTestRunnerDifferentSessionTest {
   public void test3() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession2);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();
@@ -90,7 +91,7 @@ public class ServerTestRunnerDifferentSessionTest {
   public static void afterClass() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession1);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/testing/server/runner/ServerTestRunnerDifferentSubjectTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/testing/server/runner/ServerTestRunnerDifferentSubjectTest.java
@@ -19,6 +19,7 @@ import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.server.AbstractServerSession;
 import org.eclipse.scout.rt.server.IServerSession;
 import org.eclipse.scout.rt.shared.ISession;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
 import org.eclipse.scout.rt.testing.server.runner.ServerTestRunnerDifferentSubjectTest.JUnitServerSession;
 import org.junit.AfterClass;
@@ -39,7 +40,7 @@ public class ServerTestRunnerDifferentSubjectTest {
     m_serverSessions = new HashSet<>();
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     m_transactions = new HashSet<>();
@@ -52,7 +53,7 @@ public class ServerTestRunnerDifferentSubjectTest {
   public void test1() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();
@@ -65,7 +66,7 @@ public class ServerTestRunnerDifferentSubjectTest {
   public void test2() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession);
-    assertEquals("john", serverSession.getUserId());
+    assertEquals("john", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();
@@ -77,7 +78,7 @@ public class ServerTestRunnerDifferentSubjectTest {
   public static void afterClass() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/testing/server/runner/ServerTestRunnerSameSessionTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/testing/server/runner/ServerTestRunnerSameSessionTest.java
@@ -19,6 +19,7 @@ import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.server.AbstractServerSession;
 import org.eclipse.scout.rt.server.IServerSession;
 import org.eclipse.scout.rt.shared.ISession;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
 import org.eclipse.scout.rt.testing.server.runner.ServerTestRunnerSameSessionTest.JUnitServerSession;
 import org.junit.AfterClass;
@@ -39,7 +40,7 @@ public class ServerTestRunnerSameSessionTest {
     m_serverSessions = new HashSet<>();
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     m_transactions = new HashSet<>();
@@ -52,7 +53,7 @@ public class ServerTestRunnerSameSessionTest {
   public void test1() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();
@@ -64,7 +65,7 @@ public class ServerTestRunnerSameSessionTest {
   public void test2() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();
@@ -76,7 +77,7 @@ public class ServerTestRunnerSameSessionTest {
   public static void afterClass() {
     ISession serverSession = IServerSession.CURRENT.get();
     assertTrue(serverSession instanceof JUnitServerSession);
-    assertEquals("anna", serverSession.getUserId());
+    assertEquals("anna", UserId.CURRENT.get());
     m_serverSessions.add(serverSession);
 
     ITransaction transaction = ITransaction.CURRENT.get();

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/AbstractServerSession.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/AbstractServerSession.java
@@ -23,7 +23,6 @@ import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.util.event.FastListenerList;
 import org.eclipse.scout.rt.platform.util.event.IFastListenerList;
 import org.eclipse.scout.rt.rest.cancellation.RestRequestCancellationRegistry;
-import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.server.context.ServerRunContext;
 import org.eclipse.scout.rt.server.extension.IServerSessionExtension;
 import org.eclipse.scout.rt.server.extension.ServerSessionChains.ServerSessionLoadSessionChain;
@@ -39,6 +38,7 @@ import org.eclipse.scout.rt.shared.session.ISessionListener;
 import org.eclipse.scout.rt.shared.session.SessionData;
 import org.eclipse.scout.rt.shared.session.SessionEvent;
 import org.eclipse.scout.rt.shared.session.SessionMetricsHelper;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +59,6 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
   private volatile boolean m_active;
   private volatile boolean m_stopping;
   private final SessionData m_sessionData;
-  private String m_userId;
   private final ObjectExtensions<AbstractServerSession, IServerSessionExtension<? extends AbstractServerSession>> m_objectExtensions;
 
   public AbstractServerSession(boolean autoInitConfig) {
@@ -73,10 +72,6 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
     }
   }
 
-  private void assignUserId() {
-    m_userId = BEANS.get(IAccessControlService.class).getUserIdOfCurrentSubject();
-  }
-
   /**
    * The session is running in its event loop
    */
@@ -88,11 +83,6 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
   @Override
   public boolean isStopping() {
     return m_stopping;
-  }
-
-  @Override
-  public final String getUserId() {
-    return m_userId;
   }
 
   @Override
@@ -142,13 +132,12 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
     assertFalse(isStopping(), "Session cannot be started because it is currently stopping.");
     m_id = assertNotNull(sessionId, "Session id must not be null");
 
-    assignUserId();
     interceptLoadSession();
 
     m_active = true;
 
     fireSessionChangedEvent(new SessionEvent(this, SessionEvent.TYPE_STARTED));
-    LOG.info("Server session started [session={}, user={}]", this, getUserId());
+    LOG.info("Server session started [session={}, user={}]", this, UserId.CURRENT.get());
   }
 
   /**
@@ -233,7 +222,7 @@ public abstract class AbstractServerSession implements IServerSession, Serializa
       m_stopping = false;
       fireSessionChangedEvent(new SessionEvent(this, SessionEvent.TYPE_STOPPED));
       m_sessionMetrics.sessionDestroyed(SESSION_TYPE);
-      LOG.info("Server session stopped [session={}, user={}]", this, getUserId());
+      LOG.info("Server session stopped [session={}, user={}]", this, UserId.CURRENT.get());
     }
   }
 

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/ServerConfigProperties.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/ServerConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,8 +11,11 @@ package org.eclipse.scout.rt.server;
 
 import java.util.concurrent.TimeUnit;
 
+import javax.security.auth.Subject;
+
 import org.eclipse.scout.rt.platform.config.AbstractPositiveLongConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractStringConfigProperty;
+import org.eclipse.scout.rt.platform.config.AbstractSubjectConfigProperty;
 import org.eclipse.scout.rt.server.services.common.file.RemoteFileService;
 
 public final class ServerConfigProperties {
@@ -20,13 +23,13 @@ public final class ServerConfigProperties {
   private ServerConfigProperties() {
   }
 
-  public static class ClusterSyncUserProperty extends AbstractStringConfigProperty {
+  public static class ClusterSyncUserProperty extends AbstractSubjectConfigProperty {
 
     public static final String CLUSTER_SYNC_USER_NAME = "system";
 
     @Override
-    public String getDefaultValue() {
-      return CLUSTER_SYNC_USER_NAME;
+    public Subject getDefaultValue() {
+      return convertToSubject(CLUSTER_SYNC_USER_NAME);
     }
 
     @Override

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/HttpServerRunContextProducer.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/HttpServerRunContextProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,7 @@ import org.eclipse.scout.rt.server.commons.servlet.HttpClientInfo;
 import org.eclipse.scout.rt.server.session.IServerSessionLifecycleHandler;
 import org.eclipse.scout.rt.server.session.ServerSessionCache;
 import org.eclipse.scout.rt.server.session.ServerSessionLifecycleHandler;
+import org.eclipse.scout.rt.shared.session.SessionId;
 import org.eclipse.scout.rt.shared.session.Sessions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,8 +85,11 @@ public class HttpServerRunContextProducer {
       contextToFill = ServerRunContexts.copyCurrent(true);
     }
 
+    String clientSessionId = req.getHeader(SessionId.HTTP_HEADER_NAME);
+
     final ServerRunContext serverRunContext = (ServerRunContext) getInnerRunContextProducer().produce(req, resp, contextToFill);
     serverRunContext.withUserAgent(HttpClientInfo.get(req).toUserAgents().build());
+    serverRunContext.withThreadLocal(SessionId.CURRENT, clientSessionId);
     if (!hasSessionSupport()) {
       // don't touch the session
       return serverRunContext;

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/ServerRunContextProducer.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/ServerRunContextProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.server.IServerSession;
 import org.eclipse.scout.rt.server.ServerConfigProperties.ServerSessionCacheExpirationProperty;
 import org.eclipse.scout.rt.server.session.ServerSessionProviderWithCache;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 /**
  * Producer for {@link ServerRunContext} objects having a userId based {@link IServerSession} cache that is <i>NOT</i>
@@ -43,6 +44,7 @@ public class ServerRunContextProducer extends RunContextProducer {
   public ServerRunContext produce(final Subject subject) {
     final ServerRunContext serverRunContext = ServerRunContexts.copyCurrent(true)
         .withSubject(subject)
+        .withThreadLocal(UserId.CURRENT, BEANS.get(IAccessControlService.class).getUserId(subject))
         .withTransactionScope(TransactionScope.REQUIRES_NEW);
 
     // ensure that the session belongs to the specified subject

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/bookmark/FileSystemBookmarkStorageService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/bookmark/FileSystemBookmarkStorageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,12 +21,12 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.serialization.SerializationUtility;
 import org.eclipse.scout.rt.security.ACCESS;
-import org.eclipse.scout.rt.server.session.ServerSessionProvider;
 import org.eclipse.scout.rt.shared.security.PublishUserBookmarkPermission;
 import org.eclipse.scout.rt.shared.security.UpdateUserBookmarkPermission;
 import org.eclipse.scout.rt.shared.services.common.bookmark.BookmarkFolder;
 import org.eclipse.scout.rt.shared.services.common.file.IRemoteFileService;
 import org.eclipse.scout.rt.shared.services.common.file.RemoteFile;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +65,7 @@ public class FileSystemBookmarkStorageService extends AbstractBookmarkStorageSer
 
   @Override
   protected Object getCurrentUserId() {
-    return ServerSessionProvider.currentSession().getUserId();
+    return UserId.CURRENT.get();
   }
 
   @Override

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/clustersync/ClusterSynchronizationService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/clustersync/ClusterSynchronizationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,11 +31,12 @@ import org.eclipse.scout.rt.platform.IPlatformListener;
 import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.PlatformEvent;
 import org.eclipse.scout.rt.platform.config.CONFIG;
-import org.eclipse.scout.rt.platform.security.SimplePrincipal;
 import org.eclipse.scout.rt.platform.transaction.AbstractTransactionMember;
 import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.server.ServerConfigProperties.ClusterSyncUserProperty;
 import org.eclipse.scout.rt.server.context.ServerRunContext;
 import org.eclipse.scout.rt.server.context.ServerRunContexts;
@@ -43,8 +44,8 @@ import org.eclipse.scout.rt.server.mom.IClusterMomDestinations;
 import org.eclipse.scout.rt.server.services.common.clustersync.internal.ClusterNotificationMessage;
 import org.eclipse.scout.rt.server.services.common.clustersync.internal.ClusterNotificationProperties;
 import org.eclipse.scout.rt.server.session.ServerSessionProviderWithCache;
-import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.notification.NotificationHandlerRegistry;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +58,7 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
   private final ConcurrentMap<Class<? extends Serializable>, ClusterNodeStatusInfo> m_messageStatusMap = new ConcurrentHashMap<>();
 
   private final Subject m_subject;
+  private final String m_userId;
 
   private volatile ISubscription m_subscription;
   private final Object m_subscriptionLock = new Object();
@@ -64,9 +66,16 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
   private final NodeId m_nodeId = NodeId.current();
 
   public ClusterSynchronizationService() {
-    m_subject = new Subject();
-    m_subject.getPrincipals().add(new SimplePrincipal(CONFIG.getPropertyValue(ClusterSyncUserProperty.class)));
-    m_subject.setReadOnly();
+    m_subject = CONFIG.getPropertyValue(ClusterSyncUserProperty.class);
+    m_userId = BEANS.get(IAccessControlService.class).getUserId(m_subject);
+  }
+
+  public String getUserId() {
+    return m_userId;
+  }
+
+  public Subject getSubject() {
+    return m_subject;
   }
 
   @Override
@@ -182,9 +191,8 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
 
   @Override
   public IClusterNotificationProperties getNotificationProperties() {
-    ISession curentSession = ISession.CURRENT.get();
-    String userid = curentSession != null ? curentSession.getUserId() : "";
-    return new ClusterNotificationProperties(m_nodeId, userid);
+    String userId = StringUtility.emptyIfNull(UserId.CURRENT.get());
+    return new ClusterNotificationProperties(m_nodeId, userId);
   }
 
   @Override
@@ -204,14 +212,19 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
       getStatusInfoInternal().updateReceiveStatus(notificationMessage);
       getStatusInfoInternal(notificationMessage.getNotification().getClass()).updateReceiveStatus(notificationMessage);
 
-      ServerRunContext serverRunContext = ServerRunContexts.empty();
-      serverRunContext.withSubject(m_subject);
-      serverRunContext.withSession(BEANS.get(ServerSessionProviderWithCache.class).provide(serverRunContext.copy()));
-      serverRunContext.run(() -> {
+      createRunContext().run(() -> {
         NotificationHandlerRegistry reg = BEANS.get(NotificationHandlerRegistry.class);
         reg.notifyNotificationHandlers(notificationMessage.getNotification());
       });
     }
+  }
+
+  protected ServerRunContext createRunContext() {
+    ServerRunContext serverRunContext = ServerRunContexts.empty()
+        .withSubject(m_subject)
+        .withThreadLocal(UserId.CURRENT, m_userId);
+    serverRunContext.withSession(BEANS.get(ServerSessionProviderWithCache.class).provide(serverRunContext.copy()));
+    return serverRunContext;
   }
 
   /**

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceOperationInvoker.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceOperationInvoker.java
@@ -25,15 +25,15 @@ import org.eclipse.scout.rt.platform.exception.VetoException;
 import org.eclipse.scout.rt.platform.serialization.SerializationUtility;
 import org.eclipse.scout.rt.platform.service.IService;
 import org.eclipse.scout.rt.platform.text.TEXTS;
+import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.security.ACCESS;
-import org.eclipse.scout.rt.server.IServerSession;
 import org.eclipse.scout.rt.server.services.ServiceUtility;
-import org.eclipse.scout.rt.server.session.ServerSessionProvider;
 import org.eclipse.scout.rt.shared.security.RemoteServiceAccessPermission;
 import org.eclipse.scout.rt.shared.servicetunnel.RemoteServiceAccessDenied;
 import org.eclipse.scout.rt.shared.servicetunnel.RemoteServiceWithoutAuthorization;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelResponse;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,9 +77,8 @@ public class ServiceOperationInvoker {
   }
 
   protected ServiceTunnelResponse invokeInternal(ServiceTunnelRequest serviceReq) throws ClassNotFoundException {
-    IServerSession serverSession = ServerSessionProvider.currentSession();
     if (LOG.isDebugEnabled()) {
-      String userId = serverSession != null ? serverSession.getUserId() : "";
+      String userId = StringUtility.emptyIfNull(UserId.CURRENT.get());
       LOG.debug("started {}.{} by {} at {}", serviceReq.getServiceInterfaceClassName(), serviceReq.getOperation(), userId, new Date());
     }
     ServiceTunnelResponse serviceRes = null;

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,7 @@ import org.eclipse.scout.rt.shared.servicetunnel.BinaryServiceTunnelContentHandl
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelOptions;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelResponse;
+import org.eclipse.scout.rt.shared.session.SessionId;
 import org.eclipse.scout.rt.shared.ui.UserAgents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,15 +131,18 @@ public class ServiceTunnelService {
   }
 
   protected ServerRunContext createServiceTunnelRunContext(ServiceTunnelRequest serviceRequest) {
+    final HttpServletRequest req = IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST.get();
+    String clientSessionId = req.getHeader(SessionId.HTTP_HEADER_NAME);
+
     // overwrite default settings from HTTP request with values from ServiceTunnelRequest
     final ServerRunContext serverRunContext = ServerRunContexts.copyCurrent()
         .withLocale(serviceRequest.getLocale())
         .withUserAgent(UserAgents.createByIdentifier(serviceRequest.getUserAgent()))
-        .withClientNodeId(serviceRequest.getClientNodeId());
+        .withClientNodeId(serviceRequest.getClientNodeId())
+        .withThreadLocal(SessionId.CURRENT, clientSessionId);
 
-    if (serviceRequest.getSessionId() != null) {
-      final HttpServletRequest req = IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST.get();
-      final IServerSession session = m_serverRunContextProducer.get().getOrCreateScoutSession(req, serverRunContext, serviceRequest.getSessionId());
+    if (clientSessionId != null) {
+      final IServerSession session = m_serverRunContextProducer.get().getOrCreateScoutSession(req, serverRunContext, clientSessionId);
       serverRunContext.withSession(session);
     }
     return serverRunContext;

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/UserIdSharedVariableContributor.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/session/UserIdSharedVariableContributor.java
@@ -13,12 +13,12 @@ import static org.eclipse.scout.rt.shared.ISessionVariable.SHARED_CONTEXT_USER_I
 
 import java.util.Map;
 
-import org.eclipse.scout.rt.server.AbstractServerSession;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 public class UserIdSharedVariableContributor implements IInitialSharedVariableContributor {
 
   @Override
   public void contribute(Map<String, Object> variables) {
-    variables.put(SHARED_CONTEXT_USER_ID, AbstractServerSession.CURRENT.get().getUserId());
+    variables.put(SHARED_CONTEXT_USER_ID, UserId.CURRENT.get());
   }
 }

--- a/org.eclipse.scout.rt.shared.test/src/main/java/org/eclipse/scout/rt/testing/shared/AllAccessControlService.java
+++ b/org.eclipse.scout.rt.shared.test/src/main/java/org/eclipse/scout/rt/testing/shared/AllAccessControlService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,7 @@ import org.eclipse.scout.rt.security.AbstractAccessControlService;
 import org.eclipse.scout.rt.security.AllPermissionCollection;
 import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.security.IPermissionCollection;
-import org.eclipse.scout.rt.shared.session.Sessions;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 /**
  * {@link IAccessControlService} service for testing using {@link AllPermission}
@@ -27,7 +27,7 @@ public class AllAccessControlService extends AbstractAccessControlService<String
 
   @Override
   protected String getCurrentUserCacheKey() {
-    return Sessions.getCurrentUserId();
+    return UserId.CURRENT.get();
   }
 
   @Override

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/ISession.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/ISession.java
@@ -13,7 +13,6 @@ import java.util.concurrent.Callable;
 
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.event.IFastListenerList;
-import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.shared.session.ISessionListener;
 
 /**
@@ -31,11 +30,6 @@ public interface ISession {
    * @return the session id corresponding client and server sessions do have the same id.
    */
   String getId();
-
-  /**
-   * Authenticated userId, extracted by {@link IAccessControlService#getUserIdOfCurrentSubject()}
-   */
-  String getUserId();
 
   /**
    * Returns true if the session has been loaded and is running.

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/logging/UserIdContextValueProvider.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/logging/UserIdContextValueProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,11 +12,11 @@ package org.eclipse.scout.rt.shared.logging;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.logger.DiagnosticContextValueProcessor;
 import org.eclipse.scout.rt.platform.logger.DiagnosticContextValueProcessor.IDiagnosticContextValueProvider;
-import org.eclipse.scout.rt.shared.ISession;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.slf4j.MDC;
 
 /**
- * This class provides the {@link ISession#getUserId()} to be set into the <code>diagnostic context map</code> for
+ * This class provides the {@link UserId#CURRENT} to be set into the <code>diagnostic context map</code> for
  * logging purpose.
  *
  * @see #KEY
@@ -35,7 +35,6 @@ public class UserIdContextValueProvider implements IDiagnosticContextValueProvid
 
   @Override
   public String value() {
-    final ISession currentSession = ISession.CURRENT.get();
-    return currentSession != null ? currentSession.getUserId() : null;
+    return UserId.CURRENT.get();
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/opentelemetry/OpenTelemetrySpanAttributeProcessor.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/opentelemetry/OpenTelemetrySpanAttributeProcessor.java
@@ -15,7 +15,7 @@ import org.eclipse.scout.rt.platform.chain.callable.ICallableDecorator;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.opentelemetry.OpenTelemetryProperties.OpenTelemetrySpanAttributeProcessorEnabledProperty;
 import org.eclipse.scout.rt.platform.opentelemetry.OpenTelemetryProperties.OpenTelemetryTracingEnabledProperty;
-import org.eclipse.scout.rt.shared.ISession;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 import io.opentelemetry.api.trace.Span;
 
@@ -52,7 +52,6 @@ public class OpenTelemetrySpanAttributeProcessor implements ICallableDecorator {
   }
 
   protected String getUserIdValue() {
-    final ISession currentSession = ISession.CURRENT.get();
-    return currentSession != null ? currentSession.getUserId() : null;
+    return UserId.CURRENT.get();
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelRequest.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,6 @@ public class ServiceTunnelRequest implements Serializable {
    * @since 3.8
    */
   private final long m_requestSequence = REQUEST_SEQUENCE_GENERATOR.incrementAndGet();
-  private String m_sessionId;
   private final String m_serviceInterfaceClassName;
   private final String m_operation;
   private final Class[] m_parameterTypes;
@@ -52,21 +51,6 @@ public class ServiceTunnelRequest implements Serializable {
    */
   public long getRequestSequence() {
     return m_requestSequence;
-  }
-
-  /**
-   * @return Session id or <code>null</code>, if not defined
-   */
-  public String getSessionId() {
-    return m_sessionId;
-  }
-
-  /**
-   * @param sessionId
-   *     (<code>null</code>, if not defined)
-   */
-  public void setSessionId(String sessionId) {
-    m_sessionId = sessionId;
   }
 
   /**
@@ -127,7 +111,6 @@ public class ServiceTunnelRequest implements Serializable {
     StringBuilder buf = new StringBuilder();
     buf.append("Remote call [");
     buf.append("requestSequence='").append(m_requestSequence).append("', ");
-    buf.append("sessionId='").append(m_sessionId).append("'\n");
     buf.append(m_serviceInterfaceClassName).append(".").append(m_operation);
     if (m_args != null && m_args.length > 0) {
       for (int i = 0; i < m_args.length; i++) {

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/session/SessionId.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/session/SessionId.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.session;
+
+public final class SessionId {
+
+  private SessionId() {
+  }
+
+  /**
+   * The {@code session id} of the client session which is currently associated with the current thread.
+   */
+  public static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+  /**
+   * Name of the HTTP header to transport the {@code session id}.
+   */
+  public static final String HTTP_HEADER_NAME = "X-Scout-Client-Session-Id";
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/session/Sessions.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/session/Sessions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,12 +11,7 @@ package org.eclipse.scout.rt.shared.session;
 
 import java.math.BigInteger;
 
-import javax.security.auth.Subject;
-
-import org.eclipse.scout.rt.platform.BEANS;
-import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.platform.security.SecurityUtility;
-import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.shared.ISession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,21 +53,5 @@ public final class Sessions {
 
     // use Base32 encoding because it is shorter than hex and does not include special characters and is case-insensitive (compared to Base64).
     return randomId.toString(32);
-  }
-
-  /**
-   * First, tries to get user id from session associated with current thread. If no active session can be found,
-   * {@link IAccessControlService#getUserIdOfCurrentSubject()} is called.
-   *
-   * @return current user id or <code>null</code> if user id can not be extracted from current {@link RunContext} and
-   * {@link Subject}
-   */
-  public static String getCurrentUserId() {
-    ISession session = ISession.CURRENT.get();
-    if (session != null && session.isActive()) {
-      // only an active session has a valid userId
-      return session.getUserId();
-    }
-    return BEANS.get(IAccessControlService.class).getUserIdOfCurrentSubject();
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/user/UserId.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/user/UserId.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.shared.user;
+
+import javax.security.auth.Subject;
+
+import org.eclipse.scout.rt.security.IAccessControlService;
+
+public final class UserId {
+
+  private UserId() {
+  }
+
+  /**
+   * The {@code userId} which is currently associated with the current thread. The {@code userId} is extracted from current
+   * {@link Subject} using {@link IAccessControlService#getUserIdOfCurrentSubject()} and usually corresponds to the username the of logged-in user.
+   */
+  public static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+}

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.core/src/main/java/core/AccessControlService.java
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.core/src/main/java/core/AccessControlService.java
@@ -1,17 +1,11 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package}.core;
-
 import org.eclipse.scout.rt.security.AbstractAccessControlService;
 import org.eclipse.scout.rt.security.IPermissionCollection;
-import org.eclipse.scout.rt.shared.session.Sessions;
 
 public class AccessControlService extends AbstractAccessControlService<String> {
 
   @Override
   protected String getCurrentUserCacheKey() {
-    return Sessions.getCurrentUserId();
+    return Users.CURRENT.get();
   }
 
   @Override

--- a/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.shared/src/main/java/shared/security/AccessControlService.java
+++ b/scout-helloworld-app/src/main/resources/archetype-resources/__rootArtifactId__.shared/src/main/java/shared/security/AccessControlService.java
@@ -1,13 +1,7 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package}.shared.security;
-
 import org.eclipse.scout.rt.security.AbstractAccessControlService;
 import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.security.IPermissionCollection;
 import org.eclipse.scout.rt.shared.ISession;
-import org.eclipse.scout.rt.shared.session.Sessions;
 
 /**
  * {@link IAccessControlService} service that uses {@link ISession#getUserId()} as internal cache key required by
@@ -22,7 +16,7 @@ public class AccessControlService extends AbstractAccessControlService<String> {
 
   @Override
   protected String getCurrentUserCacheKey() {
-    return Sessions.getCurrentUserId();
+    return Users.CURRENT.get();
   }
 
   @Override


### PR DESCRIPTION
As part of the move toward a stateless server session, the `userId` has been removed from the server session.

To get the user id for the current run context, the ThreadLocal `UserId.CURRENT` can be used instead.

423389