### PR TITLE
Avoid triggering double events with non value chart click

### DIFF
--- a/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
+++ b/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
@@ -2269,7 +2269,6 @@ export class ChartJsRenderer extends AbstractChartRenderer {
 
   protected _onClick(event: ChartEvent, items: ActiveElement[]) {
     if (!items.length) {
-      this.chart.handleNonValueClick(event.native);
       return;
     }
     let relevantItem = this._selectRelevantItem(items);


### PR DESCRIPTION
When the chart is clickable and a click inside the chart area but outside an element was made, two nonValue events were triggered. One from the click on the canvas, as no active element is hovered. And one from the onClick method if no item is selected, that is triggered from chartJs on the whole chart area. The latter is therefore unnecessary and can be removed again.