### PR TITLE
DesktopTab: Only close closable tabs using menu

### DIFF
--- a/eclipse-scout-core/src/desktop/desktoptab/DesktopTab.ts
+++ b/eclipse-scout-core/src/desktop/desktoptab/DesktopTab.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,14 +34,15 @@ export class DesktopTab extends SimpleTab<Form> {
   protected _onContextMenu(event: JQuery.ContextMenuEvent) {
     let menuCloseAllTabs = scout.create(Menu, {
       parent: this,
-      text: this.session.text('ui.CloseAllTabs')
+      text: this.session.text('ui.CloseAllTabs'),
+      visible: this._closeAllMenuVisible()
     });
     menuCloseAllTabs.on('action', this._onCloseAll.bind(this));
 
     let menuCloseOtherTabs = scout.create(Menu, {
       parent: this,
       text: this.session.text('ui.CloseOtherTabs'),
-      enabled: this.parent.tabs.length > 1
+      visible: this._closeOtherMenuVisible()
     });
     menuCloseOtherTabs.on('action', this._onCloseOther.bind(this));
 
@@ -57,14 +58,37 @@ export class DesktopTab extends SimpleTab<Form> {
     popup.open();
   }
 
+  /**
+   * Returns a list of all open forms with DISPLAY_HINT_VIEW that are closable.
+   *
+   * @param includeThis include the form of this desktop tab. Default is `true`.
+   */
+  protected _getCloseableViews(includeThis = true): Form[] {
+    let closeableForms = this.parent.tabs
+      .filter(desktopTab => desktopTab.closable)
+      .map(desktopTab => desktopTab.view);
+
+    if (!includeThis) {
+      arrays.remove(closeableForms, this.view);
+    }
+
+    return closeableForms;
+  }
+
+  protected _closeAllMenuVisible(): boolean {
+    // When the desktop has at least one tab which is closeable, the menu is visible.
+    return this._getCloseableViews().length > 0;
+  }
+
+  protected _closeOtherMenuVisible(): boolean {
+    return this._getCloseableViews(false).length > 0;
+  }
+
   protected _onCloseAll() {
-    let openViews = this.parent.tabs.map(desktopTab => desktopTab.view);
-    this.session.desktop.cancelViews(openViews);
+    this.session.desktop.cancelViews(this._getCloseableViews());
   }
 
   protected _onCloseOther() {
-    let openViews = this.parent.tabs.map(desktopTab => desktopTab.view);
-    arrays.remove(openViews, this.view);
-    this.session.desktop.cancelViews(openViews);
+    this.session.desktop.cancelViews(this._getCloseableViews(false));
   }
 }


### PR DESCRIPTION
The "CloseAll" and the "CloseOthers" menu on the DesktopTab is only visible when there is a closable view, attached to the desktop. It only closes the closable views.

420603