### PR TITLE
Improve performance for CodeResource

### DIFF
--- a/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/code/CodeResource.java
+++ b/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/code/CodeResource.java
@@ -10,6 +10,8 @@
 package org.eclipse.scout.rt.api.code;
 
 import static java.util.Collections.emptySet;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -18,7 +20,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import jakarta.ws.rs.Consumes;
@@ -106,8 +107,7 @@ public class CodeResource implements IRestResource {
         // order by language tag, within a language, locales without country come first ([de, en_US, de_DE, en, en_GB] -> [de, de_DE, en, en_GB, en_US])
         .sorted(Comparator.comparing(Locale::toLanguageTag))
         .forEachOrdered(otherLanguage -> {
-          // switch locale without creating a new RunContext in order to share the current transaction, especially an
-          // already leased DB connection
+          // switch locale without creating a new RunContext in order to share the current transaction, especially an already leased DB connection
           final Locale backup = NlsLocale.get();
           NlsLocale.set(otherLanguage);
           try {
@@ -129,32 +129,31 @@ public class CodeResource implements IRestResource {
     }
     target.withTexts(NlsUtility.mergeTexts(from.getTexts(), target.getTexts()));
     target.withTextsPlural(NlsUtility.mergeTexts(from.getTextsPlural(), target.getTextsPlural()));
-    Collection<CodeDo> targetChildren = getChildCodes(target);
-    from.getCodes().forEach(code -> mergeCodeTexts(code, targetChildren));
+    Map<String, CodeDo> targetChildren = groupCodesById(target.getCodes(), target.getId());
+    from.getCodes().forEach(code -> mergeCodeTexts(code, targetChildren, target.getId()));
   }
 
-  protected void mergeCodeTexts(CodeDo from, Collection<CodeDo> targetList) {
+  protected void mergeCodeTexts(CodeDo from, Map<String, CodeDo> targetMap, String codeTypeId) {
     if (from == null) {
       return;
     }
     Object codeId = from.getId();
-    CodeDo target = targetList.stream()
-        .filter(code -> Objects.equals(code.getId(), codeId))
-        .findAny().orElse(null);
+    CodeDo target = targetMap.get(codeId);
     if (target == null) {
       return;
     }
+
     target.withTexts(NlsUtility.mergeTexts(from.getTexts(), target.getTexts()));
-    Collection<CodeDo> targetChildren = getChildCodes(target);
-    from.getChildren().forEach(code -> mergeCodeTexts(code, targetChildren));
+    Map<String, CodeDo> targetChildren = groupCodesById(target.getChildren(), codeTypeId);
+    from.getChildren().forEach(code -> mergeCodeTexts(code, targetChildren, codeTypeId));
   }
 
-  protected Collection<CodeDo> getChildCodes(CodeTypeDo parent) {
-    return parent.getCodes();
-  }
-
-  protected Collection<CodeDo> getChildCodes(CodeDo parent) {
-    return parent.getChildren();
+  protected Map<String, CodeDo> groupCodesById(Collection<CodeDo> codes, String codeTypeId) {
+    return codes.stream().collect(toMap(CodeDo::getId, identity(), (existing, replacement) -> {
+      // CodeType.ts stores all codes (recursively) in a Map having the Code id as key. Therefore, duplicate Code ids are not allowed.
+      LOG.warn("Code with duplicate id '{}' found in CodeType '{}'. Only keeping the first.", existing.getId(), codeTypeId);
+      return existing; // ignoring merger
+    }));
   }
 
   protected Collection<Locale> getApplicationLanguages() {

--- a/org.eclipse.scout.rt.api/src/test/java/org/eclipse/scout/rt/api/code/CodeResourceTest.java
+++ b/org.eclipse.scout.rt.api/src/test/java/org/eclipse/scout/rt/api/code/CodeResourceTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import org.eclipse.scout.rt.api.data.code.CodeDo;
 import org.eclipse.scout.rt.api.data.code.CodeTypeDo;
@@ -79,5 +80,54 @@ public class CodeResourceTest {
     assertEquals(Map.of("en", "t1.1", "de", "t1.1-de", "en-US", "t1.1-us"), code1Texts);
     Map<String, String> code2Texts = merged.getCodes().get(1).getTexts();
     assertEquals(Map.of("en", "t1.2-updated"), code2Texts);
+  }
+
+  @Test
+  public void testDuplicateCodeId() {
+    CodeTypeDo en = BEANS.get(CodeTypeDo.class).withId("1").withText("en", "en1").withTextPlural("enp1", "en1");
+    en.getCodes().add(BEANS.get(CodeDo.class).withId("2").withText("en", "en2"));
+    en.getCodes().add(BEANS.get(CodeDo.class).withId("3").withText("en", "en3"));
+    en.getCodes().add(BEANS.get(CodeDo.class).withId("2").withText("en", "en2"));
+
+    CodeTypeDo de = BEANS.get(CodeTypeDo.class).withId("1").withText("de", "de1").withTextPlural("dep1", "de1");
+    de.getCodes().add(BEANS.get(CodeDo.class).withId("2").withText("de", "de2"));
+    de.getCodes().add(BEANS.get(CodeDo.class).withId("3").withText("de", "de3"));
+    de.getCodes().add(BEANS.get(CodeDo.class).withId("2").withText("de", "de2"));
+
+    BEANS.get(CodeResource.class).mergeCodeTypeTexts(de, Map.of("1", en));
+  }
+
+  @Test(timeout = 10_000)
+  public void testMergeCodeTypeTextsLarge() {
+    CodeTypeDo en = createLargeCodeType("en");
+    CodeTypeDo de = createLargeCodeType("de");
+    Map<String, CodeTypeDo> map = BEANS.get(CodeResource.class).convertToMap(Arrays.asList(en));
+    for (int i = 0; i < 8; i++) {
+      BEANS.get(CodeResource.class).mergeCodeTypeTexts(de, map);
+    }
+  }
+
+  protected CodeTypeDo createLargeCodeType(String lang) {
+    CodeTypeDo largeCodeType = BEANS.get(CodeTypeDo.class)
+        .withId("1")
+        .withText(lang, lang + "1")
+        .withText(lang + "a", lang + "1")
+        .withText(lang + "b", lang + "1")
+        .withText(lang + "c", lang + "1")
+        .withText(lang + "d", lang + "1")
+        .withText(lang + "e", lang + "1")
+        .withText(lang + "f", lang + "1")
+        .withTextPlural(lang, lang + "p1")
+        .withTextPlural(lang + "a", lang + "1")
+        .withTextPlural(lang + "b", lang + "1")
+        .withTextPlural(lang + "c", lang + "1")
+        .withTextPlural(lang + "d", lang + "1")
+        .withTextPlural(lang + "e", lang + "1")
+        .withTextPlural(lang + "f", lang + "1");
+    IntStream.rangeClosed(2, 100_000)
+        .mapToObj(Integer::toString)
+        .map(id -> BEANS.get(CodeDo.class).withId(id).withText(lang, lang + "t" + id))
+        .forEach(c -> largeCodeType.getCodes().add(c));
+    return largeCodeType;
   }
 }


### PR DESCRIPTION
Change mergeText from O(n^2) to O(n). Necessary for large (>10k) codes.

442715