### PR TITLE
Property for minimum password length

### DIFF
--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts.properties
@@ -68,7 +68,7 @@ CustomColumAbbreviation=C
 DateIsNotAllowed=Date is not allowed
 Day=Day
 DeepLinkError=The page you requested is not available. The resource may have been removed or the URL in the address bar is incorrect.
-DefaultPasswordPolicyText=The password does not comply with the specified guidelines.\n\nGuidelines\:\n- at least 12 characters\n- at least one number (0-9)\n- at least one lowercase letter (a-z)\n- at least one uppercase letter (A-Z)\n- at least one special character (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\”;'<>?,./)\n- not already used in the past\n- the user name must not be part of it
+DefaultPasswordPolicyText=The password does not comply with the specified guidelines.\n\nGuidelines\:\n- at least {0} characters\n- at least one number (0-9)\n- at least one lowercase letter (a-z)\n- at least one uppercase letter (A-Z)\n- at least one special character (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\”;'<>?,./)\n- not already used in the past\n- the user name must not be part of it
 DefaultSettings=Default settings
 DeleteBookmarkMenu=Delete favorite
 DeleteConfirmationText=Do you want to delete the following data?
@@ -248,7 +248,7 @@ Open=Open
 Password=Password
 PasswordHasExpiredHeader=Your password has expired and should be changed now.
 PasswordHasExpiredTitle=Password expired
-PasswordMinLength=The password must contain at least 12 characters.
+PasswordMinLength=The password must contain at least {0} characters.
 PasswordMinOnNonStdChar=The password must contain at least one special character (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\";'<>?,./).
 PasswordMinOneChar=The password must contain at least one character {0}.
 PasswordMinOneDigit=The password must contain at least one number from 0 to 9.

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_de.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_de.properties
@@ -68,7 +68,7 @@ CustomColumAbbreviation=C
 DateIsNotAllowed=Unzulässiges Datum
 Day=Tag
 DeepLinkError=Die Seite kann nicht angezeigt werden. Möglicherweise ist die gewünschte Ressource nicht mehr verfügbar oder die URL in der Adresszeile ist nicht korrekt.
-DefaultPasswordPolicyText=Das Passwort entspricht nicht den vorgegebenen Richtlinien.\n\nRichtlinien\:\n- mind. 12 Zeichen\n- mind. eine Zahl (0-9)\n- mind. ein Kleinbuchstabe (a-z)\n- mind. ein Großbuchstabe (A-Z)\n- mind. ein Sonderzeichen (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\";'<>?,./)\n- nicht schon in der Vergangenheit verwendet\n- der Benutzername darf kein Teil davon sein
+DefaultPasswordPolicyText=Das Passwort entspricht nicht den vorgegebenen Richtlinien.\n\nRichtlinien\:\n- mind. {0} Zeichen\n- mind. eine Zahl (0-9)\n- mind. ein Kleinbuchstabe (a-z)\n- mind. ein Großbuchstabe (A-Z)\n- mind. ein Sonderzeichen (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\";'<>?,./)\n- nicht schon in der Vergangenheit verwendet\n- der Benutzername darf kein Teil davon sein
 DefaultSettings=Werkseinstellungen
 DeleteBookmarkMenu=Favorit löschen
 DeleteConfirmationText=Wollen Sie folgende Daten löschen?
@@ -248,7 +248,7 @@ Open=Öffnen
 Password=Passwort
 PasswordHasExpiredHeader=Ihr Passwort ist abgelaufen, Sie sollten es jetzt ändern.
 PasswordHasExpiredTitle=Passwort abgelaufen
-PasswordMinLength=Das Passwort muss mindestens 12 Zeichen umfassen.
+PasswordMinLength=Das Passwort muss mindestens {0} Zeichen umfassen.
 PasswordMinOnNonStdChar=Das Passwort muss mindestens ein Sonderzeichen enthalten (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\";'<>?,./).
 PasswordMinOneChar=Das Passwort muss mindestens einen Buchstaben {0} enthalten.
 PasswordMinOneDigit=Das Passwort muss mindestens eine Zahl von 0 bis 9 enthalten.

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_fr.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_fr.properties
@@ -67,7 +67,7 @@ CustomColumAbbreviation=C
 DateIsNotAllowed=Date interdite
 Day=Jour
 DeepLinkError=La page demandée n'est pas disponible. Il se peut que la ressource ait été supprimée ou que l'URL de la ligne d'adresse soit incorrecte.
-DefaultPasswordPolicyText=Le mot de passe ne correspond pas aux directives données.\n\nDirectives à respecter \:\n- min. 12 caractères\n- au moins un chiffre (0-9)\n- au moins une lettre minuscule (a-z)\n- au moins une lettre majuscule (A-Z)\n- au moins un caractère spécial (\!@\#$%^&*()_+|~-\=\\N{}[]\:\\ »;'<> ?,./)\n- ne pas avoir déjà été utilisé dans le passé\n- le nom d'utilisateur ne doit pas en faire partie
+DefaultPasswordPolicyText=Le mot de passe ne correspond pas aux directives données.\n\nDirectives à respecter \:\n- min. {0} caractères\n- au moins un chiffre (0-9)\n- au moins une lettre minuscule (a-z)\n- au moins une lettre majuscule (A-Z)\n- au moins un caractère spécial (\!@\#$%^&*()_+|~-\=\\N{}[]\:\\ »;'<> ?,./)\n- ne pas avoir déjà été utilisé dans le passé\n- le nom d'utilisateur ne doit pas en faire partie
 DefaultSettings=Réglages d'usine
 DeleteBookmarkMenu=Supprimer le favori
 DeleteConfirmationText=Voulez-vous supprimer les données suivantes ?
@@ -240,7 +240,7 @@ Open=Ouvrir
 Password=Mot de passe
 PasswordHasExpiredHeader=Votre mot de passe a expiré, vous devriez le modifier dès maintenant.
 PasswordHasExpiredTitle=Mot de passe expiré
-PasswordMinLength=Le mot de passe doit comporter au moins 12 caractères.
+PasswordMinLength=Le mot de passe doit comporter au moins {0} caractères.
 PasswordMinOnNonStdChar=Le mot de passe doit contenir au moins un caractère spécial (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\";'<>?,./).
 PasswordMinOneChar=Le mot de passe doit contenir au moins une lettre {0}.
 PasswordMinOneDigit=Le mot de passe doit contenir au moins un chiffre de 0 à 9.

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_it.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_it.properties
@@ -67,7 +67,7 @@ CustomColumAbbreviation=C
 DateIsNotAllowed=Data non valida
 Day=Giorno
 DeepLinkError=Impossibile visualizzare la pagina. Probabilmente la risorsa non è più disponibile oppure l'URL nella riga dell'indirizzo non è corretto.
-DefaultPasswordPolicyText=La parola d'accesso non corrisponde alle regole prestabilite.\n\nRegole\:\n- almeno 12 caratteri\n- almeno un numero (0-9)\n- almeno una lettera minuscola (a-z)\n- almeno una lettera maiuscola (A-Z)\n- almeno un carattere speciale (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\”;'<>?,./)\n- non già utilizzato in passato\n- il nome dell'utente non deve essere parte di esso
+DefaultPasswordPolicyText=La parola d'accesso non corrisponde alle regole prestabilite.\n\nRegole\:\n- almeno {0} caratteri\n- almeno un numero (0-9)\n- almeno una lettera minuscola (a-z)\n- almeno una lettera maiuscola (A-Z)\n- almeno un carattere speciale (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\”;'<>?,./)\n- non già utilizzato in passato\n- il nome dell'utente non deve essere parte di esso
 DefaultSettings=Impostazioni di default
 DeleteBookmarkMenu=Cancellare preferito
 DeleteConfirmationText=Cancellare questi dati?
@@ -240,7 +240,7 @@ Open=Apri
 Password=Parola d'accesso
 PasswordHasExpiredHeader=La parola d'accesso è scaduta e deve essere cambiata ora.
 PasswordHasExpiredTitle=Parola d'accesso scaduta
-PasswordMinLength=La parola d'accesso deve contenere almeno 12 caratteri.
+PasswordMinLength=La parola d'accesso deve contenere almeno {0} caratteri.
 PasswordMinOnNonStdChar=La parola d'accesso deve contenere almeno un carattere speciale (\!@\#$%^&*()_+|~-\=\\`{}[]\:\\";'<>?,./).
 PasswordMinOneChar=La parola d'accesso deve contenere almeno una lettera {0}.
 PasswordMinOneDigit=La parola d'accesso deve contenere almeno un numero da 0 a 9.

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/PlatformConfigProperties.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/PlatformConfigProperties.java
@@ -13,6 +13,7 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Platform;
 import org.eclipse.scout.rt.platform.internal.PlatformImplementor;
 import org.eclipse.scout.rt.platform.inventory.internal.JandexInventoryBuilder.RebuildStrategy;
+import org.eclipse.scout.rt.platform.security.PasswordPolicy;
 import org.eclipse.scout.rt.platform.serialization.DefaultSerializerBlacklist;
 import org.eclipse.scout.rt.platform.serialization.DefaultSerializerWhitelist;
 
@@ -368,6 +369,27 @@ public final class PlatformConfigProperties {
     @Override
     public Integer getDefaultValue() {
       return 500;
+    }
+  }
+
+  /**
+   * @see PasswordPolicy
+   */
+  public static class PasswordPolicyMinLengthProperty extends AbstractPositiveIntegerConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.passwordPolicy.minLength";
+    }
+
+    @Override
+    public String description() {
+      return String.format("Minimum length for passwords checked by %s", PasswordPolicy.class.getName());
+    }
+
+    @Override
+    public Integer getDefaultValue() {
+      return 12;
     }
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/PasswordPolicy.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/security/PasswordPolicy.java
@@ -12,6 +12,8 @@ package org.eclipse.scout.rt.platform.security;
 import java.util.Arrays;
 
 import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.config.CONFIG;
+import org.eclipse.scout.rt.platform.config.PlatformConfigProperties.PasswordPolicyMinLengthProperty;
 import org.eclipse.scout.rt.platform.exception.VetoException;
 import org.eclipse.scout.rt.platform.text.TEXTS;
 
@@ -22,8 +24,6 @@ import org.eclipse.scout.rt.platform.text.TEXTS;
  */
 @Bean
 public class PasswordPolicy {
-
-  public static final int MIN_PASSWORD_LENGTH = 12;
 
   protected boolean containsUsername(char[] newPassword, String userName) {
     if (userName == null) {
@@ -49,7 +49,7 @@ public class PasswordPolicy {
    * @return a localized text that describes the policy to the user (may contain new lines)
    */
   public String getText() {
-    return TEXTS.get("DefaultPasswordPolicyText");
+    return TEXTS.get("DefaultPasswordPolicyText", "" + getMinPasswordLength());
   }
 
   /**
@@ -60,8 +60,8 @@ public class PasswordPolicy {
    *     if the password violates a rule. The exception message contains a human-readable text in the current locale.
    */
   public void check(String userName, char[] newPassword, int historyIndex) {
-    if (newPassword == null || newPassword.length < MIN_PASSWORD_LENGTH) {
-      throw new VetoException(TEXTS.get("PasswordMinLength"));
+    if (newPassword == null || newPassword.length < getMinPasswordLength()) {
+      throw new VetoException(TEXTS.get("PasswordMinLength", "" + getMinPasswordLength()));
     }
     if (historyIndex >= 0) {
       throw new VetoException(TEXTS.get("PasswordNotSameAsLasts"));
@@ -84,5 +84,9 @@ public class PasswordPolicy {
     if (containsUsername(newPassword, userName)) {
       throw new VetoException(TEXTS.get("PasswordUsernameNotPartOfPass"));
     }
+  }
+
+  protected Integer getMinPasswordLength() {
+    return CONFIG.getPropertyValue(PasswordPolicyMinLengthProperty.class);
   }
 }

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/pwd/DefaultPasswordPolicyTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/pwd/DefaultPasswordPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,12 +9,24 @@
  */
 package org.eclipse.scout.rt.server.services.common.pwd;
 
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.platform.config.PlatformConfigProperties.PasswordPolicyMinLengthProperty;
 import org.eclipse.scout.rt.platform.exception.VetoException;
 import org.eclipse.scout.rt.platform.security.PasswordPolicy;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class DefaultPasswordPolicyTest {
+
+  protected IBean<?> m_minLengthPropertyMockBean;
+
+  @After
+  public void after() {
+    BEANS.get(BeanTestingHelper.class).unregisterBean(m_minLengthPropertyMockBean);
+  }
 
   @Test
   public void testPolicy() {
@@ -32,6 +44,10 @@ public class DefaultPasswordPolicyTest {
 
     policy.check("uid", "12Characters_".toCharArray(), -1);
     policy.check(null, "12Characters_".toCharArray(), -1);
+
+    setMinPasswordLength(20);
+    assertVetoException(policy, "uname", "13Characters_".toCharArray(), -1);
+    policy.check("uname", "20CharacterPassword_".toCharArray(), -1);
   }
 
   private void assertVetoException(PasswordPolicy policy, String userName, char[] newPassword, int historyIndex) {
@@ -43,5 +59,10 @@ public class DefaultPasswordPolicyTest {
       hasException = true;
     }
     Assert.assertTrue(hasException);
+  }
+
+  protected void setMinPasswordLength(Integer minLength) {
+    BEANS.get(BeanTestingHelper.class).unregisterBean(m_minLengthPropertyMockBean);
+    m_minLengthPropertyMockBean = BEANS.get(BeanTestingHelper.class).mockConfigProperty(PasswordPolicyMinLengthProperty.class, minLength);
   }
 }


### PR DESCRIPTION
Add new config property 'scout.passwordPolicy.minLength' which controls the minimum length for passwords checked by the password policy.

441787