### PR TITLE
Mark and possibly block requests with AbstractRestProxyRequestHandler

### DIFF
--- a/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/ApiExposed.java
+++ b/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/ApiExposed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,4 +32,6 @@ import java.lang.annotation.Target;
 @Target({TYPE, FIELD, METHOD})
 @Retention(RUNTIME)
 public @interface ApiExposed {
+
+  boolean value() default true;
 }

--- a/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/ApiExposedHelper.java
+++ b/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/ApiExposedHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
 package org.eclipse.scout.rt.api.data;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
@@ -21,33 +22,63 @@ import org.eclipse.scout.rt.platform.util.StringUtility;
  * Helper class to access values of {@link ApiExposed},{@link ObjectType} and {@link FieldName} annotation values.
  */
 @ApplicationScoped
-public class ApiExposeHelper {
+public class ApiExposedHelper {
 
   public static final String OBJECT_TYPE_ATTRIBUTE_NAME = "objectType";
 
   /**
-   * @return if the given instance has the {@link ApiExposed} annotation set (directly or on one of its super classes).
+   * @return if the given instance has the {@link ApiExposed} annotation with {@link ApiExposed#value()} = {@code true} set (directly or on one of its super classes).
    */
-  public boolean hasApiExposedAnnotation(Object instance) {
+  public boolean isApiExposed(Object instance) {
     if (instance == null) {
       return false;
     }
-    return hasApiExposedAnnotation(instance.getClass());
+    return isApiExposed(instance.getClass());
   }
 
   /**
-   * @return if the given {@link IBean} has the {@link ApiExposed} annotation set (directly or on one of its super
+   * @return if the given {@link IBean} has the {@link ApiExposed} annotation with {@link ApiExposed#value()} = {@code true} set (directly or on one of its super
    * classes).
    */
-  public boolean hasApiExposedAnnotation(IBean<?> bean) {
-    return getAnnotation(bean, ApiExposed.class) != null;
+  public boolean isApiExposed(IBean<?> bean) {
+    ApiExposed ann = getAnnotation(bean, ApiExposed.class);
+    return ann != null && ann.value();
   }
 
   /**
-   * @return if the given class has the {@link ApiExposed} annotation set (directly or on one of its super classes).
+   * @return if the given class has the {@link ApiExposed} annotation with {@link ApiExposed#value()} = {@code true} set (directly or on one of its super classes).
    */
-  public boolean hasApiExposedAnnotation(Class<?> clazz) {
-    return getAnnotation(clazz, ApiExposed.class) != null;
+  public boolean isApiExposed(Class<?> clazz) {
+    ApiExposed ann = getApiExposedAnnotation(clazz);
+    return ann != null && ann.value();
+  }
+
+  /**
+   * @return if the given method has the {@link ApiExposed} annotation with {@link ApiExposed#value()} = {@code true} set (directly or its declaring class).
+   */
+  public boolean isApiExposed(Method method) {
+    ApiExposed ann = getApiExposedAnnotation(method);
+    return ann != null && ann.value();
+  }
+
+  /**
+   * @return the {@link ApiExposed} annotation if defined on the class (if available bean manager is used to determine the annotation otherwise the class itself is tested)
+   */
+  public ApiExposed getApiExposedAnnotation(Class<?> clazz) {
+    return getAnnotation(clazz, ApiExposed.class);
+  }
+
+  /**
+   * @return the {@link ApiExposed} annotation if defined for the method, if not the declaring class is checked using {@link #getApiExposedAnnotation(Class)}
+   */
+  public ApiExposed getApiExposedAnnotation(Method method) {
+    ApiExposed annotation = method.getAnnotation(ApiExposed.class);
+    if (annotation != null) {
+      return annotation;
+    }
+
+    Class<?> declaringClass = method.getDeclaringClass();
+    return getApiExposedAnnotation(declaringClass);
   }
 
   /**

--- a/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/ObjectType.java
+++ b/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/ObjectType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
 import org.eclipse.scout.rt.dataobject.TypeName;
 
 /**
- * Specifies the {@value ApiExposeHelper#OBJECT_TYPE_ATTRIBUTE_NAME} for a Scout element. It is used when creating the
+ * Specifies the {@value ApiExposedHelper#OBJECT_TYPE_ATTRIBUTE_NAME} for a Scout element. It is used when creating the
  * corresponding element in the Scout TypeScript code on the browser. This allows to customize the class that will be
  * instantiated when creating the element in the Browser.
  * <p>
@@ -33,7 +33,7 @@ import org.eclipse.scout.rt.dataobject.TypeName;
 @Retention(RUNTIME)
 public @interface ObjectType {
   /**
-   * @return The {@value ApiExposeHelper#OBJECT_TYPE_ATTRIBUTE_NAME} value.
+   * @return The {@value ApiExposedHelper#OBJECT_TYPE_ATTRIBUTE_NAME} value.
    */
   String value();
 }

--- a/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/config/ApiExposedConfigPropertyContributor.java
+++ b/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/config/ApiExposedConfigPropertyContributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,8 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.Collection;
 
-import org.eclipse.scout.rt.api.data.ApiExposeHelper;
 import org.eclipse.scout.rt.api.data.ApiExposed;
+import org.eclipse.scout.rt.api.data.ApiExposedHelper;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.config.IConfigProperty;
@@ -24,7 +24,7 @@ import org.eclipse.scout.rt.platform.config.IConfigProperty;
  */
 public class ApiExposedConfigPropertyContributor extends AbstractApiExposedConfigPropertyContributor {
 
-  private final ApiExposeHelper m_apiExposeHelper = BEANS.get(ApiExposeHelper.class);
+  private final ApiExposedHelper m_apiExposedHelper = BEANS.get(ApiExposedHelper.class);
 
   @Override
   protected Collection<? extends IConfigProperty<?>> getExposedProperties() {
@@ -36,6 +36,6 @@ public class ApiExposedConfigPropertyContributor extends AbstractApiExposedConfi
   }
 
   protected boolean isApiExposedConfigProperty(IBean<IConfigProperty> configPropertyBean) {
-    return m_apiExposeHelper.hasApiExposedAnnotation(configPropertyBean);
+    return m_apiExposedHelper.isApiExposed(configPropertyBean);
   }
 }

--- a/org.eclipse.scout.rt.api.data/src/test/java/org/eclipse/scout/rt/api/data/ApiExposedHelperTest.java
+++ b/org.eclipse.scout.rt.api.data/src/test/java/org/eclipse/scout/rt/api/data/ApiExposedHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,34 +18,34 @@ import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.security.ISecurityProvider;
 import org.junit.Test;
 
-public class ApiExposeHelperTest {
+public class ApiExposedHelperTest {
   @Test
-  public void testHasApiExposedAnnotation() {
-    ApiExposeHelper helper = BEANS.get(ApiExposeHelper.class);
+  public void testIsApiExposed() {
+    ApiExposedHelper helper = BEANS.get(ApiExposedHelper.class);
     IBean<ApiExposedBeanFixture> beanFixture = BEANS.getBeanManager().getBean(ApiExposedBeanFixture.class);
     ApiExposedFixture fixture = new ApiExposedFixture();
-    assertTrue(helper.hasApiExposedAnnotation(fixture));
-    assertTrue(helper.hasApiExposedAnnotation(beanFixture));
-    assertTrue(helper.hasApiExposedAnnotation(ApiExposedFixture.class));
+    assertTrue(helper.isApiExposed(fixture));
+    assertTrue(helper.isApiExposed(beanFixture));
+    assertTrue(helper.isApiExposed(ApiExposedFixture.class));
 
     IBean<ISecurityProvider> unexposedBean = BEANS.getBeanManager().getBean(ISecurityProvider.class);
-    assertFalse(helper.hasApiExposedAnnotation(unexposedBean));
-    assertFalse(helper.hasApiExposedAnnotation(new ApiExposeHelperTest()));
-    assertFalse(helper.hasApiExposedAnnotation(ApiExposeHelperTest.class));
-    assertFalse(helper.hasApiExposedAnnotation((IBean<?>) null));
-    assertFalse(helper.hasApiExposedAnnotation((Class<?>) null));
-    assertFalse(helper.hasApiExposedAnnotation((Object) null));
+    assertFalse(helper.isApiExposed(unexposedBean));
+    assertFalse(helper.isApiExposed(new ApiExposedHelperTest()));
+    assertFalse(helper.isApiExposed(ApiExposedHelperTest.class));
+    assertFalse(helper.isApiExposed((IBean<?>) null));
+    assertFalse(helper.isApiExposed((Class<?>) null));
+    assertFalse(helper.isApiExposed((Object) null));
   }
 
   @Test
   public void testObjectTypeOf() {
-    ApiExposeHelper helper = BEANS.get(ApiExposeHelper.class);
+    ApiExposedHelper helper = BEANS.get(ApiExposedHelper.class);
     ApiExposedFixture fixture = new ApiExposedFixture();
     assertEquals("test2", helper.objectTypeOf(fixture));
     assertEquals("test2", helper.objectTypeOf(ApiExposedFixture.class));
 
-    assertNull(helper.objectTypeOf(new ApiExposeHelperTest()));
-    assertNull(helper.objectTypeOf(ApiExposeHelperTest.class));
+    assertNull(helper.objectTypeOf(new ApiExposedHelperTest()));
+    assertNull(helper.objectTypeOf(ApiExposedHelperTest.class));
     assertNull(helper.objectTypeOf(null));
     assertNull(helper.objectTypeOf((Object) null));
     assertNull(helper.objectTypeOf(ApiExposedEmptyFixture.class));
@@ -53,13 +53,13 @@ public class ApiExposeHelperTest {
 
   @Test
   public void testFieldNameOf() {
-    ApiExposeHelper helper = BEANS.get(ApiExposeHelper.class);
+    ApiExposedHelper helper = BEANS.get(ApiExposedHelper.class);
     ApiExposedFixture fixture = new ApiExposedFixture();
     assertEquals("field2", helper.fieldNameOf(fixture));
     assertEquals("field2", helper.fieldNameOf(ApiExposedFixture.class));
 
-    assertNull(helper.fieldNameOf(new ApiExposeHelperTest()));
-    assertNull(helper.fieldNameOf(ApiExposeHelperTest.class));
+    assertNull(helper.fieldNameOf(new ApiExposedHelperTest()));
+    assertNull(helper.fieldNameOf(ApiExposedHelperTest.class));
     assertNull(helper.fieldNameOf(null));
     assertNull(helper.fieldNameOf((Object) null));
     assertNull(helper.fieldNameOf(ApiExposedEmptyFixture.class));
@@ -67,7 +67,7 @@ public class ApiExposeHelperTest {
 
   @Test
   public void testSetObjectTypeToDo() {
-    ApiExposeHelper helper = BEANS.get(ApiExposeHelper.class);
+    ApiExposedHelper helper = BEANS.get(ApiExposedHelper.class);
 
     // null safety
     helper.setObjectTypeToDo(null, null);
@@ -75,25 +75,25 @@ public class ApiExposeHelperTest {
 
     // nothing is transferred if no annotation present
     DoEntity emptyBean = BEANS.get(DoEntity.class);
-    helper.setObjectTypeToDo(new ApiExposeHelperTest(), emptyBean);
-    assertNull(emptyBean.get(ApiExposeHelper.OBJECT_TYPE_ATTRIBUTE_NAME, String.class));
+    helper.setObjectTypeToDo(new ApiExposedHelperTest(), emptyBean);
+    assertNull(emptyBean.get(ApiExposedHelper.OBJECT_TYPE_ATTRIBUTE_NAME, String.class));
 
     // value is transferred from annotation to DO
     emptyBean = BEANS.get(DoEntity.class);
     helper.setObjectTypeToDo(new ApiExposedFixture(), emptyBean);
-    assertEquals("test2", emptyBean.get(ApiExposeHelper.OBJECT_TYPE_ATTRIBUTE_NAME, String.class));
+    assertEquals("test2", emptyBean.get(ApiExposedHelper.OBJECT_TYPE_ATTRIBUTE_NAME, String.class));
 
     // empty value is ignored
     emptyBean = BEANS.get(DoEntity.class);
     helper.setObjectTypeToDo(ApiExposedEmptyFixture.class, emptyBean);
-    assertNull(emptyBean.get(ApiExposeHelper.OBJECT_TYPE_ATTRIBUTE_NAME, String.class));
+    assertNull(emptyBean.get(ApiExposedHelper.OBJECT_TYPE_ATTRIBUTE_NAME, String.class));
 
     // custom values are preserved
     DoEntity beanWithCustomValue = BEANS.get(DoEntity.class);
     String customValue = "customValue";
-    beanWithCustomValue.put(ApiExposeHelper.OBJECT_TYPE_ATTRIBUTE_NAME, customValue);
+    beanWithCustomValue.put(ApiExposedHelper.OBJECT_TYPE_ATTRIBUTE_NAME, customValue);
     helper.setObjectTypeToDo(ApiExposedFixture.class, beanWithCustomValue);
-    assertEquals(customValue, beanWithCustomValue.get(ApiExposeHelper.OBJECT_TYPE_ATTRIBUTE_NAME, String.class));
+    assertEquals(customValue, beanWithCustomValue.get(ApiExposedHelper.OBJECT_TYPE_ATTRIBUTE_NAME, String.class));
   }
 
   @Bean

--- a/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/code/CodeResource.java
+++ b/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/code/CodeResource.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import org.eclipse.scout.rt.api.data.ApiExposed;
 import org.eclipse.scout.rt.api.data.code.CodeDo;
 import org.eclipse.scout.rt.api.data.code.CodeTypeDo;
 import org.eclipse.scout.rt.api.data.code.CodeTypeRequest;
@@ -59,6 +60,7 @@ public class CodeResource implements IRestResource {
   @PUT
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @ApiExposed
   public Collection<CodeTypeDo> list(@QueryParam("allLanguages") @DefaultValue("true") boolean allLanguages, CodeTypeRequest request) {
     Set<String> ids = request == null ? null : request.getCodeTypeIds();
     Map<String, CodeTypeDo> codeTypeDos = getCodeTypesById(ids);

--- a/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/config/ConfigPropertiesResource.java
+++ b/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/config/ConfigPropertiesResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import org.eclipse.scout.rt.api.data.ApiExposed;
 import org.eclipse.scout.rt.api.data.config.ConfigPropertyDo;
 import org.eclipse.scout.rt.api.data.config.IApiExposedConfigPropertyContributor;
 import org.eclipse.scout.rt.platform.BEANS;
@@ -31,6 +32,7 @@ import org.eclipse.scout.rt.rest.IRestResource;
 public class ConfigPropertiesResource implements IRestResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @ApiExposed
   public Collection<ConfigPropertyDo> list() {
     Set<ConfigPropertyDo> configProperties = new HashSet<>();
     BEANS.all(IApiExposedConfigPropertyContributor.class).forEach(contributor -> contributor.contribute(configProperties));

--- a/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/meta/MetaResource.java
+++ b/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/meta/MetaResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,7 @@ import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import org.eclipse.scout.rt.api.data.ApiExposed;
 import org.eclipse.scout.rt.api.data.meta.MetaVersionInfoDo;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.config.CONFIG;
@@ -54,6 +55,7 @@ public class MetaResource implements IRestResource {
   @Path("version")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiDocDescription(text = "Returns the application version and application meta data in JSON format.")
+  @ApiExposed
   public MetaVersionInfoDo getMetaVersionInfo() {
     return BEANS.get(MetaVersionInfoDo.class)
         .withApplicationName(CONFIG.getPropertyValue(ApplicationNameProperty.class))
@@ -65,6 +67,7 @@ public class MetaResource implements IRestResource {
   @Path("version")
   @Produces(MediaType.TEXT_PLAIN)
   @ApiDocDescription(text = "Returns the application version in text format. If 'verbose' is true, the application name and module build date are returned as well.")
+  @ApiExposed
   public String getVersion(@QueryParam("verbose") boolean verbose) {
     if (verbose) {
       return StringUtility.join(" ",
@@ -86,6 +89,7 @@ public class MetaResource implements IRestResource {
   @GET
   @Path("ping")
   @Produces(MediaType.TEXT_PLAIN)
+  @ApiExposed
   public String ping() {
     return "Hello";
   }
@@ -93,6 +97,7 @@ public class MetaResource implements IRestResource {
   @GET
   @Path("echo{path: $|/.*}")
   @Produces(MediaType.TEXT_PLAIN + ";charset=utf-8")
+  @ApiExposed
   public String echo(@Context Request request, @Context UriInfo uriInfo) {
     Function<MultivaluedMap<String, String>, String> mapToString = (map) -> {
       if (map.isEmpty()) {
@@ -113,6 +118,7 @@ public class MetaResource implements IRestResource {
   @Path("whoami")
   @Produces(MediaType.TEXT_PLAIN)
   @ApiDocDescription(text = "Returns the principal name.")
+  @ApiExposed
   public String whoAmI() {
     Subject subject = RunContext.CURRENT.get().getSubject();
     return ObjectUtility.nvl(SecurityUtility.getPrincipalNames(subject), "(nobody)");
@@ -122,6 +128,7 @@ public class MetaResource implements IRestResource {
   @Path("locale")
   @Produces(MediaType.TEXT_PLAIN)
   @ApiDocDescription(text = "Returns the current locale.")
+  @ApiExposed
   public String locale() {
     return NlsLocale.get().toLanguageTag();
   }
@@ -129,6 +136,7 @@ public class MetaResource implements IRestResource {
   @GET
   @Path("doc")
   @ApiDocIgnore
+  @ApiExposed
   public Response getDocAsHtml(@QueryParam(ApiDocGenerator.STATIC_RESOURCE_PARAM) String staticResource, @QueryParam(ApiDocGenerator.SCOPE_PARAM) String scope) {
     return BEANS.get(ApiDocGenerator.class).getWebContent(staticResource, scope);
   }
@@ -137,6 +145,7 @@ public class MetaResource implements IRestResource {
   @Path("doc/csv")
   @ApiDocIgnore
   @Produces(MediaType.TEXT_PLAIN)
+  @ApiExposed
   public Response getDocAsText(@QueryParam(ApiDocGenerator.SCOPE_PARAM) String scope) {
     return BEANS.get(ApiDocGenerator.class).getTextContent(scope);
   }
@@ -145,6 +154,7 @@ public class MetaResource implements IRestResource {
   @Path("doc/json")
   @ApiDocIgnore
   @Produces(MediaType.APPLICATION_JSON)
+  @ApiExposed
   public Response getDocAsJson(@QueryParam(ApiDocGenerator.SCOPE_PARAM) String scope) {
     return BEANS.get(ApiDocGenerator.class).getJsonContent(scope);
   }

--- a/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/security/PermissionResource.java
+++ b/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/security/PermissionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
+import org.eclipse.scout.rt.api.data.ApiExposed;
 import org.eclipse.scout.rt.dataobject.mapping.ToDoFunctionHelper;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.rest.IRestResource;
@@ -29,6 +30,7 @@ import org.eclipse.scout.rt.security.mapping.IToPermissionCollectionDoFunction;
 public class PermissionResource implements IRestResource {
 
   @GET
+  @ApiExposed
   public Response getAllPermissions(@Context Request request) {
     var permissionCollection = BEANS.get(IAccessControlService.class).getPermissions();
     var permissionCollectionDo = BEANS.get(ToDoFunctionHelper.class).toDo(permissionCollection, IToPermissionCollectionDoFunction.class);

--- a/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationResource.java
+++ b/org.eclipse.scout.rt.api/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationResource.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 
+import org.eclipse.scout.rt.api.data.ApiExposed;
 import org.eclipse.scout.rt.api.data.uinotification.TopicDo;
 import org.eclipse.scout.rt.api.data.uinotification.UiNotificationDo;
 import org.eclipse.scout.rt.api.data.uinotification.UiNotificationRequest;
@@ -51,6 +52,7 @@ public class UiNotificationResource implements IRestResource {
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @ApiExposed
   public void get(UiNotificationRequest request, @Suspended AsyncResponse asyncResponse, @Context HttpServletRequest httpReq) {
     if (request == null) {
       throw new BadRequestException("Request must not be null");

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/uicallback/IUiCallbackHandler.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/uicallback/IUiCallbackHandler.java
@@ -9,7 +9,7 @@
  */
 package org.eclipse.scout.rt.client.ui.desktop.hybrid.uicallback;
 
-import org.eclipse.scout.rt.api.data.ApiExposeHelper;
+import org.eclipse.scout.rt.api.data.ApiExposedHelper;
 import org.eclipse.scout.rt.api.data.ObjectType;
 import org.eclipse.scout.rt.client.ui.desktop.hybrid.HybridActionContextElements;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
@@ -40,7 +40,7 @@ public interface IUiCallbackHandler<DATA, RESULT> {
    */
   default String uiCallbackHandlerObjectType() {
     // use @ObjectType annotation by default
-    return BEANS.get(ApiExposeHelper.class).objectTypeOf(this);
+    return BEANS.get(ApiExposedHelper.class).objectTypeOf(this);
   }
 
   /**

--- a/org.eclipse.scout.rt.rest.jersey.server/src/main/java/org/eclipse/scout/rt/rest/jersey/server/OptionsMethodProcessorApiExposedFilter.java
+++ b/org.eclipse.scout.rt.rest.jersey.server/src/main/java/org/eclipse/scout/rt/rest/jersey/server/OptionsMethodProcessorApiExposedFilter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.server;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.scout.rt.api.data.ApiExposed;
+import org.eclipse.scout.rt.api.data.ApiExposedHelper;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.Platform;
+import org.eclipse.scout.rt.platform.config.CONFIG;
+import org.eclipse.scout.rt.rest.error.ErrorResponseBuilder;
+import org.eclipse.scout.rt.rest.resource.AbstractApiExposedFeature.IApiExposedFeatureFilterContributor;
+import org.eclipse.scout.rt.rest.resource.ApiExposedFilter;
+import org.eclipse.scout.rt.rest.resource.ApiExposedFilter.RejectNonExposedRequestsWithNotFoundConfigProperty;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.model.Invocable;
+import org.glassfish.jersey.server.model.ResourceMethod;
+import org.glassfish.jersey.server.model.RuntimeResource;
+import org.glassfish.jersey.server.wadl.processor.OptionsMethodProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+@Priority(Priorities.AUTHORIZATION)
+@Bean
+public class OptionsMethodProcessorApiExposedFilter implements ContainerRequestFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OptionsMethodProcessorApiExposedFilter.class);
+
+  @Inject
+  private Provider<ExtendedUriInfo> m_extendedUriInfo;
+
+  private final ApiExposedHelper m_apiExposedHelper = BEANS.get(ApiExposedHelper.class);
+
+  @SuppressWarnings("deprecation")
+  private final boolean m_rejectRequests = CONFIG.getPropertyValue(RejectNonExposedRequestsWithNotFoundConfigProperty.class);
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    ExtendedUriInfo extendedUriInfo = m_extendedUriInfo.get();
+
+    String proxiedRequestHeader = requestContext.getHeaderString(ApiExposedFilter.HTTP_HEADER_NAME);
+    if (proxiedRequestHeader == null) {
+      // request is not proxied (= no header set)
+      LOG.debug("Access allowed, request is not proxied: {}", extendedUriInfo.getPath());
+      return;
+    }
+
+    List<Method> actualMethods = extendedUriInfo
+        .getMatchedRuntimeResources()
+        .stream()
+        .map(RuntimeResource::getResourceMethods)
+        .flatMap(Collection::stream)
+        .map(ResourceMethod::getInvocable)
+        .map(Invocable::getHandlingMethod)
+        .filter(m -> {
+          Class<?> declaringClass = m.getDeclaringClass();
+          if (declaringClass == null) {
+            return false;
+          }
+
+          Class<?> enclosingClass = declaringClass.getEnclosingClass();
+          if (enclosingClass == null) {
+            return true;
+          }
+
+          return !OptionsMethodProcessor.class.isAssignableFrom(enclosingClass);
+        })
+        .toList();
+
+    if (actualMethods.isEmpty()) {
+      // continue, no match
+      return;
+    }
+
+    if (actualMethods.stream().anyMatch(m_apiExposedHelper::isApiExposed)) {
+      // continue, at least one api-exposed method (even though not all may be exposed, OPTIONS request may therefore return too many methods)
+      return;
+    }
+
+    // not allowed
+    boolean increaseLogLevel = !m_rejectRequests || Platform.get().inDevelopmentMode();
+    LOG.atLevel(increaseLogLevel ? Level.WARN : Level.DEBUG).log("External access to {} not allowed, reason: classes/methods ({}) are not marked with {}", extendedUriInfo.getPath(), actualMethods, ApiExposed.class.getSimpleName());
+    if (m_rejectRequests) {
+      requestContext.abortWith(BEANS.get(ErrorResponseBuilder.class).withHttpStatus(Response.Status.NOT_FOUND).withMessage(BEANS.get(ApiExposedFilter.class).getNotFoundMessage(requestContext)).build());
+    }
+  }
+
+  public static class OptionsMethodProcessorApiExposedFilterContributor implements IApiExposedFeatureFilterContributor {
+
+    @Override
+    public boolean configure(ResourceInfo resourceInfo, FeatureContext context) {
+      Class<?> resourceClass = resourceInfo.getResourceClass();
+      Class<?> enclosingClass = resourceClass.getEnclosingClass();
+      if (enclosingClass != null && OptionsMethodProcessor.class.isAssignableFrom(enclosingClass)) {
+        LOG.debug("Install {} for {}", OptionsMethodProcessorApiExposedFilter.class.getSimpleName(), resourceInfo);
+        // do not use an application-scoped bean here otherwise jakarta.inject won't work
+        context.register(BEANS.getBeanManager().getBean(OptionsMethodProcessorApiExposedFilter.class).getBeanClazz());
+        return true;
+      }
+
+      return false;
+    }
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/ExtRestApplication.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/ExtRestApplication.java
@@ -19,12 +19,16 @@ public class ExtRestApplication extends RestApplication {
 
   @Override
   protected boolean filterClass(Class<?> clazz) {
-    return !AntiCsrfContainerFilter.class.isAssignableFrom(clazz)
-        && (!IRestResource.class.isAssignableFrom(clazz) || isExtScope(clazz));
+    return !AntiCsrfContainerFilter.class.isAssignableFrom(clazz) && isExtScope(clazz);
   }
 
   protected boolean isExtScope(Class<?> clazz) {
     RestApplicationScope annotation = clazz.getAnnotation(RestApplicationScope.class);
-    return annotation != null && ObjectUtility.isOneOf(RestApplicationScopes.EXT, annotation.value());
+    if (annotation != null) {
+      // check matching scope
+      return ObjectUtility.isOneOf(RestApplicationScopes.EXT, annotation.value());
+    }
+    // include all non-IRestResource classes
+    return !IRestResource.class.isAssignableFrom(clazz);
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/RestApplication.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/RestApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/cancellation/CancellationResource.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/cancellation/CancellationResource.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 
+import org.eclipse.scout.rt.api.data.ApiExposed;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.rest.IRestResource;
 import org.eclipse.scout.rt.security.IAccessControlService;
@@ -34,6 +35,7 @@ public class CancellationResource implements IRestResource {
 
   @PUT
   @Path("{requestId}")
+  @ApiExposed(false)
   public void cancel(@PathParam("requestId") String requestId) {
     BEANS.get(RestRequestCancellationRegistry.class).cancel(requestId, resolveCurrentUserId());
   }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
@@ -49,6 +49,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
+import org.eclipse.scout.rt.api.data.ApiExposedHelper;
 import org.eclipse.scout.rt.dataobject.DoEntityBuilder;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.IPrettyPrintDataObjectMapper;
@@ -76,6 +77,8 @@ import org.eclipse.scout.rt.rest.IRestMediaType;
 import org.eclipse.scout.rt.rest.IRestResource;
 import org.eclipse.scout.rt.rest.RestApplicationScope;
 import org.eclipse.scout.rt.rest.RestApplicationScopes;
+import org.eclipse.scout.rt.security.ACCESS;
+import org.eclipse.scout.rt.security.IAccessControlService;
 
 /**
  * Usage in a REST resource:
@@ -121,6 +124,8 @@ public class ApiDocGenerator {
   protected static final String TEXT_ELEMENT_SEPARATOR = "\t";
   protected static final String TEXT_LINE_SEPARATOR = "\n";
 
+  private ApiExposedHelper m_apiExposedHelper = BEANS.get(ApiExposedHelper.class);
+
   public List<ResourceDescriptor> getResourceDescriptors() {
     return getResourceDescriptorsInternal(BEANS.all(IRestResource.class));
   }
@@ -150,16 +155,18 @@ public class ApiDocGenerator {
   }
 
   protected List<ResourceDescriptor> getResourceDescriptorsInternal(Collection<IRestResource> restResources) {
+    boolean readAllApiDocGranted = isReadAllApiDocGranted();
     return restResources.stream()
         .filter(this::acceptRestResource)
         .sorted(Comparator.comparing(res -> res.getClass().getSimpleName()))
         .sorted(Comparator.comparing(res -> "/" + getPath(res)))
-        .map(this::toResourceDescriptor)
+        .map(resource -> toResourceDescriptor(resource, readAllApiDocGranted))
         .filter(Objects::nonNull)
+        .filter(d -> CollectionUtility.hasElements(d.getMethods())) // at least one method is required
         .collect(Collectors.toList());
   }
 
-  protected ResourceDescriptor toResourceDescriptor(IRestResource resource) {
+  protected ResourceDescriptor toResourceDescriptor(IRestResource resource, boolean readAllApiDocGranted) {
     String resourcePath = "/" + getPath(resource);
     String basePath = resourcePath.replaceAll("(/[^/]+).*", "$1");
     String name = resource.getClass().getSimpleName();
@@ -172,6 +179,7 @@ public class ApiDocGenerator {
                 .orElseGet(() -> new String[]{RestApplicationScopes.API})) // default scope
         .filter(StringUtility::hasText)
         .collect(Collectors.toList());
+    boolean ignoreApiExposed = readAllApiDocGranted || !checkForApiExposed(collect);
 
     return new ResourceDescriptor()
         .withResource(resource)
@@ -182,7 +190,7 @@ public class ApiDocGenerator {
         .withDescription(description)
         .withScopes(collect)
         .withMethods(Stream.of(resource.getClass().getMethods())
-            .filter(this::acceptMethod)
+            .filter(m -> acceptMethod(m, ignoreApiExposed))
             .sorted(Comparator.comparing(this::generateMethodSignature)) // to make sure sorting is stable
             .sorted(this::compareMethods)
             .map(this::toMethodDescriptor)
@@ -236,9 +244,10 @@ public class ApiDocGenerator {
         !res.getClass().isAnnotationPresent(ApiDocIgnore.class);
   }
 
-  protected boolean acceptMethod(Method m) {
+  protected boolean acceptMethod(Method m, boolean ignoreApiExposed) {
     return Modifier.isPublic(m.getModifiers()) &&
-        !m.isAnnotationPresent(ApiDocIgnore.class);
+        !m.isAnnotationPresent(ApiDocIgnore.class) &&
+        (ignoreApiExposed || m_apiExposedHelper.isApiExposed(m));
   }
 
   protected int compareMethods(Method m1, Method m2) {
@@ -398,6 +407,14 @@ public class ApiDocGenerator {
     return title;
   }
 
+  protected boolean isReadAllApiDocGranted() {
+    return BEANS.opt(IAccessControlService.class) != null && ACCESS.check(new ReadAllApiDocPermission());
+  }
+
+  protected boolean checkForApiExposed(List<String> scopes) {
+    return scopes != null && scopes.contains(RestApplicationScopes.API);
+  }
+
   /**
    * Same as {@link #getWebContent(String, String)} without scope filter.
    */
@@ -489,23 +506,28 @@ public class ApiDocGenerator {
         elements.add(HTML.div(HTML.raw(r.getDescription().toHtml())).cssClass("resource-description"));
       }
 
-      r.getMethods().forEach(m -> elements.add(HTML.div(
-              HTML.div(
-                      HTML.div(m.getHttpMethod()).cssClass("http " + m.getHttpMethod().toLowerCase()),
-                      HTML.div(
-                          HTML.span("(" + CollectionUtility.format(r.getScopes()) + ")").cssClass("scope"),
-                          HTML.span(r.getPath()).cssClass("resource"),
-                          HTML.span(StringUtility.box("/", m.getPath(), "")).cssClass("method")).cssClass("path"))
-                  .cssClass("header"),
-              HTML.div(
-                      HTML.div(HTML.raw(m.getDescription().toHtml())).cssClass("description"),
-                      HTML.div(m.getSignature().toString()).cssClass("signature"),
-                      HTML.div(
-                              StringUtility.hasText(m.getConsumes()) ? HTML.div(HTML.span("Consumes ").cssClass("k"), HTML.span(m.getConsumes()).cssClass("v")).cssClass("line") : null,
-                              StringUtility.hasText(m.getProduces()) ? HTML.div(HTML.span("Produces ").cssClass("k"), HTML.span(m.getProduces()).cssClass("v")).cssClass("line") : null)
-                          .cssClass("consumes-produces"))
-                  .cssClass("body"))
-          .cssClass("operation")));
+      boolean ignoreApiExposed = !checkForApiExposed(r.getScopes());
+      boolean readAllApiDocGranted = isReadAllApiDocGranted();
+      r.getMethods().forEach(m -> {
+        boolean apiExposed = ignoreApiExposed || !readAllApiDocGranted || m_apiExposedHelper.isApiExposed(m.getMethod());
+        elements.add(HTML.div(
+                HTML.div(
+                        HTML.div(m.getHttpMethod()).cssClass("http " + m.getHttpMethod().toLowerCase()),
+                        HTML.div(
+                            HTML.span("(" + CollectionUtility.format(r.getScopes()) + ")").cssClass("scope"),
+                            HTML.span(r.getPath()).cssClass("resource"),
+                            HTML.span(StringUtility.box("/", m.getPath(), "")).cssClass("method")).cssClass("path").toggleCssClass("not-api-exposed", !apiExposed))
+                    .cssClass("header"),
+                HTML.div(
+                        HTML.div(HTML.raw(m.getDescription().toHtml())).cssClass("description"),
+                        HTML.div(m.getSignature().toString()).cssClass("signature"),
+                        HTML.div(
+                                StringUtility.hasText(m.getConsumes()) ? HTML.div(HTML.span("Consumes ").cssClass("k"), HTML.span(m.getConsumes()).cssClass("v")).cssClass("line") : null,
+                                StringUtility.hasText(m.getProduces()) ? HTML.div(HTML.span("Produces ").cssClass("k"), HTML.span(m.getProduces()).cssClass("v")).cssClass("line") : null)
+                            .cssClass("consumes-produces"))
+                    .cssClass("body"))
+            .cssClass("operation"));
+      });
     });
 
     final String title = generateTitle();
@@ -629,6 +651,7 @@ public class ApiDocGenerator {
   }
 
   protected String toText(List<ResourceDescriptor> resourceDescriptors) {
+    boolean readAllApiDocGranted = isReadAllApiDocGranted();
     final StringBuilder sb = new StringBuilder();
 
     // append header
@@ -645,29 +668,40 @@ public class ApiDocGenerator {
     sb.append("produces");
     sb.append(TEXT_ELEMENT_SEPARATOR);
     sb.append("description");
+    if (readAllApiDocGranted) {
+      sb.append(TEXT_ELEMENT_SEPARATOR);
+      sb.append("apiExposed");
+    }
     sb.append(TEXT_LINE_SEPARATOR);
 
     // append all resources and methods
-    resourceDescriptors.forEach(r -> r.getMethods().forEach(m -> {
-      sb.append(r.getName());
-      sb.append(TEXT_ELEMENT_SEPARATOR);
-      sb.append(m.getHttpMethod());
-      sb.append(TEXT_ELEMENT_SEPARATOR);
-      sb.append(r.getPath());
-      if (!StringUtility.isNullOrEmpty(m.getPath())) {
-        sb.append("/");
-        sb.append(m.getPath());
-      }
-      sb.append(TEXT_ELEMENT_SEPARATOR);
-      sb.append(CollectionUtility.format(r.getScopes()));
-      sb.append(TEXT_ELEMENT_SEPARATOR);
-      sb.append(StringUtility.emptyIfNull(m.getConsumes()));
-      sb.append(TEXT_ELEMENT_SEPARATOR);
-      sb.append(StringUtility.emptyIfNull(m.getProduces()));
-      sb.append(TEXT_ELEMENT_SEPARATOR);
-      sb.append(m.getDescription().toPlainText(true));
-      sb.append(TEXT_LINE_SEPARATOR);
-    }));
+    resourceDescriptors.forEach(r -> {
+      boolean ignoreApiExposed = !checkForApiExposed(r.getScopes());
+      r.getMethods().forEach(m -> {
+        sb.append(r.getName());
+        sb.append(TEXT_ELEMENT_SEPARATOR);
+        sb.append(m.getHttpMethod());
+        sb.append(TEXT_ELEMENT_SEPARATOR);
+        sb.append(r.getPath());
+        if (!StringUtility.isNullOrEmpty(m.getPath())) {
+          sb.append("/");
+          sb.append(m.getPath());
+        }
+        sb.append(TEXT_ELEMENT_SEPARATOR);
+        sb.append(CollectionUtility.format(r.getScopes()));
+        sb.append(TEXT_ELEMENT_SEPARATOR);
+        sb.append(StringUtility.emptyIfNull(m.getConsumes()));
+        sb.append(TEXT_ELEMENT_SEPARATOR);
+        sb.append(StringUtility.emptyIfNull(m.getProduces()));
+        sb.append(TEXT_ELEMENT_SEPARATOR);
+        sb.append(m.getDescription().toPlainText(true));
+        if (!ignoreApiExposed && readAllApiDocGranted) {
+          sb.append(TEXT_ELEMENT_SEPARATOR);
+          sb.append(m_apiExposedHelper.isApiExposed(m.getMethod()));
+        }
+        sb.append(TEXT_LINE_SEPARATOR);
+      });
+    });
     return sb.toString();
   }
 
@@ -716,6 +750,7 @@ public class ApiDocGenerator {
                 .put("signature", m.getSignature().toString())
                 .putIf("consumes", m.getConsumes(), Objects::nonNull)
                 .putIf("produces", m.getProduces(), Objects::nonNull)
+                .putIf("apiExposed", m_apiExposedHelper.isApiExposed(m.getMethod()), v -> !v)
                 .build()))
         .collect(Collectors.toList());
     return BEANS.get(IPrettyPrintDataObjectMapper.class).writeValue(jsonMethods);
@@ -994,8 +1029,7 @@ public class ApiDocGenerator {
       if (type instanceof Class<?>) {
         m_class = (Class<?>) type;
       }
-      else if (type instanceof ParameterizedType) {
-        ParameterizedType parameterizedType = (ParameterizedType) type;
+      else if (type instanceof ParameterizedType parameterizedType) {
         Type[] generics = parameterizedType.getActualTypeArguments();
         Class<?> rawClass = (Class<?>) parameterizedType.getRawType();
         m_class = rawClass;

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ReadAllApiDocPermission.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ReadAllApiDocPermission.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.doc;
+
+import org.eclipse.scout.rt.api.data.security.PermissionId;
+import org.eclipse.scout.rt.security.AbstractPermission;
+
+public class ReadAllApiDocPermission extends AbstractPermission {
+  private static final long serialVersionUID = 1L;
+  public static final PermissionId ID = PermissionId.of("scout.api.doc.read.all");
+
+  public ReadAllApiDocPermission() {
+    super(ID);
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/maintenance/MaintenanceModeFeature.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/maintenance/MaintenanceModeFeature.java
@@ -37,9 +37,10 @@ public class MaintenanceModeFeature implements DynamicFeature {
 
     // compute if operation is disabled for maintenance mode, register filter if disabled for maintenance mode
     if (annotation != null && annotation.disabled()) {
-      LOG.debug("Install {} for resource {}", getMaintenanceModeFilterClass().getSimpleName(), resourceInfo);
-      context.register(getMaintenanceModeFilterClass());
-      Assertions.assertNotNull(BEANS.opt(IMaintenanceModeService.class), "{} is installed for resource {} (by annotation); however no {} bean implementation is available", getMaintenanceModeFilterClass().getSimpleName(), resourceInfo, IMaintenanceModeService.class.getSimpleName());
+      Class<? extends MaintenanceModeFilter> filterClass = getMaintenanceModeFilterClass();
+      LOG.debug("Install {} for resource {}", filterClass.getSimpleName(), resourceInfo);
+      context.register(filterClass);
+      Assertions.assertNotNull(BEANS.opt(IMaintenanceModeService.class), "{} is installed for resource {} (by annotation); however no {} bean implementation is available", filterClass.getSimpleName(), resourceInfo, IMaintenanceModeService.class.getSimpleName());
     }
   }
 

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/resource/AbstractApiExposedFeature.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/resource/AbstractApiExposedFeature.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.resource;
+
+import java.util.Set;
+
+import jakarta.ws.rs.container.DynamicFeature;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.FeatureContext;
+
+import org.eclipse.scout.rt.api.data.ApiExposed;
+import org.eclipse.scout.rt.api.data.ApiExposedHelper;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.rest.RestApplication;
+import org.eclipse.scout.rt.rest.RestApplicationScope;
+import org.eclipse.scout.rt.rest.RestApplicationScopes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract implementation of dynamic feature registering {@link ApiExposedFilter} for annotated methods/classes
+ */
+public abstract class AbstractApiExposedFeature implements DynamicFeature {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractApiExposedFeature.class);
+
+  private final ApiExposedHelper m_apiExposedHelper = BEANS.get(ApiExposedHelper.class);
+
+  @Override
+  public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+    // contributors may provide their own filters instead of this one or even skip filter registration
+    for (IApiExposedFeatureFilterContributor f : BEANS.all(IApiExposedFeatureFilterContributor.class)) {
+      if (f.configure(resourceInfo, context)) {
+        LOG.debug("Do not install {} for {} (handled by {})", ApiExposedFilter.class.getSimpleName(), resourceInfo, f.getClass().getSimpleName());
+        return;
+      }
+    }
+
+    ApiExposed annotation = getApiExposedAnnotation(resourceInfo, context);
+
+    // compute if operation is *not* api-exposed, if *not* exposed then install filter to restrict access
+    if (annotation == null || !annotation.value()) {
+      ApiExposedFilter filter = BEANS.get(ApiExposedFilter.class);
+      LOG.debug("Install {} for {}", ApiExposedFilter.class.getSimpleName(), resourceInfo + (annotation == null ? " (no annotation present)" : ""));
+      context.register(filter);
+    }
+    else {
+      LOG.debug("Do not install {} for {}", ApiExposedFilter.class.getSimpleName(), resourceInfo);
+    }
+  }
+
+  /**
+   * Get {@link ApiExposed} annotation; if provided on type and method, method wins.
+   */
+  protected ApiExposed getApiExposedAnnotation(ResourceInfo resourceInfo, FeatureContext context) {
+    return m_apiExposedHelper.getApiExposedAnnotation(resourceInfo.getResourceMethod());
+  }
+
+  public static class ApiExposedFeatureContributor implements RestApplication.IRestApplicationClassesContributor {
+    @Override
+    public Set<Class<?>> contribute() {
+      return Set.of(ApiApiExposedFeature.class);
+    }
+  }
+
+  @Bean
+  public interface IApiExposedFeatureFilterContributor {
+    boolean configure(ResourceInfo resourceInfo, FeatureContext context);
+  }
+
+  @RestApplicationScope(RestApplicationScopes.API)
+  public static class ApiApiExposedFeature extends AbstractApiExposedFeature {
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/resource/ApiExposedFilter.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/resource/ApiExposedFilter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.resource;
+
+import java.io.IOException;
+import java.net.URI;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.eclipse.scout.rt.api.data.ApiExposed;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.Platform;
+import org.eclipse.scout.rt.platform.config.AbstractBooleanConfigProperty;
+import org.eclipse.scout.rt.platform.config.CONFIG;
+import org.eclipse.scout.rt.rest.error.ErrorResponseBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+/**
+ * Dynamically installed request filter that rejects proxied requests to methods which are not marked as @{@link ApiExposed}.
+ *
+ * @see AbstractApiExposedFeature
+ */
+@Priority(Priorities.AUTHORIZATION)
+@ApplicationScoped
+public class ApiExposedFilter implements ContainerRequestFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ApiExposedFilter.class);
+
+  public static final String HTTP_HEADER_NAME = "X-Scout-Proxied-Request";
+
+  protected static final String DEFAULT_NOT_FOUND_MESSAGE = "Not found";
+
+  private final boolean m_rejectRequests = CONFIG.getPropertyValue(RejectNonExposedRequestsWithNotFoundConfigProperty.class);
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    String proxiedRequestHeader = requestContext.getHeaderString(HTTP_HEADER_NAME);
+    if (proxiedRequestHeader == null) {
+      // request is not proxied (= no header set)
+      LOG.debug("Access allowed, request is not proxied: {}", getRequestPath(requestContext));
+      return;
+    }
+
+    // not allowed
+    boolean increaseLogLevel = !m_rejectRequests || Platform.get().inDevelopmentMode();
+    LOG.atLevel(increaseLogLevel ? Level.WARN : Level.DEBUG).log("External access to {} not allowed, reason: class/method is not marked with {}", getRequestPath(requestContext), ApiExposed.class.getSimpleName());
+    if (m_rejectRequests) {
+      requestContext.abortWith(BEANS.get(ErrorResponseBuilder.class).withHttpStatus(Response.Status.NOT_FOUND).withMessage(getNotFoundMessage(requestContext)).build());
+    }
+  }
+
+  protected URI getRequestPath(ContainerRequestContext requestContext) {
+    UriInfo uriInfo = requestContext.getUriInfo();
+    return uriInfo == null ? null : uriInfo.getRequestUri();
+  }
+
+  /**
+   * Message for declined requests.
+   */
+  public String getNotFoundMessage(ContainerRequestContext requestContext) {
+    return DEFAULT_NOT_FOUND_MESSAGE;
+  }
+
+  /**
+   * @deprecated Internal config property, will be removed with 26/2 (or a future release)
+   */
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated
+  public static class RejectNonExposedRequestsWithNotFoundConfigProperty extends AbstractBooleanConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.rest.api.exposed.enforce";
+    }
+
+    @Override
+    public String description() {
+      return "Set to true to reject non api-exposed operations with a not found error (404), no warning will be logged in this case (just for development mode); if set to false only a warning will be logged but requests are not rejected (default value: " + getDefaultValue() + ")";
+    }
+
+    @Override
+    public Boolean getDefaultValue() {
+      return true;
+    }
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/resources/org/eclipse/scout/rt/rest/doc/res/doc.css
+++ b/org.eclipse.scout.rt.rest/src/main/resources/org/eclipse/scout/rt/rest/doc/res/doc.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -131,6 +131,10 @@ h2 {
 
 .http.delete {
   background-color: deeppink;
+}
+
+.not-api-exposed {
+  background-color: yellow;
 }
 
 .path {

--- a/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/id/SignatureHttpServletRequestWrapperTest.java
+++ b/org.eclipse.scout.rt.server.commons.test/src/test/java/org/eclipse/scout/rt/server/commons/id/SignatureHttpServletRequestWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.eclipse.scout.rt.server.commons.id.IdSignatureFilter.SignatureHttpServletRequestWrapper;
 import org.junit.Test;
 
 public class SignatureHttpServletRequestWrapperTest {
@@ -40,7 +39,7 @@ public class SignatureHttpServletRequestWrapperTest {
 
     assertEquals(Set.of(), set(req.getHeaderNames()));
 
-    HttpServletRequest wrapper = new SignatureHttpServletRequestWrapper(req);
+    HttpServletRequest wrapper = new IdSignatureFilter().createSignatureRequest(req);
 
     assertEquals(Boolean.TRUE.toString(), wrapper.getHeader(IdSignatureFilter.ID_SIGNATURE_HTTP_HEADER));
     assertEquals(Boolean.TRUE.toString(), wrapper.getHeader(lowercase(IdSignatureFilter.ID_SIGNATURE_HTTP_HEADER)));
@@ -63,7 +62,7 @@ public class SignatureHttpServletRequestWrapperTest {
 
     assertEquals(Set.of(IdSignatureFilter.ID_SIGNATURE_HTTP_HEADER), set(req.getHeaderNames()));
 
-    HttpServletRequest wrapper = new SignatureHttpServletRequestWrapper(req);
+    HttpServletRequest wrapper = new IdSignatureFilter().createSignatureRequest(req);
 
     assertEquals(Boolean.TRUE.toString(), wrapper.getHeader(IdSignatureFilter.ID_SIGNATURE_HTTP_HEADER));
     assertEquals(Boolean.TRUE.toString(), wrapper.getHeader(lowercase(IdSignatureFilter.ID_SIGNATURE_HTTP_HEADER)));
@@ -92,7 +91,7 @@ public class SignatureHttpServletRequestWrapperTest {
 
     assertEquals(Set.of("Dummy"), set(req.getHeaderNames()));
 
-    HttpServletRequest wrapper = new SignatureHttpServletRequestWrapper(req);
+    HttpServletRequest wrapper = new IdSignatureFilter().createSignatureRequest(req);
 
     assertEquals("42", wrapper.getHeader("Dummy"));
     assertEquals("42", wrapper.getHeader("dummy"));

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/id/IdSignatureFilter.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/id/IdSignatureFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,16 +9,8 @@
  */
 package org.eclipse.scout.rt.server.commons.id;
 
-import static java.util.Collections.enumeration;
-import static org.eclipse.scout.rt.platform.util.EnumerationUtility.*;
-import static org.eclipse.scout.rt.platform.util.StringUtility.equalsIgnoreCase;
-
 import java.io.IOException;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Collections;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -30,6 +22,7 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
 
 import org.eclipse.scout.rt.dataobject.id.IId;
 import org.eclipse.scout.rt.dataobject.id.IdCodec.IdCodecFlag;
+import org.eclipse.scout.rt.server.commons.servlet.AdditionalHeadersHttpServletRequestWrapper;
 
 /**
  * This {@link Filter} adds the {@link #ID_SIGNATURE_HTTP_HEADER} to the {@link ServletRequest}, which will be used
@@ -44,39 +37,7 @@ public class IdSignatureFilter implements Filter {
     chain.doFilter(req, response);
   }
 
-  protected SignatureHttpServletRequestWrapper createSignatureRequest(HttpServletRequest request) {
-    return new SignatureHttpServletRequestWrapper(request);
-  }
-
-  public static class SignatureHttpServletRequestWrapper extends HttpServletRequestWrapper {
-    protected final Map<String, String> m_additionalHeaders = Map.of(ID_SIGNATURE_HTTP_HEADER, Boolean.TRUE.toString());
-
-    public SignatureHttpServletRequestWrapper(HttpServletRequest request) {
-      super(request);
-    }
-
-    @Override
-    public String getHeader(String name) {
-      return m_additionalHeaders.entrySet().stream()
-          .filter(entry -> equalsIgnoreCase(name, entry.getKey()))
-          .map(Entry::getValue)
-          .findFirst()
-          .orElseGet(() -> super.getHeader(name));
-    }
-
-    @Override
-    public Enumeration<String> getHeaders(String name) {
-      return asEnumeration(Stream.concat(
-              asStream(super.getHeaders(name)),
-              m_additionalHeaders.entrySet().stream()
-                  .filter(entry -> equalsIgnoreCase(name, entry.getKey()))
-                  .map(Entry::getValue))
-          .iterator());
-    }
-
-    @Override
-    public Enumeration<String> getHeaderNames() {
-      return enumeration(Stream.concat(asStream(super.getHeaderNames()), m_additionalHeaders.keySet().stream()).collect(Collectors.toSet()));
-    }
+  protected HttpServletRequestWrapper createSignatureRequest(HttpServletRequest request) {
+    return new AdditionalHeadersHttpServletRequestWrapper(request, Collections.singletonMap(ID_SIGNATURE_HTTP_HEADER, Boolean.TRUE.toString()));
   }
 }

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/AdditionalHeadersHttpServletRequestWrapper.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/AdditionalHeadersHttpServletRequestWrapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.commons.servlet;
+
+import static java.util.Collections.enumeration;
+import static org.eclipse.scout.rt.platform.util.EnumerationUtility.*;
+import static org.eclipse.scout.rt.platform.util.StringUtility.equalsIgnoreCase;
+
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+/**
+ * {@link HttpServletRequestWrapper} to add additional headers for incoming requests.
+ */
+public class AdditionalHeadersHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+  private final Map<String, String> m_additionalHeaders;
+
+  public AdditionalHeadersHttpServletRequestWrapper(HttpServletRequest request, Map<String, String> additionalHeaders) {
+    super(request);
+    m_additionalHeaders = additionalHeaders;
+  }
+
+  @Override
+  public String getHeader(String name) {
+    return m_additionalHeaders.entrySet().stream()
+        .filter(entry -> equalsIgnoreCase(name, entry.getKey()))
+        .map(Entry::getValue)
+        .findFirst()
+        .orElseGet(() -> super.getHeader(name));
+  }
+
+  @Override
+  public Enumeration<String> getHeaders(String name) {
+    return asEnumeration(Stream.concat(
+            asStream(super.getHeaders(name)),
+            m_additionalHeaders.entrySet().stream()
+                .filter(entry -> equalsIgnoreCase(name, entry.getKey()))
+                .map(Entry::getValue))
+        .iterator());
+  }
+
+  @Override
+  public Enumeration<String> getHeaderNames() {
+    return enumeration(Stream.concat(asStream(super.getHeaderNames()), m_additionalHeaders.keySet().stream()).collect(Collectors.toSet()));
+  }
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ProcessResource.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ProcessResource.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import org.eclipse.scout.rt.api.data.ApiExposed;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.rest.IRestResource;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelConstants;
@@ -28,6 +29,7 @@ public class ProcessResource implements IRestResource {
   @POST
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  @ApiExposed(false)
   public Response process(InputStream in) throws Exception {
     return BEANS.get(ServiceTunnelService.class).incomingRequest(in);
   }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/ApiExposedCodeTypeDoContributor.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/ApiExposedCodeTypeDoContributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,8 +11,8 @@ package org.eclipse.scout.rt.shared.services.common.code;
 
 import java.util.Set;
 
-import org.eclipse.scout.rt.api.data.ApiExposeHelper;
 import org.eclipse.scout.rt.api.data.ApiExposed;
+import org.eclipse.scout.rt.api.data.ApiExposedHelper;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.Order;
@@ -23,7 +23,7 @@ import org.eclipse.scout.rt.platform.Order;
  */
 @Order(-5000) // this provider should come first so that custom providers can modify the result
 public class ApiExposedCodeTypeDoContributor implements IApiExposedCodeTypeContributor {
-  private final ApiExposeHelper m_apiExposeHelper = BEANS.get(ApiExposeHelper.class);
+  private final ApiExposedHelper m_apiExposedHelper = BEANS.get(ApiExposedHelper.class);
 
   @Override
   public void contribute(Set<ICodeType> codeTypes) {
@@ -34,6 +34,6 @@ public class ApiExposedCodeTypeDoContributor implements IApiExposedCodeTypeContr
   }
 
   protected boolean isApiExposedCodeType(IBean<ICodeType> codeTypeBean) {
-    return m_apiExposeHelper.hasApiExposedAnnotation(codeTypeBean);
+    return m_apiExposedHelper.isApiExposed(codeTypeBean);
   }
 }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/mapping/AbstractCodeToDoFunction.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/mapping/AbstractCodeToDoFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.eclipse.scout.rt.api.data.ApiExposeHelper;
+import org.eclipse.scout.rt.api.data.ApiExposedHelper;
 import org.eclipse.scout.rt.api.data.code.CodeDo;
 import org.eclipse.scout.rt.api.data.code.CodeTypeDo;
 import org.eclipse.scout.rt.dataobject.id.IId;
@@ -114,11 +114,11 @@ public abstract class AbstractCodeToDoFunction<EXPLICIT_SOURCE extends ICode<?>,
       //noinspection unchecked
       codeDo.withSortCode(codeType.getCodeIndex(code));
     }
-    BEANS.get(ApiExposeHelper.class).setObjectTypeToDo(code, codeDo);
+    BEANS.get(ApiExposedHelper.class).setObjectTypeToDo(code, codeDo);
   }
 
   protected String computeFieldName(EXPLICIT_SOURCE code) {
-    String fieldName = BEANS.get(ApiExposeHelper.class).fieldNameOf(code);
+    String fieldName = BEANS.get(ApiExposedHelper.class).fieldNameOf(code);
     if (fieldName != null) {
       return fieldName;
     }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/mapping/AbstractCodeTypeToDoFunction.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/common/code/mapping/AbstractCodeTypeToDoFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,7 @@ package org.eclipse.scout.rt.shared.services.common.code.mapping;
 import java.util.List;
 import java.util.function.Function;
 
-import org.eclipse.scout.rt.api.data.ApiExposeHelper;
+import org.eclipse.scout.rt.api.data.ApiExposedHelper;
 import org.eclipse.scout.rt.api.data.code.CodeDo;
 import org.eclipse.scout.rt.api.data.code.CodeTypeDo;
 import org.eclipse.scout.rt.dataobject.mapping.AbstractToDoFunction;
@@ -70,7 +70,7 @@ public abstract class AbstractCodeTypeToDoFunction<EXPLICIT_SOURCE extends ICode
     if (Platform.get().inDevelopmentMode()) {
       codeTypeDo.withModelClass(codeType.getClass().getName());
     }
-    BEANS.get(ApiExposeHelper.class).setObjectTypeToDo(codeType, codeTypeDo);
+    BEANS.get(ApiExposedHelper.class).setObjectTypeToDo(codeType, codeTypeDo);
   }
 
   protected List<? extends ICode<?>> getCodesToConvert(EXPLICIT_SOURCE codeType) {

--- a/org.eclipse.scout.rt.ui.html.test/src/main/java/org/eclipse/scout/rt/ui/html/AbstractRestProxyRequestHandlerTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/main/java/org/eclipse/scout/rt/ui/html/AbstractRestProxyRequestHandlerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.eclipse.scout.rt.rest.resource.ApiExposedFilter;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxy;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestOptions;
+import org.junit.Test;
+import org.mockito.internal.util.MockUtil;
+
+/**
+ * Abstract test for {@link AbstractRestProxyRequestHandler} instances
+ */
+public abstract class AbstractRestProxyRequestHandlerTest {
+
+  @Test
+  public void testProxiedHeader() throws IOException {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    doReturn("").when(req).getPathInfo();
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+
+    AbstractRestProxyRequestHandler handlerToTest = getHandlerToTest();
+    AbstractRestProxyRequestHandler handler = MockUtil.isMock(handlerToTest) ? handlerToTest : spy(handlerToTest);
+    HttpProxyRequestOptions options = mock(HttpProxyRequestOptions.class);
+    doReturn(options).when(handler).createHttpProxyRequestOptions(eq(req), eq(resp));
+
+    HttpProxy proxy = mock(HttpProxy.class);
+    when(handler.getProxy()).thenReturn(proxy);
+    handler.proxy(req, resp);
+
+    // header has been added
+    verify(options, times(1)).withCustomRequestHeader(eq(ApiExposedFilter.HTTP_HEADER_NAME), any());
+    verifyNoMoreInteractions(options);
+
+    verify(proxy, times(1)).proxy(eq(req), eq(resp), eq(options));
+    verifyNoMoreInteractions(proxy);
+  }
+
+  protected abstract AbstractRestProxyRequestHandler getHandlerToTest();
+}

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/RestProxyRequestHandlerTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/RestProxyRequestHandlerTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import static org.mockito.Mockito.*;
+
+public class RestProxyRequestHandlerTest extends AbstractRestProxyRequestHandlerTest {
+
+  @Override
+  protected AbstractRestProxyRequestHandler getHandlerToTest() {
+    return mock(AbstractRestProxyRequestHandler.class, CALLS_REAL_METHODS);
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/AbstractRestProxyRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/AbstractRestProxyRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.rest.resource.ApiExposedFilter;
 import org.eclipse.scout.rt.server.commons.servlet.HttpProxy;
 import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestContext;
 import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestOptions;
@@ -71,6 +72,7 @@ public abstract class AbstractRestProxyRequestHandler extends AbstractUiServletR
 
   protected void proxy(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     HttpProxyRequestOptions options = createHttpProxyRequestOptions(req, resp);
+    addProxiedRequestHeader(options);
     getProxy().proxy(req, resp, options);
   }
 
@@ -78,6 +80,10 @@ public abstract class AbstractRestProxyRequestHandler extends AbstractUiServletR
    * @return options to be used for an HTTP through the proxy
    */
   protected abstract HttpProxyRequestOptions createHttpProxyRequestOptions(HttpServletRequest req, HttpServletResponse resp);
+
+  protected void addProxiedRequestHeader(HttpProxyRequestOptions options) {
+    options.withCustomRequestHeader(ApiExposedFilter.HTTP_HEADER_NAME, "1");
+  }
 
   protected HttpProxyRequestContext createHttpProxyRequestContext(HttpServletRequest req) {
     return BEANS.get(HttpProxyRequestContext.class)


### PR DESCRIPTION
Not all resources in a backend application shall be directly accessible by browser; this commit breaks existing behavior, browser-accessible classes/methods must be marked with ApiExposed annotation otherwise they
 will be rejected with an HTTP 404 error if they are proxied by
 AbstractRestProxyRequestHandler.

419045