### PR TITLE
Simple tab box: Fix border for overflow item on desktop

### DIFF
--- a/eclipse-scout-core/src/desktop/desktoptab/DesktopTabArea.less
+++ b/eclipse-scout-core/src/desktop/desktoptab/DesktopTabArea.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-.desktop-tab-area {
+.desktop-tab-area.position-top {
 
   & > .simple-overflow-tab-item {
     @desktop-overflow-tab-margin-bottom: @desktop-tab-margin-right * 2;


### PR DESCRIPTION
The overflow item for tabs on the desktop incorrectly displays a white right border.

The simple tab box has been adapted to allow for vertical tabs. In the course of this adaption, an error was made in the corresponding styling.