### PR TITLE
Table: don't remove text filter if column is removed

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -4509,8 +4509,8 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     let tableFilters = filters.map(filter => this._ensureFilter(filter));
     let result = this.filterSupport.setFilters(tableFilters, applyFilter);
 
-    result.filtersAdded.forEach(filter => this.trigger('filterAdded', {filter}));
     result.filtersRemoved.forEach(filter => this.trigger('filterRemoved', {filter}));
+    result.filtersAdded.forEach(filter => this.trigger('filterAdded', {filter}));
   }
 
   protected _ensureFilter<T extends Filter<TableRow>>(filter: TableUserFilterModel | FilterOrFunction<TableRow>): Filter<TableRow> {

--- a/eclipse-scout-core/src/table/TableFooter.ts
+++ b/eclipse-scout-core/src/table/TableFooter.ts
@@ -850,7 +850,6 @@ export class TableFooter extends Widget implements TableFooterModel {
       if (currentText !== textFilter.text) {
         this._$textFilter.val(textFilter.text);
         this._updateHasFilterText();
-        this._applyFilter();
       }
     }
   }
@@ -861,7 +860,6 @@ export class TableFooter extends Widget implements TableFooterModel {
     if (event.filter instanceof TableUserFilter && event.filter.filterType === TableTextUserFilter.TYPE) {
       this._$textFilter.val('');
       this._updateHasFilterText();
-      this._applyFilter();
     }
   }
 

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -4023,10 +4023,10 @@ describe('Table', () => {
       expect(table.filters.length).toBe(1);
       expect(table.filteredRows()).toEqual([row0, row3]);
       expect(eventCollector.length).toBe(2);
-      expect(eventCollector[0].type).toBe('filterAdded');
-      expect(eventCollector[0].filter).toBe(filter2);
-      expect(eventCollector[1].type).toBe('filterRemoved');
-      expect(eventCollector[1].filter).toBe(filter1);
+      expect(eventCollector[0].type).toBe('filterRemoved');
+      expect(eventCollector[0].filter).toBe(filter1);
+      expect(eventCollector[1].type).toBe('filterAdded');
+      expect(eventCollector[1].filter).toBe(filter2);
       eventCollector = [];
 
       table.setFilters([filter2, filter1]);
@@ -4111,10 +4111,10 @@ describe('Table', () => {
       expect(table.filters.length).toBe(1);
       expect(table.filteredRows()).toEqual([row0, row3]);
       expect(eventCollector.length).toBe(2);
-      expect(eventCollector[0].type).toBe('filterAdded');
-      expect(eventCollector[0].filter).toBe(filter2);
-      expect(eventCollector[1].type).toBe('filterRemoved');
-      expect(eventCollector[1].filter).toBe(filter1);
+      expect(eventCollector[0].type).toBe('filterRemoved');
+      expect(eventCollector[0].filter).toBe(filter1);
+      expect(eventCollector[1].type).toBe('filterAdded');
+      expect(eventCollector[1].filter).toBe(filter2);
       eventCollector = [];
 
       table.setFilters([filter2, filter3]);
@@ -4135,11 +4135,28 @@ describe('Table', () => {
       expect(table.filters.length).toBe(2);
       expect(table.filteredRows()).toEqual([]);
       expect(eventCollector.length).toBe(2);
-      expect(eventCollector[0].type).toBe('filterAdded');
-      expect(eventCollector[0].filter).toBe(filter1);
-      expect(eventCollector[1].type).toBe('filterRemoved');
-      expect(eventCollector[1].filter).toBe(filter2);
+      expect(eventCollector[0].type).toBe('filterRemoved');
+      expect(eventCollector[0].filter).toBe(filter2);
+      expect(eventCollector[1].type).toBe('filterAdded');
+      expect(eventCollector[1].filter).toBe(filter1);
       eventCollector = [];
+    });
+
+    it('does not accidentally remove user filters', () => {
+      let model = helper.createModelFixture(2, 4);
+      let table = helper.createTable(model);
+      table.render();
+      table.setFooterVisible(true);
+      table.addFilter(helper.createTableTextFilter(table, '0_0'));
+      expect(table.filters.length).toBe(1);
+      expect(table.filteredRows().length).toBe(1);
+
+      // Replace with a filter which does the same
+      let applyFilterSpy = spyOn(table.filterSupport, 'applyFilters').and.callThrough();
+      table.setFilters([helper.createTableTextFilter(table, '0_0')]);
+      expect(table.filters.length).toBe(1);
+      expect(table.filteredRows().length).toBe(1);
+      expect(applyFilterSpy).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
If the table has a text filter and a column is removed, the text filter is removed as well.
This happens since commit 0ff0179b67d09cc32076582c5a55ac0da24490d2.

Reason:
If a column is removed, setFilters is called with a new instance of the text filter. This triggers a filterAdded event which does nothing because the footer already has an active text filter. It also triggers a filterRemoved which removes the text filter -> order is wrong.

Unfortunately, the filters are now applied 3 times, which is unnecessary. To solve this, TableFooter._applyFilters() is not called anymore if a filter is removed or added. It is not clear, why this was necessary at all, it seems to be obsolete.

440564