### PR TITLE
PageWithNodes: update row with text from child jsPage

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
@@ -250,6 +250,10 @@ export class OutlineAdapter extends TreeAdapter {
       this.modelAdapter._initDetailTable(page);
     }
     this.modelAdapter._linkNodeWithRowLater(page);
+
+    if (!TreeAdapter.isRemote(page, false) && TreeAdapter.isRemote(parentNode, false) && parentNode.nodeType === 'nodes') {
+      this.modelAdapter.sendNodesChanged([page]);
+    }
   }
 
   protected static override _createTreeNodeRemote(this: Outline & { modelAdapter: OutlineAdapter; _createTreeNodeOrig }, pageModel: PageModel) {

--- a/eclipse-scout-core/test/desktop/outline/OutlineAdapterSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineAdapterSpec.ts
@@ -433,6 +433,34 @@ describe('OutlineAdapter', () => {
       expect(outline.nodes[2]).toBeInstanceOf(MyJsPage);
       expect(outline.nodes[2].childNodeIndex).toBe(2);
     });
+
+    it('sends nodes changed of js child page of remote node page', () => {
+      const treeHelper = new TreeSpecHelper(session);
+      const model = helper.createModelFixture(1);
+      model.nodes[0].nodeType = 'nodes';
+      const adapter = helper.createOutlineAdapter(model);
+      const outline = adapter.createWidget(model, session.desktop) as Outline;
+
+      const [page] = outline.nodes as AdapterTreeNode[];
+
+      spyOn(adapter, 'sendNodesChanged').and.callThrough();
+
+      // top level node
+      adapter.onModelEvent(treeHelper.createNodesInsertedEvent(outline, [helper.createModelNode('1', 'newChildNode', {
+        nodeType: 'jsPage',
+        jsPageObjectType: 'outlineadapterspec.MyJsPage'
+      })]));
+
+      expect(adapter.sendNodesChanged).not.toHaveBeenCalled();
+
+      // child node of remote node page
+      adapter.onModelEvent(treeHelper.createNodesInsertedEvent(outline, [helper.createModelNode('0_0', 'newChildNode', {
+        nodeType: 'jsPage',
+        jsPageObjectType: 'outlineadapterspec.MyJsPage'
+      })], page.id));
+
+      expect(adapter.sendNodesChanged).toHaveBeenCalled();
+    });
   });
 
   describe('pageParam', () => {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithNodes.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -285,14 +285,27 @@ public abstract class AbstractPageWithNodes extends AbstractPage<ITable> impleme
   }
 
   /**
-   * Called when the table gets rebuilt.
-   * <p>
-   * Updates the cell belonging to the newly created table row with the content of the page cell. row.
+   * Updates the cell belonging to the table row with the content of the page cell.
    */
   protected void updateCellFromPageCell(Cell tableRowCell, ICell pageCell) {
     tableRowCell.updateFrom(pageCell);
     // ensure a value is set
     tableRowCell.setValue(pageCell.getText());
+  }
+
+  @Override
+  public void updateTableRowFromPage(IPage page) {
+    ITableRow row = getTableRowFor(page);
+    if (row == null) {
+      return;
+    }
+    try {
+      row.setRowChanging(true);
+      updateCellFromPageCell(row.getCellForUpdate(0), page.getCell());
+    }
+    finally {
+      row.setRowChanging(false);
+    }
   }
 
   private List<? extends IMenu> m_pageMenusOfSelection;

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/IPageWithNodes.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/IPageWithNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,4 +25,9 @@ import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 public interface IPageWithNodes extends IPage<ITable> {
 
   void rebuildTableInternal();
+
+  /**
+   * Updates the table row with the content of the page.
+   */
+  void updateTableRowFromPage(IPage page);
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/AbstractJsPage.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/AbstractJsPage.java
@@ -21,6 +21,7 @@ import org.eclipse.scout.rt.client.ui.basic.cell.ICell;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.AbstractPage;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPageWithNodes;
 import org.eclipse.scout.rt.dataobject.DoEntity;
 import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.id.IId;
@@ -204,5 +205,9 @@ public abstract class AbstractJsPage extends AbstractPage<ITable> implements IJs
     jsPageModel.put("iconId", cell.getIconId());
 
     setJsPageModel(jsPageModel);
+
+    if (getParentPage() instanceof IPageWithNodes pageWithNodes) {
+      pageWithNodes.updateTableRowFromPage(this);
+    }
   }
 }


### PR DESCRIPTION
If the child page of an AbstractPageWithNodes is an IJsPage the text, cssClass, etc. is not known to the UI server when the child page is created. Therefore, send the information about the child page back to the UI server after the child page was initialized.

427023