### PR TITLE
Add overviewText and overviewHtmlEnabled to Page

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
@@ -326,6 +326,7 @@ export class OutlineAdapter extends TreeAdapter {
   protected override _initNodeModel(nodeModel?: TreeNodeModel): ChildModelOf<Page> {
     const model = super._initNodeModel(nodeModel) as ChildModelOf<Page>;
     model.pageParam = dataObjects.deserialize(model.pageParam);
+    model.overviewIconId = model.overviewIconId || null;
     return model;
   }
 

--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -49,10 +49,9 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
    * True to select the page linked with the selected row when the row was selected. May be useful on touch devices.
    */
   drillDownOnRowClick: boolean;
-  /**
-   * The icon id which is used for icons in the tile outline overview.
-   */
+  overviewText: string;
   overviewIconId: string;
+  overviewHtmlEnabled: boolean;
   showTileOverview: boolean;
   inheritMenusFromParentTablePage: boolean;
   detailMenuContributors: PageDetailMenuContributor[];
@@ -91,7 +90,6 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
     this.classId = null;
     this.tableStatusVisible = true;
     this.drillDownOnRowClick = false;
-    this.overviewIconId = null;
     this.showTileOverview = false;
     this.inheritMenusFromParentTablePage = true;
     this.detailMenuContributors = [];
@@ -194,8 +192,16 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
     this.trigger('destroy');
   }
 
+  setOverviewText(overviewText: string) {
+    this.overviewText = overviewText;
+  }
+
   setOverviewIconId(overviewIconId: string) {
     this.overviewIconId = overviewIconId;
+  }
+
+  setOverviewHtmlEnabled(overviewHtmlEnabled: boolean) {
+    this.overviewHtmlEnabled = overviewHtmlEnabled;
   }
 
   protected _createDetailMenuContributors(): ObjectOrType<PageDetailMenuContributor>[] {

--- a/eclipse-scout-core/src/desktop/outline/pages/PageModel.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageModel.ts
@@ -32,9 +32,27 @@ export interface PageModel extends TreeNodeModel, ObjectModelWithUuid<TreeNode> 
    */
   drillDownOnRowClick?: boolean;
   /**
-   * The icon id which is used for icons in the tile outline overview.
+   * Configures the text which is used in the tile outline overview.
+   *
+   * If the value is `undefined`, the {@link PageTileButton} uses the {@link PageModel.text} instead.
+   * If no text should be displayed, set the value to `null`.
+   */
+  overviewText?: string;
+  /**
+   * Configures the icon which is used in the tile outline overview.
+   *
+   * If the value is `undefined`, the {@link PageTileButton} uses the {@link PageModel.iconId} instead.
+   * If no icon should be displayed, set the value to `null`.
    */
   overviewIconId?: string;
+  /**
+   * Configures whether HTML code in the {@link PageModel.overviewText} property should be interpreted. If set to false, the HTML will be encoded.
+   *
+   * If the value is `undefined`, the {@link PageTileButton} uses {@link PageModel.htmlEnabled} instead.
+   *
+   * Default is false.
+   */
+  overviewHtmlEnabled?: boolean;
   showTileOverview?: boolean;
   /**
    * True to inherit all menus (single selection) from the parent table page, false to inherit none.

--- a/eclipse-scout-core/src/desktop/outline/pages/PageTileButton.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageTileButton.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,9 +24,9 @@ export class PageTileButton extends TileButton implements PageTileButtonModel {
   protected override _init(model: InitModelOf<this>) {
     super._init(model);
 
-    this.label = this.page.text;
-    this.iconId = this.page.overviewIconId;
-    this.labelHtmlEnabled = this.page.htmlEnabled;
+    this.label = this._text;
+    this.iconId = this._iconId;
+    this.labelHtmlEnabled = this._htmlEnabled;
 
     this.on('click', (event: Event<Button>) => {
       this.outline.selectNode(this.page);
@@ -34,8 +34,29 @@ export class PageTileButton extends TileButton implements PageTileButtonModel {
   }
 
   notifyPageChanged() {
-    this.setLabel(this.page.text);
-    this.setIconId(this.page.overviewIconId);
-    this.setLabelHtmlEnabled(this.page.htmlEnabled);
+    this.setLabel(this._text);
+    this.setIconId(this._iconId);
+    this.setLabelHtmlEnabled(this._htmlEnabled);
+  }
+
+  protected get _text(): string {
+    if (this.page?.overviewText !== undefined) {
+      return this.page.overviewText;
+    }
+    return this.page?.text;
+  }
+
+  protected get _iconId(): string {
+    if (this.page?.overviewIconId !== undefined) {
+      return this.page.overviewIconId;
+    }
+    return this.page?.iconId;
+  }
+
+  protected get _htmlEnabled(): boolean {
+    if (this.page?.overviewHtmlEnabled !== undefined) {
+      return !!this.page.overviewHtmlEnabled;
+    }
+    return this.page?.htmlEnabled;
   }
 }

--- a/eclipse-scout-core/test/desktop/outline/pages/PageTileButtonSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageTileButtonSpec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {icons, Outline, Page, PageTileButton, scout} from '../../../../src';
+import {OutlineSpecHelper} from '../../../../src/testing';
+
+describe('PageTileButton', () => {
+
+  let session: SandboxSession;
+  let helper: OutlineSpecHelper;
+  let outline: Outline;
+  let page: Page;
+
+  beforeEach(() => {
+    setFixtures(sandbox());
+    session = sandboxSession();
+    helper = new OutlineSpecHelper(session);
+    outline = helper.createOutline(helper.createModelFixture(1));
+    page = outline.nodes[0];
+  });
+
+  describe('overview properties of page', () => {
+
+    it('are used if set', () => {
+      page.setText('Foo');
+      page.setIconId(icons.SLIPPERY);
+      page.setHtmlEnabled(false);
+
+      const pageTileButton = scout.create(PageTileButton, {
+        parent: outline,
+        outline,
+        page
+      });
+
+      // no overview properties set -> use original properties
+      expect(pageTileButton.label).toBe('Foo');
+      expect(pageTileButton.iconId).toBe(icons.SLIPPERY);
+      expect(pageTileButton.labelHtmlEnabled).toBeFalse();
+
+      // overview properties set
+      page.setOverviewText('Bar');
+      page.setOverviewIconId(icons.CLOCK);
+      page.setOverviewHtmlEnabled(true);
+      pageTileButton.notifyPageChanged();
+
+      expect(pageTileButton.label).toBe('Bar');
+      expect(pageTileButton.iconId).toBe(icons.CLOCK);
+      expect(pageTileButton.labelHtmlEnabled).toBeTrue();
+
+      // overview properties set to null -> overwrites original values
+      page.setOverviewText(null);
+      page.setOverviewIconId(null);
+      page.setOverviewHtmlEnabled(null);
+      pageTileButton.notifyPageChanged();
+
+      expect(pageTileButton.label).toBeNull();
+      expect(pageTileButton.iconId).toBeNull();
+      expect(pageTileButton.labelHtmlEnabled).toBeFalse();
+
+      // overview properties reset to undefined -> use original properties
+      page.setOverviewText(undefined);
+      page.setOverviewIconId(undefined);
+      page.setOverviewHtmlEnabled(undefined);
+      pageTileButton.notifyPageChanged();
+
+      expect(pageTileButton.label).toBe('Foo');
+      expect(pageTileButton.iconId).toBe(icons.SLIPPERY);
+      expect(pageTileButton.labelHtmlEnabled).toBeFalse();
+    });
+  });
+});


### PR DESCRIPTION
Introduce the new properties overviewText and overviewHtmlEnabled on the Page. These properties are used by the PageTileButton to display a tile outline overview like overviewIconId. The PageTileButton uses these properties if they are set (i.e. not undefined). If they are not set it text, iconId and htmlEnabled are used to display the tile overview.

427023