### PR TITLE
app-links: fix keystroke

### DIFF
--- a/eclipse-scout-core/src/calendar/CalendarComponent.ts
+++ b/eclipse-scout-core/src/calendar/CalendarComponent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {aria, Calendar, CalendarComponentEventMap, CalendarComponentModel, DateRange, dates, icons, InitModelOf, JsonDateRange, Label, Popup, Range, scout, strings, Widget, WidgetPopup} from '../index';
+import {aria, Calendar, CalendarComponentEventMap, CalendarComponentModel, DateRange, dates, events, icons, InitModelOf, JsonDateRange, Label, Popup, Range, scout, strings, Widget, WidgetPopup} from '../index';
 import $ from 'jquery';
 
 export class CalendarComponent extends Widget implements CalendarComponentModel {
@@ -466,10 +466,8 @@ export class CalendarComponent extends Widget implements CalendarComponentModel 
     });
   }
 
-  _onAppLinkAction(event: JQuery.ClickEvent) {
-    let $target = $(event.delegateTarget);
-    let ref = $target.data('ref') as string;
-    this.triggerAppLinkAction(ref);
+  _onAppLinkAction(event: JQuery.TriggeredEvent) {
+    events.triggerAppLinkAction(event, this.triggerAppLinkAction.bind(this));
   }
 }
 

--- a/eclipse-scout-core/src/form/fields/AppLinkKeyStroke.ts
+++ b/eclipse-scout-core/src/form/fields/AppLinkKeyStroke.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,7 @@ export class AppLinkKeyStroke extends KeyStroke {
     this.which = [keys.SPACE, keys.ENTER];
     this.renderingHints.render = false;
     this.inheritAccessibility = false; // Links cannot be disabled, mouse handlers work as well
+    this.stopPropagation = true;
   }
 
   protected override _accept(event: ScoutKeyboardEvent): boolean {

--- a/eclipse-scout-core/src/form/fields/beanfield/BeanField.ts
+++ b/eclipse-scout-core/src/form/fields/beanfield/BeanField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,8 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AppLinkKeyStroke, BeanFieldModel, ValueField} from '../../../index';
-import $ from 'jquery';
+import {AppLinkKeyStroke, BeanFieldModel, events, ValueField} from '../../../index';
 
 /**
  * Base class for fields where the value should be visualized.
@@ -79,8 +78,6 @@ export class BeanField<TValue extends object> extends ValueField<TValue> impleme
   }
 
   protected _onAppLinkAction(event: JQuery.TriggeredEvent) {
-    let $target = $(event.delegateTarget);
-    let ref = $target.data('ref');
-    this.triggerAppLinkAction(ref);
+    events.triggerAppLinkAction(event, this.triggerAppLinkAction.bind(this));
   }
 }

--- a/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.ts
+++ b/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,8 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AppLinkKeyStroke, HtmlFieldEventMap, HtmlFieldModel, scrollbars, SelectAllTextInFieldKeyStroke, ValueField} from '../../../index';
-import $ from 'jquery';
+import {AppLinkKeyStroke, events, HtmlFieldEventMap, HtmlFieldModel, scrollbars, SelectAllTextInFieldKeyStroke, ValueField} from '../../../index';
 
 export class HtmlField extends ValueField<string> implements HtmlFieldModel {
   declare model: HtmlFieldModel;
@@ -125,10 +124,8 @@ export class HtmlField extends ValueField<string> implements HtmlFieldModel {
     this.$field.toggleAttr('tabindex', !!this.selectable, '-1');
   }
 
-  protected _onAppLinkAction(event: JQuery.KeyboardEventBase | JQuery.ClickEvent) {
-    let $target = $(event.delegateTarget);
-    let ref = $target.data('ref') as string;
-    this.triggerAppLinkAction(ref);
+  protected _onAppLinkAction(event: JQuery.TriggeredEvent) {
+    events.triggerAppLinkAction(event, this.triggerAppLinkAction.bind(this));
   }
 
   triggerAppLinkAction(ref: string) {

--- a/eclipse-scout-core/src/form/fields/labelfield/LabelField.ts
+++ b/eclipse-scout-core/src/form/fields/labelfield/LabelField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {LabelFieldEventMap, LabelFieldModel, SelectAllTextInFieldKeyStroke, strings, texts, ValueField} from '../../../index';
+import {events, LabelFieldEventMap, LabelFieldModel, SelectAllTextInFieldKeyStroke, strings, texts, ValueField} from '../../../index';
 
 export class LabelField extends ValueField<string> implements LabelFieldModel {
   declare model: LabelFieldModel;
@@ -126,10 +126,8 @@ export class LabelField extends ValueField<string> implements LabelFieldModel {
     });
   }
 
-  protected _onAppLinkAction(event: JQuery.ClickEvent) {
-    let $target = $(event.delegateTarget);
-    let ref = $target.data('ref') as string;
-    this.triggerAppLinkAction(ref);
+  protected _onAppLinkAction(event: JQuery.TriggeredEvent) {
+    events.triggerAppLinkAction(event, this.triggerAppLinkAction.bind(this));
   }
 
   triggerAppLinkAction(ref: string) {

--- a/eclipse-scout-core/src/label/Label.ts
+++ b/eclipse-scout-core/src/label/Label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,8 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AppLinkKeyStroke, HtmlComponent, InitModelOf, KeyStrokeContext, LabelEventMap, LabelModel, strings, Widget} from '../index';
-import $ from 'jquery';
+import {AppLinkKeyStroke, events, HtmlComponent, InitModelOf, KeyStrokeContext, LabelEventMap, LabelModel, strings, Widget} from '../index';
 
 export class Label extends Widget implements LabelModel {
   declare model: LabelModel;
@@ -102,10 +101,8 @@ export class Label extends Widget implements LabelModel {
     }
   }
 
-  protected _onAppLinkAction(event: JQuery.ClickEvent | JQuery.KeyboardEventBase) {
-    let $target = $(event.delegateTarget);
-    let ref = $target.data('ref');
-    this.triggerAppLinkAction(ref);
+  protected _onAppLinkAction(event: JQuery.TriggeredEvent) {
+    events.triggerAppLinkAction(event, this.triggerAppLinkAction.bind(this));
   }
 
   triggerAppLinkAction(ref: string) {

--- a/eclipse-scout-core/src/notification/Notification.ts
+++ b/eclipse-scout-core/src/notification/Notification.ts
@@ -7,8 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {aria, HtmlComponent, Icon, icons, InitModelOf, NotificationEventMap, NotificationModel, scout, Status, StatusOrModel, strings, texts, Widget} from '../index';
-import $ from 'jquery';
+import {aria, events, HtmlComponent, Icon, icons, InitModelOf, NotificationEventMap, NotificationModel, scout, Status, StatusOrModel, strings, texts, Widget} from '../index';
 
 export class Notification extends Widget implements NotificationModel {
   declare model: NotificationModel;
@@ -201,10 +200,8 @@ export class Notification extends Widget implements NotificationModel {
     this.trigger('close');
   }
 
-  protected _onAppLinkAction(event: JQuery.ClickEvent) {
-    let $target = $(event.delegateTarget);
-    let ref = $target.data('ref') as string;
-    this.triggerAppLinkAction(ref);
+  protected _onAppLinkAction(event: JQuery.TriggeredEvent) {
+    events.triggerAppLinkAction(event, this.triggerAppLinkAction.bind(this));
   }
 
   triggerAppLinkAction(ref: string) {

--- a/eclipse-scout-core/src/style/mixins.less
+++ b/eclipse-scout-core/src/style/mixins.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -155,6 +155,35 @@
     top: @top;
     width: calc(~'100% + ' @diffW);
     height: calc(~'100% + ' @diffH);
+  }
+
+  .pseudo-overlay(@top: 0, @right: @top, @bottom: @top, @left: @top) {
+    content: '';
+    position: absolute;
+    top: @top;
+    right: @right;
+    bottom: @bottom;
+    left: @left;
+    pointer-events: none; // Necessary when used as ::after element
+  }
+
+  /**
+   * Draws an ::after element that has the focus-box-shadow.
+   * An ::after element is necessary to add a little horizontal padding.
+   */
+
+  .link-focus-overlay {
+    position: relative;
+
+    &:focus {
+      box-shadow: none;
+
+      &::after {
+        #scout.focus-box-shadow();
+        #scout.pseudo-overlay(0, -2px, 0, -2px);
+        border-radius: @border-radius;
+      }
+    }
   }
 
   /* Use dashed line instead of solid to avoid visual conflict with editable fields */

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -9,8 +9,8 @@
  */
 import {
   AbstractTableAccessibilityRenderer, Action, AggregateTableControl, Alignment, AppLinkKeyStroke, aria, arrays, BooleanColumn, Cell, CellEditorPopup, clipboard, Column, ColumnModel, CompactColumn, Comparator, ContextMenuKeyStroke,
-  ContextMenuPopup, dataObjects, DefaultTableAccessibilityRenderer, Desktop, DesktopPopupOpenEvent, Device, DisplayViewId, DoubleClickSupport, dragAndDrop, DragAndDropHandler, DropType, EnumObject, ErrorHandler, EventHandler, Filter,
-  Filterable, FilterOrFunction, FilterResult, FilterSupport, FullModelOf, graphics, HierarchicalTableAccessibilityRenderer, HtmlComponent, IconColumn, InitModelOf, Insets, IUserFilterStateDo, keys, KeyStrokeContext,
+  ContextMenuPopup, dataObjects, DefaultTableAccessibilityRenderer, Desktop, DesktopPopupOpenEvent, Device, DisplayViewId, DoubleClickSupport, dragAndDrop, DragAndDropHandler, DropType, EnumObject, ErrorHandler, EventHandler, events,
+  Filter, Filterable, FilterOrFunction, FilterResult, FilterSupport, FullModelOf, graphics, HierarchicalTableAccessibilityRenderer, HtmlComponent, IconColumn, InitModelOf, Insets, IUserFilterStateDo, keys, KeyStrokeContext,
   LimitedResultTableStatus, LoadingSupport, Menu, MenuBar, MenuDestinations, MenuItemsOrder, menus as menuUtil, menus, NumberColumn, NumberColumnAggregationFunction, NumberColumnBackgroundEffect, ObjectOrChildModel, ObjectOrModel, objects,
   Predicate, PropertyChangeEvent, Range, scout, scrollbars, ScrollToOptions, Status, StatusOrModel, strings, styles, TableClientUiPreferenceProfileDo, TableCompactHandler, TableControl, TableCopyKeyStroke, TableCustomizer, TableEventMap,
   TableFooter, TableHeader, TableLayout, TableModel, TableNavigationCollapseKeyStroke, TableNavigationDownKeyStroke, TableNavigationEndKeyStroke, TableNavigationExpandKeyStroke, TableNavigationHomeKeyStroke,
@@ -840,7 +840,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     let row = $row.data('row') as TableRow; // read row before the $row potentially could be replaced by the column specific logic on mouse up
     if (mouseButton === 1) {
       column.onMouseUp(event, $row);
-      $appLink = this._find$AppLink(event);
+      $appLink = events.find$AppLink(event);
     }
     if ($appLink) {
       this._triggerAppLinkAction(column, row, $appLink.data('ref'), $appLink);
@@ -2377,16 +2377,6 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
       column = visibleColumns[visibleColumns.length - 1];
     }
     return column;
-  }
-
-  protected _find$AppLink(event: JQuery.MouseUpEvent): JQuery {
-    let $start = $(event.target);
-    let $stop = $(event.delegateTarget);
-    let $appLink = $start.findUp($elem => $elem.hasClass('app-link'), $stop);
-    if ($appLink.length > 0) {
-      return $appLink;
-    }
-    return null;
   }
 
   /** @internal */

--- a/eclipse-scout-core/src/tile/BeanTile.ts
+++ b/eclipse-scout-core/src/tile/BeanTile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,8 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AppLinkActionEvent, HtmlComponent, Tile, TileEventMap, TileModel} from '../index';
-import $ from 'jquery';
+import {AppLinkActionEvent, events, HtmlComponent, Tile, TileEventMap, TileModel} from '../index';
 
 export interface BeanTileModel extends TileModel {
   bean?: object;
@@ -52,8 +51,6 @@ export class BeanTile<TBean extends object = object> extends Tile implements Bea
   }
 
   protected _onAppLinkAction(event: JQuery.TriggeredEvent) {
-    let $target = $(event.delegateTarget);
-    let ref = $target.data('ref');
-    this.triggerAppLinkAction(ref);
+    events.triggerAppLinkAction(event, this.triggerAppLinkAction.bind(this));
   }
 }

--- a/eclipse-scout-core/src/util/events.ts
+++ b/eclipse-scout-core/src/util/events.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {arrays, Device, objects, Predicate, strings} from '../index';
+import $ from 'jquery';
 
 function isTouchEvent(event: JQuery.Event): event is JQuery.TouchEventBase {
   return event && strings.startsWith(event.type, 'touch');
@@ -183,6 +184,34 @@ export const events = {
         events.propagateEvent(target, event);
       });
     });
+  },
+
+  /**
+   * @returns the app-link which triggered the given event, or `null` if the app-link could not be identified
+   */
+  find$AppLink(event: JQuery.TriggeredEvent): JQuery {
+    // AppLinkKeyStroke is typically bound to the container, target is the element with the tabindex (app-link).
+    // Click listeners are typically bound to the app-link directly but the link may contain inner elements.
+    // In that case the target would be the inner element which is not an app-link.
+    let $start = $(event.target);
+    let $stop = $(event.delegateTarget);
+    let $appLink = $start.findUp($elem => $elem.hasClass('app-link'), $stop);
+    if ($appLink.length > 0) {
+      return $appLink;
+    }
+    return null;
+  },
+
+  /**
+   * Calls the given `triggerFunction` with the reference of the app link that triggered the given `event`.
+   */
+  triggerAppLinkAction(event: JQuery.TriggeredEvent, triggerFunction: (ref: string) => void) {
+    let $appLink = events.find$AppLink(event);
+    if (!$appLink) {
+      return;
+    }
+    let ref = $appLink.data('ref');
+    triggerFunction(ref);
   },
 
   /**

--- a/org.eclipse.scout.rt.svg.ui.html/src/main/js/svg/SvgField.ts
+++ b/org.eclipse.scout.rt.svg.ui.html/src/main/js/svg/SvgField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,8 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AppLinkKeyStroke, FormField} from '@eclipse-scout/core';
-import $ from 'jquery';
+import {AppLinkKeyStroke, events, FormField} from '@eclipse-scout/core';
 import {SvgFieldEventMap, SvgFieldModel} from '../index';
 
 export class SvgField extends FormField implements SvgFieldModel {
@@ -47,10 +46,8 @@ export class SvgField extends FormField implements SvgFieldModel {
       .unfocusable();
   }
 
-  protected _onAppLinkAction(event: JQuery.KeyboardEventBase | JQuery.ClickEvent) {
-    let $target = $(event.delegateTarget);
-    let ref = $target.data('ref') as string;
-    this._triggerAppLinkAction(ref);
+  protected _onAppLinkAction(event: JQuery.TriggeredEvent) {
+    events.triggerAppLinkAction(event, this._triggerAppLinkAction.bind(this));
     event.preventDefault();
   }
 


### PR DESCRIPTION
The app link handler uses the delegateTarget to read the app link ref but the AppLinkKeyStroke is often bound to the container and not the app link directly -> The ref was null for most app links when the keystroke was used.
However, the click handler is often bound to the app link itself. This means the target and the delegate target are both candidates for the app link.

Also ensure keystroke stops propagation, otherwise activating it may close the form or do a drilldown if the link is on a detail form.

438213