### PR TITLE
Form: initial focus won't be restored

### DIFF
--- a/eclipse-scout-core/src/desktop/header/DesktopHeader.ts
+++ b/eclipse-scout-core/src/desktop/header/DesktopHeader.ts
@@ -302,7 +302,7 @@ export class DesktopHeader extends Widget implements DesktopHeaderModel {
 
   protected _outlineContentMenuBar(outlineContent: OutlineContent): MenuBar {
     if (outlineContent instanceof Form) {
-      return outlineContent.rootGroupBox.menuBar;
+      return outlineContent.rootGroupBox?.menuBar;
     }
     return (outlineContent as { menuBar?: MenuBar }).menuBar;
   }

--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -1546,6 +1546,10 @@ export class Form extends Widget implements FormModel, DisplayParent {
 
   renderInitialFocus() {
     let focused = false;
+    if (this.restoreFocus()) {
+      // If the form is re-rendered, the last focused element should be focused again
+      return;
+    }
     if (this.initialFocus) {
       focused = this.initialFocus.focus();
     } else {

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -95,13 +95,13 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
    */
   _rendered: boolean;
   protected _$lastFocusedElement: JQuery;
+  protected _lastFocusedWidget: Widget;
   protected _focusInListener: (event: FocusEvent | JQuery.FocusInEvent) => void;
   protected _glassPaneContributions: GlassPaneContribution[];
   protected _parentDestroyHandler: EventHandler;
   protected _parentRemovingWhileAnimatingHandler: EventHandler;
   protected _postRenderActions: (() => void)[];
   protected _scrollHandler: (event: JQuery.ScrollEvent) => void;
-  protected _storedFocusedWidget: Widget;
 
   constructor() {
     super();
@@ -157,7 +157,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
     // focus tracking
     this.trackFocus = false;
     this._$lastFocusedElement = null;
-    this._storedFocusedWidget = null;
+    this._lastFocusedWidget = null;
 
     this._glassPaneContributions = [];
     this._addCloneProperties(['visible', 'enabled', 'inheritAccessibility', 'cssClass']);
@@ -580,7 +580,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
       this.$container.off('focusin', this._focusInListener);
     }
     if (this._$lastFocusedElement) {
-      this._storedFocusedWidget = scout.widget(this._$lastFocusedElement);
+      this._lastFocusedWidget = scout.widget(this._$lastFocusedElement);
       this._$lastFocusedElement = null;
     }
     // remove children in reverse order.
@@ -2131,23 +2131,27 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
     }
   }
 
-  restoreFocus() {
+  /**
+   * Focuses the element that was focused before the widget was removed or detached.
+   *
+   * The focus can only be restored if {@link trackFocus} is enabled.
+   */
+  restoreFocus(): boolean {
     if (this._$lastFocusedElement) {
-      this.session.focusManager.requestFocus(this._$lastFocusedElement);
-    } else if (this._storedFocusedWidget) {
-      this._storedFocusedWidget.focus();
-      this._storedFocusedWidget = null;
+      return this.session.focusManager.requestFocus(this._$lastFocusedElement);
     }
+    if (this._lastFocusedWidget) {
+      let focused = this._lastFocusedWidget.focus();
+      this._lastFocusedWidget = null;
+      return focused;
+    }
+    return false;
   }
 
   /**
    * Method invoked once a 'focusin' event is fired by this context's $container or one of its child controls.
    */
   protected _onFocusIn(event: FocusEvent | JQuery.FocusInEvent) {
-    // do not track focus events during rendering to avoid initial focus to be restored.
-    if (this.rendering) {
-      return;
-    }
     if (this.$container.has(event.target)) {
       this._$lastFocusedElement = $(event.target);
     }

--- a/eclipse-scout-core/test/form/FormSpec.ts
+++ b/eclipse-scout-core/test/form/FormSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,8 +9,8 @@
  */
 import {FormSpecHelper, OutlineSpecHelper, SpecForm} from '../../src/testing/index';
 import {
-  App, CancelMenu, CloseMenu, Dimension, fields, FileChooser, Form, FormFieldMenu, FormModel, InitModelOf, MessageBox, NotificationBadgeStatus, NullWidget, NumberField, ObjectFactory, OkMenu, Popup, PopupBlockerHandler, Rectangle,
-  ResetMenu, SaveMenu, scout, SearchMenu, SequenceBox, Session, SplitBox, Status, StringField, strings, TabBox, TabItem, webstorage, WrappedFormField
+  App, CancelMenu, CloseMenu, Dimension, fields, FileChooser, Form, FormFieldMenu, FormModel, InitModelOf, MessageBox, NotificationBadgeStatus, NullWidget, NumberField, ObjectFactory, OkMenu, Outline, Page, Popup, PopupBlockerHandler,
+  Rectangle, ResetMenu, SaveMenu, scout, SearchMenu, SequenceBox, Session, SplitBox, Status, StringField, strings, TabBox, TabItem, webstorage, WrappedFormField
 } from '../../src/index';
 import {DateField, GroupBox} from '../../src';
 
@@ -989,30 +989,27 @@ describe('Form', () => {
     });
   });
 
-  describe('restore focus', () => {
-
-    let outlineHelper, desktop;
+  describe('restoreFocus', () => {
+    let outlineHelper: OutlineSpecHelper;
 
     beforeEach(() => {
-      desktop = session.desktop;
       outlineHelper = new OutlineSpecHelper(session);
     });
 
     /**
      * Scenario: Switch between two outline nodes and expect the focus in its detail forms are preserved.
      */
-    it('on detail forms', () => {
+    it('restores focus when a detail form is rendered', () => {
       // set up an outline with 2 nodes each node has a detail form with 3 fields
       let model = outlineHelper.createModelFixture(2, 0, true);
       let outline = outlineHelper.createOutline(model);
       outline.nodes.forEach(node => {
-        node.detailForm = helper.createFormWithFields(desktop, false, 3);
-        node.detailForm.nodeText = node.text;
+        node.detailForm = helper.createFormWithFields(session.desktop, false, 3);
         node.detailForm.initialFocus = node.detailForm.rootGroupBox.fields[1];
         node.detailFormVisible = true;
       });
 
-      desktop.setOutline(outline);
+      session.desktop.setOutline(outline);
       outline.selectNodes(outline.nodes[0]);
 
       // expect the initial focus of the detail form is rendered.
@@ -1027,6 +1024,84 @@ describe('Form', () => {
       // switch back and expect the focus gets restored
       outline.selectNodes(outline.nodes[0]);
       expect(outline.nodes[0].detailForm.rootGroupBox.fields[2].isFocused()).toBe(true);
+    });
+
+    it('restores focus when a view is activated', async () => {
+      // Create a page so that desktop.bringOutlineToFront() works
+      let outline = scout.create(Outline, {
+        parent: session.desktop,
+        nodes: [{
+          objectType: Page,
+          detailForm: {objectType: Form}
+        }]
+      });
+      session.desktop.setOutline(outline);
+      outline.selectNodes(outline.nodes[0]);
+
+      let model = {
+        parent: session.desktop,
+        displayHint: Form.DisplayHint.VIEW,
+        rootGroupBox: {
+          objectType: GroupBox,
+          fields: [{
+            id: 'field1',
+            objectType: StringField
+          }, {
+            id: 'field2',
+            objectType: StringField
+          }]
+        }
+      };
+      let form = scout.create(Form, model);
+      await form.open();
+      expect(form.rootGroupBox.fields[0].isFocused()).toBe(true);
+
+      session.desktop.bringOutlineToFront();
+      expect(form.rootGroupBox.fields[0].isFocused()).toBe(false);
+
+      // Focus was in field 1 before -> restore it
+      form.activate();
+      expect(form.rootGroupBox.fields[0].isFocused()).toBe(true);
+
+      let form2 = scout.create(Form, {
+        ...model,
+        initialFocus: 'field2'
+      });
+      await form2.open();
+      expect(form2.rootGroupBox.fields[1].isFocused()).toBe(true);
+
+      // Focus should still be in field 1
+      form.activate();
+      expect(form.rootGroupBox.fields[0].isFocused()).toBe(true);
+
+      // Form 2 had the initial focus set to field 2 -> It should still be there
+      form2.activate();
+      expect(form2.rootGroupBox.fields[1].isFocused()).toBe(true);
+
+      // Change focus on form 2 which had an initial focus
+      form2.rootGroupBox.fields[0].focus();
+      expect(form2.rootGroupBox.fields[0].isFocused()).toBe(true);
+
+      form.activate();
+      expect(form.rootGroupBox.fields[0].isFocused()).toBe(true);
+
+      // Change focus on form 1 which didn't have an initial focus
+      form.rootGroupBox.fields[1].focus();
+      expect(form.rootGroupBox.fields[1].isFocused()).toBe(true);
+
+      // Activate form 2 -> initial focus must be ignored because a focus another field was explicitly focused
+      form2.activate();
+      expect(form2.rootGroupBox.fields[0].isFocused()).toBe(true);
+
+      // Activate form 1 -> focus must be restored to the explicitly focused field
+      form.activate();
+      expect(form.rootGroupBox.fields[1].isFocused()).toBe(true);
+
+      session.desktop.bringOutlineToFront();
+      expect(form.rootGroupBox.fields[0].isFocused()).toBe(false);
+
+      form.activate();
+      expect(form.rootGroupBox.fields[1].isFocused()).toBe(true);
     });
   });
 


### PR DESCRIPTION
If a form is opened as view and deactivated without changing the focus first, the focus will be on the desktop when the form is activated. It should be in the field that was focused before the form was deactivated.

The problem was, that the focus tracker (onFocusIn) ignored focus events that happened during rendering, so the initial focus was not tracked. Now it is tracked even during rendering, but the form has to make sure it does not render the initial focus when it is re-rendered -> it now tries to restore the focus itself and only renders the initial focus if no focus was stored or if restore did not restore anything. The widget will also call restoreFocus after the form is rendered, but this should do nothing because the element is already focused.

437591