### PR TITLE
FocusContext: missing keyboard-navigation with activeElement.tabindex=-1

### DIFF
--- a/eclipse-scout-core/src/focus/FocusContext.ts
+++ b/eclipse-scout-core/src/focus/FocusContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -94,13 +94,15 @@ export class FocusContext {
    * behavior).
    */
   focusNextTabbable(forward = true, event?: KeyDownEvent) {
-    let $allFocusableElements = this.$container.find(':tabbable');
+    let activeElement = this.$container.activeElement(true);
+    let $allFocusableElements = this.$container.find(':focusable')
+      // Active element may have tabindex=-1 which makes it focusable but not tabbable -> include it otherwise activeElementIndex could not be resolved.
+      .filter((index, elem) => $(elem).is(':tabbable') || elem === activeElement);
     let $focusableElements = $allFocusableElements.filter((index, elem) => !this.focusManager.isElementCovertByGlassPane(elem));
     if ($focusableElements.length === 0) {
       return; // no focusable elements -> nothing to do
     }
 
-    let activeElement = this.$container.activeElement(true);
     let activeElementIndex = $focusableElements.index(activeElement);
     let firstFocusableElement = $focusableElements.first()[0];
     let lastFocusableElement = $focusableElements.last()[0];

--- a/eclipse-scout-core/test/focus/FocusManagerSpec.ts
+++ b/eclipse-scout-core/test/focus/FocusManagerSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -365,6 +365,26 @@ describe('FocusManager', () => {
       glassPane3.render($(input3));
       focusManager.focusNextTabbable(input1);
       expect(document.activeElement).toBe(session.$entryPoint[0]);
+    });
+
+    it('works even if active element is not tabbable', () => {
+      let $container = session.$entryPoint.appendDiv();
+      let $elem1 = $container.appendDiv().attr('tabindex', '0');
+      let $elem2 = $container.appendDiv().attr('tabindex', '-1');
+      let $elem3 = $container.appendDiv().attr('tabindex', '0');
+      focusManager.installFocusContext($container);
+
+      focusManager.requestFocus($elem2);
+      expect(document.activeElement).toBe($elem2[0]);
+
+      focusManager.focusNextTabbable($container.activeElement(), false);
+      expect(document.activeElement).toBe($elem1[0]);
+      expect($elem1).toHaveClass('keyboard-navigation');
+
+      focusManager.focusNextTabbable($container.activeElement());
+      expect(document.activeElement).toBe($elem3[0]);
+      expect($elem3).toHaveClass('keyboard-navigation');
+      expect($elem1).not.toHaveClass('keyboard-navigation');
     });
   });
 });


### PR DESCRIPTION
If active element has tabindex=-1 it is not considered tabbable, only focusable. So the user can click into it and it gets the focus. When pressing tab, the next tabbable should be focused and get the class keyboard-navigation. The focusing will likely work because the browser takes care of it, but the keyboard-navigation class is missing.

439786