### PR TITLE
Define a maximum runtime for test methods

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/testing/client/runner/parameterized/ParameterizedClientTestRunnerTimeoutTransactionTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/testing/client/runner/parameterized/ParameterizedClientTestRunnerTimeoutTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,9 +39,9 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(ParameterizedClientTestRunner.class)
 @RunWithSubject("default")
 @RunWithClientSession(TestEnvironmentClientSession.class)
-public class ParameterizedServerTestRunnerTimeoutTransactionTest {
+public class ParameterizedClientTestRunnerTimeoutTransactionTest {
 
-  private Map<String, Set<PropertyMap>> s_protocolByTestMethod;
+  private Map<String, Set<PropertyMap>> m_protocolByTestMethod;
   private static Map<String, Integer> s_expectedPropertyMapsCountByTestMethod;
 
   @Rule
@@ -49,10 +49,10 @@ public class ParameterizedServerTestRunnerTimeoutTransactionTest {
 
   private ParameterizedServerTestRunnerTestParameter m_param;
 
-  public ParameterizedServerTestRunnerTimeoutTransactionTest(ParameterizedServerTestRunnerTestParameter param) {
+  public ParameterizedClientTestRunnerTimeoutTransactionTest(ParameterizedServerTestRunnerTestParameter param) {
     m_param = param;
 
-    s_protocolByTestMethod = new HashMap<>();
+    m_protocolByTestMethod = new HashMap<>();
     s_expectedPropertyMapsCountByTestMethod = new HashMap<>();
     s_expectedPropertyMapsCountByTestMethod.put("testDefault", 1);
     s_expectedPropertyMapsCountByTestMethod.put("testTimeout", 3);
@@ -70,11 +70,7 @@ public class ParameterizedServerTestRunnerTimeoutTransactionTest {
 
   protected void updateProtocol() {
     String testName = getMethodName();
-    Set<PropertyMap> p = s_protocolByTestMethod.get(testName);
-    if (p == null) {
-      p = new HashSet<>(3);
-      s_protocolByTestMethod.put(testName, p);
-    }
+    Set<PropertyMap> p = m_protocolByTestMethod.computeIfAbsent(testName, k -> new HashSet<>(3));
     p.add(PropertyMap.CURRENT.get());
   }
 
@@ -83,7 +79,7 @@ public class ParameterizedServerTestRunnerTimeoutTransactionTest {
     Integer expectedTransactionCount = s_expectedPropertyMapsCountByTestMethod.get(testName);
     assertNotNull(expectedTransactionCount);
 
-    Set<PropertyMap> transactions = s_protocolByTestMethod.get(testName);
+    Set<PropertyMap> transactions = m_protocolByTestMethod.get(testName);
     int actualTransactionCount = transactions == null ? 0 : transactions.size();
 
     assertEquals(expectedTransactionCount.intValue(), actualTransactionCount);

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/PlatformTestRunner.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/runner/PlatformTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,12 +12,14 @@ package org.eclipse.scout.rt.testing.platform.runner;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IPlatform;
 import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.reflect.ReflectionUtility;
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.testing.platform.runner.statement.AssertNoRunningJobsStatement;
 import org.eclipse.scout.rt.testing.platform.runner.statement.BeanAnnotationsCleanupStatement;
 import org.eclipse.scout.rt.testing.platform.runner.statement.BeanAnnotationsInitStatement;
@@ -153,11 +155,16 @@ public class PlatformTestRunner extends BlockJUnit4ClassRunner {
     return new BeanAnnotationsCleanupStatement(s1);
   }
 
+  protected Statement withMaximumRuntime(final FrameworkMethod method, final Statement next) {
+    return new MonitorRuntimeStatement(method, next);
+  }
+
   @Override
   protected Statement methodBlock(final FrameworkMethod method) {
     final Statement superStatement = PlatformTestRunner.super.methodBlock(method);
+    final Statement statementWithMaximumRuntime = withMaximumRuntime(method, superStatement);
 
-    return interceptMethodLevelStatement(superStatement, getTestClass().getJavaClass(), method.getMethod());
+    return interceptMethodLevelStatement(statementWithMaximumRuntime, getTestClass().getJavaClass(), method.getMethod());
   }
 
   protected Statement interceptBeforeClassStatement(Statement beforeClassStatement, Class<?> javaClass) {
@@ -364,6 +371,70 @@ public class PlatformTestRunner extends BlockJUnit4ClassRunner {
         }
       }
       MultipleFailureException.assertEmpty(m_errors);
+    }
+  }
+
+  /**
+   * Each test method should not exceed a specific default runtime, however we cannot set timeouts just for all methods as timeouts would also create a different behavior (timeout test methods are executed in a different thread).
+   * <p>
+   * This statement just monitors the runtime for each test method and after everything is finished an error is thrown if the maximum runtime has been exceeded.
+   * It may be useful to identify test methods which suddenly take a much longer time.
+   * </p>
+   * <p>
+   * This statement defines a default maximum runtime of three minutes; if a test is supposed to take longer than three minutes a higher timeout should be defined on the specific test-method to increase this maximum expected runtime.
+   * </p>
+   *
+   * @see Test#timeout()
+   */
+  protected static class MonitorRuntimeStatement extends Statement {
+
+    private static final long DEFAULT_MAXIMUM_RUNTIME = TimeUnit.MINUTES.toMillis(3);
+
+    private final long m_timeout;
+    private final Statement m_next;
+
+    public MonitorRuntimeStatement(FrameworkMethod method, Statement next) {
+      m_timeout = calculateTimeout(method);
+      m_next = next;
+    }
+
+    protected long getConfiguredDefaultMaximumRuntime() {
+      return DEFAULT_MAXIMUM_RUNTIME;
+    }
+
+    protected long calculateTimeout(FrameworkMethod frameworkMethod) {
+      long configuredDefaultMaximumRuntime = getConfiguredDefaultMaximumRuntime();
+      Method method = frameworkMethod.getMethod();
+
+      Test annotation = ReflectionUtility.getAnnotation(Test.class, method);
+      if (annotation == null) {
+        return configuredDefaultMaximumRuntime; // set a default timeout, we usually do not want our tests to run forever
+      }
+
+      long timeout = annotation.timeout();
+      if (timeout < 0L) {
+        return 0L; // forever
+      }
+      else if (timeout >= 0L && timeout <= configuredDefaultMaximumRuntime) {
+        return configuredDefaultMaximumRuntime; // override default timeout, we do not want to run our tests forever
+      }
+      return timeout;
+    }
+
+    protected Statement getNext() {
+      return m_next;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+      long startMillis = System.nanoTime() / 1_000_000;
+      m_next.evaluate(); // run the next statement
+      long endMillis = System.nanoTime() / 1_000_000;
+      long elapsed = endMillis - startMillis;
+
+      if (elapsed > m_timeout) {
+        throw new AssertionException("Test including pre-/post-methods took longer than maximum expected runtime (maximum expected: {}, actual runtime: {}); specify a higher timeout on the @Test method to increase maximum time for specific test methods", m_timeout, elapsed);
+      }
     }
   }
 }

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/testing/platform/runner/statement/MonitorRuntimeStatementTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/testing/platform/runner/statement/MonitorRuntimeStatementTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.testing.platform.runner.statement;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runners.MethodSorters;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+public class MonitorRuntimeStatementTest {
+
+  @Test
+  public void testStatement() throws InitializationError {
+    Result result = new JUnitCore().run(createRunner());
+
+    assertEquals(3, result.getRunCount()); // all tests must be run
+    assertEquals(1, result.getFailureCount()); // only testFirst may fail
+    assertEquals(0, result.getIgnoreCount()); // nothing should be ignored
+    assertTrue(result.getRunTime() > 1000L); // two sleeps below, must run at least 1 second
+  }
+
+  public PlatformTestRunner createRunner() throws InitializationError {
+    return new PlatformTestRunner(TestCase.class) { // customized runner just for our test case below
+      @Override
+      protected Statement withMaximumRuntime(FrameworkMethod method, Statement next) {
+        return new MonitorRuntimeStatement(method, next) {
+          @Override
+          protected long getConfiguredDefaultMaximumRuntime() {
+            return 250; // shorter runtime for testing
+          }
+        };
+      }
+    };
+  }
+
+  // no actual test cases; should just be run/used within other test cases
+  @SuppressWarnings({"JUnitMalformedDeclaration", "JUnit3StyleTestMethodInJUnit4Class"})
+  @FixMethodOrder(MethodSorters.NAME_ASCENDING)
+  public static class TestCase {
+
+    @Test
+    public void testFirst() throws InterruptedException {
+      Thread.sleep(500);
+    }
+
+    @Test(timeout = 5000)
+    public void testSecond() throws InterruptedException {
+      Thread.sleep(500);
+    }
+
+    @Test
+    public void testThird() {
+      // nop: just an ordinary test method which should be executed (not influenced by previous failures)
+    }
+  }
+}


### PR DESCRIPTION
Runtime is checked after execution has finished and if maximum time has been exceeded test fails with an error. No actual timeout is defined as timeouts would result in a behavior change for several tests (methods would be executed in different threads); however with the maximum runtime we should still be able to identify newly long-running tests faster.

422336