### PR TITLE
TableFooter: prevent initial focus for table status menu

### DIFF
--- a/eclipse-scout-core/src/table/TableFooter.ts
+++ b/eclipse-scout-core/src/table/TableFooter.ts
@@ -147,6 +147,7 @@ export class TableFooter extends Widget implements TableFooterModel {
     this._infoTableStatusMenu = scout.create(Menu, {
       parent: this,
       toggleAction: true,
+      preventInitialFocus: true,
       cssClass: 'table-info-item table-info-status'
     });
     this._infoTableStatusMenu.render(this._$info);


### PR DESCRIPTION
All other actions in the table footer have this already set by default. Prevents unwanted focus when pressing Ctrl-R on a JS table page with searchRequired=true.