### PR TITLE
Chart: fix axis label on combo chart

### DIFF
--- a/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
+++ b/eclipse-scout-chart/src/chart/ChartJsRenderer.ts
@@ -2930,8 +2930,8 @@ export class ChartJsRenderer extends AbstractChartRenderer {
 
     let yAxisType = (datasets[0].type || type),
       yAxisDiffTypeType = (datasetsDiffType[0].type || type),
-      yAxisTypeLabel = this.chart.session.text('ui.' + yAxisType),
-      yAxisDiffTypeTypeLabel = this.chart.session.text('ui.' + yAxisDiffTypeType),
+      yAxisTypeLabel = this._typeText(yAxisType),
+      yAxisDiffTypeTypeLabel = this._typeText(yAxisDiffTypeType),
       yAxisScaleLabel = options.scaleLabelByTypeMap ? options.scaleLabelByTypeMap[yAxisType] : null,
       yAxisDiffTypeScaleLabel = options.scaleLabelByTypeMap ? options.scaleLabelByTypeMap[yAxisDiffTypeType] : null;
 
@@ -2946,6 +2946,17 @@ export class ChartJsRenderer extends AbstractChartRenderer {
     datasetsDiffType.forEach(dataset => {
       dataset.yAxisID = 'yDiffType';
     });
+  }
+
+  protected _typeText(chartType: ChartType) {
+    if (chartType === Chart.Type.BAR) {
+      return this.chart.session.text('ui.ChartTypeBar');
+    }
+    if (chartType === Chart.Type.LINE) {
+      return this.chart.session.text('ui.ChartTypeLine');
+    }
+    // Not relevant for other types because the text is only used for the COMBO_BAR_LINE chart
+    return '';
   }
 
   protected _adjustAxisMaxMin(axis: AxisWithMaxMin, maxTicks: number, maxMinValue: Boundary) {

--- a/org.eclipse.scout.rt.chart.ui.html/src/main/java/org/eclipse/scout/rt/chart/ui/html/ChartUiTextContributor.java
+++ b/org.eclipse.scout.rt.chart.ui.html/src/main/java/org/eclipse/scout/rt/chart/ui/html/ChartUiTextContributor.java
@@ -38,7 +38,6 @@ public class ChartUiTextContributor implements IUiTextContributor {
         "ui.groupedByWeekday",
         "ui.groupedByMonth",
         "ui.groupedByYear",
-        "ui.groupedByDate",
-        "ui.line"));
+        "ui.groupedByDate"));
   }
 }


### PR DESCRIPTION
ui.bar and ui.line were removed because it looked like they were unused. But they are needed for the y-axis of a combo chart. -> Use newly introduced text keys and don't concat texts anymore so
   they can be found by a textual search.