### PR TITLE
Table: Fix scrollToSelection on tables with async validating rows

### DIFF
--- a/eclipse-scout-core/src/table/TableUpdateBuffer.ts
+++ b/eclipse-scout-core/src/table/TableUpdateBuffer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -81,9 +81,13 @@ export class TableUpdateBuffer extends EventEmitter {
       this.table._renderViewportBlocked = false;
     }
 
-    // Update the viewport as well if rendering was blocked
+    // Update the viewport and selection as well if rendering was blocked
     if (this.table._isDataRendered()) {
       this.table._renderViewport();
+
+      if (this.table.scrollToSelection) {
+        this.table.revealSelection();
+      }
     }
     this.trigger('complete');
   }


### PR DESCRIPTION
When a table has at least one row that validates its value async, the scrollToSelection flag did not have an effect on newly inserted rows. This is because the insert event gets packed into the table buffer, and the rendering of the viewport is paused. At the end of the pause, the selection was not rendered. This got fixed with this change.

422941