### PR TITLE
Add SLF4JBridgeHandler for tests

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/main/resources/logback-test-scout.xml
+++ b/org.eclipse.scout.rt.platform.test/src/main/resources/logback-test-scout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+  ~ Copyright (c) 2010, 2026 BSI Business Systems Integration AG
   ~
   ~ This program and the accompanying materials are made
   ~ available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,9 @@
   -->
 <included>
   <!-- This file is included in all scout test logback configurations -->
+
+  <contextListener class="org.eclipse.scout.rt.platform.logger.AutoRegisteringJulLevelChangePropagator" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="org.eclipse.scout.rt.platform.logger.LevelRangeFilter">
       <levelMin>TRACE</levelMin>

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/AutoRegisteringJulLevelChangePropagator.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/logger/AutoRegisteringJulLevelChangePropagator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -48,17 +48,34 @@ public class AutoRegisteringJulLevelChangePropagator extends LevelChangePropagat
 
   @Override
   public void start() {
-    if (isRemoveRootHandlers()) {
-      addInfo("removing all handlers for java.util.logging root logger");
-      SLF4JBridgeHandler.removeHandlersForRootLogger();
+    if (isSlf4jBridgeAvailable()) {
+      if (isRemoveRootHandlers()) {
+        addInfo("removing all handlers for java.util.logging root logger");
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+      }
+      SLF4JBridgeHandler.install();
     }
-    SLF4JBridgeHandler.install();
     super.start();
   }
 
   @Override
   public void stop() {
     super.stop();
-    SLF4JBridgeHandler.uninstall();
+    if (isSlf4jBridgeAvailable()) {
+      SLF4JBridgeHandler.uninstall();
+    }
+  }
+
+  /**
+   * JUL to SLF4J bridge (jul-to-slf4j) is an optional dependency
+   */
+  protected boolean isSlf4jBridgeAvailable() {
+    try {
+      Class.forName("org.slf4j.bridge.SLF4JBridgeHandler", false, getClass().getClassLoader());
+    }
+    catch (ClassNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 }


### PR DESCRIPTION
Adds SLF4JBridgeHandler in logback configuration for tests to ensure that log messages are redirected to SLF4J, providing consistent logging

445808