### PR TITLE
Add WAV MimeType

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/resource/MagicBytePatternTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/resource/MagicBytePatternTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.resource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MagicBytePatternTest {
+
+  @Test
+  public void testBytePatternCreation() {
+    runTestBytePatternCreation("aabb", new byte[]{-86, -69}, new boolean[]{false, false});
+    runTestBytePatternCreation("aaxxbb", new byte[]{-86, 0, -69}, new boolean[]{false, true, false});
+    runTestBytePatternCreation("xxbb", new byte[]{0, -69}, new boolean[]{true, false});
+    runTestBytePatternCreation("aaxx", new byte[]{-86, 0}, new boolean[]{false, true});
+    runTestBytePatternCreation("aaxxbbxxcc", new byte[]{-86, 0, -69, 0, -52}, new boolean[]{false, true, false, true, false});
+    runTestBytePatternCreation("aaxxxxxxbb", new byte[]{-86, 0, 0, 0, -69}, new boolean[]{false, true, true, true, false});
+    runTestBytePatternCreation("aaaaaaaaxxxxxxbbbbbb", new byte[]{-86, -86, -86, -86, 0, 0, 0, -69, -69, -69}, new boolean[]{false, false, false, false, true, true, true, false, false, false});
+    runTestBytePatternCreation("aaaa aaaa xxxx xxbb bbbb", new byte[]{-86, -86, -86, -86, 0, 0, 0, -69, -69, -69}, new boolean[]{false, false, false, false, true, true, true, false, false, false});
+    runTestBytePatternCreation("AAAA AAAA XXXX XXBB BBBB", new byte[]{-86, -86, -86, -86, 0, 0, 0, -69, -69, -69}, new boolean[]{false, false, false, false, true, true, true, false, false, false});
+
+    assertBytePatternThrows("", AssertionException.class, "Assertion error: hexMagic must not be empty");
+    assertBytePatternThrows("a", AssertionException.class, "Assertion error: hexMagic must contain an even number of chars");
+    assertBytePatternThrows("ax", AssertionException.class, "Assertion error: Expect finding skip char at even char indexes");
+    assertBytePatternThrows("aaxb", AssertionException.class, "Assertion error: Skip chars must come in pairs");
+  }
+
+  protected void runTestBytePatternCreation(String hexMagic, byte[] expectedBytes, boolean[] expectedSkips) {
+    MagicBytePattern bytePattern = new MagicBytePattern(0, hexMagic);
+    assertThat(bytePattern.m_bytes, is(expectedBytes));
+    assertThat(bytePattern.m_skips, is(expectedSkips));
+  }
+
+  protected void assertBytePatternThrows(String hexMagic, Class<? extends Exception> expectedException, String expectedMessage) {
+    Exception actualException = Assert.assertThrows(expectedException, () -> new MagicBytePattern(0, hexMagic));
+
+    assertThat(actualException.getMessage(), is(expectedMessage));
+  }
+
+  @Test
+  public void testBytePatternMatches() {
+    runTestBytePatternMatches(0, "aa", new byte[]{-86}, true);
+    runTestBytePatternMatches(0, "aa", new byte[]{33}, false);
+    runTestBytePatternMatches(0, "aabb", new byte[]{-86, -69}, true);
+    runTestBytePatternMatches(0, "aabb", new byte[]{11, 22}, false);
+    runTestBytePatternMatches(0, "aaxxbb", new byte[]{-86, 33, -69}, true);
+    runTestBytePatternMatches(4, "aaxxbb", new byte[]{-128, -127, -126, -125, -86, 33, -69}, true);
+    runTestBytePatternMatches(0, "aaxxbb", new byte[]{-128, -127, -126, -125, -86, 33, -69}, false);
+  }
+
+  protected void runTestBytePatternMatches(int pos, String hexMagic, byte[] content, boolean expectedMatches) {
+    MagicBytePattern bytePattern = new MagicBytePattern(pos, hexMagic);
+    assertThat(bytePattern.matches(content), is(expectedMatches));
+  }
+}

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/resource/MimeTypesTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/resource/MimeTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,8 @@
 package org.eclipse.scout.rt.platform.resource;
 
 import static org.eclipse.scout.rt.platform.resource.MimeTypes.verifyMagic;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -91,5 +93,23 @@ public class MimeTypesTest {
 
     BinaryResource binRes = BinaryResources.create().withContent(bytes).build();
     assertTrue(verifyMagic(binRes));
+  }
+
+  @Test
+  public void testWave() {
+    runWaveTest("5249 4646 2e2e 2e2e 5741 5645", true); // RIFF....WAVE
+    runWaveTest("5249 4646 3132 3334 5741 5645", true); // RIFF1234WAVE
+    runWaveTest("5249 4646 3536 3738 5741 5645", true); // RIFF5678WAVE
+    runWaveTest("3132 3334 3536 3738 4156 49", false); // 12345678WAVE
+    runWaveTest("5249 4646 3536 3738 4156 49", false); // RIFF5678AVI
+    runWaveTest("3132 3334 3536 3738 4156 49", false); // 12345678AVI
+  }
+
+  protected void runWaveTest(String content, boolean expectedValid) {
+    byte[] bytes = HexUtility.decode(content);
+    assertThat(MimeType.WAV.getMagic().matches(bytes), is(expectedValid));
+
+    BinaryResource binRes = BinaryResources.create().withContent(bytes).withFilename("foo.wav").build();
+    assertThat(verifyMagic(binRes), is(expectedValid));
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/IMimeMagic.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/IMimeMagic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,8 +9,11 @@
  */
 package org.eclipse.scout.rt.platform.resource;
 
+import java.util.Arrays;
+
+import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.platform.security.MalwareScanner;
-import org.eclipse.scout.rt.platform.util.HexUtility;
+import org.eclipse.scout.rt.platform.util.Assertions;
 
 /**
  * Typically used in combination with {@link MalwareScanner}
@@ -21,23 +24,24 @@ import org.eclipse.scout.rt.platform.util.HexUtility;
  */
 public interface IMimeMagic {
   IMimeMagic AVIF = createMagic(4, "6674797061766966");
-  IMimeMagic DOC_XLS_PPT = createMagic(0, "d0cf11e0a1b11ae1");
-  IMimeMagic DOCX_XLSX_PPTX = createMagic(0, "d0cf11e0a1b11ae1", "504b0304", "504b0506", "504b0708"); // union of DOC_XLS_PPT (used for protected office files) and ZIP (used for non-protected office files)
-  IMimeMagic BMP = createMagic(0, "424d");
-  IMimeMagic EXE_DLL_SYS = createMagic(0, "4d5a", "5a4d");
-  IMimeMagic GIF = createMagic(0, "474946383761", "474946383961");
-  IMimeMagic GZ = createMagic(0, "1f8b");
-  IMimeMagic ICO = createMagic(0, "00000100");
-  IMimeMagic JPEG_JPG = createMagic(0, "ffd8ff");
-  IMimeMagic MKV = createMagic(0, "1a45dfa3");
-  IMimeMagic MP3 = createMagic(0, "494433", "fff2", "fff3", "fffb");
+  IMimeMagic DOC_XLS_PPT = createMagic("d0cf11e0a1b11ae1");
+  IMimeMagic DOCX_XLSX_PPTX = createMagic("d0cf11e0a1b11ae1", "504b0304", "504b0506", "504b0708"); // union of DOC_XLS_PPT (used for protected office files) and ZIP (used for non-protected office files)
+  IMimeMagic BMP = createMagic("424d");
+  IMimeMagic EXE_DLL_SYS = createMagic("4d5a", "5a4d");
+  IMimeMagic GIF = createMagic("474946383761", "474946383961");
+  IMimeMagic GZ = createMagic("1f8b");
+  IMimeMagic ICO = createMagic("00000100");
+  IMimeMagic JPEG_JPG = createMagic("ffd8ff");
+  IMimeMagic MKV = createMagic("1a45dfa3");
+  IMimeMagic MP3 = createMagic("494433", "fff2", "fff3", "fffb");
   IMimeMagic MP4 = createMagic(4, "6674797069736f6d", "667479706D703432");
-  IMimeMagic MSG = createMagic(0, "2320637265617465", "6e616d6573706163", "d0cf11e0a1b11ae1");
-  IMimeMagic PDF = createMagic(0, "25504446");
-  IMimeMagic PNG = createMagic(0, "89504e470d0a1a0a");
-  IMimeMagic TIF_TIFF = createMagic(0, "49492a00", "4d4d002a");
-  IMimeMagic WOFF = createMagic(0, "774f4646", "774f4632");
-  IMimeMagic ZIP = createMagic(0, "504b0304", "504b0506", "504b0708");
+  IMimeMagic MSG = createMagic("2320637265617465", "6e616d6573706163", "d0cf11e0a1b11ae1");
+  IMimeMagic PDF = createMagic("25504446");
+  IMimeMagic PNG = createMagic("89504e470d0a1a0a");
+  IMimeMagic TIF_TIFF = createMagic("49492a00", "4d4d002a");
+  IMimeMagic WAV = createMagic("52494646XXXXXXXX57415645"); // The first 4 bytes have to be 'RIFF', then 4 bytes are skipped, then the 4 wav magic bytes are expected.
+  IMimeMagic WOFF = createMagic("774f4646", "774f4632");
+  IMimeMagic ZIP = createMagic("504b0304", "504b0506", "504b0708");
 
   /**
    * @return The number of bytes of the longest magic number (including offset if present).
@@ -63,19 +67,37 @@ public interface IMimeMagic {
     return res != null && matches(res.getContent());
   }
 
+  /**
+   * @see MagicBytePattern for desciption of the hexMagics parameter.
+   */
+  static IMimeMagic createMagic(String... hexMagics) {
+    return createMagic(0, hexMagics);
+  }
+
+  /**
+   * @see MagicBytePattern for desciption of the hexMagics parameter.
+   */
   static IMimeMagic createMagic(int pos, String... hexMagics) {
-    byte[][] magics = new byte[hexMagics.length][];
-    int maxLen = 0; // longest magic marker
-    for (int i = 0; i < hexMagics.length; i++) {
-      magics[i] = HexUtility.decode(hexMagics[i]);
-      maxLen = Math.max(maxLen, magics[i].length);
-    }
-    int magicsMaxLen = maxLen;
+    return createMagic(Arrays.stream(hexMagics)
+        .map(hexMagic -> new MagicBytePattern(pos, hexMagic))
+        .toArray(MagicBytePattern[]::new));
+  }
+
+  /**
+   * @see MagicBytePattern for desciption of the hexMagics parameter.
+   */
+  static IMimeMagic createMagic(MagicBytePattern... patterns) {
+    Assertions.assertTrue(patterns.length > 0, "At least one pattern must be provided");
+
+    int length = Arrays.stream(patterns)
+        .mapToInt(bytePattern -> bytePattern.getPos() + bytePattern.getLength())
+        .max()
+        .orElseThrow(() -> new ProcessingException("Unreachable, as provided patterns must not be empty")); // longest magic marker
 
     return new IMimeMagic() {
       @Override
       public int length() {
-        return pos + magicsMaxLen;
+        return length;
       }
 
       @Override
@@ -83,25 +105,17 @@ public interface IMimeMagic {
         if (content == null || content.length == 0) {
           return false;
         }
-        for (byte[] magic : magics) {
-          if (content.length < pos + magic.length) {
+        for (MagicBytePattern pattern : patterns) {
+          if (content.length < pattern.getPos() + pattern.getLength()) {
             continue;
           }
-          if (matchesMagic(content, magic)) {
+          if (pattern.matches(content)) {
             return true;
           }
         }
         return false;
       }
-
-      private boolean matchesMagic(byte[] content, byte[] magic) {
-        for (int i = 0; i < magic.length; i++) {
-          if (content[pos + i] != magic[i]) {
-            return false;
-          }
-        }
-        return true;
-      }
     };
   }
 }
+

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/MagicBytePattern.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/MagicBytePattern.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.resource;
+
+import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.platform.util.HexUtility;
+
+public class MagicBytePattern {
+
+  protected final int m_pos;
+  protected final byte[] m_bytes;
+  protected final boolean[] m_skips;
+
+  /**
+   * Creates a new instance with a position offset of 0.
+   *
+   * @param hexMagic
+   *     The byte pattern to check.
+   *     <p>
+   *     Supply a hex-coded string to define the pattern to check for. Bytes that should be skipped when checking the pattern can be defined by providing two consecutive 'x' chars.
+   *     <p>
+   *     The pattern is not case-sensitive, so use lower or upper case characters as your desire; you may also use spaces to structure longer patterns.
+   *     <p>
+   *     Examples:
+   *     <ul>
+   *       <li>"aa": The first checked byte must be -86</li>
+   *       <li>"aabb": The first two checked bytes must be -86 and -69</li>
+   *       <li>"aaxxbb": The first checked byte must be -86 followed by any byte followed by -69</li>
+   *     </ul>
+   *
+   */
+  public MagicBytePattern(String hexMagic) {
+    this(0, hexMagic);
+  }
+
+  /**
+   * Creates a new instance.
+   *
+   * @param pos
+   *     The position offset in the content from which the supplied pattern is checked.
+   * @param hexMagic
+   *     The byte pattern to check.
+   *     <p>
+   *     Supply a hex-coded string to define the pattern to check for. Bytes that should be skipped when checking the pattern can be defined by providing two consecutive 'x' chars.
+   *     <p>
+   *     The pattern is not case-sensitive, so use lower or upper case characters as your desire; you may also use spaces to structure longer patterns.
+   *     <p>
+   *     Examples:
+   *     <ul>
+   *       <li>"aa": The first checked byte must be -86</li>
+   *       <li>"aabb": The first two checked bytes must be -86 and -69</li>
+   *       <li>"aaxxbb": The first checked byte must be -86 followed by any byte followed by -69</li>
+   *     </ul>
+   *
+   */
+  public MagicBytePattern(int pos, String hexMagic) {
+    Assertions.assertNotNullOrEmpty(hexMagic, "hexMagic must not be empty");
+    hexMagic = hexMagic.replaceAll(" ", "");
+    Assertions.assertEqual(hexMagic.length() % 2, 0, "hexMagic must contain an even number of chars");
+
+    hexMagic = hexMagic.toLowerCase();
+
+    m_pos = pos;
+    m_bytes = HexUtility.decode(hexMagic.replaceAll("xx", "00"));
+    m_skips = new boolean[m_bytes.length];
+
+    int patternPos = 0;
+    int skipPos = hexMagic.indexOf('x', patternPos);
+
+    while (skipPos > -1) {
+      Assertions.assertEqual(skipPos % 2, 0, "Expect finding skip char at even char indexes");
+      Assertions.assertEqual(hexMagic.charAt(skipPos + 1), 'x', "Skip chars must come in pairs");
+      m_skips[skipPos / 2] = true;
+
+      patternPos = skipPos + 2;
+      skipPos = hexMagic.indexOf('x', patternPos);
+    }
+  }
+
+  public int getPos() {
+    return m_pos;
+  }
+
+  public int getLength() {
+    return m_bytes.length;
+  }
+
+  public boolean matches(byte[] content) {
+    for (int i = 0; i < m_bytes.length; i++) {
+      if (m_skips[i]) {
+        continue;
+      }
+      if (content[m_pos + i] != m_bytes[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/MimeType.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/resource/MimeType.java
@@ -101,6 +101,7 @@ public enum MimeType implements IMimeType {
   VCARD("text/vcard", "vcard"),
   VCF("text/x-vcard", "vcf"),
   VCS("text/x-vcalendar", "vcs"),
+  WAV("audio/wav", "wav", IMimeMagic.WAV),
   WEBP("image/webp", "webp"),
   WEBM("video/webm", "webm"),
   WOFF("application/font-woff", "woff", IMimeMagic.WOFF),


### PR DESCRIPTION
This change introduces the new MimeType `WAV` with content type string
"audio/wav" and file extension "wav".

As checking the magic bytes of wav blobs involves skipping byte 5-8,
which was previously not possible with the IMimeMagic pattern matching,
this change also extends the magic bytes pattern matching mechanism to
allow for skipping bytes while checking the magic byte pattern.
Checking wav blob magic bytes makes use of this new enhancement.