### PR TITLE
Remove obsolete LazyValues

### DIFF
--- a/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/id/AbstractIdCodecDeserializer.java
+++ b/org.eclipse.scout.rt.jackson/src/main/java/org/eclipse/scout/rt/jackson/dataobject/id/AbstractIdCodecDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,14 +9,13 @@
  */
 package org.eclipse.scout.rt.jackson.dataobject.id;
 
-import static java.util.Collections.unmodifiableSet;
-
+import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.scout.rt.dataobject.id.IdCodec;
 import org.eclipse.scout.rt.dataobject.id.IdCodec.IIdCodecFlag;
 import org.eclipse.scout.rt.jackson.dataobject.ScoutDataObjectModuleContext;
-import org.eclipse.scout.rt.platform.util.LazyValue;
+import org.eclipse.scout.rt.platform.BEANS;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
@@ -28,19 +27,20 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 public abstract class AbstractIdCodecDeserializer<T> extends StdDeserializer<T> {
   private static final long serialVersionUID = 1L;
 
+  protected final IdCodec m_idCodec = BEANS.get(IdCodec.class);
   protected final ScoutDataObjectModuleContext m_moduleContext;
-
-  protected final LazyValue<IdCodec> m_idCodec = new LazyValue<>(IdCodec.class);
-  protected final LazyValue<Set<IIdCodecFlag>> m_idCodecFlags = new LazyValue<>(() -> unmodifiableSet(computeIdCodecFlags()));
+  protected final Set<IIdCodecFlag> m_idCodecFlags;
 
   public AbstractIdCodecDeserializer(ScoutDataObjectModuleContext moduleContext, Class<?> valueClass) {
     super(valueClass);
     m_moduleContext = moduleContext;
+    m_idCodecFlags = Collections.unmodifiableSet(computeIdCodecFlags());
   }
 
   public AbstractIdCodecDeserializer(ScoutDataObjectModuleContext moduleContext, JavaType valueType) {
     super(valueType);
     m_moduleContext = moduleContext;
+    m_idCodecFlags = Collections.unmodifiableSet(computeIdCodecFlags());
   }
 
   protected ScoutDataObjectModuleContext moduleContext() {
@@ -48,7 +48,7 @@ public abstract class AbstractIdCodecDeserializer<T> extends StdDeserializer<T> 
   }
 
   protected IdCodec idCodec() {
-    return m_idCodec.get();
+    return m_idCodec;
   }
 
   protected Set<IIdCodecFlag> computeIdCodecFlags() {
@@ -56,6 +56,6 @@ public abstract class AbstractIdCodecDeserializer<T> extends StdDeserializer<T> 
   }
 
   protected Set<IIdCodecFlag> idCodecFlags() {
-    return m_idCodecFlags.get();
+    return m_idCodecFlags;
   }
 }


### PR DESCRIPTION
LazyValue not required in a StdDeserializer:
 * There should be no cycles between IdCodec constructor and this constructor.
 * Creation cached within an ApplicationScoped IDataObjectMapper instance (Creation will be eventually always required).