### PR TITLE
PageResolver: don't destroy the page

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -139,7 +139,7 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
   /**
    * Writes the static model to the page instance and initializes the {@link pageParam}.
    * This allows the {@link PageResolver} to find the correct page without having to initialize it completely.
-   *
+   * A page initialized with this method does not need to be destroyed.
    * **Important:** Always use {@link scout.create} to create and initialize page instances. This method is *only* intended to be used for page resolving!
    */
   minimalInit() {

--- a/eclipse-scout-core/src/desktop/outline/pages/PageResolver.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageResolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -84,10 +84,6 @@ export class PageResolver implements PageResolverModel, ObjectWithType {
       let message = `Unable to create and initialize ${objectType}. Cannot check for PageParam. Error: ${e.message}`;
       $.log.error(message);
       this.session.sendLogRequest(message);
-    } finally {
-      if (page) {
-        page.destroy();
-      }
     }
   }
 


### PR DESCRIPTION
A page may have implemented _destroy and for example accessed the outline property. Destroying such a page initialized with minimalInit() would throw an exception. Because outline (parent) is a mandatory property, null checks in _destroy() are not expected. It should be safe to not destroy() such a page because minimalInit() does nothing that requires a cleanup.