### PR TITLE
DoSet, DoCollection: Fix equals if nested data structure is manipulated

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectHelperTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DataObjectHelperTest.java
@@ -16,9 +16,11 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -26,8 +28,10 @@ import java.util.UUID;
 
 import org.eclipse.scout.rt.dataobject.fixture.CollectionFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.EntityFixtureDo;
+import org.eclipse.scout.rt.dataobject.fixture.EntityMapperFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.ListEntityContributionFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.OtherEntityFixtureDo;
+import org.eclipse.scout.rt.dataobject.fixture.OtherEntityMapperFixtureDo;
 import org.eclipse.scout.rt.dataobject.fixture.SimpleFixtureDo;
 import org.eclipse.scout.rt.dataobject.migration.fixture.house.CustomerFixtureDo;
 import org.eclipse.scout.rt.dataobject.testing.TestingDataObjectHelper;
@@ -411,6 +415,46 @@ public class DataObjectHelperTest {
     assertFalse(testObj.otherEntities().get(1).id().exists());
     assertTrue(testObj.otherEntities().get(1).nestedOtherEntity().exists());
     assertFalse(testObj.otherEntities().get(1).nestedOtherEntity().get().id().exists());
+  }
+
+  @Test
+  public void testEqualityAfterCleaning_DoSet() {
+    EntityMapperFixtureDo testObj1 = BEANS.get(EntityMapperFixtureDo.class)
+        .withId("1")
+        .withEntitySet(BEANS.get(OtherEntityMapperFixtureDo.class).withId(null));
+
+    EntityMapperFixtureDo testObj2 = BEANS.get(EntityMapperFixtureDo.class)
+        .withId("1")
+        .withEntitySet(BEANS.get(OtherEntityMapperFixtureDo.class).withId(null));
+
+    assertEquals(testObj1, testObj2);
+    assertEquals(testObj1.getEntitySet(), testObj2.getEntitySet());
+    m_helper.clean(testObj1);
+    m_helper.clean(testObj2);
+    assertEquals(testObj1, testObj2);
+    assertEquals(testObj1.getEntitySet(), testObj2.getEntitySet());
+  }
+
+  @Test
+  public void testEqualityAfterCleaning_DoCollection() {
+    EntityMapperFixtureDo testObj1 = BEANS.get(EntityMapperFixtureDo.class);
+    // setup DoCollection attribute using a LinkedHashSet internally
+    Collection<OtherEntityMapperFixtureDo> col1 = new LinkedHashSet<>();
+    col1.add(BEANS.get(OtherEntityMapperFixtureDo.class).withId(null));
+    testObj1.putCollection(testObj1.entityCollection().getAttributeName(), col1);
+
+    EntityMapperFixtureDo testObj2 = BEANS.get(EntityMapperFixtureDo.class);
+    // setup DoCollection attribute using a LinkedHashSet internally
+    Collection<OtherEntityMapperFixtureDo> col2 = new LinkedHashSet<>();
+    col2.add(BEANS.get(OtherEntityMapperFixtureDo.class).withId(null));
+    testObj2.putCollection(testObj1.entityCollection().getAttributeName(), col2);
+
+    assertEquals(testObj1, testObj2);
+    assertEquals(testObj1.getEntityCollection(), testObj2.getEntityCollection());
+    m_helper.clean(testObj1);
+    m_helper.clean(testObj2);
+    assertEquals(testObj1, testObj2);
+    assertEquals(testObj1.getEntityCollection(), testObj2.getEntityCollection());
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoCollectionTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoCollectionTest.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.eclipse.scout.rt.dataobject.DataObjectHelperTest.FixtureDoEntity;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.junit.Before;
 import org.junit.Test;
@@ -434,6 +436,7 @@ public class DoCollectionTest {
 
     assertEquals(collection1, collection2); // order of elements is not relevant for equality
     assertEquals(collection2, collection1);
+    //noinspection EqualsWithItself
     assertEquals(collection1, collection1);
     assertEquals(collection1.hashCode(), collection2.hashCode());
 
@@ -445,7 +448,66 @@ public class DoCollectionTest {
     assertEquals(collection1.hashCode(), collection2.hashCode());
 
     assertNotEquals(null, collection1);
+    //noinspection MisorderedAssertEqualsArguments
     assertNotEquals(collection1, new Object());
+  }
+
+  @Test
+  public void testEqualsHashCode_manipulatedArrayList() {
+    DoCollection<FixtureDoEntity> col1 = DoCollection.of(new ArrayList<>());
+    col1.add(BEANS.get(FixtureDoEntity.class).withName("foo"));
+
+    DoCollection<FixtureDoEntity> col2 = DoCollection.of(new ArrayList<>());
+    col2.add(BEANS.get(FixtureDoEntity.class).withName("foo"));
+
+    assertEquals(col1, col2);
+    assertEquals(col1.hashCode(), col2.hashCode());
+    assertTrue(col1.contains(col2.iterator().next()));
+    assertTrue(col2.contains(col1.iterator().next()));
+
+    // manipulate nested dataobject, this causes the hashCode of nested object to change which corrupts internal LinkedHashSet structure
+    col1.iterator().next().withName(null);
+    col2.iterator().next().withName(null);
+
+    assertEquals(col1, col2);
+    assertEquals(col1.hashCode(), col2.hashCode());
+    assertTrue(col1.contains(col2.iterator().next()));
+    assertTrue(col2.contains(col1.iterator().next()));
+
+    // equality of internal LinkedHashSet is not given
+    assertEquals(col1.get(), col2.get());
+    assertEquals(col1.get().hashCode(), col2.get().hashCode());
+    assertTrue(col1.get().contains(col2.get().iterator().next()));
+    assertTrue(col2.get().contains(col1.get().iterator().next()));
+  }
+
+  @Test
+  public void testEqualsHashCode_manipulatedHashSet() {
+    DoCollection<FixtureDoEntity> col1 = DoCollection.of(new LinkedHashSet<>());
+    col1.add(BEANS.get(FixtureDoEntity.class).withName("foo"));
+
+    DoCollection<FixtureDoEntity> col2 = DoCollection.of(new LinkedHashSet<>());
+    col2.add(BEANS.get(FixtureDoEntity.class).withName("foo"));
+
+    assertEquals(col1, col2);
+    assertEquals(col1.hashCode(), col2.hashCode());
+    assertTrue(col1.contains(col2.iterator().next()));
+    assertTrue(col2.contains(col1.iterator().next()));
+
+    // manipulate nested dataobject, this causes the hashCode of nested object to change which corrupts internal LinkedHashSet structure
+    col1.iterator().next().withName(null);
+    col2.iterator().next().withName(null);
+
+    assertEquals(col1, col2);
+    assertEquals(col1.hashCode(), col2.hashCode());
+    assertTrue(col1.contains(col2.iterator().next()));
+    assertTrue(col2.contains(col1.iterator().next()));
+
+    // equality of internal LinkedHashSet is not given
+    assertNotEquals(col1.get(), col2.get());
+    assertEquals(col1.get().hashCode(), col2.get().hashCode());
+    assertFalse(col1.get().contains(col2.get().iterator().next()));
+    assertFalse(col2.get().contains(col1.get().iterator().next()));
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoSetTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/DoSetTest.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.eclipse.scout.rt.dataobject.DataObjectHelperTest.FixtureDoEntity;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.junit.Before;
 import org.junit.Test;
@@ -371,6 +373,7 @@ public class DoSetTest {
 
     assertEquals(set1, set2); // order of elements is not relevant for equality
     assertEquals(set2, set1);
+    //noinspection EqualsWithItself
     assertEquals(set1, set1);
     assertEquals(set1.hashCode(), set2.hashCode());
 
@@ -382,7 +385,38 @@ public class DoSetTest {
     assertEquals(set1.hashCode(), set2.hashCode());
 
     assertNotEquals(null, set1);
+    //noinspection MisorderedAssertEqualsArguments
     assertNotEquals(set1, new Object());
+  }
+
+  @Test
+  public void testEqualsHashCode_manipulated() {
+    DoSet<FixtureDoEntity> set1 = new DoSet<>();
+    set1.add(BEANS.get(FixtureDoEntity.class).withName("foo"));
+
+    DoSet<FixtureDoEntity> set2 = new DoSet<>();
+    set2.add(BEANS.get(FixtureDoEntity.class).withName("foo"));
+
+    assertEquals(set1, set2);
+    assertEquals(set1.hashCode(), set2.hashCode());
+    assertTrue(set1.contains(set2.iterator().next()));
+    assertTrue(set2.contains(set1.iterator().next()));
+
+
+    // manipulate nested dataobject, this causes the hashCode of nested object to change which corrupts internal LinkedHashSet structure
+    set1.iterator().next().withName(null);
+    set2.iterator().next().withName(null);
+
+    assertEquals(set1, set2);
+    assertEquals(set1.hashCode(), set2.hashCode());
+    assertTrue(set1.contains(set2.iterator().next()));
+    assertTrue(set2.contains(set1.iterator().next()));
+
+    // equality of internal LinkedHashSet is not given
+    assertNotEquals(set1.get(), set2.get());
+    assertEquals(set1.get().hashCode(), set2.get().hashCode());
+    assertFalse(set1.get().contains(set2.get().iterator().next()));
+    assertFalse(set2.get().contains(set1.get().iterator().next()));
   }
 
   @Test

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DataObjectHelper.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DataObjectHelper.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -324,6 +325,30 @@ public class DataObjectHelper {
       // (2) clean all contributions (i.e. itself implementations of DoEntity)
       //noinspection deprecation
       caseDoEntityContributions(entity.getAllContributions());
+    }
+
+    @Override
+    protected void caseDoSet(DoSet<?> doSet) {
+      super.caseDoSet(doSet);
+      cleanSet(doSet.get());
+    }
+
+    @Override
+    protected void caseDoCollection(DoCollection<?> doCollection) {
+      super.caseDoCollection(doCollection);
+      if (doCollection.get() instanceof Set<?> set) {
+        cleanSet(set);
+      }
+    }
+
+    /**
+     * Reset {@link Set} by clear and re-adding all elements to recreate internal {@link LinkedHashSet} structure
+     * after manipulating nested data objects (which corrupts internal hash-code based {@link LinkedHashSet}).
+     */
+    protected <V> void cleanSet(Set<V> set) {
+      Set<V> copy = new HashSet<>(set);
+      set.clear();
+      set.addAll(copy);
     }
   }
 

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoCollection.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoCollection.java
@@ -11,14 +11,24 @@ package org.eclipse.scout.rt.dataobject;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
 
 /**
  * Wrapper for a generic collection of values of type {@code V} inside a {@link DoEntity} object. As opposed to
  * {@link DoList}, no order is guaranteed here and as opposed to {@link DoSet} it may contain duplicates.
  * {@link DataObjectHelper#normalize(IDataObject)} may be used to apply a deterministic order to {@link DoCollection}.
+ *
+ * <p>Note: {@link DoCollection} is backed by a {@link Collection} instance. If a {@link Set} implementation
+ * is used as nested type, great care must be exercised if mutable objects are used as set elements.
+ * The behavior of a set is not specified if the value of an object is changed in a manner that affects {
+ * @code equals} comparisons while the object is an element in the set. See javadoc of {@link Set} for further details.<br>
+ * {@link DoCollection} guarantees correct equality {@link DoCollection#equals(Object)}),
+ * hashcode ({@link DoCollection#hashCode()}) and contains ({@link DoSet#contains(Object)}) operations
+ * if used as {@link DoCollection} wrapper and not using the wrapped {@link Collection} instance directly.
  *
  * @param <V>
  *     If instances within collection are {@link Comparable}, they must be mutually comparable (required for order
@@ -55,6 +65,14 @@ public final class DoCollection<V> extends AbstractDoCollection<V, Collection<V>
   @Override
   public void set(Collection<V> newValue) {
     super.set(emptyCollectionIfNull(newValue));
+  }
+
+  @Override
+  public boolean contains(V item) {
+    if (!exists()) {
+      return false;
+    }
+    return get().stream().anyMatch(i -> ObjectUtility.equals(i, item));
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoSet.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/DoSet.java
@@ -9,13 +9,25 @@
  */
 package org.eclipse.scout.rt.dataobject;
 
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.ObjectUtility;
+
 /**
  * Wrapper for a generic set of values of type {@code V} inside a {@link DoEntity} object.
  * {@link DataObjectHelper#normalize(IDataObject)} may be used to apply a deterministic order to {@link DoSet}.
+ *
+ * <p>Note: {@link DoSet} is backed by a {@link Set}, therefore great care must be exercised if mutable objects
+ * are used as set elements. The behavior of a set is not specified if the value of an object is changed in
+ * a manner that affects {@code equals} comparisons while the object is an element in the set. See javadoc
+ * of {@link Set} for further details.<br>
+ * {@link DoSet} guarantees correct equality {@link DoSet#equals(Object)}), hashcode ({@link DoSet#hashCode()})
+ * and contains ({@link DoSet#contains(Object)}) operations if used as {@link DoSet} wrapper and not using the
+ * wrapped {@link Set} instance directly.
  *
  * @param <V>
  *     If instances within set are {@link Comparable}, they must be mutually comparable (required for order
@@ -53,7 +65,28 @@ public final class DoSet<V> extends AbstractDoCollection<V, Set<V>> {
     super.set(emptySetIfNull(newValue));
   }
 
-  // LinkedHashSet already implemented hashCode/equals without considering element position, thus no need to override valueHashCode/valueEquals.
+  @Override
+  public boolean contains(V item) {
+    if (!exists()) {
+      return false;
+    }
+    return get().stream().anyMatch(i -> ObjectUtility.equals(i, item));
+  }
+
+  // LinkedHashSet already implements hashCode without considering element position, thus no need to override valueHashCode.
+
+  /**
+   * Use CollectionUtility.equalsCollection which implements iterator-based equality, instead of {@link LinkedHashSet#equals(Object)}
+   * which uses containsAll-based equality based on hashCode of contained objects which may be corrupted by mutating nested data objects.
+   */
+  @Override
+  protected boolean valueEquals(DoNode other) {
+    if (!exists() && !other.exists()) {
+      return true;
+    }
+    //noinspection unchecked
+    return CollectionUtility.equalsCollection(get(), (Collection<V>) other.get(), false);
+  }
 
   @Override
   public String toString() {


### PR DESCRIPTION
- Implement equals for DoSet and DoCollection supporting changes in nested data objects which causes corruption of internal hashcode-based data structure.
- DataObjectHelper recreate internal structure for set-attributes when cleaning data object

446243