### PR TITLE
Fix missing CSP nonce for lazy webpack import() statements

### DIFF
--- a/eclipse-scout-cli/scripts/KeepNonceVariablePlugin.js
+++ b/eclipse-scout-cli/scripts/KeepNonceVariablePlugin.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const pluginName = 'KeepNonceVariablePlugin';
+const {toConstantDependency} = require('webpack/lib/javascript/JavascriptParserHelpers');
+
+/**
+ * Plugin that instructs webpack to NOT replace '__webpack_nonce__' with '__webpack_require__.nc'.
+ * This is required for all library builds because the variable should only be replaced for application builds targeting the browser.
+ * @type {KeepNonceVariablePlugin}
+ */
+module.exports = class KeepNonceVariablePlugin {
+  apply(compiler) {
+    // see https://github.com/webpack/webpack/blob/v5.104.1/lib/APIPlugin.js#L207
+    // see https://webpack.js.org/api/parser/#expression
+    compiler.hooks.normalModuleFactory.tap(pluginName, factory => {
+      factory.hooks.parser.for('javascript/auto').tap(pluginName, (parser, options) => {
+        const webpackNonce = '__webpack_nonce__';
+        parser.hooks.expression.for(webpackNonce).tap(pluginName, expression => {
+          const dep = toConstantDependency(parser, webpackNonce, [webpackNonce]);
+          return dep(expression);
+        });
+      });
+    });
+  }
+};

--- a/eclipse-scout-cli/scripts/webpack-defaults.js
+++ b/eclipse-scout-cli/scripts/webpack-defaults.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const {CycloneDxWebpackPlugin} = require('@cyclonedx/webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const AfterEmitWebpackPlugin = require('./AfterEmitWebpackPlugin');
+const KeepNonceVariablePlugin = require('./KeepNonceVariablePlugin');
 const {SourceMapDevToolPlugin, WatchIgnorePlugin, ProgressPlugin} = require('webpack');
 const ts = require('typescript');
 
@@ -410,6 +411,11 @@ function libraryConfig(config, options = {}) {
     }
     return plugin;
   });
+
+  // Do NOT replace '__webpack_nonce__' for libraries as it should only be replaced for browser builds.
+  // Otherwise, the final build targeting the browser cannot find '__webpack_nonce__' (as it has already been replaced in the first run).
+  // If it is not replaced in the final build, the nonce is set to the wrong '__webpack_require__' instance which lets all dynamic import() statements fail.
+  plugins.push(new KeepNonceVariablePlugin());
 
   return {
     ...config,


### PR DESCRIPTION
Do NOT replace '__webpack_nonce__' for library builds as it should only be replaced for browser builds. Otherwise, the final build targeting the browser cannot find '__webpack_nonce__' anymore (as it has already been replaced in the first run).
If it is not replaced in the final build, the nonce is set to the wrong '__webpack_require__' instance which lets all lazy import() statements fail because of the missing nonce.

440473