### PR TITLE
ApiDocGenerator: Improve api-exposed documentation

### DIFF
--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
@@ -525,7 +525,7 @@ public class ApiDocGenerator {
                       HTML.div(
                           HTML.span("(" + CollectionUtility.format(r.getScopes()) + ")").cssClass("scope"),
                           HTML.span(r.getPath()).cssClass("resource"),
-                          HTML.span(StringUtility.box("/", m.getPath(), "")).cssClass("method")).cssClass("path").toggleCssClass("not-api-exposed", readAllApiDocGranted && !m.isApiExposed()))
+                          HTML.span(StringUtility.box("/", m.getPath(), "")).cssClass("method")).cssClass("path"))
                   .cssClass("header"),
               HTML.div(
                       HTML.div(HTML.raw(m.getDescription().toHtml())).cssClass("description"),
@@ -533,7 +533,8 @@ public class ApiDocGenerator {
                       HTML.div(
                               StringUtility.hasText(m.getConsumes()) ? HTML.div(HTML.span("Consumes ").cssClass("k"), HTML.span(m.getConsumes()).cssClass("v")).cssClass("line") : null,
                               StringUtility.hasText(m.getProduces()) ? HTML.div(HTML.span("Produces ").cssClass("k"), HTML.span(m.getProduces()).cssClass("v")).cssClass("line") : null)
-                          .cssClass("consumes-produces"))
+                          .cssClass("consumes-produces"),
+                      readAllApiDocGranted && !m.isApiExposed() ? HTML.div("Operation is not exposed (not external accessible).").cssClass("not-api-exposed") : null)
                   .cssClass("body"))
           .cssClass("operation")));
     });
@@ -746,6 +747,7 @@ public class ApiDocGenerator {
   }
 
   protected String toJsonString(List<ResourceDescriptor> resourceDescriptors) {
+    boolean readAllApiDocGranted = isReadAllApiDocGranted();
     List<IDoEntity> jsonMethods = resourceDescriptors.stream()
         .flatMap(r -> r.getMethods().stream()
             .map(m -> BEANS.get(DoEntityBuilder.class)
@@ -757,7 +759,7 @@ public class ApiDocGenerator {
                 .put("signature", m.getSignature().toString())
                 .putIf("consumes", m.getConsumes(), Objects::nonNull)
                 .putIf("produces", m.getProduces(), Objects::nonNull)
-                .putIf("apiExposed", m.isApiExposed(), v -> !v)
+                .putIf("apiExposed", m.isApiExposed(), v -> readAllApiDocGranted)
                 .build()))
         .collect(Collectors.toList());
     return BEANS.get(IPrettyPrintDataObjectMapper.class).writeValue(jsonMethods);

--- a/org.eclipse.scout.rt.rest/src/main/resources/org/eclipse/scout/rt/rest/doc/res/doc.css
+++ b/org.eclipse.scout.rt.rest/src/main/resources/org/eclipse/scout/rt/rest/doc/res/doc.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -133,10 +133,6 @@ h2 {
   background-color: deeppink;
 }
 
-.not-api-exposed {
-  background-color: yellow;
-}
-
 .path {
   flex: 1;
   font-family: monospace;
@@ -173,6 +169,11 @@ h2 {
 
 .consumes-produces > .line > .v {
   font-family: monospace;
+}
+
+.not-api-exposed {
+  margin-top: 1em;
+  color: red;
 }
 
 .footer {


### PR DESCRIPTION
- Nowhere described what the yellow highlighting was supposed to mean; use clear description (red as text color).
- If JSON prints out apiExposed attribute all cases shall be printed out.

447124