### PR TITLE
Allow reading of boundary string of REST multipart messages

### DIFF
--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/multipart/MultipartMessage.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/multipart/MultipartMessage.java
@@ -63,6 +63,18 @@ public class MultipartMessage {
   protected String m_boundary; // cached boundary in case #toEntity is called multiple times
   protected MediaType m_mediaType = DEFAULT_MIME_TYPE;
 
+  public void ensureBoundary() {
+    if (m_boundary == null) {
+      // create a new unique boundary if it wasn't already cached before for this multipart message
+      m_boundary = BEANS.get(IUuidProvider.class).createUuid().toString().replace("-", "");
+    }
+  }
+
+  public String getBoundary() {
+    ensureBoundary();
+    return m_boundary;
+  }
+
   public MultipartMessage addPart(MultipartPart part) {
     m_parts.add(part);
     return this;
@@ -93,10 +105,7 @@ public class MultipartMessage {
   }
 
   protected MediaType createMultipartMediaType() {
-    if (m_boundary == null) {
-      // create a new unique boundary if it wasn't already cached before for this multipart message
-      m_boundary = BEANS.get(IUuidProvider.class).createUuid().toString().replace("-", "");
-    }
+    ensureBoundary();
     return new MediaType(getMediaType().getType(), getMediaType().getSubtype(), CollectionUtility.hashMap(ImmutablePair.of(BOUNDARY_PARAMETER, m_boundary)));
   }
 


### PR DESCRIPTION
When sending REST multipart messages, the boundary identifier has to be included in the Content-Type header.
Using BEANS.get(MultipartMessage.class) an identifier will be set and the Content-Type header can be set like:
"multipart/form-data; boundary=" + multipartMessage.getBoundary();