### PR TITLE
Tree: don't prevent stop propagation on node control click

### DIFF
--- a/eclipse-scout-core/src/form/fields/smartfield/TreeProposalChooser.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/TreeProposalChooser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,6 @@ export class TreeProposalChooser<TValue> extends ProposalChooser<TValue, Tree, P
   protected override _createContent(): Tree {
     let tree = scout.create(Tree, {
       parent: this,
-      requestFocusOnNodeControlMouseDown: false,
       scrollToSelection: true,
       textFilterEnabled: false
     });

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -859,9 +859,8 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   }
 
   protected _onRowDoubleClick(event: JQuery.DoubleClickEvent) {
-    let $row = $(event.currentTarget),
-      column = this._columnAtX(event.pageX);
-
+    let $row = $(event.currentTarget);
+    let column = this._columnAtX(event.pageX);
     this.doRowAction($row.data('row'), column);
   }
 

--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -81,7 +81,6 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
   nodeWidth: number;
   maxNodeWidth: number;
   nodeWidthDirty: boolean;
-  requestFocusOnNodeControlMouseDown: boolean;
   initialTraversing: boolean;
   defaultMenuTypes: string[];
   $data: JQuery;
@@ -173,7 +172,6 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
     this.nodeWidthDirty = false;
     this.$data = null;
     this._scrollDirections = 'both';
-    this.requestFocusOnNodeControlMouseDown = true;
     this.defaultMenuTypes = [Tree.MenuType.EmptySpace];
     this._$mouseDownNode = null;
   }
@@ -441,10 +439,7 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
       .on('focus', this._onFocus.bind(this))
       .on('mousedown', '.tree-node', this._onNodeMouseDown.bind(this))
       .on('mouseup', '.tree-node', this._onNodeMouseUp.bind(this))
-      .on('dblclick', '.tree-node', this._onNodeDoubleClick.bind(this))
-      .on('mousedown', '.tree-node-control', this._onNodeControlMouseDown.bind(this))
-      .on('mouseup', '.tree-node-control', this._onNodeControlMouseUp.bind(this))
-      .on('dblclick', '.tree-node-control', this._onNodeControlDoubleClick.bind(this));
+      .on('dblclick', '.tree-node', this._onNodeDoubleClick.bind(this));
     aria.role(this.$data, 'tree');
     HtmlComponent.install(this.$data, this.session);
 
@@ -2904,6 +2899,12 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
       // if node does not belong to this tree, do nothing (may happen if another tree is embedded inside the node)
       return;
     }
+
+    if (this._isNodeControl($(event.target))) {
+      this._onNodeControlMouseDown(event);
+      return;
+    }
+
     this._$mouseDownNode = $node;
     $node.window().one('mouseup', () => {
       this._$mouseDownNode = null;
@@ -2918,7 +2919,6 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
       }
       this.checkNode(node, !node.checked);
     }
-    return true;
   }
 
   /** @internal */
@@ -2938,7 +2938,6 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
     this.trigger('nodeClick', {
       node: node
     });
-    return true;
   }
 
   protected _isCheckboxClicked(event: JQuery.MouseDownEvent): boolean {
@@ -3458,7 +3457,7 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
   }
 
   protected _onNodeDoubleClick(event: JQuery.DoubleClickEvent) {
-    if (this.isBreadcrumbStyleActive()) {
+    if (this.isBreadcrumbStyleActive() || this._isNodeControl($(event.target))) {
       return;
     }
 
@@ -3481,14 +3480,12 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
     }
   }
 
-  protected _onNodeControlMouseDown(event: JQuery.MouseDownEvent): boolean {
-    this._doubleClickSupport.mousedown(event);
-    if (this._doubleClickSupport.doubleClicked()) {
-      // don't execute on double click events
-      return false;
-    }
+  protected _isNodeControl($target: JQuery): boolean {
+    return $target.hasClass('tree-node-control');
+  }
 
-    let $node = $(event.currentTarget).parent();
+  protected _onNodeControlMouseDown(event: JQuery.MouseDownEvent): boolean {
+    let $node = $(event.currentTarget);
     let node = $node.data('node') as TreeNode;
     let expanded = !$node.hasClass('expanded');
     let expansionOpts: TreeNodeExpandOptions = {
@@ -3507,27 +3504,8 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
         return false;
       }
     }
-    // Because we suppress handling by browser we have to set focus manually
-    if (this.requestFocusOnNodeControlMouseDown) {
-      this.focus();
-    }
     this.selectNodes(node); // <---- ### 1
     this.setNodeExpanded(node, expanded, expansionOpts); // <---- ### 2
-    // prevent bubbling to _onNodeMouseDown()
-    $.suppressEvent(event);
-
-    // ...but return true, so Outline.js can override this method and check if selection has been changed or not
-    return true;
-  }
-
-  protected _onNodeControlMouseUp(event: JQuery.MouseUpEvent): boolean {
-    // prevent bubbling to _onNodeMouseUp()
-    return false;
-  }
-
-  protected _onNodeControlDoubleClick(event: JQuery.DoubleClickEvent): boolean {
-    // prevent bubbling to _onNodeDoubleClick()
-    return false;
   }
 
   protected _onContextMenu(event: JQuery.ContextMenuEvent) {

--- a/eclipse-scout-core/src/tree/TreeModel.ts
+++ b/eclipse-scout-core/src/tree/TreeModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -125,11 +125,5 @@ export interface TreeModel extends WidgetModel {
    */
   filters?: FilterOrFunction<TreeNode>[];
   textFilterEnabled?: boolean;
-  /**
-   * Defines whether to focus the tree when the node control is clicked.
-   *
-   * Default is true.
-   */
-  requestFocusOnNodeControlMouseDown?: boolean;
   defaultMenuTypes?: string[];
 }

--- a/eclipse-scout-core/test/tree/TreeSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1849,6 +1849,52 @@ describe('Tree', () => {
     });
   });
 
+  describe('node control mouse down', () => {
+    beforeEach(() => {
+      $('<style>' +
+        '.tree-node {position: relative;}' +
+        '.tree-node-control {position: absolute; height: 100%; width: 4px;}' +
+        '</style>').appendTo($('#sandbox'));
+    });
+
+    it('expands or collapses the node', () => {
+      let model = helper.createModelFixture(1, 1, false);
+      let tree = helper.createTree(model);
+      tree.render();
+
+      let $nodeControl = tree.$container.find('.tree-node-control:first');
+      let $node = $nodeControl.parent();
+      expect($node).not.toHaveClass('expanded');
+
+      JQueryTesting.triggerMouseDown($nodeControl);
+      expect($node).toHaveClass('expanded');
+
+      JQueryTesting.triggerMouseDown($nodeControl);
+      expect($node).toHaveClass('expanded'); // Double click support prevents immediate second execution
+
+      tree._doubleClickSupport._lastTimestamp -= 5000; // simulate last click 5 seconds ago
+
+      JQueryTesting.triggerMouseDown($nodeControl);
+      expect($node).not.toHaveClass('expanded');
+    });
+
+    it('does not stop event propagation', () => {
+      session.$entryPoint[0].focus();
+      expect(session.$entryPoint).toBeFocused();
+
+      let model = helper.createModelFixture(1, 1, false);
+      let tree = helper.createTree(model);
+      tree.render();
+
+      let bubbled = false;
+      session.$entryPoint.one('mousedown', () => bubbled = true);
+
+      let $nodeControl = tree.nodes[0].$node.children('.tree-node-control');
+      JQueryTesting.triggerMouseDown($nodeControl);
+      expect(bubbled).toBe(true);
+    });
+  });
+
   describe('node control double click', () => {
     it('does the same as control single click (does NOT expand and immediately collapse again)', () => {
       let model = helper.createModelFixture(1, 1, false);
@@ -1862,7 +1908,6 @@ describe('Tree', () => {
       JQueryTesting.triggerDoubleClick($nodeControl);
       expect($node).toHaveClass('expanded');
 
-      // Reset internal state because there is no "sleep" in JS
       tree._doubleClickSupport._lastTimestamp -= 5000; // simulate last click 5 seconds ago
 
       JQueryTesting.triggerDoubleClick($nodeControl);


### PR DESCRIPTION
If the mouse down event can't bubble up, other mouse down handlers won't be notified.

This creates these two issues:
- Outline has preventClickFocus set to true, but when clicking the node control, it still gets the focus. This is because the mouse down handler of the FocusManager cannot prevent it.
- If an element is dragged (e.g. table header item) and dropped on the node control, the dragging won't stop.

Also removed the obsolete property requestFocusOnNodeControlMouseDown. The content of a proposal chooser is never focusable, a special treatment for the node control is not necessary.

386935