### PR TITLE
Property for maximum thread pool size of Jetty server

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,7 @@ import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
@@ -44,6 +45,7 @@ import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationAutoCreateSelfSignedCertificateProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationCertificateAliasProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationConsoleInputHandlerEnabledProperty;
@@ -54,12 +56,14 @@ import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationHttpSessio
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationJvmShutdownHookEnabledProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationKeyStorePasswordProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationKeyStorePathProperty;
+import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationMonitorLowResourceProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationPortProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationPrivateKeyPasswordProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCookieConfigHttpOnlyProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCookieConfigSameSiteProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCookieConfigSecureProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionTimeoutProperty;
+import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationThreadPoolMaxSizeProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationUseTlsProperty;
 import org.eclipse.scout.rt.app.servlet.ScoutServletContextHandler;
 import org.eclipse.scout.rt.jetty.IServletContributor;
@@ -164,7 +168,8 @@ public class Application {
 
   @SuppressWarnings("resource")
   protected Server createServer() {
-    Server server = new Server();
+    QueuedThreadPool threadPool = new QueuedThreadPool(CONFIG.getPropertyValue(ScoutApplicationThreadPoolMaxSizeProperty.class));
+    Server server = new Server(threadPool);
     ServerConnector connector;
     if (CONFIG.getPropertyValue(ScoutApplicationUseTlsProperty.class)) {
       connector = createHttpsServerConnector(server);
@@ -175,6 +180,7 @@ public class Application {
     connector.setPort(CONFIG.getPropertyValue(ScoutApplicationPortProperty.class));
     server.addConnector(connector);
     installErrorHandler(server);
+    installLowResourceMonitor(server);
 
     Handler handler = createHandler();
     server.setHandler(handler);
@@ -337,6 +343,16 @@ public class Application {
     handler.setShowMessageInTitle(false);
     handler.setShowStacks(false);
     server.setErrorHandler(handler);
+  }
+
+  protected void installLowResourceMonitor(Server server) {
+    if (!CONFIG.getPropertyValue(ScoutApplicationMonitorLowResourceProperty.class)) {
+      return;
+    }
+    LowResourceMonitor lowResourceMonitor = BEANS.get(ScoutJettyLowResourceMonitorFactory.class).createLowResourceMonitor(server);
+    if (lowResourceMonitor != null) {
+      server.addBean(lowResourceMonitor);
+    }
   }
 
   protected Handler createHandler() {

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -360,6 +360,42 @@ public final class ApplicationProperties {
     @Override
     public String description() {
       return "Specifies whether the application context handler should also lookup resources w/o base resource. The default value is false.";
+    }
+  }
+
+  public static class ScoutApplicationThreadPoolMaxSizeProperty extends AbstractPositiveIntegerConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.app.threadPool.maxSize";
+    }
+
+    @Override
+    public Integer getDefaultValue() {
+      return 2000;
+    }
+
+    @Override
+    public String description() {
+      return "Maximum number of threads that will be created for the application. Default value is " + getDefaultValue() + ".";
+    }
+  }
+
+  public static class ScoutApplicationMonitorLowResourceProperty extends AbstractBooleanConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.app.monitorLowResource";
+    }
+
+    @Override
+    public Boolean getDefaultValue() {
+      return Boolean.FALSE;
+    }
+
+    @Override
+    public String description() {
+      return "Enables monitoring for low resources of the Jetty server. Default value is " + getDefaultValue() + ".";
     }
   }
 }

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ScoutJettyLowResourceMonitorFactory.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ScoutJettyLowResourceMonitorFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.app;
+
+import org.eclipse.jetty.server.LowResourceMonitor;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+/**
+ * Factory to create a {@link LowResourceMonitor} to monitor the Jetty server for low resources.
+ */
+@ApplicationScoped
+public class ScoutJettyLowResourceMonitorFactory {
+
+  public LowResourceMonitor createLowResourceMonitor(Server server) {
+    LowResourceMonitor lowResourceMonitor = new LowResourceMonitor(server);
+    initLowResourceMonitor(lowResourceMonitor);
+    return lowResourceMonitor;
+  }
+
+  protected void initLowResourceMonitor(LowResourceMonitor lowResourceMonitor) {
+    lowResourceMonitor.setMonitorThreads(true); // monitor if the thread pool of the server is low on threads
+  }
+}


### PR DESCRIPTION
* Add new config property 'scout.app.threadPool.maxSize' which controls the maximum number of threads for the Jetty server thread pool. New default value: 2000
* Add low resource monitor to log a warning if the Jetty server is low on threads
* Add new config property 'scout.app.monitorLowResource' which controls if the monitor for low resources of the Jetty server should be active. Default: disabled

441286