### PR TITLE
Tree: fix animations while expanding all parents

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1548,7 +1548,7 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
       return;
     }
     if (node.expanded || node.expandedLazy) {
-      this._addChildrenToFlatList(node, null, true, null, true /* required so that double-clicking a table-page-row expands the clicked child row */);
+      this._addChildrenToFlatList(node, null, scout.nvl(opts.renderAnimated, true), null, true /* required so that double-clicking a table-page-row expands the clicked child row */);
     } else {
       this._removeChildrenFromFlatList(node, false);
     }


### PR DESCRIPTION
If e.g. a page with table performs a drill-down to a child page with nodes and expands all of these pages, there will be multiple batches of inserted nodes that are rendered. As these batches need to be rendered as one the method _expandAllParentNodes disables all animations. At some point during this expansion process a node needs to ensure that it is visible under its parent and rebuilds its parent. When this happened the method _rebuildParent ignored the flag whether animations are enabled or not which leads to several animations that are scheduled for the inserted batches of nodes.
At the end of _expandAllParentNodes the viewport is ensured to be rendered using _rerenderViewport. This removes all rendered nodes immediately but waits for running animation before rendering the viewport again, which leads to flickering.
Therefore, do not ignore the renderAnimated-flag while rebuilding a parent node to ensure there are no unwanted animations scheduled and prevent the flickering.

378077