### PR TITLE
FileChooserField: propagate properties to FileInput

### DIFF
--- a/eclipse-scout-core/src/form/fields/filechooserfield/FileChooserField.ts
+++ b/eclipse-scout-core/src/form/fields/filechooserfield/FileChooserField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,12 +30,17 @@ export class FileChooserField extends ValueField<File> implements FileChooserFie
     super._init(model);
 
     this.fileInput.on('change', this._onFileChange.bind(this));
-    this.on('propertyChange', event => {
-      if (event.propertyName === 'enabledComputed') {
-        // Propagate "enabledComputed" to inner widget
-        this.fileInput.setEnabled(event.newValue);
+    // Propagate properties "acceptTypes", "displayText", "enabledComputed" and "maximumUploadSize" to inner widget
+    this.on('propertyChange:acceptTypes', event => this.fileInput.setAcceptTypes(event.newValue));
+    this.on('propertyChange:displayText', event => {
+      const text = event.newValue;
+      this.fileInput.setText(text);
+      if (!text) {
+        this.fileInput.clear();
       }
     });
+    this.on('propertyChange:enabledComputed', event => this.fileInput.setEnabled(event.newValue));
+    this.on('propertyChange:maximumUploadSize', event => this.fileInput.setMaximumUploadSize(event.newValue));
   }
 
   /**
@@ -75,21 +80,12 @@ export class FileChooserField extends ValueField<File> implements FileChooserFie
     this.addField(this.fileInput.$container);
   }
 
-  override setDisplayText(text: string) {
-    super.setDisplayText(text);
-    this.fileInput.setText(text);
-    if (!text) {
-      this.fileInput.clear();
-    }
-  }
-
   protected override _readDisplayText(): string {
     return this.fileInput.text;
   }
 
   setAcceptTypes(acceptTypes: string) {
     this.setProperty('acceptTypes', acceptTypes);
-    this.fileInput.setAcceptTypes(acceptTypes);
   }
 
   protected override _renderEnabled() {
@@ -113,7 +109,6 @@ export class FileChooserField extends ValueField<File> implements FileChooserFie
 
   setMaximumUploadSize(maximumUploadSize: number) {
     this.setProperty('maximumUploadSize', maximumUploadSize);
-    this.fileInput.setMaximumUploadSize(maximumUploadSize);
   }
 
   protected override _clear() {

--- a/eclipse-scout-core/test/form/fields/filechooserfield/FileChooserFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/filechooserfield/FileChooserFieldSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -63,6 +63,85 @@ describe('FileChooserField', () => {
     });
   });
 
+  describe('acceptTypes', () => {
+
+    it('is propagated to fileInput', () => {
+      const field = scout.create(FileChooserField, {
+        parent: session.desktop,
+        acceptTypes: '.png,.jpg'
+      });
+
+      expect(field.fileInput.acceptTypes).toBe('.png,.jpg');
+
+      field.setAcceptTypes('.pdf');
+      expect(field.fileInput.acceptTypes).toBe('.pdf');
+
+      field.setAcceptTypes(null);
+      expect(field.fileInput.acceptTypes).toBeNull();
+
+      field.setAcceptTypes('.csv');
+      expect(field.fileInput.acceptTypes).toBe('.csv');
+    });
+  });
+
+  describe('displayText', () => {
+
+    it('is propagated to fileInput', () => {
+      const field = scout.create(FileChooserField, {
+        parent: session.desktop,
+        displayText: 'Foo.png'
+      });
+
+      expect(field.fileInput.text).toBe('Foo.png');
+
+      field.setDisplayText('Bar.pdf');
+      expect(field.fileInput.text).toBe('Bar.pdf');
+
+      field.setDisplayText(null);
+      expect(field.fileInput.text).toBeNull();
+
+      field.setDisplayText('test.csv');
+      expect(field.fileInput.text).toBe('test.csv');
+    });
+
+    it('updates hasText', () => {
+      const field = scout.create(FileChooserField, {
+        parent: session.desktop,
+        displayText: 'Foo.png'
+      });
+      field.render();
+
+      expect(field.hasText).toBeTrue();
+
+      field.setDisplayText('Bar.pdf');
+      expect(field.hasText).toBeTrue();
+
+      field.setDisplayText(null);
+      expect(field.hasText).toBeFalse();
+
+      field.setDisplayText('test.csv');
+      expect(field.hasText).toBeTrue();
+
+      field.remove();
+      expect(field.hasText).toBeTrue();
+
+      field.setDisplayText(null);
+      expect(field.hasText).toBeTrue();
+
+      field.render();
+      expect(field.hasText).toBeFalse();
+
+      field.remove();
+      expect(field.hasText).toBeFalse();
+
+      field.setDisplayText('test.csv');
+      expect(field.hasText).toBeFalse();
+
+      field.render();
+      expect(field.hasText).toBeTrue();
+    });
+  });
+
   describe('maximumUploadSize', () => {
 
     it('is validated when setting new value', () => {
@@ -103,6 +182,24 @@ describe('FileChooserField', () => {
       field.setMaximumUploadSize(10);
       expect(field.errorStatus).toBe(null);
       expect(field.value).toBe(largeFile);
+    });
+
+    it('is propagated to fileInput', () => {
+      const field = scout.create(FileChooserField, {
+        parent: session.desktop,
+        maximumUploadSize: 42
+      });
+
+      expect(field.fileInput.maximumUploadSize).toBe(42);
+
+      field.setMaximumUploadSize(13);
+      expect(field.fileInput.maximumUploadSize).toBe(13);
+
+      field.setMaximumUploadSize(null);
+      expect(field.fileInput.maximumUploadSize).toBeNull();
+
+      field.setMaximumUploadSize(7);
+      expect(field.fileInput.maximumUploadSize).toBe(7);
     });
   });
 


### PR DESCRIPTION
The properties "acceptTypes", "displayText" and "maximumUploadSize" of the FileChooserField are propagated to the inner FileInput. This propagation was previously done in the setters after the default implementation has completed. In the meantime the changed properties are e.g. rendered.
Rendering the "displayText" property updates the "hasText" property of a value field and for a FileChooserField the "hasText" property is set to true iff the fileInputs property "text" is truthy. Therefore, the propagation of the "displayText" property to the fileInput needs to be done before the property is rendered. This is achieved by changing the propagation to a property change listener as the listener is executed directly after the property was changed and before the property is rendered.

435099