### PR TITLE
JSONObject - Prevent unnecessary escaping of '/'

### DIFF
--- a/org.eclipse.scout.json/src/main/java/org/json/JSONStringer.java
+++ b/org.eclipse.scout.json/src/main/java/org/json/JSONStringer.java
@@ -30,6 +30,7 @@ import java.util.List;
  * Changes to the original code:
  * -----------------------------
  * - Applied Scout code formatting rules
+ * - Prevent unnecessary escaping of '/'
  *
  * Copyright (c) 2015 BSI Business Systems Integration AG.
  */
@@ -311,7 +312,6 @@ public class JSONStringer {
       switch (c) {
         case '"':
         case '\\':
-        case '/':
           out.append('\\').append(c);
           break;
 

--- a/org.eclipse.scout.json/src/test/java/org/json/JSONStringerTest.java
+++ b/org.eclipse.scout.json/src/test/java/org/json/JSONStringerTest.java
@@ -240,6 +240,9 @@ public class JSONStringerTest extends TestCase {
     assertEscapedAllWays("\\u0000", "\0");
     assertEscapedAllWays("\\u0019", "\u0019");
     assertEscapedAllWays(" ", " ");
+    assertEscapedAllWays("a/", "a/");
+    assertEscapedAllWays("/", "/");
+    assertEscapedAllWays("</b>", "</b>");
   }
 
   private void assertEscapedAllWays(String escaped, String original) throws JSONException {


### PR DESCRIPTION
According to RFC 4627 it's optional to escape the '/' character in JSON. For historical reasons '/' still gets escaped following a '<' to prevent accidental HTML tag termination.

372618