### PR TITLE
Make ValidationFailedStatus and ParsingFailedStatus extendable

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/ParsingFailedStatus.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/ParsingFailedStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ import org.eclipse.scout.rt.platform.status.Status;
  * @see AbstractValueField#parseValueInternal(String)
  */
 @Order(10)
-public final class ParsingFailedStatus extends Status {
+public class ParsingFailedStatus extends Status {
   private static final long serialVersionUID = 1L;
   private final String m_parseInputString;
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/ValidationFailedStatus.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/ValidationFailedStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ import org.eclipse.scout.rt.platform.status.Status;
  * @see AbstractValueField#validateValueInternal(Object)
  */
 @Order(20)
-public final class ValidationFailedStatus<VALUE> extends Status {
+public class ValidationFailedStatus<VALUE> extends Status {
 
   private static final long serialVersionUID = 1L;
   private final VALUE m_invalidValue;
@@ -37,7 +37,11 @@ public final class ValidationFailedStatus<VALUE> extends Status {
   }
 
   public ValidationFailedStatus(String message, int severity, int code, VALUE invalidValue) {
-    super(message, severity, code);
+    this(message, severity, code, invalidValue, null);
+  }
+
+  public ValidationFailedStatus(String message, int severity, int code, VALUE invalidValue, String iconId) {
+    super(message, severity, code, iconId);
     m_invalidValue = invalidValue;
   }
 


### PR DESCRIPTION
These statuses receive special treatment by widgets, most notably removal before re-validation. This treatment is desired also for statuses not part of Eclipse Scout, therefore the `final` modifier is removed.

431560