### PR TITLE
File chooser: Correct handling of JS-files in Firefox

### DIFF
--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/basic/filechooser/JsonFileChooserAcceptAttributeBuilderTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/basic/filechooser/JsonFileChooserAcceptAttributeBuilderTest.java
@@ -9,11 +9,10 @@
  */
 package org.eclipse.scout.rt.ui.html.json.basic.filechooser;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.scout.rt.platform.resource.MimeType;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -21,74 +20,98 @@ public class JsonFileChooserAcceptAttributeBuilderTest {
 
   @Test
   public void testNop() {
-    Assert.assertEquals(setOf(), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of(), new JsonFileChooserAcceptAttributeBuilder()
         .build());
   }
 
   @Test
   public void testNull() {
-    Assert.assertEquals(setOf(), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of(), new JsonFileChooserAcceptAttributeBuilder()
         .withType(null)
         .build());
   }
 
   @Test
   public void testNulls() {
-    Assert.assertEquals(setOf(), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of(), new JsonFileChooserAcceptAttributeBuilder()
         .withTypes(null)
         .build());
   }
 
   @Test
   public void testExt1() {
-    Assert.assertEquals(setOf("text/plain"), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of("text/plain"), new JsonFileChooserAcceptAttributeBuilder()
         .withType("txt")
         .build());
   }
 
   @Test
   public void testExt2() {
-    Assert.assertEquals(setOf("text/plain"), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of("text/plain"), new JsonFileChooserAcceptAttributeBuilder()
         .withType(".txt")
         .build());
   }
 
   @Test
   public void testExt3() {
-    Assert.assertEquals(setOf("text/plain"), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of("text/plain"), new JsonFileChooserAcceptAttributeBuilder()
         .withType("*.txt")
         .build());
   }
 
   @Test
   public void testMime() {
-    Assert.assertEquals(setOf("text/plain"), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of("text/plain"), new JsonFileChooserAcceptAttributeBuilder()
         .withType(MimeType.TXT.getType())
         .build());
   }
 
   @Test
   public void testExtWithCsv() {
-    Assert.assertEquals(setOf(".csv"), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of(".csv"), new JsonFileChooserAcceptAttributeBuilder()
         .withType("csv")
         .build());
   }
 
   @Test
   public void testMimeWithCsv() {
-    Assert.assertEquals(setOf(".csv"), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of(".csv"), new JsonFileChooserAcceptAttributeBuilder()
         .withType(MimeType.CSV.getType())
         .build());
   }
 
   @Test
+  public void testMimeWithJs() {
+    Assert.assertEquals(Set.of(".js", ".mjs"), new JsonFileChooserAcceptAttributeBuilder()
+        .withType(MimeType.JS.getType())
+        .build());
+  }
+
+  @Test
+  public void testExtWithJs() {
+    Assert.assertEquals(Set.of(".js", ".mjs"), new JsonFileChooserAcceptAttributeBuilder()
+        .withType("js")
+        .build());
+  }
+
+  @Test
+  public void testExtWithMjs() {
+    Assert.assertEquals(Set.of(".js", ".mjs"), new JsonFileChooserAcceptAttributeBuilder()
+        .withType("mjs")
+        .build());
+  }
+
+  @Test
   public void testUnknownMime() {
-    Assert.assertEquals(setOf("foo/bar"), new JsonFileChooserAcceptAttributeBuilder()
+    Assert.assertEquals(Set.of("foo/bar"), new JsonFileChooserAcceptAttributeBuilder()
         .withType("foo/bar")
         .build());
   }
 
-  private static Set<String> setOf(String... elements) {
-    return new HashSet<>(Arrays.asList(elements));
+  @Test
+  public void testMultiple() {
+    Assert.assertEquals(Set.of(".js", ".mjs", "image/png", "video/avi"), new JsonFileChooserAcceptAttributeBuilder()
+        .withTypes(CollectionUtility.arrayList(MimeType.JS.getType(), MimeType.PNG.getType(), MimeType.AVI.getType()))
+        .build());
   }
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/basic/filechooser/JsonFileChooserAcceptAttributeBuilder.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/basic/filechooser/JsonFileChooserAcceptAttributeBuilder.java
@@ -11,28 +11,35 @@ package org.eclipse.scout.rt.ui.html.json.basic.filechooser;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.FileUtility;
 
 /**
- * Microsoft internet explorer is not correctly handlig mime types in the 'accept' atttribute.
- * <p>
- * For example valid text/csv is not recognized.
- * <p>
- * Therefore as a fallback for IE only we use file extensions for selected white-listed types.
- * <p>
  * This bean builds the content of the accept attribute in
  * <code>&lt;input accept="file_extension|audio/*|video/*|image/*|media_type"&gt;</code>
+ * In this class we correct for browser-side bugs such as:
+ * <ul>
+ *   <li>
+ *     Microsoft Internet Explorer is not correctly handling mime types in the 'accept' attribute. <br/>
+ *     For example valid text/csv is not recognized. <br/>
+ *     Therefore as a fallback for IE only we use file extensions for selected white-listed types.
+ *   </li>
+ *   <li>
+ *     Mozilla Firefox has a bug (Bugzilla 201480) with the MIME type text/javascript. <br/>
+ *     As a fallback we also use the file extensions defined in RFC 9239 for this MIME type.
+ *   </li>
+ * </ul>
  *
  * @since 5.2
  */
 @Bean
 public class JsonFileChooserAcceptAttributeBuilder {
-  private final Map<String, String> m_mimeTypeToAcceptType = new HashMap<>();
+  private final Map<String, Set<String>> m_mimeTypeToAcceptType = new HashMap<>();
 
   /**
    * append the collection of media types to the list
@@ -86,7 +93,9 @@ public class JsonFileChooserAcceptAttributeBuilder {
    * @return the completed set of accept types
    */
   public Set<String> build() {
-    return new HashSet<>(m_mimeTypeToAcceptType.values());
+    return m_mimeTypeToAcceptType.values().stream()
+        .flatMap(s -> s.stream())
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -98,18 +107,24 @@ public class JsonFileChooserAcceptAttributeBuilder {
    * <p>
    * typically this is the mime type or the file extension with a leading '.'
    */
-  protected String convertToAcceptType(String mimeType, String ext) {
+  protected Set<String> convertToAcceptType(String mimeType, String ext) {
     switch (mimeType) {
       case "text/csv":
       case "text/comma-separated-values":
-        return ".csv";
+        return CollectionUtility.hashSet(".csv");
+      case "text/javascript":
+        return CollectionUtility.hashSet(".js", ".mjs");
     }
     if (ext != null) {
       switch (ext) {
         case "csv":
-          return ".csv";
+          return CollectionUtility.hashSet(".csv");
+        case "js":
+          return CollectionUtility.hashSet(".js");
+        case "mjs":
+          return CollectionUtility.hashSet(".mjs");
       }
     }
-    return mimeType;
+    return CollectionUtility.hashSet(mimeType);
   }
 }


### PR DESCRIPTION
Firefox does not support the MIME type "text/javascript" as defined in RFC 9239 in the accept-attribute of input fields of type "file". This means that setting "js" as an allowed file extension on the Scout field is being ignored. This presents the user with a faulty default setting on the file chooser.

See also Bugzilla 2014180.

432191