### PR TITLE
Support for Session Nonce in PopupWindow

### DIFF
--- a/eclipse-scout-core/src/desktop/PopupWindow.ts
+++ b/eclipse-scout-core/src/desktop/PopupWindow.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ export class PopupWindow extends EventEmitter {
   session: Session;
   initialized: boolean;
   resizeToPrefSize: boolean;
+  nonce: string;
   htmlComp: HtmlComponent;
   $container: JQuery;
 
@@ -31,6 +32,7 @@ export class PopupWindow extends EventEmitter {
     this.form = form;
     this.session = form.session;
     this.initialized = false;
+    this.nonce = null;
     this.$container = null;
     this.htmlComp = null;
 
@@ -63,6 +65,9 @@ export class PopupWindow extends EventEmitter {
     // Establish the link again, as Chrome removes this property after a page load.
     // (page load is made by design in PopupBlockerHandler.openWindow)
     this.myWindow[PopupWindow.PROP_POPUP_WINDOW] = this;
+
+    // store nonce of the popup-window before removing from the DOM
+    this.nonce = myDocument.body?.dataset?.scoutNonce || '';
 
     scout.prepareDOM(myDocument);
 

--- a/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.ts
+++ b/eclipse-scout-core/src/form/fields/htmlfield/HtmlField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {AppLinkKeyStroke, events, HtmlFieldEventMap, HtmlFieldModel, scrollbars, SelectAllTextInFieldKeyStroke, ValueField} from '../../../index';
+import {App, AppLinkKeyStroke, events, HtmlFieldEventMap, HtmlFieldModel, scrollbars, SelectAllTextInFieldKeyStroke, ValueField} from '../../../index';
 
 export class HtmlField extends ValueField<string> implements HtmlFieldModel {
   declare model: HtmlFieldModel;
@@ -48,12 +48,27 @@ export class HtmlField extends ValueField<string> implements HtmlFieldModel {
     this._renderEmpty();
   }
 
+  protected _prepareDisplayText(displayText: string): string {
+    const popupWindowNonce = this.findNonWrappedForm()?.popupWindow?.nonce;
+    if (!popupWindowNonce) {
+      return displayText;
+    }
+
+    // In case this HtmlField belongs to a form running in a popup-window (see PopupWindow.ts).
+    // The popup-window gets its own CSP nonce which is different from the main window opening the popup.
+    // If the HtmlField's displayText contains inline scripts having a nonce (see SessionNonce.java and JsonHtmlField#initJsonProperties), this is the nonce of the main window (as returned from the UI backend).
+    // To allow the script to be executed, the nonce must be switched to the one of the popup-window.
+    // This is safe to do with a simple replace as the nonce is a 256bit secure random (collisions almost impossible).
+    return displayText.replaceAll(`nonce="${App.get().nonce}"`, `nonce="${popupWindowNonce}"`);
+  }
+
   protected override _renderDisplayText() {
     if (!this.displayText) {
       this.$field.empty();
       return;
     }
-    this.$field.html(this.displayText);
+
+    this.$field.html(this._prepareDisplayText(this.displayText));
 
     // Add action to app-links
     this.$field.find('.app-link')

--- a/eclipse-scout-core/test/form/fields/htmlfield/HtmlFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/htmlfield/HtmlFieldSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {HtmlField, scout} from '../../../../src/index';
+import {App, Form, GroupBox, HtmlField, PopupWindow, scout} from '../../../../src/index';
 
 describe('HtmlField', () => {
   let session: SandboxSession;
@@ -36,6 +36,40 @@ describe('HtmlField', () => {
       // value and displayText are unchanged after acceptInput
       expect(field.value).toBe(origValue);
       expect(field.displayText).toBe(origDisplayText);
+    });
+  });
+
+  describe('nonce in popup window', () => {
+    let origNonce = null;
+    beforeEach(() => {
+      origNonce = App.get().nonce;
+    });
+
+    afterEach(() => {
+      App.get().nonce = origNonce;
+    });
+
+    it('is correctly replaced', () => {
+      const rootNonce = 'orig-nonce';
+      App.get().nonce = rootNonce;
+      const form = scout.create({
+        objectType: Form,
+        rootGroupBox: {
+          id: 'root',
+          objectType: GroupBox,
+          fields: [{
+            id: 'html',
+            objectType: HtmlField
+          }]
+        },
+        parent: session.desktop
+      });
+      form.render();
+      const popup = new PopupWindow(window, form);
+      popup.nonce = 'expected-nonce';
+      const field = form.widget('html') as HtmlField;
+      field.setDisplayText(`<script nonce="${rootNonce}"></script>`);
+      expect(field.$field.html()).toEqual(`<script nonce="${popup.nonce}"></script>`);
     });
   });
 


### PR DESCRIPTION
A popup-window gets its own CSP nonce which is different from the main window opening the popup.
If a HtmlField belongs to a form running in such a popup-window (see PopupWindow.ts) and contains an inline script having a SessionNonce (see SessionNonce.java and JsonHtmlField#initJsonProperties), the initial nonce of the script tag is the one from the main window (because it comes from the main window).
To allow the script to be executed in the popup-window, the nonce must be switched to the one of the popup-window. This is safe to do with a simple replace as the nonce is a 256bit secure random (collisions almost impossible).