### PR TITLE
Avoid multi invalidation of HTTP session

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/ServletFilterHelper.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/authentication/ServletFilterHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -372,8 +372,15 @@ public class ServletFilterHelper {
   public void doLogout(HttpServletRequest req) {
     HttpSession session = req.getSession(false);
     if (session != null) {
-      LOG.info("Invalidating HTTP session with ID {}", session.getId());
-      session.invalidate();
+      try {
+        session.getCreationTime(); // check whether session is already invalidated; supress the following log line in this case
+        LOG.info("Invalidating HTTP session with ID {}", session.getId());
+        session.invalidate();
+      }
+      catch (IllegalStateException e) {
+        // session is already invalidated, no more action necessary
+        LOG.debug("Session was already invalidated", e);
+      }
     }
   }
 


### PR DESCRIPTION
If session is already invalidated do not call invalidate again; also if invalidate fails because session is already invalidated ignore it.

Similar code used in SessionStore.checkHttpSessionOutsideWriteLock

377031