### PR TITLE
TileGrid: fix text selection behavior

### DIFF
--- a/eclipse-scout-core/src/table/TableTileGridMediator.ts
+++ b/eclipse-scout-core/src/table/TableTileGridMediator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -476,11 +476,6 @@ export class TableTileGridMediator extends Widget implements TableTileGridMediat
     }
     if (event.propertyName === 'selectedTiles') {
       this._syncSelectionFromTileGridToTable(event.source.getSelectedTiles());
-      if (this.tileAccordion.rendered) {
-        // Depending on the tiles content, selecting tiles with shift can lead to a mix of selecting the tiles content
-        // and the tiles itself, which doesn't look nice. Remove the text selection when selection tiles to avoid this.
-        this.tileAccordion.$container.document(true).getSelection().removeAllRanges();
-      }
     } else if (event.propertyName === 'filteredTiles') {
       this._updateGroupVisibility();
     }

--- a/eclipse-scout-core/src/tile/TileGridSelectionHandler.ts
+++ b/eclipse-scout-core/src/tile/TileGridSelectionHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, HorizontalGrid, PlaceholderTile, Tile, TileGrid} from '../index';
+import {arrays, events, HorizontalGrid, PlaceholderTile, Tile, TileGrid} from '../index';
 import $ from 'jquery';
 
 export interface TileGridSelectionInstruction {
@@ -61,6 +61,10 @@ export class TileGridSelectionHandler {
       if (!this.isHorizontalGridActive()) {
         return;
       }
+
+      // Prevent text from being selected while selecting multiple tiles
+      events.preventSelectionStartUntilMouseUp(this.tileGrid.$container);
+
       let tiles = this.getVisibleTiles();
       let focusedTile = this.getFocusedTile();
       if (!focusedTile) {

--- a/eclipse-scout-core/src/util/events.ts
+++ b/eclipse-scout-core/src/util/events.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -212,6 +212,16 @@ export const events = {
     }
     let ref = $appLink.data('ref');
     triggerFunction(ref);
+  },
+
+  /**
+   * Prevents text selection for the given `$container` until a mouse up occurs anywhere on the window.
+   */
+  preventSelectionStartUntilMouseUp($container: JQuery) {
+    const preventSelectionHandler = event => event.preventDefault();
+    $container
+      .on('selectstart', preventSelectionHandler)
+      .window().one('mouseup', () => $container?.off('selectstart', preventSelectionHandler));
   },
 
   /**


### PR DESCRIPTION
The tile table removes all selection ranges when tiles are selected to prevent text being selected when using shift to multi select tiles. This may remove the cursor from a focused input in Chrome because all selection ranges are removed not just the ones from the selected tiles. This is also applied when tiles are selected using keyboard even though the problem only exists when using mouse with shift. Furthermore, a regular tile grid could have the same issue, so why only apply it to the tile table?

The new solution prevents text selection when tiles are selected with the mouse while pressing shift without generally disabling text selection on selectable tiles.

448709