### PR TITLE
Make reloadReason accessible in TableMaxResultsHelper

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -22,6 +22,7 @@ export class PageWithTable extends Page implements PageWithTableModel {
   searchRequired = false;
   searchFilterCompleted = false;
 
+  protected _reloadReason: TableReloadReason;
   protected _tableRowDeleteHandler: EventHandler<TableRowsDeletedEvent | TableAllRowsDeletedEvent>;
   protected _tableRowInsertHandler: EventHandler<TableRowsInsertedEvent>;
   protected _tableRowUpdateHandler: EventHandler<TableRowsUpdatedEvent>;
@@ -39,6 +40,7 @@ export class PageWithTable extends Page implements PageWithTableModel {
     this.inheritMenusFromParentTablePage = false;
     this.alwaysCreateChildPage = false;
 
+    this._reloadReason = null;
     this._tableRowDeleteHandler = this._onTableRowsDeleted.bind(this);
     this._tableRowInsertHandler = this._onTableRowsInserted.bind(this);
     this._tableRowUpdateHandler = this._onTableRowsUpdated.bind(this);
@@ -392,7 +394,7 @@ export class PageWithTable extends Page implements PageWithTableModel {
    * @returns the resulting request with the added contribution.
    */
   protected _withMaxRowCountContribution<T>(dataObject: T): T {
-    return scout.create(TableMaxResultsHelper).withMaxRowCountContribution(dataObject, this.detailTable);
+    return scout.create(TableMaxResultsHelper).withMaxRowCountContribution(dataObject, this.detailTable, this._reloadReason);
   }
 
   /**
@@ -401,6 +403,7 @@ export class PageWithTable extends Page implements PageWithTableModel {
   loadTableData(reloadReason?: TableReloadReason): JQuery.Promise<any> {
     this.ensureDetailTable();
     this.detailTable.setLoading(true);
+    this._reloadReason = reloadReason || this._reloadReason;
     const restoreSelectionInfo = this._getRestoreSelectionInfo();
     const searchFilter = this._createSearchFilter();
 

--- a/eclipse-scout-core/src/table/TableMaxResultsHelper.ts
+++ b/eclipse-scout-core/src/table/TableMaxResultsHelper.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {BaseDoEntity, dataObjects, DoEntity, scout, Table, typeName} from '../index';
+import {BaseDoEntity, dataObjects, DoEntity, scout, Table, TableReloadReason, typeName} from '../index';
 
 export class TableMaxResultsHelper {
 
@@ -25,10 +25,11 @@ export class TableMaxResultsHelper {
   /**
    * Adds a DataObject contribution of type {@link MaxRowCountContributionDo} to the given dataObject if necessary, removes an existing contribution otherwise.
    * @param dataObject The DataObject to which the contribution should be added.
-   * @param table The table to read the maxRowCount property that should be used in the contribution.
+   * @param table The table for which the {@link MaxRowCountContributionDo} should be added.
+   * @param reloadReason The reason of the reload for which the {@link MaxRowCountContributionDo} should be added.
    */
-  withMaxRowCountContribution<T extends { _contributions?: DoEntity[] }>(dataObject: T, table: Table): T {
-    const maxRowCountContribution = this.buildMaxRowCountContribution(table);
+  withMaxRowCountContribution<T extends { _contributions?: DoEntity[] }>(dataObject: T, table: Table, reloadReason?: TableReloadReason): T {
+    const maxRowCountContribution = this.buildMaxRowCountContribution(table, reloadReason);
     if (maxRowCountContribution) {
       dataObject = dataObject || {} as T;
       // see ScoutDataObjectModule.DEFAULT_CONTRIBUTIONS_ATTRIBUTE_NAME
@@ -40,11 +41,13 @@ export class TableMaxResultsHelper {
   }
 
   /**
-   * Reads the maximum number of rows for the given table and converts it to a {@link MaxRowCountContributionDo}.
+   * Reads the maximum number of rows for the given table and reason and converts it to a {@link MaxRowCountContributionDo}.
+   * @param table The table for which the {@link MaxRowCountContributionDo} should be returned.
+   * @param reloadReason The reason of the reload for which the {@link MaxRowCountContributionDo} should be added.
    * @returns the {@link MaxRowCountContributionDo} if there is a valid maxRowCount for the given table or null if no row count constraint is used.
    */
-  buildMaxRowCountContribution(table: Table): MaxRowCountContributionDo {
-    const maxOutlineRowCount = this.getMaxTableRowCount(table);
+  buildMaxRowCountContribution(table: Table, reloadReason: TableReloadReason): MaxRowCountContributionDo {
+    const maxOutlineRowCount = this.getMaxTableRowCount(table, reloadReason);
     if (maxOutlineRowCount > 0) {
       return scout.create(MaxRowCountContributionDo, {hint: maxOutlineRowCount});
     }
@@ -52,9 +55,11 @@ export class TableMaxResultsHelper {
   }
 
   /**
-   * Gets the maximum number of rows for the given table.
+   * @param table The table for which the max table row count should be returned.
+   * @param reloadReason The reason of the reload for which the max table row count should be returned.
+   * @returns the maximum number of rows for the given table and reload reason.
    */
-  getMaxTableRowCount(table: Table): number {
+  getMaxTableRowCount(table: Table, reloadReason: TableReloadReason): number {
     return table?.maxRowCount;
   }
 }

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
@@ -9,7 +9,7 @@
  */
 import {
   arrays, Column, Form, GroupBox, InitModelOf, MaxRowCountContributionDo, NumberColumn, NumberField, ObjectOrModel, Outline, Page, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl, SearchMenu, SmartColumn,
-  StaticLookupCall, StringField, Table, TableRow, WidgetModel
+  StaticLookupCall, StringField, Table, TableReloadReason, TableRow, WidgetModel
 } from '../../../../src/index';
 import {OutlineSpecHelper, TableSpecHelper} from '../../../../src/testing/index';
 
@@ -46,6 +46,8 @@ describe('PageWithTable', () => {
   });
 
   class SpecPageWithTable extends PageWithTable {
+    override _reloadReason: TableReloadReason = null;
+
     override _createSearchFilter(): any {
       return super._createSearchFilter();
     }
@@ -161,6 +163,31 @@ describe('PageWithTable', () => {
     expect(page.detailTable.maxRowCount).toBe(456);
     expect(page.detailTable.estimatedRowCount).toBe(1111);
     expect(page.detailTable.tableStatus.message).toBe('[undefined text: MaxOutlineRowWarningWithEstimatedRowCount]');
+  });
+
+  it('stores reload reason', () => {
+    page._loadTableData = searchFilter => {
+      return $.resolvedPromise({
+        _contributions: [{
+          _type: 'scout.LimitedResultInfoContribution',
+          limitedResult: true,
+          maxRowCount: 456,
+          estimatedRowCount: 1111
+        }]
+      });
+    };
+    page._transformTableDataToTableRows = data => undefined;
+    page.detailTable.reload();
+    jasmine.clock().tick(10);
+    page.detailTable.footer._compactStyle = false;
+    page.detailTable.footer._infoLoadAction.doAction();
+    jasmine.clock().tick(10);
+    expect(page._reloadReason).toEqual(Table.ReloadReason.OVERRIDE_ROW_LIMIT);
+
+    // reload reason must stay on next reloads. otherwise the override gets lost. Keep it until a new reason is provided.
+    page.detailTable.reload();
+    jasmine.clock().tick(10);
+    expect(page._reloadReason).toEqual(Table.ReloadReason.OVERRIDE_ROW_LIMIT);
   });
 
   it('should handle errors in _onLoadTableDataDone', () => {


### PR DESCRIPTION
This allows to customize the max row counts based on the reason of the reload. E.g. to load more data for reload reason 'overrideRowLimit' (see TableFooter._onInfoLoadAction).

432873