### PR TITLE
Tree: don't fail if nodes are deleted while expanding

### DIFF
--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -1425,6 +1425,9 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
     $nodes.each((index: number, element: HTMLElement) => {
       let $node = $(element);
       let node = $node.data('node') as TreeNode;
+      if (node?.destroyed) {
+        return;
+      }
       let paddingLeft = this._computeNodePaddingLeft(node);
       $node.cssPaddingLeft(objects.isNullOrUndefined(paddingLeft) ? '' : paddingLeft);
       node._updateControl($node.children('.tree-node-control'));

--- a/eclipse-scout-core/test/tree/TreeSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeSpec.ts
@@ -1069,12 +1069,12 @@ describe('Tree', () => {
   describe('deleteAllChildNodes', () => {
     let model: SpecTreeModel;
     let tree: SpecTree;
-    let node0;
-    let node1;
-    let node2;
-    let node1Child0;
-    let node1Child1;
-    let node1Child2;
+    let node0: TreeNode;
+    let node1: TreeNode;
+    let node2: TreeNode;
+    let node1Child0: TreeNode;
+    let node1Child1: TreeNode;
+    let node1Child2: TreeNode;
 
     beforeEach(() => {
       model = helper.createModelFixture(3, 1, true);
@@ -1174,6 +1174,21 @@ describe('Tree', () => {
       expect(node1.expandedLazy).toBeFalse();
 
       expect(tree.visibleNodesFlat).toEqual([node0, node1, node2]);
+    });
+
+    it('does not fail when deleting nodes that are being collapsed', () => {
+      // Ensure _computeNodePaddingLeftForLevel() is called which happens because the selection needs to be re-rendered if a selected node is deleted
+      node1.setIconId('my-icon');
+      tree.nodePaddingLevelDiffParentHasIcon = 10;
+      tree.selectNode(node1Child0);
+      tree.render();
+
+      // Ensure collapse animation runs
+      $.fx.off = false;
+      jasmine.clock().uninstall();
+
+      tree.collapseNode(node1);
+      tree.deleteAllChildNodes(node1);
     });
   });
 


### PR DESCRIPTION
Fixes following issue:
1. Parent node has an icon
2. Child node is selected
3. Collapse parent and delete all children -> error

Reason: _computeNodePaddingLeftForLevel() tries to access a childNode but deleteNodes / deleteAllChildNodes removes the childNodes. Actually, the padding must not be computed for a removed node, but because the collapse animation runs, _destroyNode() does not remove it. It will be removed later by _removeNodes(). Moving _removeNodes() up would solve it, but may cause a side effect -> it will be moved with 26.2.

449682