### PR TITLE
Table: add enter keystroke for defaultRowAction

### DIFF
--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -518,6 +518,7 @@ export * from './table/TableEventMap';
 export * from './table/TableAdapter';
 export * from './table/TableCompactHandler';
 export * from './table/TableCompactHandlerModel';
+export * from './table/TableDefaultRowActionKeyStroke';
 export * from './table/TableRow';
 export * from './table/TableMaxResultsHelper';
 export * from './table/TableRowModel';

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -12,8 +12,8 @@ import {
   DesktopPopupOpenEvent, Device, DisplayViewId, DoubleClickSupport, dragAndDrop, DragAndDropHandler, DropType, EnumObject, ErrorHandler, EventHandler, events, Filter, Filterable, FilterOrFunction, FilterResult, FilterSupport, FullModelOf,
   graphics, GridAriaRules, HtmlComponent, IconColumn, InitModelOf, Insets, IUserFilterStateDo, keys, KeyStrokeContext, LimitedResultTableStatus, LoadingSupport, Menu, MenuBar, MenuDestinations, MenuItemsOrder, menus as menuUtil, menus,
   NumberColumn, NumberColumnAggregationFunction, NumberColumnBackgroundEffect, ObjectOrChildModel, ObjectOrModel, objects, Predicate, PropertyChangeEvent, Range, scout, scrollbars, ScrollToAlignment, ScrollToOptions, Status, StatusOrModel,
-  strings, styles, TabbableCoordinator, TableClientUiPreferenceProfileDo, TableCompactHandler, TableControl, TableCopyKeyStroke, TableCustomizer, TableEventMap, TableFooter, TableHeader, TableLayout, TableModel,
-  TableNavigationCollapseKeyStroke, TableNavigationDownKeyStroke, TableNavigationEndKeyStroke, TableNavigationExpandKeyStroke, TableNavigationHomeKeyStroke, TableNavigationPageDownKeyStroke, TableNavigationPageUpKeyStroke,
+  strings, styles, TabbableCoordinator, TableClientUiPreferenceProfileDo, TableCompactHandler, TableControl, TableCopyKeyStroke, TableCustomizer, TableDefaultRowActionKeyStroke, TableEventMap, TableFooter, TableHeader, TableLayout,
+  TableModel, TableNavigationCollapseKeyStroke, TableNavigationDownKeyStroke, TableNavigationEndKeyStroke, TableNavigationExpandKeyStroke, TableNavigationHomeKeyStroke, TableNavigationPageDownKeyStroke, TableNavigationPageUpKeyStroke,
   TableNavigationUpKeyStroke, TableOrganizer, TableRefreshKeyStroke, TableRow, TableRowModel, TableSelectAllKeyStroke, TableSelectionHandler, TableSelectKeyStroke, TableStartCellEditKeyStroke, TableTextUserFilter, TableTileGridMediator,
   TableToggleRowKeyStroke, TableTooltip, TableUiPreferences, tableUiPreferences, TableUpdateBuffer, TableUserFilter, TableUserFilterModel, Tile, TileTableHeaderBox, tooltips, TooltipSupport, TreeGridAriaRules, UiPreferences,
   UpdateFilteredElementsOptions, UserFilterStateMappers, ValueField, Widget
@@ -555,7 +555,8 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
       new TableToggleRowKeyStroke(this),
       new TableCopyKeyStroke(this),
       new ContextMenuKeyStroke(this, this.showContextMenu, this),
-      new AppLinkKeyStroke(this, this.handleAppLinkAction)
+      new AppLinkKeyStroke(this, this.handleAppLinkAction),
+      new TableDefaultRowActionKeyStroke(this)
     ]);
   }
 

--- a/eclipse-scout-core/src/table/TableDefaultRowActionKeyStroke.ts
+++ b/eclipse-scout-core/src/table/TableDefaultRowActionKeyStroke.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {keys, KeyStroke, scout, ScoutKeyboardEvent, Table} from '../index';
+
+/**
+ * This {@link KeyStroke} executes the {@link Table#defaultRowAction} on ENTER if present and stops propagation of the event.
+ */
+export class TableDefaultRowActionKeyStroke extends KeyStroke {
+
+  declare field: Table;
+
+  constructor(table: Table) {
+    super();
+
+    this.field = scout.assertInstance(table, Table);
+    this.which = [keys.ENTER];
+    this.renderingHints.render = false;
+    this.stopPropagation = true;
+    this.stopImmediatePropagation = true;
+  }
+
+  protected override _accept(event: ScoutKeyboardEvent): boolean {
+    return super._accept(event) && !!this.field.defaultRowAction;
+  }
+
+  override handle(event: JQuery.KeyboardEventBase) {
+    this.field.defaultRowAction.doAction();
+  }
+}

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  Action, arrays, BeanColumn, BooleanColumn, Cell, Column, ColumnModel, Device, graphics, IconColumn, icons, Menu, MenuDestinations, NumberColumn, ObjectFactory, Point, Range, RemoteEvent, scout, scrollbars, SmartColumn, StaticLookupCall,
-  Status, strings, Table, TableAdapter, TableField, TableRow, TableRowModel, TableUserFilter, Tooltip
+  Action, arrays, BeanColumn, BooleanColumn, Cell, Column, ColumnModel, Device, graphics, IconColumn, icons, keys, Menu, MenuDestinations, NumberColumn, ObjectFactory, Point, Range, RemoteEvent, scout, scrollbars, SmartColumn,
+  StaticLookupCall, Status, strings, Table, TableAdapter, TableField, TableRow, TableRowModel, TableUserFilter, Tooltip
 } from '../../src/index';
 import {JQueryTesting, LocaleSpecHelper, SpecTable, SpecTableModel, TableSpecHelper} from '../../src/testing/index';
 import $ from 'jquery';
@@ -1094,6 +1094,56 @@ describe('Table', () => {
 
       table.doRowAction(row);
       expect(count).toBe(1);
+    });
+  });
+
+  describe('defaultRowAction', () => {
+
+    it('is executed when ENTER is pressed', () => {
+      const table = helper.createTable({
+        ...helper.createModelFixture(2, 5),
+        defaultRowAction: '42',
+        menus: [{
+          id: '42',
+          objectType: Menu
+        }]
+      });
+      table.render();
+
+      const row = table.rows[0];
+      table.selectRows(row);
+
+      const menu = table.menus[0];
+      expect(menu).toBe(table.defaultRowAction as Menu);
+
+      // when ENTER executes the defaultRowAction, the event propagation is stopped
+      let desktopEnterCount = 0;
+      const desktopEnterListener = (event: JQuery.KeyboardEventBase) => {
+        if (event.which === keys.ENTER) {
+          desktopEnterCount++;
+        }
+      };
+      session.desktop.$container.on('keydown', desktopEnterListener);
+
+      let menuActionCount = 0;
+      menu.on('action', () => menuActionCount++);
+
+      expect(desktopEnterCount).toBe(0);
+      expect(menuActionCount).toBe(0);
+
+      JQueryTesting.triggerKeyDownCapture(table.$container, keys.ENTER);
+      JQueryTesting.triggerKeyUpCapture(table.$container, keys.ENTER);
+      expect(desktopEnterCount).toBe(0);
+      expect(menuActionCount).toBe(1);
+
+      table.setDefaultRowAction(null);
+
+      JQueryTesting.triggerKeyDownCapture(table.$container, keys.ENTER);
+      JQueryTesting.triggerKeyUpCapture(table.$container, keys.ENTER);
+      expect(desktopEnterCount).toBe(1);
+      expect(menuActionCount).toBe(1);
+
+      session.desktop.$container.off('keydown', desktopEnterListener);
     });
   });
 


### PR DESCRIPTION
Scout Classic executes the default menu on enter if it is present. This is done by adding an enter keystroke that stops propagation if the default menu is set. This is now done in Scout JS as well. Therefore, pressing enter on a Scout JS table executes the defaultRowAction like it does in a Scout Classic table.

448050