### PR TITLE
Improve font icon removal in PlainTextEncoder

### DIFF
--- a/eclipse-scout-core/src/encoder/PlainTextEncoder.ts
+++ b/eclipse-scout-core/src/encoder/PlainTextEncoder.ts
@@ -55,7 +55,7 @@ export class PlainTextEncoder {
     text = text.replace(/<\/td>/gi, ' ');
 
     if (options.removeFontIcons) {
-      text = text.replace(/<span\s+class="[^"]*font-icon[^"]*">[^<]*<\/span>/gmi, '');
+      text = text.replace(/<span\s+[^>]*class="[^"]*font-icon[^"]*"[^>]*>[^<]*<\/span>/gmi, '');
     }
 
     // Remove script and style contents

--- a/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.ts
+++ b/eclipse-scout-core/test/encoder/PlainTextEncoderSpec.ts
@@ -155,6 +155,15 @@ describe('PlainTextEncoder', () => {
     htmlText = '<span\nclass="font-icon xy-icon"></span>\n<span class="text">Text</span>';
     expect(encoder.encode(htmlText)).toBe('\nText');
     expect(encoder.encode(htmlText, {removeFontIcons: true})).toBe('\nText');
-  });
 
+    // Other attributes before class attribute
+    htmlText = '<span\n aria-hidden="false" class="font-icon xy-icon"></span>\n<span class="text">Text</span>';
+    expect(encoder.encode(htmlText)).toBe('\nText');
+    expect(encoder.encode(htmlText, {removeFontIcons: true})).toBe('\nText');
+
+    // Other attributes after class attribute
+    htmlText = '<span\n class="font-icon xy-icon" aria-hidden="false"></span>\n<span class="text">Text</span>';
+    expect(encoder.encode(htmlText)).toBe('\nText');
+    expect(encoder.encode(htmlText, {removeFontIcons: true})).toBe('\nText');
+  });
 });


### PR DESCRIPTION
* Adjusts PlainTextEncoder font icon regex to also remove HTML elements
with font icons even if the class attribute is surrounded by other HTML
attributes. The old behavior lead to an issue in a table's row icon
column which displayed an ugly tooltip.
* Backports part of the encoder improvements made in 25.2.
See commit 931bba46dcc7c55a5e58ba288d17e3ff16b04f81. Thus, this fix is
not cherry-picked to higher release.

449641