### PR TITLE
Do not send popups with unresolvable anchors to Scout JS

### DIFF
--- a/eclipse-scout-core/src/tile/TileGridLayout.ts
+++ b/eclipse-scout-core/src/tile/TileGridLayout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -250,6 +250,11 @@ export class TileGridLayout extends LogicalGridLayout {
   protected _onAnimationDone() {
     this._updateScrollbar();
     this.widget.trigger('layoutAnimationDone');
+
+    // tiles may be the anchors of popups, reposition popups after all tiles are at their final position
+    for (const popup of this.widget.findDesktop().getPopupsFor(this.widget)) {
+      popup.position();
+    }
   }
 
   protected _animateTileBounds(tile: Tile, fromBounds: Rectangle, bounds: Rectangle): JQuery.Promise<JQuery> {

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/popup/PopupTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/popup/PopupTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.popup;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.ui.desktop.IDesktop;
+import org.eclipse.scout.rt.client.ui.form.fields.stringfield.AbstractStringField;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(TestEnvironmentClientSession.class)
+public class PopupTest {
+
+  @Test
+  public void testPopupDisposeOnAnchorDispose() {
+
+    // dispose current anchor -> popup is closed
+
+    MyPopup popup = new MyPopup();
+    MyStringField anchor = new MyStringField();
+    popup.setAnchor(anchor);
+    popup.open();
+
+    assertTrue(IDesktop.CURRENT.get().getAddOn(PopupManager.class).getPopups().contains(popup));
+    assertFalse(popup.isDisposeDone());
+    assertFalse(anchor.isDisposeDone());
+
+    anchor.dispose();
+
+    assertFalse(IDesktop.CURRENT.get().getAddOn(PopupManager.class).getPopups().contains(popup));
+    assertTrue(popup.isDisposeDone());
+    assertTrue(anchor.isDisposeDone());
+
+    // dispose former anchor -> popup is not closed
+
+    popup = new MyPopup();
+    anchor = new MyStringField();
+    popup.setAnchor(anchor);
+    popup.open();
+
+    assertTrue(IDesktop.CURRENT.get().getAddOn(PopupManager.class).getPopups().contains(popup));
+    assertFalse(popup.isDisposeDone());
+    assertFalse(anchor.isDisposeDone());
+
+    popup.setAnchor(null);
+    anchor.dispose();
+
+    assertTrue(IDesktop.CURRENT.get().getAddOn(PopupManager.class).getPopups().contains(popup));
+    assertFalse(popup.isDisposeDone());
+    assertTrue(anchor.isDisposeDone());
+  }
+
+  protected static class MyStringField extends AbstractStringField {
+  }
+
+  protected static class MyPopup extends AbstractPopup {
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/popup/AbstractPopup.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/popup/AbstractPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.scout.rt.client.ui.popup;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
 import org.eclipse.scout.rt.client.ModelContextProxy;
 import org.eclipse.scout.rt.client.ModelContextProxy.ModelContext;
@@ -24,6 +27,7 @@ import org.eclipse.scout.rt.platform.classid.ClassId;
 public abstract class AbstractPopup extends AbstractWidget implements IPopup {
 
   private IPopupUIFacade m_uiFacade;
+  private P_AnchorDisposeListener m_anchorDisposeListener;
 
   public AbstractPopup() {
     this(true);
@@ -247,6 +251,15 @@ public abstract class AbstractPopup extends AbstractWidget implements IPopup {
   protected void initConfig() {
     super.initConfig();
     m_uiFacade = BEANS.get(ModelContextProxy.class).newProxy(new P_UIFacade(), ModelContext.copyCurrent());
+    m_anchorDisposeListener = createAnchorDisposeListener();
+    addPropertyChangeListener(IPopup.PROP_ANCHOR, event -> {
+      if (event.getOldValue() instanceof IWidget) {
+        ((IWidget) event.getOldValue()).removePropertyChangeListener(IWidget.PROP_DISPOSE_DONE, getAnchorDisposeListener());
+      }
+      if (event.getNewValue() instanceof IWidget) {
+        ((IWidget) event.getNewValue()).addPropertyChangeListener(IWidget.PROP_DISPOSE_DONE, getAnchorDisposeListener());
+      }
+    });
 
     setAnchor(getConfiguredAnchor());
     setAnimateOpening(getConfiguredAnimateOpening());
@@ -290,5 +303,21 @@ public abstract class AbstractPopup extends AbstractWidget implements IPopup {
   public void close() {
     getPopupManager().close(this);
     dispose();
+  }
+
+  protected P_AnchorDisposeListener getAnchorDisposeListener() {
+    return m_anchorDisposeListener;
+  }
+
+  protected P_AnchorDisposeListener createAnchorDisposeListener() {
+    return new P_AnchorDisposeListener();
+  }
+
+  protected class P_AnchorDisposeListener implements PropertyChangeListener {
+
+    @Override
+    public void propertyChange(PropertyChangeEvent event) {
+      close();
+    }
   }
 }

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/popup/JsonPopupManagerTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/json/popup/JsonPopupManagerTest.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html.json.popup;
+
+import static org.eclipse.scout.rt.platform.util.Assertions.assertInstance;
+import static org.junit.Assert.*;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.client.ui.form.fields.stringfield.AbstractStringField;
+import org.eclipse.scout.rt.client.ui.popup.AbstractPopup;
+import org.eclipse.scout.rt.client.ui.popup.PopupManager;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
+import org.eclipse.scout.rt.ui.html.json.JsonAdapterUtility;
+import org.eclipse.scout.rt.ui.html.json.JsonPropertyChangeEvent;
+import org.eclipse.scout.rt.ui.html.json.fixtures.UiSessionMock;
+import org.eclipse.scout.rt.ui.html.json.testing.JsonTestUtility;
+import org.json.JSONArray;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(TestEnvironmentClientSession.class)
+public class JsonPopupManagerTest {
+
+  private UiSessionMock m_uiSession;
+
+  @Before
+  public void setUp() {
+    m_uiSession = new UiSessionMock();
+    JsonTestUtility.endRequest(m_uiSession);
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestUtility.endRequest(m_uiSession);
+    getPopupManager().getPopups().forEach(getPopupManager()::close);
+  }
+
+  private PopupManager getPopupManager() {
+    return m_uiSession.getClientSession().getDesktop().getAddOn(PopupManager.class);
+  }
+
+  @Test
+  public void testPropertyChangeEvent() {
+    JsonPopupManager<PopupManager> jsonPopupManager = m_uiSession.createJsonAdapter(getPopupManager(), m_uiSession.getRootJsonAdapter());
+
+    MyPopup popupWithoutAnchor = new MyPopup();
+
+    MyPopup popupWithAnchorWithoutJsonAdapter = new MyPopup();
+    popupWithAnchorWithoutJsonAdapter.setAnchor(new MyStringField());
+
+    MyPopup popupWithAnchorWithJsonAdapter = new MyPopup();
+    MyStringField anchor = new MyStringField();
+    m_uiSession.createJsonAdapter(anchor, m_uiSession.getRootJsonAdapter());
+    popupWithAnchorWithJsonAdapter.setAnchor(anchor);
+
+    getPopupManager().open(popupWithoutAnchor);
+    getPopupManager().open(popupWithAnchorWithoutJsonAdapter);
+    getPopupManager().open(popupWithAnchorWithJsonAdapter);
+
+    // property change event does not contain popups with anchors that do not have a json adapter
+    assertEquals(Set.of(popupWithAnchorWithoutJsonAdapter.getAnchor()), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    JsonPropertyChangeEvent event = assertInstance(m_uiSession.currentJsonResponse().getEventList().get(0), JsonPropertyChangeEvent.class);
+    assertEquals("property", event.getType());
+    assertEquals(jsonPopupManager.getId(), event.getTarget());
+    assertEquals(1, event.getProperties().size());
+    assertTrue(event.getProperties().containsKey(PopupManager.PROP_POPUPS));
+    JSONArray jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(2, jsonPopups.length());
+    assertEquals(
+        Set.of(
+            JsonAdapterUtility.findChildAdapter(jsonPopupManager, popupWithoutAnchor).getId(),
+            JsonAdapterUtility.findChildAdapter(jsonPopupManager, popupWithAnchorWithJsonAdapter).getId()
+        ),
+        IntStream.range(0, jsonPopups.length())
+            .mapToObj(jsonPopups::getString)
+            .collect(Collectors.toSet())
+    );
+  }
+
+  @Test
+  public void testPropertyChangeEventOnAnchorChanges() {
+    JsonPopupManager<PopupManager> jsonPopupManager = m_uiSession.createJsonAdapter(getPopupManager(), m_uiSession.getRootJsonAdapter());
+
+    // no anchor -> popup is part of property change event
+
+    MyPopup popup = new MyPopup();
+    getPopupManager().open(popup);
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    JsonPropertyChangeEvent event = assertInstance(m_uiSession.currentJsonResponse().getEventList().get(0), JsonPropertyChangeEvent.class);
+    assertEquals("property", event.getType());
+    assertEquals(jsonPopupManager.getId(), event.getTarget());
+    assertEquals(1, event.getProperties().size());
+    assertTrue(event.getProperties().containsKey(PopupManager.PROP_POPUPS));
+    JSONArray jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(1, jsonPopups.length());
+    assertEquals(JsonAdapterUtility.findChildAdapter(jsonPopupManager, popup).getId(), jsonPopups.getString(0));
+
+    // anchor without json adapter -> popup is not part of property change event
+
+    popup.setAnchor(new MyStringField());
+
+    assertEquals(Set.of(popup.getAnchor()), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(0, jsonPopups.length());
+
+    // anchor with json adapter -> popup is part of property change event
+
+    MyStringField anchor = new MyStringField();
+    m_uiSession.createJsonAdapter(anchor, m_uiSession.getRootJsonAdapter());
+    popup.setAnchor(anchor);
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(1, jsonPopups.length());
+    assertEquals(JsonAdapterUtility.findChildAdapter(jsonPopupManager, popup).getId(), jsonPopups.getString(0));
+
+    // popup closed -> popup is not part of property change event, no matter what its anchor looks like
+
+    getPopupManager().close(popup);
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(0, jsonPopups.length());
+
+    popup.setAnchor(new MyStringField());
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(0, jsonPopups.length());
+
+    popup.setAnchor(null);
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(0, jsonPopups.length());
+  }
+
+  @Test
+  public void testPropertyChangeEventOnAnchorJsonAdapterChanges() {
+    JsonPopupManager<PopupManager> jsonPopupManager = m_uiSession.createJsonAdapter(getPopupManager(), m_uiSession.getRootJsonAdapter());
+
+    // anchor without json adapter -> popup is not part of property change event
+
+    MyPopup popup = new MyPopup();
+    MyStringField anchor = new MyStringField();
+    popup.setAnchor(anchor);
+
+    getPopupManager().open(popup);
+
+    assertEquals(Set.of(popup.getAnchor()), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    JsonPropertyChangeEvent event = assertInstance(m_uiSession.currentJsonResponse().getEventList().get(0), JsonPropertyChangeEvent.class);
+    assertEquals("property", event.getType());
+    assertEquals(jsonPopupManager.getId(), event.getTarget());
+    assertEquals(1, event.getProperties().size());
+    assertTrue(event.getProperties().containsKey(PopupManager.PROP_POPUPS));
+    JSONArray jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(0, jsonPopups.length());
+
+    // anchor with json adapter -> popup is part of property change event
+
+    IJsonAdapter<MyStringField> jsonAnchor = m_uiSession.createJsonAdapter(anchor, m_uiSession.getRootJsonAdapter());
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(1, jsonPopups.length());
+    assertEquals(JsonAdapterUtility.findChildAdapter(jsonPopupManager, popup).getId(), jsonPopups.getString(0));
+
+    // anchor without json adapter that was part of property change event -> popup is still part of property change event (no need to remove it as the browser does not try to render it again)
+
+    jsonAnchor.dispose();
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(1, jsonPopups.length());
+    assertEquals(JsonAdapterUtility.findChildAdapter(jsonPopupManager, popup).getId(), jsonPopups.getString(0));
+
+    // popup closed -> popup is not part of property change event, no matter what its anchor looks like
+
+    getPopupManager().close(popup);
+
+    jsonAnchor = m_uiSession.createJsonAdapter(anchor, m_uiSession.getRootJsonAdapter());
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(0, jsonPopups.length());
+
+    jsonAnchor.dispose();
+
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+    assertEquals(1, m_uiSession.currentJsonResponse().getEventList().size());
+    assertEquals(event, m_uiSession.currentJsonResponse().getEventList().get(0));
+    jsonPopups = assertInstance(event.getProperties().get(PopupManager.PROP_POPUPS), JSONArray.class);
+    assertEquals(0, jsonPopups.length());
+  }
+
+  @Test
+  public void testAnchorWithoutJsonAdapter() {
+    JsonPopupManager<PopupManager> jsonPopupManager = m_uiSession.createJsonAdapter(getPopupManager(), m_uiSession.getRootJsonAdapter());
+
+    MyPopup popup1 = new MyPopup();
+    MyPopup popup2 = new MyPopup();
+    MyPopup popup3 = new MyPopup();
+    MyPopup popup4 = new MyPopup();
+
+    MyStringField anchor1 = new MyStringField();
+    MyStringField anchor2 = new MyStringField();
+
+    IJsonAdapter<MyStringField> jsonAnchor1;
+    IJsonAdapter<MyStringField> jsonAnchor2;
+
+    // open and close a popup without an anchor
+    getPopupManager().open(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    // open and close a popup with an anchor without a json adapter
+    popup1.setAnchor(anchor1);
+
+    getPopupManager().open(popup1);
+    assertEquals(Set.of(anchor1), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(null);
+
+    // open and close a popup with an anchor with a json adapter
+    popup1.setAnchor(anchor1);
+    jsonAnchor1 = m_uiSession.createJsonAdapter(anchor1, m_uiSession.getRootJsonAdapter());
+
+    getPopupManager().open(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    jsonAnchor1.dispose();
+    popup1.setAnchor(null);
+
+    // open and close multiple popups without an anchor
+    getPopupManager().open(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().open(popup2);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup2);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    // open and close multiple popups with the same anchor without a json adapter
+    popup1.setAnchor(anchor1);
+    popup2.setAnchor(anchor1);
+
+    getPopupManager().open(popup1);
+    assertEquals(Set.of(anchor1), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().open(popup2);
+    assertEquals(Set.of(anchor1), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    assertEquals(Set.of(anchor1), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup2);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(null);
+    popup2.setAnchor(null);
+
+    // open and close multiple popups with the same anchor with a json adapter
+    popup1.setAnchor(anchor1);
+    popup2.setAnchor(anchor1);
+    jsonAnchor1 = m_uiSession.createJsonAdapter(anchor1, m_uiSession.getRootJsonAdapter());
+
+    getPopupManager().open(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().open(popup2);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup2);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    jsonAnchor1.dispose();
+    popup1.setAnchor(null);
+    popup2.setAnchor(null);
+
+    // update the anchor of an open popup
+    jsonAnchor1 = m_uiSession.createJsonAdapter(anchor1, m_uiSession.getRootJsonAdapter());
+
+    getPopupManager().open(popup1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(anchor2);
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(anchor1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(anchor2);
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(null);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    jsonAnchor1.dispose();
+
+    // update the anchors of multiple open popups
+    jsonAnchor1 = m_uiSession.createJsonAdapter(anchor1, m_uiSession.getRootJsonAdapter());
+
+    getPopupManager().open(popup1);
+    getPopupManager().open(popup2);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(anchor2);
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup2.setAnchor(anchor2);
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(anchor1);
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup2.setAnchor(anchor1);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(anchor2);
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup2.setAnchor(anchor2);
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup1.setAnchor(null);
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    popup2.setAnchor(null);
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    getPopupManager().close(popup2);
+    jsonAnchor1.dispose();
+
+    // create json adapters for multiple open popups
+    popup1.setAnchor(anchor1);
+    popup2.setAnchor(anchor2);
+    popup3.setAnchor(anchor2);
+
+    getPopupManager().open(popup1);
+    getPopupManager().open(popup2);
+    getPopupManager().open(popup3);
+    getPopupManager().open(popup4);
+    assertEquals(Set.of(anchor1, anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    jsonAnchor1 = m_uiSession.createJsonAdapter(anchor1, m_uiSession.getRootJsonAdapter());
+    assertEquals(Set.of(anchor2), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    jsonAnchor2 = m_uiSession.createJsonAdapter(anchor2, m_uiSession.getRootJsonAdapter());
+    assertEquals(Set.of(), jsonPopupManager.getAnchorsWithoutJsonAdapter());
+
+    getPopupManager().close(popup1);
+    getPopupManager().close(popup2);
+    getPopupManager().close(popup3);
+    getPopupManager().close(popup4);
+    jsonAnchor1.dispose();
+    jsonAnchor2.dispose();
+  }
+
+  protected static class MyStringField extends AbstractStringField {
+  }
+
+  protected static class MyPopup extends AbstractPopup {
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/popup/JsonPopupManager.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/popup/JsonPopupManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,19 +9,36 @@
  */
 package org.eclipse.scout.rt.ui.html.json.popup;
 
-import java.util.Set;
+import static java.util.function.Predicate.not;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.scout.rt.client.job.ModelJobs;
+import org.eclipse.scout.rt.client.ui.IWidget;
 import org.eclipse.scout.rt.client.ui.popup.IPopup;
 import org.eclipse.scout.rt.client.ui.popup.PopupManager;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.ui.html.IUiSession;
+import org.eclipse.scout.rt.ui.html.UiSessionEvent;
+import org.eclipse.scout.rt.ui.html.UiSessionListener;
 import org.eclipse.scout.rt.ui.html.json.AbstractJsonPropertyObserver;
 import org.eclipse.scout.rt.ui.html.json.IJsonAdapter;
+import org.eclipse.scout.rt.ui.html.json.JsonAdapterUtility;
 import org.eclipse.scout.rt.ui.html.json.form.fields.JsonAdapterProperty;
 
 /**
  * @since 9.0
  */
 public class JsonPopupManager<T extends PopupManager> extends AbstractJsonPropertyObserver<T> {
+
+  private P_PopupAnchorChangeListener m_popupAnchorChangeListener;
+  private P_AnchorAdapterChangeListener m_anchorAdapterChangeListener;
+  private final Set<IWidget> m_anchorsWithoutJsonAdapter = new HashSet<>();
 
   public JsonPopupManager(T model, IUiSession uiSession, String id, IJsonAdapter<?> parent) {
     super(model, uiSession, id, parent);
@@ -35,11 +52,247 @@ public class JsonPopupManager<T extends PopupManager> extends AbstractJsonProper
   @Override
   protected void initJsonProperties(T model) {
     super.initJsonProperties(model);
-    putJsonProperty(new JsonAdapterProperty<T>(PopupManager.PROP_POPUPS, model, getUiSession()) {
+    putJsonProperty(new JsonAdapterProperty<>(PopupManager.PROP_POPUPS, model, getUiSession()) {
       @Override
       protected Set<IPopup> modelValue() {
-        return getModel().getPopups();
+        // The json adapter of a popup uses a JsonAdapterRefProperty for its anchor property.
+        // When the value of this property is resolved and an anchor is present, an exception is thrown if there is no json adapter for the anchor.
+        // Therefore, remove all popups that have anchors without a json adapter.
+        return getModel().getPopups().stream()
+            .filter(Objects::nonNull)
+            .filter(popup -> !isAnchorWithoutJsonAdapter(popup.getAnchor()))
+            .collect(Collectors.toSet());
       }
     });
+  }
+
+  @Override
+  protected void attachModel() {
+    super.attachModel();
+
+    // create listener initially
+    if (m_popupAnchorChangeListener != null) {
+      throw new IllegalStateException();
+    }
+    m_popupAnchorChangeListener = new P_PopupAnchorChangeListener();
+
+    // install listener on all current popups
+    Set<IPopup> popups = getModel().getPopups();
+    if (!CollectionUtility.isEmpty(popups)) {
+      popups.forEach(this::installPopupListeners);
+    }
+  }
+
+  @Override
+  protected void detachModel() {
+    super.detachModel();
+
+    // uninstall listener from all current popups
+    Set<IPopup> popups = getModel().getPopups();
+    if (!CollectionUtility.isEmpty(popups)) {
+      popups.forEach(this::uninstallPopupListeners);
+    }
+  }
+
+  @Override
+  protected void handleModelPropertyChange(PropertyChangeEvent event) {
+    // update listeners for all added/removed popups
+    if (event.getPropertyName().equals(PopupManager.PROP_POPUPS)) {
+      //noinspection unchecked
+      handleModelPopupsChange((Set<IPopup>) event.getOldValue(), (Set<IPopup>) event.getNewValue());
+    }
+    super.handleModelPropertyChange(event);
+  }
+
+  /**
+   * Updates the listeners on the given {@link IPopup}s.
+   * Calls {@link #installPopupListeners(IPopup)} for all added {@link IPopup}s and {@link #uninstallPopupListeners(IPopup)} for all removed ones.
+   */
+  protected void handleModelPopupsChange(Set<IPopup> oldPopups, Set<IPopup> newPopups) {
+    Set<IPopup> removedPopups = CollectionUtility.hashSetWithoutNullElements(oldPopups);
+    if (newPopups != null) {
+      removedPopups.removeAll(newPopups);
+    }
+
+    Set<IPopup> addedPopups = CollectionUtility.hashSetWithoutNullElements(newPopups);
+    if (oldPopups != null) {
+      addedPopups.removeAll(oldPopups);
+    }
+
+    removedPopups.forEach(this::uninstallPopupListeners);
+    addedPopups.forEach(this::installPopupListeners);
+  }
+
+  /**
+   * Installs the {@link #m_popupAnchorChangeListener} on the given {@link IPopup}.
+   * Additionally, the anchor of the {@link IPopup} is added to the {@link #getAnchorsWithoutJsonAdapter()} (see {@link #addAnchorWithoutJsonAdapter(IWidget)}).
+   */
+  protected void installPopupListeners(IPopup popup) {
+    if (popup == null) {
+      return;
+    }
+
+    popup.addPropertyChangeListener(IPopup.PROP_ANCHOR, m_popupAnchorChangeListener);
+    addAnchorWithoutJsonAdapter(popup.getAnchor());
+  }
+
+  /**
+   * Uninstalls the {@link #m_popupAnchorChangeListener} from the given {@link IPopup}.
+   * Additionally, the anchor of the {@link IPopup} is removed from the {@link #getAnchorsWithoutJsonAdapter()} (see {@link #removeAnchorWithoutJsonAdapter(IWidget)}).
+   */
+  protected void uninstallPopupListeners(IPopup popup) {
+    if (popup == null) {
+      return;
+    }
+
+    popup.removePropertyChangeListener(IPopup.PROP_ANCHOR, m_popupAnchorChangeListener);
+
+    // remove observed anchor, if anchor is set and is not an anchor of any other popup
+    IWidget anchor = popup.getAnchor();
+    if (anchor != null && getModel().getPopups().stream()
+        .filter(not(popup::equals))
+        .map(IPopup::getAnchor)
+        .noneMatch(anchor::equals)) {
+      removeAnchorWithoutJsonAdapter(anchor);
+    }
+  }
+
+  /**
+   * All currently observed anchors that do not have an {@link IJsonAdapter}, used by the {@link P_AnchorAdapterChangeListener} to decide whether the json property {@link PopupManager#PROP_POPUPS} needs to be updated.
+   */
+  protected Set<IWidget> getAnchorsWithoutJsonAdapter() {
+    return m_anchorsWithoutJsonAdapter;
+  }
+
+  /**
+   * Checks whether the given {@link IWidget} is part of the {@link #getAnchorsWithoutJsonAdapter()}.
+   */
+  protected boolean isAnchorWithoutJsonAdapter(IWidget anchor) {
+    return getAnchorsWithoutJsonAdapter().contains(anchor);
+  }
+
+  /**
+   * Adds the given anchor to the {@link #getAnchorsWithoutJsonAdapter()} if there is no {@link IJsonAdapter} for it.
+   * If this changes the {@link #getAnchorsWithoutJsonAdapter()} the {@link #m_anchorAdapterChangeListener} is updated if necessary.
+   *
+   * @return <code>true</code> if {@link #getAnchorsWithoutJsonAdapter()} changed
+   */
+  protected boolean addAnchorWithoutJsonAdapter(IWidget anchor) {
+    if (anchor == null) {
+      return false;
+    }
+
+    // there is a json adapter for the anchor -> nothing to observe
+    if (JsonAdapterUtility.findChildAdapter(getUiSession().getRootJsonAdapter(), anchor) != null) {
+      return false;
+    }
+
+    // anchor is already observed
+    if (!getAnchorsWithoutJsonAdapter().add(anchor)) {
+      return false;
+    }
+
+    // listener is created already
+    if (m_anchorAdapterChangeListener != null) {
+      return true;
+    }
+
+    m_anchorAdapterChangeListener = new P_AnchorAdapterChangeListener();
+    getUiSession().addListener(m_anchorAdapterChangeListener, UiSessionEvent.TYPE_ADAPTER_CREATED);
+
+    return true;
+  }
+
+  /**
+   * Removes the given anchor from the {@link #getAnchorsWithoutJsonAdapter()}.
+   * If this changes the {@link #getAnchorsWithoutJsonAdapter()} the {@link #m_anchorAdapterChangeListener} is updated if necessary.
+   *
+   * @return <code>true</code> if {@link #getAnchorsWithoutJsonAdapter()} changed
+   */
+  protected boolean removeAnchorWithoutJsonAdapter(IWidget anchor) {
+    if (anchor == null) {
+      return false;
+    }
+
+    // anchor was not observed
+    if (!getAnchorsWithoutJsonAdapter().remove(anchor)) {
+      return false;
+    }
+
+    // still something to observe or listener is destroyed already
+    if (!getAnchorsWithoutJsonAdapter().isEmpty() || m_anchorAdapterChangeListener == null) {
+      return true;
+    }
+
+    getUiSession().removeListener(m_anchorAdapterChangeListener, UiSessionEvent.TYPE_ADAPTER_CREATED);
+    m_anchorAdapterChangeListener = null;
+
+    return true;
+  }
+
+  /**
+   * Updates the json property {@link PopupManager#PROP_POPUPS} of this json adapter.
+   */
+  protected void updatePopupsJsonProperty() {
+    handleModelPropertyChange(new PropertyChangeEvent(getModel(), PopupManager.PROP_POPUPS, getModel().getPopups(), getModel().getPopups()));
+  }
+
+  /**
+   * Updates the {@link #getAnchorsWithoutJsonAdapter()} when the anchor of a popup changes.
+   */
+  protected class P_PopupAnchorChangeListener implements PropertyChangeListener {
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+      ModelJobs.assertModelThread();
+
+      IWidget oldAnchor = (IWidget) evt.getOldValue();
+      IWidget newAnchor = (IWidget) evt.getNewValue();
+
+      // remove observed anchor, if oldAnchor is part of anchorsWithoutJsonAdapter and is not an anchor of any other popup
+      boolean isOldAnchorWithoutJsonAdapter = getAnchorsWithoutJsonAdapter().contains(oldAnchor);
+      if (isOldAnchorWithoutJsonAdapter && getModel().getPopups().stream()
+          .filter(not(evt.getSource()::equals))
+          .map(IPopup::getAnchor)
+          .noneMatch(oldAnchor::equals)) {
+        removeAnchorWithoutJsonAdapter(oldAnchor);
+      }
+
+      addAnchorWithoutJsonAdapter(newAnchor);
+
+      // old and new anchor do both have a json adapter or do both not have a json adapter -> no need to update the property
+      boolean isNewAnchorWithoutJsonAdapter = getAnchorsWithoutJsonAdapter().contains((IWidget) evt.getNewValue());
+      if (isOldAnchorWithoutJsonAdapter == isNewAnchorWithoutJsonAdapter) {
+        return;
+      }
+
+      updatePopupsJsonProperty();
+    }
+  }
+
+  /**
+   * Updates the json property {@link PopupManager#PROP_POPUPS} (see {@link #updatePopupsJsonProperty()}) when a json adapter is created for one of the {@link #getAnchorsWithoutJsonAdapter()}.
+   * This is relevant e.g. when the {@link JsonPopupManager} is processed before the json adapter of one of its popups anchors is processed which may happen e.g. when the browser is reloaded.
+   * As the <code>PopupManager.ts</code> only renders newly added popups and as a formerly rendered popup will be removed when its anchor is removed, it is not necessary to listen on json adapter disposals.
+   * The only time the <code>PopupManager.ts</code> will try to rerender these popups with potentially unavailable anchors is when the browser is reloaded
+   * and in this case the property {@link PopupManager#PROP_POPUPS} will be sent again and is therefore correctly filtered.
+   */
+  protected class P_AnchorAdapterChangeListener implements UiSessionListener {
+
+    @Override
+    public void sessionChanged(UiSessionEvent e) {
+      Object model = e.getJsonAdapter().getModel();
+      if (!(model instanceof IWidget)) {
+        return;
+      }
+
+      IWidget widget = (IWidget) model;
+      if (!removeAnchorWithoutJsonAdapter(widget)) {
+        // anchor was not observed
+        return;
+      }
+
+      updatePopupsJsonProperty();
+    }
   }
 }


### PR DESCRIPTION
The PopupManager contains a set of popups, which themselves may contain anchors. When a JsonPopup builds its json it may happen that there is no json adapter for the anchor of the popup, because the anchor is e.g. part of an outline that is currently not the active outline. The JsonPopup can not leave its anchor property empty as a popup without anchor will be rendered directly which would be incorrect. In addition, the JsonPopup can not return null when creating its json as this leads to other errors.
Therefore, the JsonPopupManager needs to filter its set of popups and ensure that no popup containing an anchor without a json adapter is sent to Scout JS. To ensure correct updates of its property "popups" the JsonPopupManager needs to observe all current anchors of its popups and perform an update of its property "popups" if json adapters are created for one of these observed anchors. This is relevant e.g. when the JsonPopupManager is processed before the json adapter of one of its popups anchors is processed which may happen e.g. when the browser is reloaded.
As the PopupManager.ts only renders newly added popups and as a formerly rendered popup will be removed when its anchor is removed, it is not necessary to listen on json adapter disposals. The only time the PopupManager.ts will try to rerender these popups with potentially unavailable anchors is when the browser is reloaded and in this case the property "popups" will be sent again and is therefore correctly filtered.
Additionally, close a Popup if its anchor is disposed to prevent memory leaks.
Some popup anchors may be part of tiles. Therefore, reposition those popups after the layout animation of the TileGrid is done.

448950