### PR TITLE
Calendar: avoid opening menu on unselected component

### DIFF
--- a/eclipse-scout-core/src/calendar/Calendar.ts
+++ b/eclipse-scout-core/src/calendar/Calendar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1560,6 +1560,11 @@ export class Calendar extends Widget implements CalendarModel {
 
     let func = function func(event: JQuery.ContextMenuEvent, allowedType: string) {
       if (!this.rendered || !this.attached || !this._calculateContextMenuVisible(event)) { // check needed because function is called asynchronously
+        return;
+      }
+      if (allowedType === Calendar.MenuType.CalendarComponent && !this.selectedComponent) {
+        // When right click is started outside the component and released on the component,
+        // no component is selected -> no context menu is opened
         return;
       }
       let filteredMenus = menus.filter(this.menus, [allowedType], {


### PR DESCRIPTION
The javascript 'contextmenu' event is not consistent with its order. On some machines, it is triggered right after right-click 'mousedown', on other machines after 'mouseup'. This can lead to an unexpected behavior, when the right-click is started outside a component and is finished on a component. Because the selection is applied on 'mousedown', no component is selected, but the context menu of the component is opened. This change cancels the opening of the popup window when this case occurs.

451116