### PR TITLE
SMTP/e-mail: Improve UTF-8 handling

### DIFF
--- a/org.eclipse.scout.rt.mail.test/src/test/java/org/eclipse/scout/rt/mail/MailHelperTest.java
+++ b/org.eclipse.scout.rt.mail.test/src/test/java/org/eclipse/scout/rt/mail/MailHelperTest.java
@@ -480,6 +480,15 @@ public class MailHelperTest {
   }
 
   @Test
+  public void testIsEmailAddressValidAsciiOnly() {
+    MailHelper mailHelper = BEANS.get(MailHelper.class);
+    assertFalse(mailHelper.isEmailAddressValid("foo@bär.de", false));
+    assertFalse(mailHelper.isEmailAddressValid("foo@domaintest.みんな", false));
+    assertFalse(mailHelper.isEmailAddressValid("füü@bär.de", false));
+    assertFalse(mailHelper.isEmailAddressValid("I❤\uFE0FCHOCOLATE@example.com", false));
+  }
+
+  @Test
   public void testEnsureFromAddressWithoutFromAndDefaultFrom() throws MessagingException {
     MailMessage mailMessage = BEANS.get(MailMessage.class)
         .withBodyPlainText("lorem");

--- a/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/MailHelper.java
+++ b/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/MailHelper.java
@@ -955,13 +955,17 @@ public class MailHelper {
    */
   @SuppressWarnings("squid:S1166")
   public boolean isEmailAddressValid(String emailAddress) {
+    return isEmailAddressValid(emailAddress, true);
+  }
+
+  public boolean isEmailAddressValid(String emailAddress, boolean utf8) {
     if (StringUtility.isNullOrEmpty(emailAddress)) {
       return false;
     }
 
     try {
       new InternetAddress(BEANS.get(MailIDNConverter.class).toASCII(emailAddress), true);
-      return true;
+      return utf8 || StandardCharsets.US_ASCII.newEncoder().canEncode(emailAddress);
     }
     catch (AddressException | IllegalArgumentException e) {
       return false;

--- a/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/smtp/SmtpHelper.java
+++ b/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/smtp/SmtpHelper.java
@@ -196,11 +196,13 @@ public class SmtpHelper {
     if (readTimeout != null) {
       props.setProperty(propertyBaseName + ".timeout", Integer.toString(readTimeout));
     }
+    if (config.isUseUtf8()) {
+      props.setProperty("mail.mime.allowutf8", "true");
+    }
 
     if (!CollectionUtility.isEmpty(config.getAdditionalSessionProperties())) {
       props.putAll(config.getAdditionalSessionProperties());
     }
-
     LOG.debug("Session created with properties {}", props);
 
     return Session.getInstance(props, null);

--- a/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/smtp/SmtpServerConfig.java
+++ b/org.eclipse.scout.rt.mail/src/main/java/org/eclipse/scout/rt/mail/smtp/SmtpServerConfig.java
@@ -32,6 +32,7 @@ public class SmtpServerConfig {
   private boolean m_useStartTls;
   private String m_sslProtocols;
   private boolean m_oAuth2;
+  private boolean m_useUtf8;
 
   private Map<String, String> m_additionalSessionProperties;
 
@@ -209,6 +210,19 @@ public class SmtpServerConfig {
     return this;
   }
 
+  public boolean isUseUtf8() {
+    return m_useUtf8;
+  }
+
+  /**
+   * @param useUtf8
+   *     Enables UTF-8 support.
+   */
+  public SmtpServerConfig withUseUtf8(boolean useUtf8) {
+    m_useUtf8 = useUtf8;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     final int prime = 31;
@@ -225,6 +239,7 @@ public class SmtpServerConfig {
     result = prime * result + (m_useSmtps ? 1231 : 1237);
     result = prime * result + (m_useStartTls ? 1231 : 1237);
     result = prime * result + ((m_username == null) ? 0 : m_username.hashCode());
+    result = prime * result + (m_useUtf8 ? 1231 : 1237);
     return result;
   }
 
@@ -304,6 +319,9 @@ public class SmtpServerConfig {
       }
     }
     else if (!m_username.equals(other.m_username)) {
+      return false;
+    }
+    if (m_useUtf8 != other.m_useUtf8) {
       return false;
     }
     return true;


### PR DESCRIPTION
There are SMTP servers that support UTF-8 encoded
email addresses. Currently there is no server options
to pass this information to the SMTP session.

This PR adds support for explicitly enabling UTF-8
support and adds a new method on the helper to
validate ASCII-only addresses.

410361