### PR TITLE
Inheritance of @ApiDocIgnore annotation

### DIFF
--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
@@ -56,6 +56,7 @@ import org.eclipse.scout.rt.dataobject.IDoEntity;
 import org.eclipse.scout.rt.dataobject.IPrettyPrintDataObjectMapper;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.config.PlatformConfigProperties.ApplicationNameProperty;
 import org.eclipse.scout.rt.platform.config.PlatformConfigProperties.ApplicationVersionProperty;
@@ -248,12 +249,44 @@ public class ApiDocGenerator {
 
   protected boolean acceptRestResource(IRestResource res) {
     return res.getClass().isAnnotationPresent(Path.class) &&
-        !res.getClass().isAnnotationPresent(ApiDocIgnore.class);
+        !isApiDocIgnore(res.getClass());
   }
 
   protected boolean acceptMethod(Method m) {
     return Modifier.isPublic(m.getModifiers()) &&
-        !m.isAnnotationPresent(ApiDocIgnore.class);
+        !isApiDocIgnore(m);
+  }
+
+  protected boolean isApiDocIgnore(Class<?> clazz) {
+    ApiDocIgnore ann = getApiDocIgnoreAnnotation(clazz);
+    return ann != null && ann.value();
+  }
+
+  protected boolean isApiDocIgnore(Method method) {
+    ApiDocIgnore ann = getApiDocIgnoreAnnotation(method);
+    return ann != null && ann.value();
+  }
+
+  protected ApiDocIgnore getApiDocIgnoreAnnotation(Class<?> clazz) {
+    // ask bean first: is faster and supports more features (inherited annotations from interfaces)
+    IBean<?> bean = BEANS.getBeanManager().optBean(clazz);
+    if (bean != null) {
+      ApiDocIgnore ann = bean.getBeanAnnotation(ApiDocIgnore.class);
+      if (ann != null) {
+        return ann;
+      }
+    }
+    return clazz.getAnnotation(ApiDocIgnore.class);
+  }
+
+  protected ApiDocIgnore getApiDocIgnoreAnnotation(Method method) {
+    ApiDocIgnore annotation = method.getAnnotation(ApiDocIgnore.class);
+    if (annotation != null) {
+      return annotation;
+    }
+
+    Class<?> declaringClass = method.getDeclaringClass();
+    return getApiDocIgnoreAnnotation(declaringClass);
   }
 
   protected int compareMethods(Method m1, Method m2) {

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocIgnore.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocIgnore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
 package org.eclipse.scout.rt.rest.doc;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -17,7 +18,10 @@ import java.lang.annotation.Target;
 /**
  * Annotation used to exclude some REST resources or methods from being emitted by {@link ApiDocGenerator}.
  */
+@Inherited
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiDocIgnore {
+
+  boolean value() default true;
 }


### PR DESCRIPTION
The @ApiDocIgnore is now inherited and can be disabled on subclasses via value parameter.

449990