### PR TITLE
FieldStatus: opening tooltip with menus fails if context menu is open

### DIFF
--- a/eclipse-scout-core/src/form/fields/FieldStatus.ts
+++ b/eclipse-scout-core/src/form/fields/FieldStatus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -211,12 +211,22 @@ export class FieldStatus extends Widget implements FieldStatusModel {
     }
   }
 
-  hideTooltip() {
-    if (this.tooltip) {
-      let event = this.trigger('hideTooltip');
-      if (!event.defaultPrevented) {
-        this.tooltip.destroy();
-        this._removeParentListeners();
+  /**
+   * Closes the open tooltip.
+   *
+   * @param immediately true, to immediately close it without waiting for the remove animation.
+   */
+  hideTooltip(immediately = false) {
+    if (!this.tooltip) {
+      return;
+    }
+
+    let event = this.trigger('hideTooltip');
+    if (!event.defaultPrevented) {
+      this.tooltip.destroy();
+      this._removeParentListeners();
+      if (immediately) {
+        this.tooltip.removeImmediately();
       }
     }
   }
@@ -255,11 +265,12 @@ export class FieldStatus extends Widget implements FieldStatusModel {
     }
 
     this._updateParentListeners();
-    this.hideContextMenu();
+    this.hideContextMenu(true);
     if (this.tooltip && this.tooltip.autoRemove !== this.autoRemove) {
-      // close
+      // Close tooltip if the autoRemove property changes, the other properties can be updated even if the tooltip is open.
       this.hideTooltip();
     }
+
     if (this.tooltip) {
       // update existing tooltip
       this.tooltip.setText(this.status.message);
@@ -290,9 +301,19 @@ export class FieldStatus extends Widget implements FieldStatusModel {
     }
   }
 
-  hideContextMenu() {
-    if (this.contextMenu) {
-      this.contextMenu.close();
+  /**
+   * Closes the open context menu.
+   *
+   * @param immediately true, to immediately close it without waiting for the remove animation.
+   */
+  hideContextMenu(immediately = false) {
+    if (!this.contextMenu) {
+      return;
+    }
+
+    this.contextMenu.close();
+    if (immediately) {
+      this.contextMenu.removeImmediately();
     }
   }
 
@@ -301,13 +322,8 @@ export class FieldStatus extends Widget implements FieldStatusModel {
       // at least one menu item must be visible
       return;
     }
-    // close both contextMenu and status tooltip
-    this.hidePopup();
 
-    // Context menu must be removed immediately before it can be opened because cloneMenuItems is false
-    if (this.contextMenu && this.contextMenu.isRemovalPending()) {
-      this.contextMenu.removeImmediately();
-    }
+    this.hidePopup(true);
 
     this.contextMenu = scout.create(ContextMenuPopup, {
       parent: this,
@@ -330,9 +346,14 @@ export class FieldStatus extends Widget implements FieldStatusModel {
     });
   }
 
-  hidePopup() {
-    this.hideTooltip();
-    this.hideContextMenu();
+  /**
+   * Closes the open popup (tooltip or context menu).
+   *
+   * @param immediately true, to immediately close it without waiting for the remove animation.
+   */
+  hidePopup(immediately = false) {
+    this.hideTooltip(immediately);
+    this.hideContextMenu(immediately);
   }
 
   togglePopup() {

--- a/eclipse-scout-core/src/form/fields/StatusMenuMapping.ts
+++ b/eclipse-scout-core/src/form/fields/StatusMenuMapping.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,14 @@
  */
 import {Menu, ObjectOrChildModel, SomeRequired, StatusMenuMappingModel, StatusSeverity, Widget} from '../../index';
 
+/**
+ * Defines which menu should be visible when the error status of a field is shown.
+ *
+ * In order to display the menu only when a certain status code or severity is active, use {@link StatusMenuMappingModel.codes} or
+ * {@link StatusMenuMappingModel.severities} to define the restriction.
+ *
+ * The menu has to be a menu of the form field, otherwise it won't be displayed.
+ */
 export class StatusMenuMapping extends Widget implements StatusMenuMappingModel {
   declare model: StatusMenuMappingModel;
   declare initModel: SomeRequired<this['model'], 'parent' | 'menu'>;

--- a/eclipse-scout-core/src/form/fields/StatusMenuMappingModel.ts
+++ b/eclipse-scout-core/src/form/fields/StatusMenuMappingModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,22 @@
 import {Menu, ObjectOrChildModel, StatusSeverity, WidgetModel} from '../../index';
 
 export interface StatusMenuMappingModel extends WidgetModel {
+  /**
+   * Configures the codes the status should have to display the menu.
+   *
+   * If no codes are defined, the menu is shown for every code.
+   */
   codes?: number[];
+  /**
+   * Configures the severities the status should have to display the menu.
+   *
+   * If no severities are defined, the menu is shown for every severity.
+   */
   severities?: StatusSeverity[];
-  menu?: ObjectOrChildModel<Menu>;
+  /**
+   * Configures the menu that should be shown.
+   *
+   * If an id is provided, the menu is resolved automatically using the {@link WidgetModel.parent}.
+   */
+  menu?: ObjectOrChildModel<Menu> | string;
 }


### PR DESCRIPTION
Use case:
A field has status menu mappings to display some menus in tooltip.
1. Click on the field status to open the context menu
2. Click into the field to open the tooltip with menus -> An error occurs because the menus are still rendered in the context menu due to the remove animation.

Solution is to close the context menu immediately when a tooltip needs to be shown.

439853