### PR TITLE
Outline: add keystroke to reload the root page

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.ts
+++ b/eclipse-scout-core/src/desktop/outline/Outline.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -48,6 +48,8 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
   nodePaddingLevelHierarchyRow: number;
   detailMenuBarVisible: boolean;
   selectedViewTabs: Map<DisplayViewId, Form>;
+  /** Keystroke context with the scope desktop so these keystrokes can be used from anywhere not only if the outline is focused */
+  outlineKeyStrokeContext: OutlineKeyStrokeContext;
 
   views: Form[];
   dialogs: Form[];
@@ -102,6 +104,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
     this.messageBoxes = [];
     this.fileChoosers = [];
     this.selectedViewTabs = new Map();
+    this.outlineKeyStrokeContext = this._createOutlineKeyStrokeContext();
     this.formController = null;
     this.messageBoxController = null;
     this.fileChooserController = null;
@@ -218,11 +221,19 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
 
   protected override _initTreeKeyStrokeContext() {
     super._initTreeKeyStrokeContext();
+    this._initOutlineKeyStrokeContext();
+  }
 
-    // Create an outline keystroke context with the scope desktop so these keystrokes can be used from anywhere not only if the outline is focused
-    let modifierBitMask = keyStrokeModifier.CTRL | keyStrokeModifier.SHIFT; // NOSONAR
-    let outlineKeyStrokeContext = new OutlineKeyStrokeContext(this);
-    outlineKeyStrokeContext.registerKeyStrokes([
+  protected _createOutlineKeyStrokeContext(): OutlineKeyStrokeContext {
+    return new OutlineKeyStrokeContext(this);
+  }
+
+  protected _initOutlineKeyStrokeContext() {
+    this.outlineKeyStrokeContext.$scopeTarget = () => this.$container;
+    this.outlineKeyStrokeContext.$bindTarget = () => this.session.$entryPoint;
+
+    const modifierBitMask = keyStrokeModifier.CTRL | keyStrokeModifier.SHIFT; // NOSONAR
+    this.outlineKeyStrokeContext.registerKeyStrokes([
       new OutlineNavigateToTopKeyStroke(this, modifierBitMask),
       new TreeNavigationUpKeyStroke(this, modifierBitMask),
       new TreeNavigationDownKeyStroke(this, modifierBitMask),
@@ -232,16 +243,12 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
       new TreeExpandOrDrillDownKeyStroke(this, modifierBitMask, keys.RIGHT, '→'),
       new TreeExpandOrDrillDownKeyStroke(this, modifierBitMask, keys.ADD)
     ]);
-    outlineKeyStrokeContext.$scopeTarget = () => this.$container;
-    outlineKeyStrokeContext.$bindTarget = () => this.session.$entryPoint;
-    for (const keyStroke of outlineKeyStrokeContext.keyStrokes) {
+    for (const keyStroke of this.outlineKeyStrokeContext.keyStrokes) {
       if (keyStroke instanceof AbstractTreeNavigationKeyStroke) {
         // Don't focus the tree when using these keystrokes to not visualize the focused node because the selection will be moved.
         keyStroke.setFocusTree(false);
       }
     }
-    this.on('render', () => this.session.keyStrokeManager.installKeyStrokeContext(outlineKeyStrokeContext));
-    this.on('remove', () => this.session.keyStrokeManager.uninstallKeyStrokeContext(outlineKeyStrokeContext));
 
     // Remove the keystrokes which are replaced by outline specific ones
     this.keyStrokeContext.unregisterKeyStroke(this.keyStrokeContext.keyStrokes.find(keystroke => keystroke instanceof TreeCollapseAllKeyStroke || keystroke instanceof TreeSelectKeyStroke));
@@ -250,6 +257,8 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
 
   protected override _render() {
     super._render();
+
+    this.session.keyStrokeManager.installKeyStrokeContext(this.outlineKeyStrokeContext);
 
     // Override layout
     this.htmlComp.setLayout(new OutlineLayout(this));
@@ -282,6 +291,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
     super._remove();
     this._removeTitle();
     this._removeIcon();
+    this.session.keyStrokeManager.uninstallKeyStrokeContext(this.outlineKeyStrokeContext);
   }
 
   protected _renderTitle() {

--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  App, ChildModelOf, dataObjects, ErrorHandler, EventHandler, Form, icons, objects, Outline, Page, PageModel, PageParamDo, PageResolver, RemoteEvent, scout, Table, TableAdapter, TableFilterRemovedEvent, TableRow, TableRowInitEvent,
-  TableRowsInsertedEvent, TreeAdapter, TreeNodeModel
+  App, ChildModelOf, dataObjects, ErrorHandler, EventHandler, Form, icons, objects, Outline, OutlineReloadKeyStroke, Page, PageModel, PageParamDo, PageResolver, RemoteEvent, scout, Table, TableAdapter, TableFilterRemovedEvent, TableRow,
+  TableRowInitEvent, TableRowsInsertedEvent, TreeAdapter, TreeNodeModel
 } from '../../index';
 
 export class OutlineAdapter extends TreeAdapter {
@@ -174,6 +174,7 @@ export class OutlineAdapter extends TreeAdapter {
     objects.replacePrototypeFunction(Outline, 'updateDetailMenus', OutlineAdapter.updateDetailMenusRemote, true);
     objects.replacePrototypeFunction(Outline, '_initTreeNodeInternal', OutlineAdapter._initTreeNodeInternalRemote, true);
     objects.replacePrototypeFunction(Outline, '_createTreeNode', OutlineAdapter._createTreeNodeRemote, true);
+    objects.replacePrototypeFunction(Outline, '_initOutlineKeyStrokeContext', OutlineAdapter._initOutlineKeyStrokeContextRemote, true);
     objects.replacePrototypeFunction(Page, '_updateDetailFormMenus', OutlineAdapter._updateDetailFormMenus, true);
     objects.replacePrototypeFunction(Page, '_updateDetailTableMenus', OutlineAdapter._updateDetailTableMenus, true);
     objects.replacePrototypeFunction(Page, 'linkWithRow', OutlineAdapter.linkWithRow, true);
@@ -274,6 +275,13 @@ export class OutlineAdapter extends TreeAdapter {
     }
 
     return this._createTreeNodeOrig(pageModel);
+  }
+
+  protected static _initOutlineKeyStrokeContextRemote(this: Outline & { modelAdapter: OutlineAdapter; _initOutlineKeyStrokeContextOrig }) {
+    this._initOutlineKeyStrokeContextOrig();
+    if (this.modelAdapter) {
+      this.outlineKeyStrokeContext.registerKeyStroke(new OutlineReloadKeyStroke(this));
+    }
   }
 
   protected _createJsPage(pageModel: PageModel, createPage: (pageModel: PageModel) => Page): Page {

--- a/eclipse-scout-core/src/desktop/outline/keystrokes/OutlineReloadKeyStroke.ts
+++ b/eclipse-scout-core/src/desktop/outline/keystrokes/OutlineReloadKeyStroke.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {HybridActionContextElements, HybridManager, keys, KeyStroke, Outline, scout, ScoutKeyboardEvent} from '../../../index';
+
+/**
+ * Keystroke to reload all nodes of an outline on the UI server via hybrid action. Only active when no node is selected.
+ */
+export class OutlineReloadKeyStroke extends KeyStroke {
+  declare field: Outline;
+
+  protected _reloading = false;
+
+  constructor(outline: Outline) {
+    super();
+    this.field = outline;
+    this.which = [keys.F5];
+
+    this.renderingHints.offset = 8; // increase distance from left edge
+    this.renderingHints.$drawingArea = ($drawingArea, event) => this.field.$title || this.field.$data; // same as OutlineNavigateToTopKeyStroke
+  }
+
+  protected override _accept(event: ScoutKeyboardEvent): boolean {
+    if (this._reloading) {
+      return false; // prevent parallel hybrid actions
+    }
+    if (this.field.selectedNodes.length) {
+      return false; // keystroke not available when a node is selected
+    }
+    return super._accept(event);
+  }
+
+  override handle(event: JQuery.KeyboardEventBase) {
+    // noinspection JSIgnoredPromiseFromCall
+    this._handleAsync(event);
+  }
+
+  protected async _handleAsync(event: JQuery.KeyboardEventBase): Promise<void> {
+    this._reloading = true;
+    try {
+      let contextElements = scout.create(HybridActionContextElements)
+        .withElement('outline', this.field);
+      await HybridManager.get(this.field.session).callActionAndWait('scout.ReloadOutline', undefined, contextElements);
+    } finally {
+      this._reloading = false;
+    }
+  }
+}

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -1180,6 +1180,7 @@ export * from './desktop/outline/navigation/NavigateUpButton';
 export * from './desktop/outline/keystrokes/OutlineKeyStrokeContext';
 export * from './desktop/outline/keystrokes/OutlineNavigateToTopKeyStroke';
 export * from './desktop/outline/keystrokes/OutlineSelectKeyStroke';
+export * from './desktop/outline/keystrokes/OutlineReloadKeyStroke';
 export * from './desktop/outline/overview/OutlineOverview';
 export * from './desktop/outline/overview/OutlineOverviewModel';
 export * from './desktop/outline/overview/TileOutlineOverview';

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/ReloadOutlineHybridAction.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/ReloadOutlineHybridAction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.desktop.outline;
+
+import org.eclipse.scout.rt.client.ui.desktop.hybrid.AbstractHybridAction;
+import org.eclipse.scout.rt.client.ui.desktop.hybrid.HybridActionType;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.js.LoadChildPagesHybridActionDo;
+
+@HybridActionType(ReloadOutlineHybridAction.TYPE)
+public class ReloadOutlineHybridAction extends AbstractHybridAction<LoadChildPagesHybridActionDo> {
+
+  protected static final String TYPE = "scout.ReloadOutline";
+
+  @Override
+  public void execute(LoadChildPagesHybridActionDo data) {
+    try {
+      var outline = getContextElement("outline").getWidget(IOutline.class);
+      var rootPage = outline.getRootPage();
+      if (rootPage != null) {
+        rootPage.reloadPage();
+      }
+    }
+    finally { // always signal the end of the action to the UI, even in the case of an error on the server
+      fireHybridActionEndEvent();
+    }
+  }
+}


### PR DESCRIPTION
If a user wishes to recreate a page (e.g. because its content has been changed, but it offers no means to be refreshed), they can usually just reload the detail table of the parent page. However, since the outline in JS has no root page, this is not possible for top-level pages. For a pure JS outline, this can be resolved by recreating the entire application (reload page in browser, Ctrl-R), but for classic outlines, the server-side model has to be updated.

A new keystroke (F5) provides this function with the help of a hybrid action. It is only active for remote outlines, and only when no page is selected.

411299