### PR TITLE
Add UI session id header for requests from UI

### DIFF
--- a/eclipse-scout-core/src/App.ts
+++ b/eclipse-scout-core/src/App.ts
@@ -513,8 +513,9 @@ export class App extends EventEmitter {
   protected _beforeAjaxCall(request: JQuery.jqXHR, settings: AjaxSettings) {
     request.setRequestHeader('X-Scout-Correlation-Id', numbers.correlationId());
     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest'); // explicitly add here because jQuery only adds it automatically if it is no crossDomain request
-    if (this.sessions[0] && this.sessions[0].ready) {
+    if (this.sessions[0]?.ready) {
       request.setRequestHeader('Accept-Language', this.sessions[0].locale.languageTag);
+      request.setRequestHeader('X-Scout-Ui-Session-Id', this.sessions[0].uiSessionId);
     }
   }
 

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/ClientSessionIdHttpProxyRequestOptionsModifierTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/ClientSessionIdHttpProxyRequestOptionsModifierTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestContext;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestOptions;
+import org.eclipse.scout.rt.shared.session.SessionId;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.eclipse.scout.rt.ui.html.json.testing.JsonTestUtility;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(TestEnvironmentClientSession.class)
+public class ClientSessionIdHttpProxyRequestOptionsModifierTest {
+
+  /**
+   * Request on HTTP session that knows the UI session - client session ID header should be present on proxied request
+   */
+  @Test
+  public void testExistingUiSessionId() {
+    UiSession uiSession = createAndInitializeUiSession();
+    HttpServletRequest request = createRequest(getHttpSession(uiSession), uiSession.getUiSessionId());
+
+    ClientSessionIdHttpProxyRequestOptionsModifier modifier = new ClientSessionIdHttpProxyRequestOptionsModifier();
+    HttpProxyRequestOptions options = new HttpProxyRequestOptions();
+    modifier.modify(options, createRequestContext(request));
+
+    assertTrue(options.getCustomRequestHeaders().containsKey(SessionId.HTTP_HEADER_NAME));
+    assertEquals(uiSession.getClientSessionId(), options.getCustomRequestHeaders().get(SessionId.HTTP_HEADER_NAME));
+  }
+
+  /**
+   * Request on HTTP session with existing UI session, but unknown UI Session ID
+   */
+  @Test
+  public void testNonExistingUiSessionId() {
+    UiSession uiSession = createAndInitializeUiSession();
+    HttpServletRequest request = createRequest(getHttpSession(uiSession), "12345");
+
+    ClientSessionIdHttpProxyRequestOptionsModifier modifier = new ClientSessionIdHttpProxyRequestOptionsModifier();
+    HttpProxyRequestOptions options = new HttpProxyRequestOptions();
+    modifier.modify(options, createRequestContext(request));
+
+    assertFalse(options.getCustomRequestHeaders().containsKey(SessionId.HTTP_HEADER_NAME));
+  }
+
+  /**
+   * Request on different HTTP session that does not know the UI session
+   */
+  @Test
+  public void testDifferentHttpSession() {
+    UiSession uiSession = createAndInitializeUiSession();
+    HttpServletRequest request = createRequest(mock(HttpSession.class), uiSession.getUiSessionId());
+
+    ClientSessionIdHttpProxyRequestOptionsModifier modifier = new ClientSessionIdHttpProxyRequestOptionsModifier();
+    HttpProxyRequestOptions options = new HttpProxyRequestOptions();
+    modifier.modify(options, createRequestContext(request));
+
+    assertFalse(options.getCustomRequestHeaders().containsKey(SessionId.HTTP_HEADER_NAME));
+  }
+
+  protected HttpProxyRequestContext createRequestContext(HttpServletRequest request) {
+    return BEANS.get(HttpProxyRequestContext.class)
+        .withRequest(request);
+  }
+
+  protected UiSession createAndInitializeUiSession() {
+    // create ui session
+    UiSession uiSession = (UiSession) JsonTestUtility.createAndInitializeUiSession();
+    final HttpSession httpSession = getHttpSession(uiSession);
+
+    // register ui session in session store
+    final ISessionStore sessionStore = BEANS.get(HttpSessionHelper.class).getSessionStore(httpSession);
+    sessionStore.registerUiSession(uiSession);
+    return uiSession;
+  }
+
+  protected HttpSession getHttpSession(UiSession uiSession) {
+    return UiSessionTestUtility.getHttpSession(uiSession);
+  }
+
+  protected HttpServletRequest createRequest(HttpSession httpSession, String uiSessionId) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader(eq(IUiSession.ID_HTTP_HEADER_NAME))).thenReturn(uiSessionId);
+    when(request.getSession(false)).thenReturn(httpSession);
+    return request;
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/AbstractRestProxyRequestHandler.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/AbstractRestProxyRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/ClientSessionIdHttpProxyRequestOptionsModifier.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/ClientSessionIdHttpProxyRequestOptionsModifier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestContext;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestOptions;
+import org.eclipse.scout.rt.server.commons.servlet.IHttpProxyRequestOptionsModifier;
+import org.eclipse.scout.rt.shared.session.SessionId;
+
+/**
+ * Adds the {@value SessionId#HTTP_HEADER_NAME} header to the proxied request based on UI session ID read from UI request.
+ */
+public class ClientSessionIdHttpProxyRequestOptionsModifier implements IHttpProxyRequestOptionsModifier {
+
+  @Override
+  public void modify(HttpProxyRequestOptions options, HttpProxyRequestContext context) {
+    HttpServletRequest req = context.getRequest();
+    String uiSessionId = req.getHeader(IUiSession.ID_HTTP_HEADER_NAME);
+    IUiSession uiSession = UiSession.get(req, uiSessionId);
+    if (uiSession == null) {
+      return;
+    }
+    String clientSessionId = uiSession.getClientSessionId();
+    options.withCustomRequestHeader(SessionId.HTTP_HEADER_NAME, clientSessionId);
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/IUiSession.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/IUiSession.java
@@ -47,6 +47,11 @@ public interface IUiSession {
   String PREFERRED_LOCALE_COOKIE_NAME = "scout.preferredLocale";
 
   /**
+   * Name of the HTTP header to transport the ID of the {@link IUiSession}.
+   */
+  String ID_HTTP_HEADER_NAME = "X-Scout-Ui-Session-Id";
+
+  /**
    * Returns a reentrant lock that can be used to synchronize on the {@link IUiSession}.
    */
   ReentrantLock uiSessionLock();


### PR DESCRIPTION
Additionally, for requests proxied to the backend, the corresponding client session ID gets resolved and sent to the backend via HTTP header

443929