### PR TITLE
Skip CSP for rest responses with disposition attachment

### DIFF
--- a/org.eclipse.scout.rt.rest.test/src/main/java/org/eclipse/scout/rt/rest/csp/CspRestContainerFilterTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/main/java/org/eclipse/scout/rt/rest/csp/CspRestContainerFilterTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.csp;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import jakarta.ws.rs.container.ContainerResponseContext;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CspRestContainerFilterTest {
+  @Test
+  public void testIsAttachment() {
+    assertIsAttachment(true, "attachment");
+    assertIsAttachment(true, "attachment; filename=\"file name.jpg\"");
+    assertIsAttachment(true, "attachment; filename*=UTF-8''file%20name.jpg");
+    assertIsAttachment(true, "filename*=UTF-8''file%20name.jpg; attachment");
+    assertIsAttachment(false, "filename*=UTF-8''file%20name.jpg; attachment-");
+    assertIsAttachment(false, "inline");
+    assertIsAttachment(false, "");
+    assertIsAttachment(false, "  ");
+    assertIsAttachment(false, null);
+  }
+
+  protected void assertIsAttachment(boolean expectation, String header) {
+    ContainerResponseContext context = mock(ContainerResponseContext.class);
+    when(context.getHeaderString(eq("Content-Disposition"))).thenReturn(header);
+    Assert.assertEquals(expectation, new CspRestContainerFilter().isAttachment(context));
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/csp/CspRestContainerFilter.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/csp/CspRestContainerFilter.java
@@ -10,12 +10,14 @@
 package org.eclipse.scout.rt.rest.csp;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.util.LazyValue;
+import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.rest.container.IRestContainerResponseFilter;
 import org.eclipse.scout.rt.security.csp.BlockAllContentSecurityPolicy;
 import org.eclipse.scout.rt.security.csp.ContentSecurityPolicy;
@@ -26,14 +28,27 @@ public class CspRestContainerFilter implements IRestContainerResponseFilter {
 
   @Override
   public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
-    if (!isCspHeaderPresent(responseContext)) {
-      // append a block-all default CSP header (in case a REST response is text/html, image/svg or text/javascript which might be interpreted by the browser)
-      responseContext.getHeaders().putSingle(ContentSecurityPolicy.HTTP_HEADER, m_blockAllCsp.get());
+    if (isCspHeaderPresent(responseContext)) {
+      return; // policy already set. Do not add default policy
     }
+    if (isAttachment(responseContext)) {
+      return; // attachments are downloaded and not rendered by the browser: no need to add a policy
+    }
+    // append a block-all default CSP header (in case a REST response is text/html, image/svg or text/javascript which might be interpreted by the browser)
+    responseContext.getHeaders().putSingle(ContentSecurityPolicy.HTTP_HEADER, m_blockAllCsp.get());
   }
 
   protected boolean isCspHeaderPresent(ContainerResponseContext responseContext) {
     return responseContext.containsHeaderString(ContentSecurityPolicy.HTTP_HEADER, v -> true /* accept any value */);
+  }
+
+  protected boolean isAttachment(ContainerResponseContext responseContext) {
+    String disposition = responseContext.getHeaderString("Content-Disposition");
+    if (!StringUtility.hasText(disposition)) {
+      return false;
+    }
+    return Pattern.compile(";").splitAsStream(disposition)
+        .anyMatch(s -> "attachment".equalsIgnoreCase(StringUtility.trim(s)));
   }
 
   protected ContentSecurityPolicy createRestPolicy() {


### PR DESCRIPTION
If the browser does not render the response, there is no need to add a content security policy.

453042