### PR TITLE
Revert jetty to version 12.0.33

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
@@ -25,12 +25,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
-import org.eclipse.jetty.compression.gzip.GzipCompression;
-import org.eclipse.jetty.compression.gzip.GzipDecoderConfig;
-import org.eclipse.jetty.compression.gzip.GzipEncoderConfig;
-import org.eclipse.jetty.compression.server.CompressionConfig;
-import org.eclipse.jetty.compression.server.CompressionConfig.Builder;
-import org.eclipse.jetty.compression.server.CompressionHandler;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.SessionHandler;
 import org.eclipse.jetty.http.HttpCookie.SameSite;
@@ -51,6 +45,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.GracefulHandler;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -445,7 +440,7 @@ public class Application {
     }
 
     if (CONFIG.getPropertyValue(ScoutApplicationGzipEnabled.class)) {
-      returnHandler = createCompressionHandler(returnHandler);
+      returnHandler = createGzipHandler(returnHandler);
     }
 
     if (CONFIG.getPropertyValue(ScoutApplicationGracefulShutdownProperty.class)) {
@@ -456,54 +451,43 @@ public class Application {
   }
 
   /**
-   * Create a {@link CompressionHandler} and wrap the input handler with it.
+   * Create a {@link GzipHandler} and wrap the input handler with it.
    *
    * @param handler
    *     original handler (to be wrapped)
-   * @return original handler wrapped by {@link CompressionHandler}
+   * @return original handler wrapped by {@link GzipHandler}
    */
-  protected Handler createCompressionHandler(Handler handler) {
-    CompressionHandler compressionHandler = new CompressionHandler();
-    GzipCompression gzipCompression = new GzipCompression();
-    GzipDecoderConfig decoderConfig = new GzipDecoderConfig();
-    GzipEncoderConfig encoderConfig = new GzipEncoderConfig();
+  protected Handler createGzipHandler(Handler handler) {
+    GzipHandler gzipHandler = new GzipHandler();
 
-    Builder configBuilder = CompressionConfig.builder();
+    setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedInflatePaths.class, gzipHandler::setExcludedInflatePaths);
+    setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedMethods.class, gzipHandler::setExcludedMethods);
+    setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedMimeTypes.class, gzipHandler::setExcludedMimeTypes);
+    setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedPaths.class, gzipHandler::setExcludedPaths);
 
-    setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedInflatePaths.class, configBuilder::decompressExcludePath);
-    setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedMethods.class, configBuilder::compressExcludeMethod);
-    setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedMimeTypes.class, configBuilder::compressExcludeMimeType);
-    setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedPaths.class, configBuilder::compressExcludePath);
+    setStringPropertyValueIfFilled(ScoutApplicationGzipIncludedInflatePaths.class, gzipHandler::setIncludedInflatePaths);
+    setStringPropertyValueIfFilled(ScoutApplicationGzipIncludedMethods.class, gzipHandler::setIncludedMethods);
+    setStringPropertyValueIfFilled(ScoutApplicationGzipIncludedMimeTypes.class, gzipHandler::setIncludedMimeTypes);
+    setStringPropertyValueIfFilled(ScoutApplicationGzipIncludedPaths.class, gzipHandler::setIncludedPaths);
 
-    setStringPropertyValueIfFilled(ScoutApplicationGzipIncludedInflatePaths.class, configBuilder::decompressIncludePath);
-    setStringPropertyValueIfFilled(ScoutApplicationGzipIncludedMethods.class, configBuilder::compressIncludeMethod);
-    setStringPropertyValueIfFilled(ScoutApplicationGzipIncludedMimeTypes.class, configBuilder::compressIncludeMimeType);
-    setStringPropertyValueIfFilled(ScoutApplicationGzipIncludedPaths.class, configBuilder::compressIncludePath);
+    Optional.ofNullable(CONFIG.getPropertyValue(ScoutApplicationGzipMinSize.class)).ifPresent(gzipHandler::setMinGzipSize);
+    gzipHandler.setSyncFlush(CONFIG.getPropertyValue(ScoutApplicationGzipSyncFlush.class));
 
-    CompressionConfig compressionConfig = configBuilder.build();
-    compressionHandler.putConfiguration("/*", compressionConfig);
+    gzipHandler.setInflateBufferSize(CONFIG.getPropertyValue(ScoutApplicationGzipInflateBufferSize.class)); // positive buffer size to enable compressed requests
 
-    Optional.ofNullable(CONFIG.getPropertyValue(ScoutApplicationGzipMinSize.class)).ifPresent(gzipCompression::setMinCompressSize);
-    encoderConfig.setSyncFlush(CONFIG.getPropertyValue(ScoutApplicationGzipSyncFlush.class));
-    decoderConfig.setBufferSize(CONFIG.getPropertyValue(ScoutApplicationGzipInflateBufferSize.class));// positive buffer size to enable compressed requests
-
-    gzipCompression.setDefaultDecoderConfig(decoderConfig);
-    gzipCompression.setDefaultEncoderConfig(encoderConfig);
-
-    compressionHandler.putCompression(gzipCompression);
     // wrap the original handler
-    compressionHandler.setHandler(handler);
-    return compressionHandler;
+    gzipHandler.setHandler(handler);
+    return gzipHandler;
   }
 
   protected Handler createGracefulHandler(Handler handler) {
     return new GracefulHandler(handler);
   }
 
-  protected void setStringPropertyValueIfFilled(Class<? extends IConfigProperty<List<String>>> propertyClass, Consumer<String> setter) {
-    List<String> propertyValues = CONFIG.getPropertyValue(propertyClass);
-    if (!CollectionUtility.isEmpty(propertyValues)) {
-      propertyValues.forEach(setter);
+  protected void setStringPropertyValueIfFilled(Class<? extends IConfigProperty<List<String>>> propertyClass, Consumer<String[]> setter) {
+    List<String> propertyValue = CONFIG.getPropertyValue(propertyClass);
+    if (!CollectionUtility.isEmpty(propertyValue)) {
+      setter.accept(propertyValue.toArray(n -> new String[n]));
     }
   }
 

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
@@ -12,12 +12,8 @@ package org.eclipse.scout.rt.app;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jetty.compression.gzip.GzipCompression;
-import org.eclipse.jetty.compression.gzip.GzipDecoderConfig;
-import org.eclipse.jetty.compression.gzip.GzipEncoderConfig;
-import org.eclipse.jetty.compression.server.CompressionConfig;
-import org.eclipse.jetty.compression.server.CompressionHandler;
 import org.eclipse.jetty.http.HttpCookie.SameSite;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Platform;
 import org.eclipse.scout.rt.platform.config.AbstractBooleanConfigProperty;
@@ -393,7 +389,7 @@ public final class ApplicationProperties {
   }
 
   /**
-   * @see CompressionHandler
+   * @see GzipHandler
    */
   public static class ScoutApplicationGzipEnabled extends AbstractBooleanConfigProperty {
 
@@ -404,7 +400,7 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Specifies whether " + CompressionHandler.class.getName() + " is used. Default value is " + getDefaultValue() + ".";
+      return "Specifies whether " + GzipHandler.class.getName() + " is used. Default value is " + getDefaultValue() + ".";
     }
 
     @Override
@@ -414,7 +410,7 @@ public final class ApplicationProperties {
   }
 
   /**
-   * @see CompressionConfig.Builder#decompressExcludePath(String)
+   * @see GzipHandler#setExcludedInflatePaths(String...)
    */
   public static class ScoutApplicationGzipExcludedInflatePaths extends AbstractStringListConfigProperty {
 
@@ -425,12 +421,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Excluded inflate paths for " + CompressionHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
+      return "Excluded inflate paths for " + GzipHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
     }
   }
 
   /**
-   * @see CompressionConfig.Builder#compressExcludeMethod(String)
+   * @see GzipHandler#setExcludedMethods(String...)
    */
   public static class ScoutApplicationGzipExcludedMethods extends AbstractStringListConfigProperty {
 
@@ -441,12 +437,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Excluded methods for " + CompressionHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
+      return "Excluded methods for " + GzipHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
     }
   }
 
   /**
-   * @see CompressionConfig.Builder#compressExcludeMimeType(String)
+   * @see GzipHandler#setExcludedMimeTypes(String...)
    */
   public static class ScoutApplicationGzipExcludedMimeTypes extends AbstractStringListConfigProperty {
 
@@ -457,12 +453,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Excluded MIME types for " + CompressionHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
+      return "Excluded MIME types for " + GzipHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
     }
   }
 
   /**
-   * @see CompressionConfig.Builder#compressExcludePath(String)
+   * @see GzipHandler#setExcludedPaths(String...)
    */
   public static class ScoutApplicationGzipExcludedPaths extends AbstractStringListConfigProperty {
 
@@ -473,12 +469,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Excluded paths for " + CompressionHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
+      return "Excluded paths for " + GzipHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
     }
   }
 
   /**
-   * @see CompressionConfig.Builder#decompressIncludePath(String)
+   * @see GzipHandler#setIncludedInflatePaths(String...)
    */
   public static class ScoutApplicationGzipIncludedInflatePaths extends AbstractStringListConfigProperty {
 
@@ -489,12 +485,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Included inflate paths for " + CompressionHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
+      return "Included inflate paths for " + GzipHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
     }
   }
 
   /**
-   * @see CompressionConfig.Builder#compressIncludeMethod(String)
+   * @see GzipHandler#setIncludedMethods(String...)
    */
   public static class ScoutApplicationGzipIncludedMethods extends AbstractStringListConfigProperty {
 
@@ -505,12 +501,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Included methods for " + CompressionHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
+      return "Included methods for " + GzipHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
     }
   }
 
   /**
-   * @see CompressionConfig.Builder#compressIncludeMimeType(String)
+   * @see GzipHandler#setIncludedMimeTypes(String...)
    */
   public static class ScoutApplicationGzipIncludedMimeTypes extends AbstractStringListConfigProperty {
 
@@ -521,12 +517,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Included MIME types for " + CompressionHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
+      return "Included MIME types for " + GzipHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
     }
   }
 
   /**
-   * @see CompressionConfig.Builder#compressIncludePath(String)
+   * @see GzipHandler#setIncludedPaths(String...)
    */
   public static class ScoutApplicationGzipIncludedPaths extends AbstractStringListConfigProperty {
 
@@ -537,12 +533,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Included paths for " + CompressionHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
+      return "Included paths for " + GzipHandler.class.getName() + " (respected only if at least one is set otherwise Jetty default is used).";
     }
   }
 
   /**
-   * @see GzipCompression#setMinCompressSize(int)
+   * @see GzipHandler#setMinGzipSize(int)
    */
   public static class ScoutApplicationGzipMinSize extends AbstractPositiveIntegerConfigProperty {
 
@@ -553,12 +549,12 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Minimum size to trigger compression for " + CompressionHandler.class.getName() + ". If not set Jetty default value will be used.";
+      return "Minimum size to trigger compression for " + GzipHandler.class.getName() + ". If not set Jetty default value will be used.";
     }
   }
 
   /**
-   * @see GzipDecoderConfig#setBufferSize(int)
+   * @see GzipHandler#setInflateBufferSize(int)
    */
   public static class ScoutApplicationGzipInflateBufferSize extends AbstractPositiveIntegerConfigProperty {
 
@@ -569,7 +565,7 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Inflater buffer size for " + CompressionHandler.class.getName() + " to enable compressed requests. Default value: " + getDefaultValue();
+      return "Inflater buffer size for " + GzipHandler.class.getName() + " to enable compressed requests. Default value: " + getDefaultValue();
     }
 
     @Override
@@ -579,7 +575,7 @@ public final class ApplicationProperties {
   }
 
   /**
-   * @see GzipEncoderConfig#setSyncFlush(boolean)
+   * @see GzipHandler#setSyncFlush(boolean)
    */
   public static class ScoutApplicationGzipSyncFlush extends AbstractBooleanConfigProperty {
 
@@ -590,7 +586,7 @@ public final class ApplicationProperties {
 
     @Override
     public String description() {
-      return "Enables sync flush for " + CompressionHandler.class.getName() + ". Default value is " + getDefaultValue() + ".";
+      return "Enables sync flush for " + GzipHandler.class.getName() + ". Default value is " + getDefaultValue() + ".";
     }
 
     @Override

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/handler/ScoutJettyErrorHandler.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/handler/ScoutJettyErrorHandler.java
@@ -31,7 +31,7 @@ public class ScoutJettyErrorHandler extends ErrorHandler {
   }
 
   @Override
-  protected void writeErrorJson(Request request, PrintWriter writer, int code, String message, Throwable cause) {
+  protected void writeErrorJson(Request request, PrintWriter writer, int code, String message, Throwable cause, boolean showStacks) {
     JSONObject json = new JSONObject();
     json.put("status", Integer.toString(code));
     json.put("message", message);
@@ -45,7 +45,7 @@ public class ScoutJettyErrorHandler extends ErrorHandler {
   }
 
   @Override
-  protected void writeErrorPlain(Request request, PrintWriter writer, int code, String message, Throwable cause) {
+  protected void writeErrorPlain(Request request, PrintWriter writer, int code, String message, Throwable cause, boolean showStacks) {
     writer.write("HTTP ERROR ");
     writer.write(Integer.toString(code));
     writer.write("\n");

--- a/org.eclipse.scout.rt.jetty/pom.xml
+++ b/org.eclipse.scout.rt.jetty/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+  ~ Copyright (c) 2010, 2024 BSI Business Systems Integration AG
   ~
   ~ This program and the accompanying materials are made
   ~ available under the terms of the Eclipse Public License 2.0
@@ -44,14 +44,6 @@
       <!-- alpn implementation, needed to enable HTTP/2 over TLS, see https://xy2401.com/local-docs/java/jetty.9.4.24.v20191120/alpn-chapter.html -->
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-java-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.compression</groupId>
-      <artifactId>jetty-compression-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.compression</groupId>
-      <artifactId>jetty-compression-gzip</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -124,7 +124,7 @@
     <scout.base.version>26.2.0</scout.base.version>
     <base.version>${scout.base.version}</base.version>
     <org.eclipse.scout.rt.version>${project.version}</org.eclipse.scout.rt.version>
-    <jetty.version>12.1.5</jetty.version>
+    <jetty.version>12.0.33</jetty.version>
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.21</logback.version>
     <jackson.version>2.20.1</jackson.version>


### PR DESCRIPTION
Due to the following issues a downgrade to latest 12.0.33 version
- https://github.com/jetty/jetty.project/issues/14264
- https://github.com/jetty/jetty.project/issues/14564

Co-authored-by: matthiaso <matthias.otterbach@bsi-software.com>

451954