### PR TITLE
HybridManager: improve widget disposal

### DIFF
--- a/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
+++ b/eclipse-scout-core/src/desktop/hybrid/HybridManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  AnyDoEntity, App, Event, EventHandler, EventListener, EventMapOf, Form, HybridActionContextElements, HybridActionEvent, HybridManagerEventMap, HybridManagerWidgetAddEvent, HybridManagerWidgetRemoveEvent, InitModelOf, ObjectOrChildModel,
-  scout, Session, UuidPool, Widget
+  AnyDoEntity, App, arrays, DisposeWidgetsHybridActionDo, Event, EventHandler, EventListener, EventMapOf, Extension, Form, HybridActionContextElements, HybridActionEvent, HybridManagerEventMap, HybridManagerWidgetAddEvent,
+  HybridManagerWidgetRemoveEvent, InitModelOf, ObjectOrChildModel, objects, scout, Session, strings, UuidPool, Widget
 } from '../../index';
 
 /**
@@ -21,6 +21,17 @@ export class HybridManager extends Widget {
   declare self: HybridManager;
 
   widgets: Record<string, Widget>;
+
+  /**
+   * Set of {@link HybridManagerWidget}s that will be disposed in the next batch.
+   * See {@link #_callDisposeWidgets} for more information.
+   */
+  protected _widgetsToBeDisposed: Set<HybridManagerWidget> = null;
+  /**
+   * Set of ids that were scheduled in former batches.
+   * See {@link #_callDisposeWidgets} for more information.
+   */
+  protected _widgetIdsBeingDisposed = new Set<string>();
 
   constructor() {
     super();
@@ -61,26 +72,61 @@ export class HybridManager extends Widget {
   // widgets
 
   protected _setWidgets(widgets: Record<string, ObjectOrChildModel<Widget>>) {
+    const presentWidgetIds = new Set<string>();
+    for (const [id, widgetOrModel] of Object.entries(widgets)) {
+      let widgetId: string;
+      if (typeof widgetOrModel === 'string') {
+        widgetId = widgetOrModel;
+      } else if (objects.isObject(widgetOrModel)) {
+        widgetId = widgetOrModel.id;
+      }
+
+      if (!widgetId?.length) {
+        continue;
+      }
+
+      // collect widget id
+      presentWidgetIds.add(widgetId);
+
+      if (this._widgetIdsBeingDisposed.has(widgetId)) {
+        // do not accept disposed widgets
+        delete widgets[id];
+      }
+    }
+
+    for (const id of this._widgetIdsBeingDisposed) {
+      if (!presentWidgetIds.has(id)) {
+        // widget is no longer present -> no need to remember id any longer
+        this._widgetIdsBeingDisposed.delete(id);
+      }
+    }
+
     widgets = this._ensureWidgets(widgets);
 
-    const removedWidgets: Record<string, Widget> = {};
+    const removedWidgets: Record<string, HybridManagerWidget> = {};
     for (const [id, widget] of Object.entries(this.widgets)) {
       if (!widgets[id] || widgets[id] !== widget) {
         removedWidgets[id] = widget;
+        this._uninstallHybridManagerWidget(widget);
       }
     }
-    const addedWidgets: Record<string, Widget> = {};
+    const addedWidgets: Record<string, HybridManagerWidget> = {};
     for (const [id, widget] of Object.entries(widgets as Record<string, Widget>)) {
       if (!this.widgets[id] || this.widgets[id] !== widget) {
         addedWidgets[id] = widget;
+        this._installHybridManagerWidget(widget, id);
       }
     }
     this._destroyOrUnlinkChildren(Object.values(removedWidgets));
 
     this._setProperty('widgets', widgets);
 
-    Object.entries(addedWidgets).forEach(([id, widget]) => this._triggerWidgetAdd(id, widget));
-    Object.entries(removedWidgets).forEach(([id, widget]) => this._triggerWidgetRemove(id, widget));
+    Object.entries(addedWidgets).forEach(([id, widget]) => {
+      this._triggerWidgetAdd(id, widget);
+    });
+    Object.entries(removedWidgets).forEach(([id, widget]) => {
+      this._triggerWidgetRemove(id, widget);
+    });
   }
 
   protected _ensureWidgets(modelsOrWidgets: Record<string, ObjectOrChildModel<Widget>>): Record<string, Widget> {
@@ -90,6 +136,19 @@ export class HybridManager extends Widget {
       result[id] = this._createChildren(modelsOrWidgets[id]);
     });
     return result;
+  }
+
+  protected _installHybridManagerWidget(widget: HybridManagerWidget, remoteId: string) {
+    scout.assertParameter('widget', widget);
+    scout.assertParameter('remoteId', strings.nullIfEmpty(remoteId));
+
+    // mark widget with remote id
+    widget.__remoteId = remoteId;
+  }
+
+  protected _uninstallHybridManagerWidget(widget: HybridManagerWidget) {
+    // clear remote id marker
+    delete widget?.__remoteId;
   }
 
   protected _triggerWidgetAdd(id: string, widget: Widget) {
@@ -221,6 +280,58 @@ export class HybridManager extends Widget {
     return form;
   }
 
+  /**
+   * Calls the hybrid action with the action type 'scout.DisposeWidgets' to dispose the given widgets on the UI server.
+   */
+  disposeWidgets(widgets: Widget | Widget[]) {
+    this._callDisposeWidgets(widgets);
+  }
+
+  /**
+   * Calls the hybrid action with the action type 'scout.DisposeWidgets' to dispose the given widgets on the UI server.
+   * The given widgets are collected in {@link #_widgetsToBeDisposed} and sent in one hybrid action.
+   * After the hybrid action is called the ids of the {@link HybridManagerWidget}s in {@link #_widgetsToBeDisposed} are transferred to {@link #_widgetIdsBeingDisposed} and {@link #_widgetsToBeDisposed} is reset.
+   */
+  protected _callDisposeWidgets(widgets: HybridManagerWidget | HybridManagerWidget[]) {
+    // filter remote widgets that are not being disposed already
+    widgets = arrays.ensure(widgets).filter(widget => !!widget.__remoteId && !this._widgetIdsBeingDisposed.has(widget.__remoteId));
+
+    // nothing to dispose
+    if (!widgets.length) {
+      return;
+    }
+
+    // if next batch was not created already, create it and queue microtask to sent hybrid action
+    if (!this._widgetsToBeDisposed) {
+      this._widgetsToBeDisposed = new Set<HybridManagerWidget>();
+      queueMicrotask(() => {
+        // collect remote ids, transfer widget ids to this._widgetsToBeDisposed and reset next batch
+        const remoteIds: string[] = [];
+        for (const widget of [...this._widgetsToBeDisposed]) {
+          if (!widget.__remoteId) {
+            continue;
+          }
+          remoteIds.push(widget.__remoteId);
+          this._widgetIdsBeingDisposed.add(widget.id);
+        }
+        this._widgetsToBeDisposed = null;
+
+        // no widgets to dispose
+        if (!remoteIds.length) {
+          return;
+        }
+
+        // call hybrid action
+        this.callAction('scout.DisposeWidgets', scout.create(DisposeWidgetsHybridActionDo, {ids: remoteIds}));
+      });
+    }
+
+    // add remote id to next batch
+    for (const widget of widgets) {
+      this._widgetsToBeDisposed.add(widget);
+    }
+  }
+
   // event support
 
   override one<K extends string & keyof EventMapOf<this['self']>>(type: K | `${K}:${string}`, handler: EventHandler<EventMapOf<this>[K] & Event<this>>) {
@@ -251,3 +362,27 @@ interface HybridManagerForm extends Form {
    */
   __closeTriggered?: boolean;
 }
+
+export interface HybridManagerWidget extends Widget {
+  __remoteId?: string;
+}
+
+export class HybridManagerWidgetExtension extends Extension<HybridManagerWidget> {
+
+  init() {
+    this.extend(Widget.prototype, 'destroy');
+  }
+
+  destroy() {
+    if (this.extended.__remoteId) {
+      this.extended.destroying = true;
+      HybridManager.get(this.extended.session).disposeWidgets(this.extended);
+      return;
+    }
+    this.next();
+  }
+}
+
+App.addListener('installExtensions', () => {
+  Extension.install(HybridManagerWidgetExtension);
+});

--- a/eclipse-scout-core/test/desktop/hybrid/HybridManagerSpec.ts
+++ b/eclipse-scout-core/test/desktop/hybrid/HybridManagerSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Form, FormAdapter, HybridActionContextElements, HybridManager, HybridManagerAdapter, LabelField, NumberField, scout, StringField, Tree, TreeAdapter, TreeNode, UuidPool, Widget} from '../../../src';
-import {FormSpecHelper, TreeSpecHelper} from '../../../src/testing';
+import {
+  Deferred, DisposeWidgetsHybridActionDo, Form, FormAdapter, HybridActionContextElements, HybridActionEvent, HybridManager, HybridManagerAdapter, LabelField, NumberField, scout, StringField, Tree, TreeAdapter, TreeNode, UuidPool, Widget
+} from '../../../src';
+import {FormSpecHelper, JasmineScoutUtil, TreeSpecHelper} from '../../../src/testing';
 
 describe('HybridManager', () => {
   let session: SandboxSession, formHelper: FormSpecHelper;
@@ -161,6 +163,154 @@ describe('HybridManager', () => {
       expect(labelField.destroyed).toBeTrue();
       expect(stringField.destroyed).toBeTrue();
       expect(numberField.destroyed).toBeFalse();
+    });
+
+    it('removes widgets, cancels destroy and sends \'scout.DisposeWidgets\' if widgets are destroyed', async () => {
+      const hybridManager = HybridManager.get(session);
+      expect(Object.entries(hybridManager.widgets).length).toBe(0);
+
+      session._processSuccessResponse({
+        adapterData: mapAdapterData([
+          {id: 'ebe86dba-ac69-4176-8f4d-e0a60e8821dd', objectType: 'StringField'},
+          {id: 'bbe0a00d-1f4a-4804-a0ac-20b50a40a206', objectType: 'StringField'},
+          {id: '7b7e2da6-e43d-43d6-b83d-c252cb1c07f8', objectType: 'StringField'},
+          {id: '451a8fae-eca3-4d2f-ae17-612fdbf59546', objectType: 'StringField'}
+        ]),
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            field1: 'ebe86dba-ac69-4176-8f4d-e0a60e8821dd',
+            field2: 'bbe0a00d-1f4a-4804-a0ac-20b50a40a206',
+            field3: '7b7e2da6-e43d-43d6-b83d-c252cb1c07f8',
+            field4: '451a8fae-eca3-4d2f-ae17-612fdbf59546'
+          }
+        })]
+      });
+
+      const {field1, field2, field3, field4} = hybridManager.widgets;
+
+      expect(Object.entries(hybridManager.widgets).length).toBe(4);
+      expect(field1).toBeInstanceOf(StringField);
+      expect(field1.destroyed).toBeFalse();
+      expect(field1.destroying).toBeFalse();
+      expect(field2).toBeInstanceOf(StringField);
+      expect(field2.destroyed).toBeFalse();
+      expect(field2.destroying).toBeFalse();
+      expect(field3).toBeInstanceOf(StringField);
+      expect(field3.destroyed).toBeFalse();
+      expect(field3.destroying).toBeFalse();
+      expect(field4).toBeInstanceOf(StringField);
+      expect(field4.destroyed).toBeFalse();
+      expect(field4.destroying).toBeFalse();
+
+      let disposeWidgetsCalled = false;
+      const disposedWidgetIdsDeferred = new Deferred<string[]>();
+      JasmineScoutUtil.mockHybridAction(session, 'scout.DisposeWidgets', (event: HybridActionEvent<DisposeWidgetsHybridActionDo>) => {
+        disposeWidgetsCalled = true;
+        disposedWidgetIdsDeferred.resolve(event.data.data.ids);
+        return null;
+      });
+
+      field2.destroy();
+
+      expect(field1.destroyed).toBeFalse();
+      expect(field1.destroying).toBeFalse();
+      expect(field2.destroyed).toBeFalse();
+      expect(field2.destroying).toBeTrue();
+      expect(field3.destroyed).toBeFalse();
+      expect(field3.destroying).toBeFalse();
+      expect(field4.destroyed).toBeFalse();
+      expect(field4.destroying).toBeFalse();
+      expect(disposeWidgetsCalled).toBeFalse();
+
+      field3.destroy();
+
+      expect(field1.destroyed).toBeFalse();
+      expect(field1.destroying).toBeFalse();
+      expect(field2.destroyed).toBeFalse();
+      expect(field2.destroying).toBeTrue();
+      expect(field3.destroyed).toBeFalse();
+      expect(field3.destroying).toBeTrue();
+      expect(field4.destroyed).toBeFalse();
+      expect(field4.destroying).toBeFalse();
+      expect(disposeWidgetsCalled).toBeFalse();
+
+      hybridManager.disposeWidgets(field4);
+
+      expect(field1.destroyed).toBeFalse();
+      expect(field1.destroying).toBeFalse();
+      expect(field2.destroyed).toBeFalse();
+      expect(field2.destroying).toBeTrue();
+      expect(field3.destroyed).toBeFalse();
+      expect(field3.destroying).toBeTrue();
+      expect(field4.destroyed).toBeFalse(); // scheduling a widget disposal does not destroy the widget immediately in Scout JS
+      expect(field4.destroying).toBeFalse(); // scheduling a widget disposal does not destroy the widget immediately in Scout JS
+      expect(disposeWidgetsCalled).toBeFalse();
+
+      const disposedWidgetIds = await disposedWidgetIdsDeferred.promise();
+
+      expect(disposeWidgetsCalled).toBeTrue();
+      expect(disposedWidgetIds).toEqual(['field2', 'field3', 'field4']);
+    });
+
+    it('widgets for which \'scout.DisposeWidgets\' was sent are ignored on property change events', async () => {
+      const hybridManager = HybridManager.get(session);
+      expect(Object.entries(hybridManager.widgets).length).toBe(0);
+
+      session._processSuccessResponse({
+        adapterData: mapAdapterData([
+          {id: 'b531e00b-a42e-4ac9-b023-262bf3d62e8e', objectType: 'StringField'},
+          {id: '3c4b64d0-145f-4ef9-951d-7fbbfda4e219', objectType: 'StringField'},
+          {id: '8ae24bcb-edd5-4f73-bb0d-0c119a052893', objectType: 'StringField'},
+          {id: '4788f1bd-eca0-4f3c-a4d2-be6707819b97', objectType: 'StringField'}
+        ]),
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            field1: 'b531e00b-a42e-4ac9-b023-262bf3d62e8e',
+            field2: '3c4b64d0-145f-4ef9-951d-7fbbfda4e219',
+            field3: '8ae24bcb-edd5-4f73-bb0d-0c119a052893',
+            field4: '4788f1bd-eca0-4f3c-a4d2-be6707819b97'
+          }
+        })]
+      });
+
+      expect(Object.entries(hybridManager.widgets).length).toBe(4);
+      expect(hybridManager.widgets['field1']).toBeDefined();
+      expect(hybridManager.widgets['field2']).toBeDefined();
+      expect(hybridManager.widgets['field3']).toBeDefined();
+      expect(hybridManager.widgets['field4']).toBeDefined();
+      expect(hybridManager.widgets['field5']).not.toBeDefined();
+
+      const disposedWidgetIdsDeferred = new Deferred<void>();
+      JasmineScoutUtil.mockHybridAction(session, 'scout.DisposeWidgets', (event: HybridActionEvent<DisposeWidgetsHybridActionDo>) => {
+        disposedWidgetIdsDeferred.resolve();
+        return null;
+      });
+
+      hybridManager.disposeWidgets([hybridManager.widgets['field3'], hybridManager.widgets['field4']]);
+      await disposedWidgetIdsDeferred.promise();
+
+      session._processSuccessResponse({
+        adapterData: mapAdapterData([
+          {id: '0a1fbfb5-ad5f-4f1e-92b5-1781e8b5b319', objectType: 'StringField'}
+        ]),
+        events: [createPropertyChangeEvent(hybridManager, {
+          widgets: {
+            field1: 'b531e00b-a42e-4ac9-b023-262bf3d62e8e',
+            field2: '3c4b64d0-145f-4ef9-951d-7fbbfda4e219',
+            field3: '8ae24bcb-edd5-4f73-bb0d-0c119a052893',
+            field4: '4788f1bd-eca0-4f3c-a4d2-be6707819b97',
+            field5: '0a1fbfb5-ad5f-4f1e-92b5-1781e8b5b319'
+          }
+        })]
+      });
+
+      // disposed widgets field3 and field4 are removed from hybridManager.widgets on property change event from server
+      expect(Object.entries(hybridManager.widgets).length).toBe(3);
+      expect(hybridManager.widgets['field1']).toBeDefined();
+      expect(hybridManager.widgets['field2']).toBeDefined();
+      expect(hybridManager.widgets['field3']).not.toBeDefined();
+      expect(hybridManager.widgets['field4']).not.toBeDefined();
+      expect(hybridManager.widgets['field5']).toBeDefined();
     });
   });
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/DisposeWidgetsHybridAction.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/DisposeWidgetsHybridAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@ package org.eclipse.scout.rt.client.ui.desktop.hybrid;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.scout.rt.client.ui.IWidget;
 import org.slf4j.Logger;
@@ -30,13 +31,24 @@ public class DisposeWidgetsHybridAction extends AbstractHybridAction<DisposeWidg
 
   @Override
   public void execute(DisposeWidgetsHybridActionDo data) {
-    for (String id : data.getIds()) {
-      IWidget widget = hybridManager().getWidgetById(id);
-      if (widget != null) {
-        widget.dispose();
-        LOG.debug("Disposed hybrid widget with id {}", id);
-      }
-    }
+    // get all widgets that need to be disposed
+    Map<String, IWidget> widgets = data.getIds().stream()
+        .map(id -> new IdWidgetTuple(id, hybridManager().getWidgetById(id)))
+        .filter(idWidgetTuple -> idWidgetTuple.widget() != null)
+        .collect(Collectors.toMap(IdWidgetTuple::id, IdWidgetTuple::widget));
+
+    // remove widgets from hybrid manager before disposing the widgets to reduce the update count of the hybrid managers widgets property
+    hybridManager().removeWidgetsById(widgets.keySet());
+
+    // dispose widgets
+    widgets.forEach((id, widget) -> {
+      widget.dispose();
+      LOG.debug("Disposed hybrid widget with id {}", id);
+    });
+
     fireHybridActionEndEvent();
+  }
+
+  protected record IdWidgetTuple(String id, IWidget widget) {
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/HybridManager.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/hybrid/HybridManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -183,7 +183,7 @@ public class HybridManager extends AbstractPropertyObserver {
     widget.addPropertyChangeListener(IWidget.PROP_DISPOSE_DONE, getWidgetDisposeListener());
   }
 
-  protected String getWidgetId(IWidget widget) {
+  public String getWidgetId(IWidget widget) {
     return getWidgets().entrySet().stream()
         .filter(entry -> ObjectUtility.equals(entry.getValue(), widget))
         .map(Entry::getKey)


### PR DESCRIPTION
Add api to HybridManager.ts for widget disposal. Widgets that need to be disposed are collected and the scout.DisposeWidgets-hybrid action is only called once. In addition, send a scout.DisposeWidgets-hybrid action and stop destroying for all widgets belonging to the HybridManager if they are destroyed.
All widgets for which a disposal was scheduled are excluded from property change events in the future as destroyed widgets may no longer be resolved.
Improve performance of DisposeWidgetsHybridAction. The HybridManager adds dispose-listeners to all its widgets and removes them from itself when they are disposed. For this the HybridManager needs to build a new map of widgets, each time its "widgets" property is updated. If a great amount of widgets is disposed, each disposal triggers a rebuild of the HybridManagers "widgets" property. The DisposeWidgetsHybridAction will now remove all widgets that are to be disposed from the HybridManager at once and dispose them afterward. With this the "widgets" property of the HybridManager is only updated once which improves performance when great amounts of widgets are disposed.

379008