### PR TITLE
Table: improve tile mode

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -5209,8 +5209,10 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   createTiles(rows: TableRow[]): Tile[] {
     return rows.map(row => {
       let tile = this.createTileForRow(row);
-      this._adaptTile(tile);
-      tile.rowId = row.id;
+      if (tile) {
+        this._adaptTile(tile);
+        tile.rowId = row.id;
+      }
       return tile;
     });
   }

--- a/eclipse-scout-core/src/table/TableTileGridMediator.ts
+++ b/eclipse-scout-core/src/table/TableTileGridMediator.ts
@@ -190,6 +190,7 @@ export class TableTileGridMediator extends Widget implements TableTileGridMediat
   }
 
   setTiles(tiles: ObjectOrChildModel<Tile>[]) {
+    tiles = [...new Set(tiles)].filter(Boolean); // remove duplicates and nulls
     this.setProperty('tiles', tiles);
   }
 
@@ -435,7 +436,7 @@ export class TableTileGridMediator extends Widget implements TableTileGridMediat
     this.table.loadingSupport.renderLoading(true);
   }
 
-  override destroy() {
+  protected override _destroy() {
     // destroy tiles manually since owner is the mediator thus the tileGrid can't destroy them
     this.tiles.forEach(tile => tile.destroy());
     this.tileAccordion.destroy();
@@ -528,7 +529,7 @@ export class TableTileGridMediator extends Widget implements TableTileGridMediat
     if (!this.table.tileMode || $.isEmptyObject(this.tilesMap)) {
       return;
     }
-    this.tiles = this.table.rows.map(row => this.tilesMap[row.id]);
+    this.tiles = [...new Set(this.table.rows.map(row => this.tilesMap[row.id]))].filter(Boolean); // remove duplicates and nulls
     this.tileAccordion.setTiles(this.tiles);
   }
 

--- a/eclipse-scout-core/src/table/TileTableHeaderBox.ts
+++ b/eclipse-scout-core/src/table/TileTableHeaderBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -166,34 +166,34 @@ export class TileTableHeaderBox extends GroupBox implements TileTableHeaderBoxMo
   }
 
   protected _syncSortingGroupingFields() {
-    let primaryGroupingColumn = arrays.find(this.table.visibleColumns(), column => column.grouped && column.sortIndex === 0);
-    if (primaryGroupingColumn) {
-      this.groupByField.setValue(primaryGroupingColumn);
-    } else {
-      this.groupByField.setValue(null);
+    if (!this.isGrouping) {
+      let primaryGroupingColumn = arrays.find(this.table.visibleColumns(), column => column.grouped && column.sortIndex === 0);
+      if (primaryGroupingColumn) {
+        this.groupByField.setValue(primaryGroupingColumn);
+      } else {
+        this.groupByField.setValue(null);
+      }
     }
 
-    let primarySortingColumn = arrays.find(this.table.visibleColumns(), column => column.sortActive && column.sortIndex === 0);
-    if (primarySortingColumn) {
-      this.sortByField.setValue(this._findSortByLookupRowForKey({
-        column: primarySortingColumn,
-        asc: primarySortingColumn.sortAscending
-      }));
-    } else {
-      this.sortByField.setValue(null);
+    if (!this.isSorting) {
+      let primarySortingColumn = arrays.find(this.table.visibleColumns(), column => column.sortActive && column.sortIndex === 0);
+      if (primarySortingColumn) {
+        this.sortByField.setValue(this._findSortByLookupRowForKey({
+          column: primarySortingColumn,
+          asc: primarySortingColumn.sortAscending
+        }));
+      } else {
+        this.sortByField.setValue(null);
+      }
     }
   }
 
   protected _onTableGroup(event: TableGroupEvent) {
-    if (!this.isGrouping) {
-      this._syncSortingGroupingFields();
-    }
+    this._syncSortingGroupingFields();
   }
 
   protected _onTableSort(event: TableSortEvent) {
-    if (!this.isSorting) {
-      this._syncSortingGroupingFields();
-    }
+    this._syncSortingGroupingFields();
   }
 
   protected _onTableColumnStructureChanged(event: TableColumnStructureChangedEvent) {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTileTableHeader.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTileTableHeader.java
@@ -30,6 +30,7 @@ import org.eclipse.scout.rt.platform.text.TEXTS;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.ImmutablePair;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
+import org.eclipse.scout.rt.shared.AbstractIcons;
 import org.eclipse.scout.rt.shared.data.basic.FontSpec;
 import org.eclipse.scout.rt.shared.services.lookup.ILookupCall;
 import org.eclipse.scout.rt.shared.services.lookup.ILookupRow;
@@ -308,8 +309,11 @@ public abstract class AbstractTileTableHeader extends AbstractGroupBox implement
       for (IColumn col : getTable().getColumns()) {
         if (col.isVisible() && isColumnTypeAllowedForSorting(col)) {
           String colLabel = ObjectUtility.nvl(col.getHeaderCell().getText(), col.getHeaderCell().getTooltipText());
-          lookupRows.add(new LookupRow<>(new ImmutablePair<>(col, true), colLabel + " ↑")); // U+2191
-          lookupRows.add(new LookupRow<>(new ImmutablePair<>(col, false), colLabel + " ↓")); // U+2193
+          lookupRows.add(new LookupRow<>(new ImmutablePair<>(col, true), colLabel + " (" + TEXTS.get("ascending") + ")")
+              .withIconId(AbstractIcons.LongArrowUpBold));
+          lookupRows.add(new LookupRow<>(new ImmutablePair<>(col, false), colLabel + " (" + TEXTS.get("descending") + ")")
+              .withIconId(AbstractIcons.LongArrowDownBold)
+          );
         }
       }
 

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts.properties
@@ -351,5 +351,7 @@ YearToDateTwoYearsBefore=two years ago
 Yes=Yes
 YesButton=Yes
 and=and
+ascending=ascending
+descending=descending
 from=from
 to=to

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_de.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_de.properties
@@ -351,5 +351,7 @@ YearToDateTwoYearsBefore=vor zwei Jahren
 Yes=Ja
 YesButton=Ja
 and=und
+ascending=aufsteigend
+descending=absteigend
 from=von
 to=bis

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_fr.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_fr.properties
@@ -351,5 +351,7 @@ YearToDateTwoYearsBefore=il y a deux ans
 Yes=Oui
 YesButton=Oui
 and=et
+ascending=croissant
+descending=décroissant
 from=de
 to=à

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_it.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_it.properties
@@ -351,5 +351,7 @@ YearToDateTwoYearsBefore=due anni fa
 Yes=Sì
 YesButton=Sì
 and=e
+ascending=crescente
+descending=decrescente
 from=da
 to=a


### PR DESCRIPTION
Table: improve tile mode

There may not always be a tile for a row. Therefore, implement Table.createTiles more lenient in order to avoid null pointer exceptions. In addition, the TableTileGridMediator ensures that null values are removed from its list of tiles.
The list of tiles of the TableTileGridMediator needs to be unique as the tiles will be rendered one after another. If there are duplicates in the list of tiles an 'Already rendered'-error will be thrown if the second occurrence is rendered. Therefore, the TableTileGridMediator removes all duplicates from its list of tiles.

379008

---

Align sort lookup call for table in tile mode

The Scout JS implementation of the sort lookup call for tables in tile mode uses lookup row icons to indicate whether a selected entry sorts ascending or descending while the Scout Classic implementation has added these icons to its text. Align these two implementations and use the style from Scout JS as it looks cleaner.

379008