### PR TITLE
Downgrade Jackson because of regression introduced with 2.21.0

### DIFF
--- a/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JacksonDataObjectMapperTest.java
+++ b/org.eclipse.scout.rt.jackson.test/src/test/java/org/eclipse/scout/rt/jackson/dataobject/JacksonDataObjectMapperTest.java
@@ -245,13 +245,11 @@ public class JacksonDataObjectMapperTest {
    */
   @Test
   public void testStreamReadConstraints_maxDocumentLength() {
-    String shortJson = "{\"attribute\" : \"12345\"}";
-    assertThrows(PlatformException.class, () -> runTestStreamReadConstraints(b -> b.maxDocumentLength(shortJson.length() - 10), shortJson).get("attribute"));
-    assertEquals("12345", runTestStreamReadConstraints(b -> b.maxDocumentLength(shortJson.length()), shortJson).get("attribute"));
+    // Jackson does not check document length for very short input streams
+    assertEquals("12345", runTestStreamReadConstraints(b -> b.maxDocumentLength(3), "{\"attribute\" : \"12345\"}").get("attribute"));
 
-    String longJson = "{\"attribute\" : \"" + m_longStringValue + "\"}";
-    assertThrows(PlatformException.class, () -> runTestStreamReadConstraints(b -> b.maxDocumentLength(3), longJson));
-    assertEquals(m_longStringValue, runTestStreamReadConstraints(b -> b.maxDocumentLength(m_longStringValue.length()), longJson).get("attribute"));
+    // Jackson checks document length correctly only for longer input streams
+    assertThrows(PlatformException.class, () -> runTestStreamReadConstraints(b -> b.maxDocumentLength(3), "{\"attribute\" : \"" + m_longStringValue + "\"}"));
   }
 
   /**

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -127,7 +127,7 @@
     <jetty.version>12.0.33</jetty.version>
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.32</logback.version>
-    <jackson.version>2.21.1</jackson.version>
+    <jackson.version>2.18.2</jackson.version>
     <io.netty-version>4.1.131.Final</io.netty-version>
     <apache.tika-version>3.0.0</apache.tika-version>
     <batik.version>1.18</batik.version>


### PR DESCRIPTION
https://github.com/FasterXML/jackson-core/issues/363