### PR TITLE
Use ConfigurableContentSecurityPolicy for dynamic resources.

### DIFF
--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/cache/HttpCacheObject.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/cache/HttpCacheObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
 package org.eclipse.scout.rt.server.commons.servlet.cache;
 
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,7 +27,7 @@ public class HttpCacheObject implements Serializable {
 
   private final HttpCacheKey m_cacheKey;
   private final BinaryResource m_resource;
-  private final Set<IHttpResponseInterceptor> m_httpResponseInterceptors = new HashSet<>();
+  private final Set<IHttpResponseInterceptor> m_httpResponseInterceptors = new LinkedHashSet<>();
 
   /**
    * @param cacheKey

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/cache/HttpCacheObjectTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/cache/HttpCacheObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,11 +9,21 @@
  */
 package org.eclipse.scout.rt.ui.html.cache;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.eclipse.scout.rt.platform.holders.StringHolder;
 import org.eclipse.scout.rt.platform.resource.BinaryResources;
 import org.eclipse.scout.rt.platform.util.Assertions;
+import org.eclipse.scout.rt.security.csp.ContentSecurityPolicy;
 import org.eclipse.scout.rt.server.commons.servlet.cache.HttpCacheKey;
 import org.eclipse.scout.rt.server.commons.servlet.cache.HttpCacheObject;
+import org.eclipse.scout.rt.server.commons.servlet.cache.IHttpResponseInterceptor;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class HttpCacheObjectTest {
 
@@ -35,5 +45,28 @@ public class HttpCacheObjectTest {
   @Test
   public void testOkOk() {
     new HttpCacheObject(new HttpCacheKey(null), BinaryResources.create().build());
+  }
+
+  /**
+   * Tests insertion order stability of IHttpResponseInterceptor executions.
+   */
+  @Test
+  public void testInterceptorOrder() {
+    HttpCacheObject httpCacheObject = new HttpCacheObject(new HttpCacheKey(null), BinaryResources.create().build());
+    IHttpResponseInterceptor i1 = (req, resp) -> resp.setHeader(ContentSecurityPolicy.HTTP_HEADER, "1");
+    IHttpResponseInterceptor i2 = (req, resp) -> resp.setHeader(ContentSecurityPolicy.HTTP_HEADER, "2");
+    IHttpResponseInterceptor i3 = (req, resp) -> resp.setHeader(ContentSecurityPolicy.HTTP_HEADER, "3");
+    httpCacheObject.addHttpResponseInterceptor(i1);
+    httpCacheObject.addHttpResponseInterceptor(i2);
+    httpCacheObject.addHttpResponseInterceptor(i3);
+
+    HttpServletResponse resp = Mockito.mock(HttpServletResponse.class);
+    StringHolder result = new StringHolder();
+    doAnswer(a -> {
+      result.setValue(a.getArgument(1));
+      return null;
+    }).when(resp).setHeader(anyString(), anyString());
+    httpCacheObject.applyHttpResponseInterceptors(null, resp);
+    assertEquals("3", result.getValue());
   }
 }

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/BinaryResourceHolder.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/res/BinaryResourceHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,7 +9,7 @@
  */
 package org.eclipse.scout.rt.ui.html.res;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.eclipse.scout.rt.platform.resource.BinaryResource;
@@ -21,14 +21,14 @@ import org.eclipse.scout.rt.server.commons.servlet.cache.IHttpResponseIntercepto
 public class BinaryResourceHolder {
 
   private final BinaryResource m_binaryResource;
-  private final Set<IHttpResponseInterceptor> m_httpResponseInterceptors = new HashSet<>();
+  private final Set<IHttpResponseInterceptor> m_httpResponseInterceptors = new LinkedHashSet<>();
 
   public BinaryResourceHolder(BinaryResource binaryResource) {
     m_binaryResource = binaryResource;
   }
 
   /**
-   * @return the provided binary resource (may be <code>null</code>)
+   * @return the provided binary resource or {@code null}.
    */
   public BinaryResource get() {
     return m_binaryResource;
@@ -45,7 +45,7 @@ public class BinaryResourceHolder {
   /**
    * @return live set of associated {@link IHttpResponseInterceptor} (although it is recommended to use the
    * {@link #addHttpResponseInterceptor(IHttpResponseInterceptor)} and
-   * {@link #removeHttpResponseInterceptor(IHttpResponseInterceptor)} methods). Never <code>null</code>.
+   * {@link #removeHttpResponseInterceptor(IHttpResponseInterceptor)} methods). Never {@code null}.
    */
   public Set<IHttpResponseInterceptor> getHttpResponseInterceptors() {
     return m_httpResponseInterceptors;


### PR DESCRIPTION
Retain insertion order for IHttpResponseInterceptors on HttpCacheObject and BinaryResourceHolder. This prevents random behavior if multiple interceptors of the same BinaryResource change the same aspect of the response (e.g. the same HTTP header).

This is especially important for the interceptor adding the default CSP for dynamic resources (see DynamicResourceLoader#loadResource). It must be called first (for the HttpCacheObject) to allow the interceptors registered in the BinaryResourceHolder to customize it.

453833