### PR TITLE
OrganizeColumnsForm: column order may be wrong when loading a config

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/HeaderCell.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/HeaderCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,9 +34,6 @@ public class HeaderCell extends AbstractPropertyObserver implements IHeaderCell 
     int currentColIndex = getColumnIndex();
     if (currentColIndex < 0) {
       doSetColumnIndex(index);
-    }
-    else {
-      LOG.warn(null, new IllegalAccessException("do not use this internal method"));
     }
   }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractColumn.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/columns/AbstractColumn.java
@@ -1502,6 +1502,11 @@ public abstract class AbstractColumn<VALUE> extends AbstractPropertyObserver imp
   }
 
   public void setColumnIndexInternal(int index) {
+    int currentColIndex = getColumnIndex();
+    if (currentColIndex >= 0) {
+      LOG.warn("Unexpected column index {} for column {}", currentColIndex, this, new Exception("Stacktrace"));
+      return;
+    }
     m_headerCell.setColumnIndexInternal(index);
   }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/OrganizeColumnsForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1111,6 +1111,9 @@ public class OrganizeColumnsForm extends AbstractForm implements IOrganizeColumn
       m_organizedTable.getReloadHandler().reload(IReloadReason.ORGANIZE_COLUMNS);
     }
     getColumnsTableField().reloadTableData();
+    // After reloading, the columnsTableField now contains the expected columns in the correct order
+    // -> ensure the order of columns is correctly applied to the table
+    updateColumnVisibilityAndOrder();
   }
 
   protected void applyConfigImpl(String configName) {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/ShowInvisibleColumnsForm.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/organizer/ShowInvisibleColumnsForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -264,10 +264,17 @@ public class ShowInvisibleColumnsForm extends AbstractForm implements IShowInvis
         newCols.add(col);
         col.setVisible(true);
       }
-      if (m_insertAfterColumn == null || newCols.isEmpty()) {
+      if (newCols.isEmpty()) {
         return;
       }
-      ColumnSet colSet = newCols.get(0).getTable().getColumnSet();
+
+      ITable table = newCols.getFirst().getTable();
+      if (m_insertAfterColumn == null) {
+        ClientUIPreferences.getInstance().setAllTableColumnPreferences(table);
+        return;
+      }
+
+      ColumnSet colSet = table.getColumnSet();
       List<IColumn<?>> newOrder = new ArrayList<>();
       List<IColumn<?>> visibleColumns = colSet.getVisibleColumns();
       int position = 0;
@@ -305,7 +312,7 @@ public class ShowInvisibleColumnsForm extends AbstractForm implements IShowInvis
         i++;
       }
       colSet.setVisibleColumns(newOrder);
-      ClientUIPreferences.getInstance().setAllTableColumnPreferences(newCols.get(0).getTable());
+      ClientUIPreferences.getInstance().setAllTableColumnPreferences(table);
     }
 
     @Override


### PR DESCRIPTION
Use case:
1. Add a custom column (not at the end)
2. Save the state in a new custom config
3. Load the default config
4. Load the custom config -> custom column is placed at the end, even though the order is correct in the organize columns form

454064