### PR TITLE
Replace deprecated 'unload' with modern 'pagehide' event listener

### DIFF
--- a/eclipse-scout-core/src/desktop/PopupWindow.ts
+++ b/eclipse-scout-core/src/desktop/PopupWindow.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -44,8 +44,7 @@ export class PopupWindow extends EventEmitter {
     myWindow.name = 'Scout popup-window ' + form.modelClass;
   }
 
-  protected _onUnload() {
-    $.log.isDebugEnabled() && $.log.debug('stored form ID ' + this.form.id + ' to session storage');
+  protected _onPageHide() {
     if (this.form.destroyed) {
       $.log.isDebugEnabled() && $.log.debug('form ID ' + this.form.id + ' is already destroyed - don\'t trigger unload event');
     } else {
@@ -97,7 +96,7 @@ export class PopupWindow extends EventEmitter {
 
     // Attach event handlers on window
     $(this.myWindow)
-      .on('unload', this._onUnload.bind(this))
+      .on('pagehide', this._onPageHide.bind(this))
       .on('resize', this._onResize.bind(this));
 
     // Delegate uncaught JavaScript errors in the popup-window to the main-window

--- a/eclipse-scout-core/src/session/Session.ts
+++ b/eclipse-scout-core/src/session/Session.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -429,9 +429,9 @@ export class Session extends EventEmitter implements SessionModel, ModelAdapterL
     this.uiSessionId = data.startupData.uiSessionId;
 
     // Destroy UI session on server when page is closed or reloaded
-    $(window)
-      .on('beforeunload.' + this.uiSessionId, this._onWindowBeforeUnload.bind(this))
-      .on('unload.' + this.uiSessionId, this._onWindowUnload.bind(this));
+    window.addEventListener('beforeunload', event => this._onWindowBeforeUnload(event));
+    window.addEventListener('pagehide', event => this._onWindowPageHide(event));
+    window.addEventListener('pageshow', event => this._onWindowPageShow(event));
 
     // Special case: Page must be reloaded on startup (e.g. theme changed)
     if (data.startupData.reloadPage) {
@@ -681,6 +681,8 @@ export class Session extends EventEmitter implements SessionModel, ModelAdapterL
       urlHint = 'log';
     } else if (request.syncResponseQueue) {
       urlHint = 'sync';
+    } else if (request.startup) {
+      urlHint = 'startup';
     }
     if (urlHint) {
       url = new URL(url).addParameter(urlHint).toString();
@@ -1539,7 +1541,7 @@ export class Session extends EventEmitter implements SessionModel, ModelAdapterL
     });
   }
 
-  protected _onWindowBeforeUnload(evt: BeforeUnloadEvent) {
+  protected _onWindowBeforeUnload(event: BeforeUnloadEvent) {
     $.log.isInfoEnabled() && $.log.info('Session before unloading...');
     // TODO [7.0] bsh: Cancel pending requests
 
@@ -1551,6 +1553,22 @@ export class Session extends EventEmitter implements SessionModel, ModelAdapterL
       // reset the flag after a short period of time.
       this.unloading = false;
     }, 200);
+  }
+
+  protected _onWindowPageHide(event: PageTransitionEvent) {
+    if (event.persisted) {
+      // Make content invisible to avoid flashing during future 'pageshow' event (which will perform a page reload anyway, see _onWindowPageShow)
+      this.$entryPoint.addClass('hidden');
+    }
+    // Unload UI session
+    this._onWindowUnload();
+  }
+
+  protected _onWindowPageShow(event: PageTransitionEvent) {
+    if (event.persisted) {
+      // Perform a reload to get a new UI session (the old one was disposed in _onWindowUnload).
+      location.reload();
+    }
   }
 
   protected _onWindowUnload() {

--- a/eclipse-scout-core/src/testing/JasmineScout.ts
+++ b/eclipse-scout-core/src/testing/JasmineScout.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,8 +55,6 @@ declare global {
   function sendQueuedAjaxCalls(response?: JasmineAjaxResponse, time?: number);
 
   function receiveResponseForAjaxCall(request: JasmineAjaxRequest, response?: JasmineAjaxResponse);
-
-  function uninstallUnloadHandlers(session: Session);
 
   function createPropertyChangeEvent(model: { id: string }, properties: object);
 
@@ -211,15 +209,6 @@ window.receiveResponseForAjaxCall = (request, response) => {
   if (request && request.onload) {
     request.respondWith(response);
   }
-};
-
-/**
- * Uninstalls 'beforeunload' and 'unload' events from window that were previously installed by session.start()
- */
-window.uninstallUnloadHandlers = session => {
-  $(window)
-    .off('beforeunload.' + session.uiSessionId)
-    .off('unload.' + session.uiSessionId);
 };
 
 window.createPropertyChangeEvent = (model, properties) => ({

--- a/eclipse-scout-core/test/calendar/CalendarSpec.ts
+++ b/eclipse-scout-core/test/calendar/CalendarSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,6 @@ describe('Calendar', () => {
     jasmine.Ajax.install();
     jasmine.clock().install();
     session = sandboxSession();
-    uninstallUnloadHandlers(session);
   });
 
   afterEach(() => {

--- a/eclipse-scout-core/test/focus/FocusManagerSpec.ts
+++ b/eclipse-scout-core/test/focus/FocusManagerSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ describe('FocusManager', () => {
     formHelper = new FormSpecHelper(session);
     focusHelper = new FocusManagerSpecHelper();
     jasmine.clock().install();
-    uninstallUnloadHandlers(session);
   });
 
   afterEach(() => {

--- a/eclipse-scout-core/test/form/FormAdaperSpec.ts
+++ b/eclipse-scout-core/test/form/FormAdaperSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,6 @@ describe('FormAdapter', () => {
     jasmine.clock().install();
     session = sandboxSession();
     helper = new FormSpecHelper(session);
-    uninstallUnloadHandlers(session);
   });
 
   afterEach(() => {

--- a/eclipse-scout-core/test/form/FormSpec.ts
+++ b/eclipse-scout-core/test/form/FormSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,7 +31,6 @@ describe('Form', () => {
     });
     helper = new FormSpecHelper(session);
     outlineHelper = new OutlineSpecHelper(session);
-    uninstallUnloadHandlers(session);
   });
 
   afterEach(() => {

--- a/eclipse-scout-core/test/session/ModelAdapterSpec.ts
+++ b/eclipse-scout-core/test/session/ModelAdapterSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,7 +22,6 @@ describe('ModelAdapter', () => {
     jasmine.clock().install();
     session = sandboxSession();
     helper = new FormSpecHelper(session);
-    uninstallUnloadHandlers(session);
     $sandbox = $('#sandbox');
 
     // // Create a private object factory used for these tests

--- a/eclipse-scout-core/test/session/SessionSpec.ts
+++ b/eclipse-scout-core/test/session/SessionSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -572,7 +572,6 @@ describe('Session', () => {
       let session = createSession();
       session.start();
 
-      uninstallUnloadHandlers(session);
       sendQueuedAjaxCalls();
 
       let requestData = mostRecentJsonRequest();
@@ -592,7 +591,6 @@ describe('Session', () => {
       }));
       session.start();
 
-      uninstallUnloadHandlers(session);
       sendQueuedAjaxCalls();
 
       let requestData = mostRecentJsonRequest();


### PR DESCRIPTION
When the user leaves the current page (either because they close the tab or navigate away) or just simply reloads the page, the UI session should be disposed. Otherwise, UI sessions might accumulate if the HTTP session itself is still in use. To notify the UI server about a disposed UI session, a window listener for the 'unload' event was used.

Recently, some browsers have declared the 'unload' event to be obsolete and started to ignore it by default [1]. To make sure UI sessions are still disposed on the UI server when no longer in use, the event listeners have to changed to the more modern 'pagehide' event. However, using this event can under some circumstances enable the browser's back/forward cache [2]. This would store and restore the previous state of a page for a faster user experience. Since this can potentially cause problems for Scout Classic applications, we simply reload the page when being restored from the bfcache to make sure the state in the browser is up-to-date.

Some old Jasmine contained a call to a special JasmineScout method uninstallUnloadHandlers(). This method has not been necessary or useful for several years. Therefore, it was removed.

[1] https://developer.chrome.com/docs/web-platform/deprecating-unload
[2] https://web.dev/articles/bfcache

454776