### PR TITLE
PageWithTable: fix error on drill-down to JS page with search required

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -223,7 +223,18 @@ export class PageWithTable extends Page implements PageWithTableModel {
     this._resetTableData();
   }
 
+  /**
+   * Reverts the data in the {@link detailTable} to the original state by reloading it. For tables with
+   * {@link searchRequired} = true, the data is not reloaded. Instead, the old rows are deleted, a table
+   * status is displayed and {@link searchFilterCompleted} is set to false.
+   *
+   * This method must only be called after the detail table has been created ({@link ensureDetailTable}).
+   */
   protected _resetTableData() {
+    // It's allowed to have no table - but we don't have to load data in that case
+    if (!this.detailTable) {
+      return;
+    }
     if (this.searchRequired) {
       this.detailTable.deleteAllRows();
       this.setSearchFilterCompleted(false);
@@ -273,6 +284,8 @@ export class PageWithTable extends Page implements PageWithTableModel {
 
   override ensureLoadChildren(): JQuery.Promise<any> {
     if (this.searchRequired && !this.searchFilterCompleted) {
+      // Show table status
+      this.ensureDetailTable();
       this._resetTableData();
       return $.resolvedPromise();
     }

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  arrays, Column, Form, GroupBox, InitModelOf, MaxRowCountContributionDo, NumberColumn, NumberField, ObjectOrModel, Outline, Page, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl, SearchMenu, SmartColumn,
-  StaticLookupCall, StringField, Table, TableReloadReason, TableRow, WidgetModel
+  arrays, Column, Form, GroupBox, InitModelOf, MaxRowCountContributionDo, NumberColumn, NumberField, ObjectOrModel, Outline, Page, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl, SearchMenu,
+  SearchRequiredTableStatus, SmartColumn, StaticLookupCall, StringField, Table, TableReloadReason, TableRow, WidgetModel
 } from '../../../../src/index';
 import {OutlineSpecHelper, TableSpecHelper} from '../../../../src/testing/index';
 
@@ -660,5 +660,106 @@ describe('PageWithTable', () => {
     expect(usedFilter.numVal).toBe(2);
     expect(searchFormData.strVal).toBe('new');
     expect(searchFormData.numVal).toBe(2);
+  });
+
+  describe('searchRequired', () => {
+
+    it('shows a table status if searchRequired is true instead of loading the data', async () => {
+      let pageWithSearchRequired = scout.create(SpecPageWithTable, {
+        parent: outline,
+        detailTable: {
+          objectType: Table
+        },
+        searchRequired: true
+      });
+      spyOn(pageWithSearchRequired, '_loadTableData').and.callFake(() => $.resolvedPromise());
+
+      outline.insertNodes([pageWithSearchRequired], null);
+      expect(pageWithSearchRequired.outline).toBe(outline);
+      expect(pageWithSearchRequired.detailTable).toBe(null);
+
+      outline.expandNode(pageWithSearchRequired); // <-- calls ensureLoadChildren() before the detail table is initialized
+      outline.selectNode(pageWithSearchRequired);
+      expect(pageWithSearchRequired._loadTableData).not.toHaveBeenCalled();
+      expect(pageWithSearchRequired.detailTable).toBeInstanceOf(Table);
+      expect(pageWithSearchRequired.detailTable.tableStatus).toEqual(SearchRequiredTableStatus.info(session.text('TooManyRows')));
+
+      // -----
+
+      let pageWithSearchRequiredWithoutDetailTable = scout.create(SpecPageWithTable, {
+        parent: outline,
+        searchRequired: true
+      });
+      spyOn(pageWithSearchRequiredWithoutDetailTable, '_loadTableData').and.callFake(() => $.resolvedPromise());
+
+      outline.insertNodes([pageWithSearchRequiredWithoutDetailTable], null);
+      expect(pageWithSearchRequiredWithoutDetailTable.outline).toBe(outline);
+      expect(pageWithSearchRequiredWithoutDetailTable.detailTable).toBe(null);
+
+      outline.expandNode(pageWithSearchRequiredWithoutDetailTable); // <-- calls ensureLoadChildren() before the detail table is initialized
+      outline.selectNode(pageWithSearchRequiredWithoutDetailTable);
+      expect(pageWithSearchRequiredWithoutDetailTable._loadTableData).not.toHaveBeenCalled();
+      expect(pageWithSearchRequiredWithoutDetailTable.detailTable).toBe(null);
+    });
+
+    it('loads the data if searchRequired is false or searchFilterCompleted is true', async () => {
+      let pageWithoutSearchRequired = scout.create(SpecPageWithTable, {
+        parent: outline,
+        detailTable: {
+          objectType: Table
+        }
+      });
+      spyOn(pageWithoutSearchRequired, '_loadTableData').and.callFake(() => $.resolvedPromise());
+
+      outline.insertNodes([pageWithoutSearchRequired], null);
+      expect(pageWithoutSearchRequired.outline).toBe(outline);
+      expect(pageWithoutSearchRequired.detailTable).toBe(null);
+
+      outline.expandNode(pageWithoutSearchRequired); // <-- calls ensureLoadChildren() before the detail table is initialized
+      outline.selectNode(pageWithoutSearchRequired);
+      expect(pageWithoutSearchRequired._loadTableData).toHaveBeenCalled();
+      expect(pageWithoutSearchRequired.detailTable).toBeInstanceOf(Table);
+      expect(pageWithoutSearchRequired.detailTable.tableStatus).toBeFalsy();
+
+      // -----
+
+      let pageWithSearchRequiredAndFilterCompleted = scout.create(SpecPageWithTable, {
+        parent: outline,
+        detailTable: {
+          objectType: Table
+        },
+        searchRequired: true
+      });
+      spyOn(pageWithSearchRequiredAndFilterCompleted, '_loadTableData').and.callFake(() => $.resolvedPromise());
+      pageWithSearchRequiredAndFilterCompleted.searchFilterCompleted = true;
+
+      outline.insertNodes(pageWithSearchRequiredAndFilterCompleted);
+      expect(pageWithSearchRequiredAndFilterCompleted.outline).toBe(outline);
+      expect(pageWithSearchRequiredAndFilterCompleted.detailTable).toBe(null);
+
+      outline.expandNode(pageWithSearchRequiredAndFilterCompleted); // <-- calls ensureLoadChildren() before the detail table is initialized
+      outline.selectNode(pageWithSearchRequiredAndFilterCompleted);
+      expect(pageWithSearchRequiredAndFilterCompleted._loadTableData).toHaveBeenCalled();
+      expect(pageWithSearchRequiredAndFilterCompleted.detailTable).toBeInstanceOf(Table);
+      expect(pageWithSearchRequiredAndFilterCompleted.detailTable.tableStatus).toBeFalsy();
+
+      // -----
+
+      let pageWithSearchRequiredWithoutDetailTable = scout.create(SpecPageWithTable, {
+        parent: outline,
+        searchRequired: true
+      });
+      spyOn(pageWithSearchRequiredWithoutDetailTable, '_loadTableData').and.callFake(() => $.resolvedPromise());
+      pageWithSearchRequiredWithoutDetailTable.searchFilterCompleted = true;
+
+      outline.insertNodes(pageWithSearchRequiredWithoutDetailTable);
+      expect(pageWithSearchRequiredWithoutDetailTable.outline).toBe(outline);
+      expect(pageWithSearchRequiredWithoutDetailTable.detailTable).toBe(null);
+
+      outline.expandNode(pageWithSearchRequiredWithoutDetailTable); // <-- calls ensureLoadChildren() before the detail table is initialized
+      outline.selectNode(pageWithSearchRequiredWithoutDetailTable);
+      expect(pageWithSearchRequiredWithoutDetailTable._loadTableData).not.toHaveBeenCalled();
+      expect(pageWithSearchRequiredWithoutDetailTable.detailTable).toBe(null);
+    });
   });
 });


### PR DESCRIPTION
If a JS table page is marked with searchRequired=true and the user activates it with a double click on the corresponding row in the parent node's detail table, an error occurred in _resetTableData(), because the detail table was not yet created. This has been fixed by calling ensureDetailTable() before calling _resetTableData().

457043