### PR TITLE
Use reentrant semaphore lock for BoundedResolveCacheWrapper

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/cache/BoundedResolveCacheWrapperTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/cache/BoundedResolveCacheWrapperTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.cache;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.job.Jobs;
+import org.eclipse.scout.rt.platform.util.LambdaUtility;
+import org.junit.Test;
+
+public class BoundedResolveCacheWrapperTest {
+
+  private ICache<Integer, Integer> m_lastCreatedCache;
+
+  protected ICache<Integer, Integer> createCache(String id, ICacheValueResolver<Integer, Integer> resolver) {
+    @SuppressWarnings("unchecked")
+    ICacheBuilder<Integer, Integer> cacheBuilder = BEANS.get(ICacheBuilder.class);
+    ICache<Integer, Integer> cache = cacheBuilder
+        .withCacheId(id)
+        .withValueResolver(resolver)
+        .withThreadSafe(false)
+        .withReplaceIfExists(true)
+        .withMaxConcurrentResolve(1) // sets the BoundedResolveCacheWrapper, default reentrant
+        .build();
+    cache.invalidate(new AllCacheEntryFilter<>(), true);
+    m_lastCreatedCache = cache;
+    return cache;
+  }
+
+  @Test
+  public void testReentrantSameThread() {
+    AtomicInteger counter = new AtomicInteger(0);
+
+    ICache<Integer, Integer> cache = createCache("BoundedResolveCacheWrapperTest_testReentrantSameThread", key -> {
+      int count = counter.incrementAndGet();
+      if (count % 2 == 1) {
+        return m_lastCreatedCache.get(key);
+      }
+      return count;
+    });
+
+    assertEquals(2, (int) cache.get(1));
+  }
+
+  @Test
+  public void testReentrantMultipleThreads() throws InterruptedException {
+    AtomicInteger counter = new AtomicInteger(0);
+    CountDownLatch startedLatch = new CountDownLatch(1);
+    CountDownLatch returnLatch = new CountDownLatch(1);
+
+    ICache<Integer, Integer> cache = createCache("BoundedResolveCacheWrapperTest_testReentrantMultipleThreads", key -> LambdaUtility.invokeSafely(() -> {
+      int count = counter.incrementAndGet();
+      if (count % 2 == 1) {
+        return m_lastCreatedCache.get(key);
+      }
+      startedLatch.countDown();
+      returnLatch.await();
+      return count;
+    }));
+
+    // start 10 jobs
+    List<IFuture<Integer>> futures = IntStream.range(0, 10).mapToObj(i -> Jobs.schedule(() -> cache.get(i), Jobs.newInput())).toList();
+
+    // await at least one job has been started
+    startedLatch.await();
+    assertEquals(2, counter.get());
+
+    // continue (return first result)
+    returnLatch.countDown();
+
+    // await and verify all results
+    assertEquals(
+        IntStream.rangeClosed(1, 10).mapToObj(i -> 2 * i).collect(Collectors.toSet()),
+        futures.stream().map(f -> LambdaUtility.invokeSafely(() -> f.awaitDoneAndGet())).collect(Collectors.toSet()));
+    assertEquals(20, counter.get());
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/BoundedResolveCacheWrapper.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/BoundedResolveCacheWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
-
-import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruptedError;
+import java.util.function.Supplier;
 
 /**
  * This wrapper bounds the maximum concurrent resolve operation of a cache. In case a waiting operation is interrupted,
@@ -26,10 +25,16 @@ import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruptedError;
  */
 public class BoundedResolveCacheWrapper<K, V> extends AbstractCacheWrapper<K, V> {
   private final Semaphore m_semaphore;
+  private final ThreadLocal<Boolean> m_semaphoreAcquired;
 
   public BoundedResolveCacheWrapper(ICache<K, V> delegate, int maximumResolves) {
+    this(delegate, maximumResolves, true);
+  }
+
+  public BoundedResolveCacheWrapper(ICache<K, V> delegate, int maximumResolves, boolean reentrant) {
     super(delegate);
     m_semaphore = new Semaphore(maximumResolves);
+    m_semaphoreAcquired = reentrant ? new ThreadLocal<>() : null;
   }
 
   @Override
@@ -38,20 +43,7 @@ public class BoundedResolveCacheWrapper<K, V> extends AbstractCacheWrapper<K, V>
     if (value != null) {
       return value;
     }
-    try {
-      m_semaphore.acquire();
-    }
-    catch (InterruptedException e) {
-      // interrupted, mark thread again as interrupted and resolve without a semaphore anyway
-      Thread.currentThread().interrupt();
-      throw new ThreadInterruptedError("Interrupted during acquire", e);
-    }
-    try {
-      return super.get(key);
-    }
-    finally {
-      m_semaphore.release();
-    }
+    return callWithSemaphore(() -> super.get(key));
   }
 
   @Override
@@ -68,18 +60,32 @@ public class BoundedResolveCacheWrapper<K, V> extends AbstractCacheWrapper<K, V>
     if (result.size() == keys.size()) {
       return result;
     }
+    return callWithSemaphore(() -> super.getAll(keys));
+  }
+
+  protected <RET> RET callWithSemaphore(Supplier<RET> callable) {
+    if (m_semaphoreAcquired != null && m_semaphoreAcquired.get() != null) {
+      return callable.get();
+    }
+
     try {
       m_semaphore.acquire();
     }
     catch (InterruptedException e) {
       // interrupted, mark thread again as interrupted and resolve without a semaphore anyway
       Thread.currentThread().interrupt();
-      return super.getAll(keys);
+      return callable.get();
     }
     try {
-      return super.getAll(keys);
+      if (m_semaphoreAcquired != null) {
+        m_semaphoreAcquired.set(true);
+      }
+      return callable.get();
     }
     finally {
+      if (m_semaphoreAcquired != null) {
+        m_semaphoreAcquired.remove();
+      }
       m_semaphore.release();
     }
   }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/ICacheBuilder.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/cache/ICacheBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -186,6 +186,10 @@ public interface ICacheBuilder<K, V> {
    * <p>
    * Can be used to bound the maximum number of concurrent value resolve operations (non-fair). There is a risk of
    * deadlocks if the {@link #withValueResolver(ICacheValueResolver)} itself may be blocked.
+   * </p>
+   * <p>
+   * Each thread will be counted only once towards this maximum number (reentrant).
+   * </p>
    *
    * @param maxConcurrentResolve
    *     maximum concurrent resolves


### PR DESCRIPTION
One (and the same thread) should not acquire multiple semaphores, if it holds already the semaphore it may continue w/o semaphore.

419260