### PR TITLE
Improve performance of EventSupport

### DIFF
--- a/eclipse-scout-core/src/code/CodeTypeCache.ts
+++ b/eclipse-scout-core/src/code/CodeTypeCache.ts
@@ -36,8 +36,8 @@ export class CodeTypeCache extends EventEmitter implements ObjectModel<CodeTypeC
 
   constructor() {
     super();
-    this.events.registerSubTypePredicate('codeTypeChange', (event: CodeTypeChangeEvent, codeTypeId) => event.codeType.id === codeTypeId); // only works if the CodeTypeId can be converted to a string
-    this.events.registerSubTypePredicate('codeTypeRemove', (event: CodeTypeRemoveEvent, codeTypeId) => event.id === codeTypeId); // only works if the CodeTypeId can be converted to a string
+    this.events.registerSubTypeProvider('codeTypeChange', (event: CodeTypeChangeEvent) => event.codeType.id); // only works if the CodeTypeId can be converted to a string
+    this.events.registerSubTypeProvider('codeTypeRemove', (event: CodeTypeRemoveEvent) => event.id); // only works if the CodeTypeId can be converted to a string
     this.registry = new Map();
     this._reloadTimeoutId = -1;
     this._idsToUpdate = [];

--- a/eclipse-scout-core/src/desktop/outline/pages/Page.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/Page.ts
@@ -93,7 +93,7 @@ export class Page extends TreeNode implements PageModel, ObjectWithUuid {
     this.inheritMenusFromParentTablePage = true;
     this.detailMenuContributors = [];
     this.events = new EventSupport();
-    this.events.registerSubTypePredicate('propertyChange', (event: PropertyChangeEvent, propertyName) => event.propertyName === propertyName);
+    this.events.registerSubTypeProvider('propertyChange', (event: PropertyChangeEvent) => event.propertyName);
     this.pageChanging = 0;
     this._tableFilterHandler = this._onTableFilter.bind(this);
     this._tableRowClickHandler = this._onTableRowClick.bind(this);

--- a/eclipse-scout-core/src/events/EventSupport.ts
+++ b/eclipse-scout-core/src/events/EventSupport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -104,21 +104,36 @@ export class EventSupport {
     return deferred.promise();
   }
 
+  /**
+   * Adds the given {@link EventListener} if it is not present.
+   */
   addListener(listener: EventListener) {
-    this._eventListeners.push(listener);
+    arrays.pushSet(this._eventListeners, listener);
   }
 
+  /**
+   * Removes the given {@link EventListener} if it is present.
+   */
   removeListener(listener: EventListener) {
     arrays.remove(this._eventListeners, listener);
   }
 
+  /**
+   * Counts all {@link EventListener}s that match the given filters.
+   *
+   * The type-filter will match all listeners that are triggered by all given types.
+   * For example if there are two listeners registered with type 'lorem' and 'lorem ipsum dolor' the filter 'lorem' will match 2 listeners.
+   * In this example, the type-filter 'ipsum dolor' will match 1 listener like 'dolor' or 'dolor ipsum lorem'.
+   *
+   * The func-filter will match all listeners that are registered using this exact {@link EventHandler}.
+   */
   count(type?: string, func?: EventHandler): number {
     let count = 0;
     this._eventListeners.forEach(listener => {
-      if (type && type !== listener.type) {
+      if (type && (!listener.type || !arrays.containsAll(listener.type.split(' '), type.split(' ').filter(Boolean)))) {
         return;
       }
-      if (func && func !== listener.func) {
+      if (func && !(func === listener.func || func === listener.origFunc)) {
         return;
       }
       count++;
@@ -127,13 +142,19 @@ export class EventSupport {
   }
 
   /**
-   * @returns the event types of the registered listeners
+   * Returns a list of unique single types of all registered listeners.
+   * Example: If there are two listeners registered for 'lorem' and 'lorem ipsum dolor' the multi-type is split and ['lorem', 'ipsum', 'dolor'] is returned.
    */
   types(): string[] {
     let types = new Set<string>();
     for (const listener of this._eventListeners) {
-      if (listener.type) {
-        types.add(listener.type);
+      if (!listener.type) {
+        continue;
+      }
+      for (const type of listener.type.split(' ')) {
+        if (type) {
+          types.add(type);
+        }
       }
     }
     return Array.from(types);

--- a/eclipse-scout-core/src/events/EventSupport.ts
+++ b/eclipse-scout-core/src/events/EventSupport.ts
@@ -7,19 +7,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, Event, EventHandler, EventListener, objects, scout} from '../index';
+import {Event, EventHandler, EventListener, scout, strings} from '../index';
 import $ from 'jquery';
 
-export type EventSubTypePredicate = (type: Event, subType: string) => boolean;
-
 export class EventSupport {
-  protected _eventListeners: EventListener[];
-  protected _subTypePredicates: EventSubTypePredicate[];
-
-  constructor() {
-    this._eventListeners = [];
-    this._subTypePredicates = objects.createMap();
-  }
+  protected _eventListenersByType = new Map<string, Set<EventListener>>();
+  protected _eventListenersByHandler = new Map<EventHandler, Set<EventListener>>();
+  protected _subTypeProviders = new Map<string, EventSubTypeProvider>();
 
   protected _assertFunc(func: EventHandler) {
     if (!func) {
@@ -71,25 +65,73 @@ export class EventSupport {
    *      If no handler is specified, all handlers are de-registered for the given type.
    */
   off(type: string, func?: EventHandler) {
+    type = strings.trim(type);
+
     if (!type && !func) {
+      // nothing to remove
       return;
     }
 
-    for (let i = this._eventListeners.length - 1; i >= 0; i--) {
-      let listener = this._eventListeners[i];
-      let funcMatches = (func === listener.func || func === listener.origFunc);
-      let typeMatches = (type === listener.type);
-      let remove = false;
-      if (func && type) {
-        remove = (funcMatches && typeMatches);
-      } else if (func) {
-        remove = funcMatches;
-      } else { // always type. all other cases have been checked above
-        remove = typeMatches;
+    // validates the types of a listener against the given type-filter
+    const typePredicate = (listener: EventListener) => type === listener.type;
+
+    if (func) {
+      // func-filter is set -> get listeners by func
+      const listenersByHandler = this._getListenersByHandler(func);
+      if (!listenersByHandler.size) {
+        // nothing to remove
+        return;
       }
 
-      if (remove) {
-        this._eventListeners.splice(i, 1);
+      // if type is set only process those listeners matching the typePredicate
+      for (const listener of (type ? [...listenersByHandler].filter(typePredicate) : listenersByHandler)) {
+        // remove listeners by handler
+        listenersByHandler.delete(listener);
+
+        // get additional handler of listener
+        const additionalHandler = func === listener.func ? listener.origFunc : listener.func;
+        if (additionalHandler) {
+          // remove listeners by additional handler
+          this._removeListenerByHandler(additionalHandler, listener);
+        }
+
+        if (!type) {
+          // no type -> remove from all types
+          for (const t of this._eventListenersByType.keys()) {
+            this._removeListenerByType(t, listener);
+          }
+        }
+
+        // type set -> remove from all matching listenersByType
+        for (const t of this._splitTypes(type)) {
+          this._removeListenerByType(t, listener);
+        }
+      }
+
+      // remove entry from map if there are no listeners left
+      if (listenersByHandler.size === 0) {
+        this._eventListenersByHandler.delete(func);
+      }
+      return;
+    }
+
+    // type set -> remove from all matching listenersByType
+    for (const t of this._splitTypes(type)) {
+      // get all listeners for type
+      const listenersByType = this._getListenersByType(t);
+
+      // remove all listeners matching the type predicate
+      for (const listener of [...listenersByType].filter(typePredicate)) {
+        listenersByType.delete(listener);
+
+        // remove listeners by handlers
+        this._removeListenerByHandler(listener.func, listener);
+        this._removeListenerByHandler(listener.origFunc, listener);
+      }
+
+      // remove entry from map if there are no listeners left
+      if (listenersByType.size === 0) {
+        this._eventListenersByType.delete(t);
       }
     }
   }
@@ -108,14 +150,53 @@ export class EventSupport {
    * Adds the given {@link EventListener} if it is not present.
    */
   addListener(listener: EventListener) {
-    arrays.pushSet(this._eventListeners, listener);
+    if (!listener) {
+      return;
+    }
+
+    // add listener for handlers
+    this._addListenerByHandler(listener.func, listener);
+    this._addListenerByHandler(listener.origFunc, listener);
+
+    const listenerType = strings.trim(listener.type);
+    if (!listenerType) {
+      // listener has no type -> add for all events
+      this._addListenerByType(null, listener);
+      return;
+    }
+
+    // add listener for all types given
+    const types = this._splitTypes(listenerType);
+    for (const type of types) {
+      this._addListenerByType(type, listener);
+    }
   }
 
   /**
    * Removes the given {@link EventListener} if it is present.
    */
   removeListener(listener: EventListener) {
-    arrays.remove(this._eventListeners, listener);
+    if (!listener) {
+      return;
+    }
+
+    // remove listeners by handlers
+    this._removeListenerByHandler(listener.func, listener);
+    this._removeListenerByHandler(listener.origFunc, listener);
+
+    const listenerType = strings.trim(listener.type);
+    if (!listenerType) {
+      // listener has no type -> remove from all-events-listeners
+      this._removeListenerByType(null, listener);
+      return;
+    }
+
+    // remove listener for all types given
+    const types = this._splitTypes(listenerType);
+    for (const type of types) {
+      // remove listeners by specific type
+      this._removeListenerByType(type, listener);
+    }
   }
 
   /**
@@ -128,17 +209,45 @@ export class EventSupport {
    * The func-filter will match all listeners that are registered using this exact {@link EventHandler}.
    */
   count(type?: string, func?: EventHandler): number {
-    let count = 0;
-    this._eventListeners.forEach(listener => {
-      if (type && (!listener.type || !arrays.containsAll(listener.type.split(' '), type.split(' ').filter(Boolean)))) {
-        return;
+    if (this._eventListenersByType.size === 0) {
+      return 0;
+    }
+
+    type = strings.trim(type);
+
+    if (!type && !func) {
+      // no type- and no func-filter -> combine all listener sets in order to remove duplicates (e.g. because a listener was added for multiple types) and return size
+      return [...this._eventListenersByType.values()]
+        .reduce((a, b) => new Set([...a, ...b]), new Set())
+        .size;
+    }
+
+    const types = [...this._splitTypes(type)];
+    // validates the types of a listener against all types of the given type-filter
+    const typePredicate = (listener: EventListener) => {
+      const listenerTypes = this._splitTypes(listener.type);
+      return types.every(t => listenerTypes.has(t));
+    };
+
+    if (func) {
+      // func-filter is set -> get listeners by func
+      const listenersByHandler = this._getListenersByHandler(func);
+
+      if (!type) {
+        // only func-filter -> count all listeners found by func-filter
+        return listenersByHandler.size;
       }
-      if (func && !(func === listener.func || func === listener.origFunc)) {
-        return;
-      }
-      count++;
-    });
-    return count;
+
+      // type-filter set -> only count those matching the typePredicate
+      return [...listenersByHandler].filter(typePredicate).length;
+    }
+
+    // type-filter is set -> types contains at least one element
+    // if listeners are registered for multiple types they are present in each single-type-set
+    const listenersByType = this._getListenersByType(types[0]);
+
+    // count all relevant listeners matching the predicate
+    return [...listenersByType].filter(typePredicate).length;
   }
 
   /**
@@ -146,75 +255,188 @@ export class EventSupport {
    * Example: If there are two listeners registered for 'lorem' and 'lorem ipsum dolor' the multi-type is split and ['lorem', 'ipsum', 'dolor'] is returned.
    */
   types(): string[] {
-    let types = new Set<string>();
-    for (const listener of this._eventListeners) {
-      if (!listener.type) {
-        continue;
-      }
-      for (const type of listener.type.split(' ')) {
-        if (type) {
-          types.add(type);
-        }
-      }
-    }
-    return Array.from(types);
+    const types = new Set(this._eventListenersByType.keys());
+    types.delete(null);
+    return [...types];
   }
 
   trigger(type: string, event?: Event) {
+    type = strings.trim(type);
+    if (!type) {
+      return;
+    }
+
     event = event || {} as Event;
     event.type = type;
 
-    // Create copy because firing a trigger might modify the list of listeners
-    let listeners = this._eventListeners.slice();
-    // Use traditional "for" loop to reduce size of stack trace
-    for (let i = 0; i < listeners.length; i++) {
-      let listener = listeners[i];
-      if (!listener.type || this._typeMatches(event, listener.type)) {
-        listener.func(event);
-      }
-    }
-  }
+    // get relevant types, always add all-events-listeners, i.e. listeners registered for type = null
+    const relevantTypes = new Set([null, event.type]);
 
-  protected _typeMatches(event: Event, listenerType: string): boolean {
-    let eventType = event.type;
-    let types = listenerType.split(' ');
-    // support for multi type definition 'type1 type2 [...]'
-    for (let i = 0; i < types.length; i++) {
-      if (eventType === types[i]) {
-        return true;
-      }
-      if (this._subTypeMatches(event, types[i])) {
-        return true;
+    // consider subType if present
+    const subTypeProvider = this._subTypeProviders.get(event.type);
+    if (subTypeProvider) {
+      const subType = subTypeProvider(event);
+      if (subType) {
+        relevantTypes.add(`${type}:${subType}`);
       }
     }
-    return false;
-  }
 
-  protected _subTypeMatches(event: Event, listenerType: string): boolean {
-    if (listenerType.indexOf(':') < 0) {
-      return false;
+    // remove all types from relevantTypes for which no listeners exist
+    for (const relevantType of relevantTypes) {
+      if (!this._eventListenersByType.has(relevantType)) {
+        relevantTypes.delete(relevantType);
+      }
     }
-    let parts = listenerType.split(':');
-    let type = parts[0];
-    let subType = parts[1];
-    if (type !== event.type) {
-      return false;
-    }
-    let predicate = this._subTypePredicates[type];
-    if (!predicate) {
+
+    if (!relevantTypes.size) {
+      // there are no relevant listeners -> return
       return;
     }
-    return predicate(event, subType);
+
+    // collect all listeners for the relevant types in a set in order to remove duplicates
+    const listeners = [...relevantTypes]
+      .map(t => this._getListenersByType(t))
+      .reduce((a, b) => new Set([...a, ...b]), new Set());
+
+    // trigger all listeners
+    for (const listener of listeners) {
+      listener.func(event);
+    }
   }
 
   /**
-   *
-   * @param type the type which could contain a subtype
-   * @param predicate the predicate which will be tested when an event with the given type is triggered.
+   * Gets a {@link Set} of {@link EventListener}s for the requested type.
+   * The result of this method is never `null`.
+   * If the create-flag is set, the {@link Set} is added to {@link _eventListenersByType}.
    */
-  registerSubTypePredicate(type: string, predicate: EventSubTypePredicate) {
+  protected _getListenersByType(type: string, create = false): Set<EventListener> {
+    return this._getListenersByIdentifier(this._eventListenersByType, type || null, create);
+  }
+
+  /**
+   * Adds an {@link EventListener} to {@link _eventListenersByType} for the given identifier.
+   */
+  protected _addListenerByType(type: string, listener: EventListener) {
+    this._addListenerByIdentifier(this._eventListenersByType, type || null, listener);
+  }
+
+  /**
+   * Removes an {@link EventListener} from {@link _eventListenersByType} for the given identifier.
+   */
+  protected _removeListenerByType(type: string, listener: EventListener) {
+    this._removeListenerByIdentifier(this._eventListenersByType, type || null, listener);
+  }
+
+  /**
+   * Gets a {@link Set} of {@link EventListener}s for the requested {@link EventHandler}.
+   * The result of this method is never `null`.
+   * If the create-flag is set, the {@link Set} is added to {@link _eventListenersByHandler}.
+   */
+  protected _getListenersByHandler(handler: EventHandler, create = false): Set<EventListener> {
+    if (!handler) {
+      return new Set();
+    }
+
+    return this._getListenersByIdentifier(this._eventListenersByHandler, handler, create);
+  }
+
+  /**
+   * Adds an {@link EventListener} to {@link _eventListenersByHandler} for the given identifier.
+   */
+  protected _addListenerByHandler(handler: EventHandler, listener: EventListener) {
+    if (!handler) {
+      return;
+    }
+
+    this._addListenerByIdentifier(this._eventListenersByHandler, handler, listener);
+  }
+
+  /**
+   * Removes an {@link EventListener} from {@link _eventListenersByHandler} for the given identifier.
+   */
+  protected _removeListenerByHandler(handler: EventHandler, listener: EventListener) {
+    if (!handler) {
+      return;
+    }
+
+    this._removeListenerByIdentifier(this._eventListenersByHandler, handler, listener);
+  }
+
+  /**
+   * Gets a {@link Set} of {@link EventListener}s for the requested identifier from the given {@link Map}.
+   * The result of this method is never `null`.
+   * If the create-flag is set, the {@link Set} is added to the {@link Map}.
+   */
+  protected _getListenersByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListener>>, identifier: TIdentifier, create = false): Set<EventListener> {
+    if (!listenerMap) {
+      return new Set();
+    }
+
+    let listeners = listenerMap.get(identifier);
+    if (listeners) {
+      return listeners;
+    }
+
+    listeners = new Set();
+    if (!create) {
+      return listeners;
+    }
+
+    listenerMap.set(identifier, listeners);
+    return listeners;
+  }
+
+  /**
+   * Adds an {@link EventListener} to the given {@link Map} for the given identifier.
+   */
+  protected _addListenerByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListener>>, identifier: TIdentifier, listener: EventListener) {
+    if (!listenerMap || !listener) {
+      return;
+    }
+
+    this._getListenersByIdentifier(listenerMap, identifier, true).add(listener);
+  }
+
+  /**
+   * Removes an {@link EventListener} from the given {@link Map} for the given identifier.
+   */
+  protected _removeListenerByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListener>>, identifier: TIdentifier, listener: EventListener) {
+    if (!listenerMap || !listener) {
+      return;
+    }
+
+    const listeners = this._getListenersByIdentifier(listenerMap, identifier);
+    listeners.delete(listener);
+
+    // remove entry from map if there are no listeners left
+    if (listeners.size === 0) {
+      listenerMap.delete(identifier);
+    }
+  }
+
+  /**
+   * Splits the given type into unique single types (e.g.: 'lorem ipsum dolor' -> ['lorem', 'ipsum', 'dolor']).
+   */
+  protected _splitTypes(type: string): Set<string> {
+    if (!type) {
+      return new Set();
+    }
+    return new Set(type.split(' ').filter(Boolean));
+  }
+
+  /**
+   * Registers a {@link EventSubTypeProvider} for a specific event type.
+   */
+  registerSubTypeProvider(type: string, provider: EventSubTypeProvider) {
     scout.assertParameter('type', type);
-    scout.assertParameter('predicate', predicate);
-    this._subTypePredicates[type] = predicate;
+    scout.assertParameter('provider', provider);
+    this._subTypeProviders.set(type, provider);
   }
 }
+
+/**
+ * Builds a complete type for an {@link Event}.
+ * Consider a `FancyEvent` that is always triggered with the type 'fancy' but has a property `subType` which can hold the values 'foo' or 'bar'.
+ * If there is an {@link EventSubTypeProvider} returning this `subType`, listeners registered for 'fancy:foo' or 'fancy:bar' will be executed when the `subType` matches.
+ */
+export type EventSubTypeProvider = (type: Event) => string;

--- a/eclipse-scout-core/src/events/PropertyEventEmitter.ts
+++ b/eclipse-scout-core/src/events/PropertyEventEmitter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,7 @@ export class PropertyEventEmitter extends EventEmitter {
 
   constructor() {
     super();
-    this.events.registerSubTypePredicate('propertyChange', (event: PropertyChangeEvent, propertyName) => event.propertyName === propertyName);
+    this.events.registerSubTypeProvider('propertyChange', (event: PropertyChangeEvent) => event.propertyName);
     this.propertyDecorations = {
       computed: new Set<string>()
     };

--- a/eclipse-scout-core/test/desktop/outline/OutlineSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -267,24 +267,22 @@ describe('Outline', () => {
       helper.setMobileFlags(outline);
       let node0 = outline.nodes[0];
       let node1 = outline.nodes[1];
-      // @ts-expect-error
-      let eventListeners = node0.detailTable.events._eventListeners;
-      let initialListenerCount = eventListeners.length;
+      let initialListenerCount = node0.detailTable.events.count();
 
       outline.selectNodes(node0);
-      let selectionListenerCount = eventListeners.length;
+      let selectionListenerCount = node0.detailTable.events.count();
       expect(selectionListenerCount).toBe(initialListenerCount + 2); // destroy and propertyChange listener
 
       outline.selectNodes(node1);
-      selectionListenerCount = eventListeners.length;
+      selectionListenerCount = node0.detailTable.events.count();
       expect(selectionListenerCount).toBe(initialListenerCount); // listeners removed
 
       outline.selectNodes(node0);
-      selectionListenerCount = eventListeners.length;
+      selectionListenerCount = node0.detailTable.events.count();
       expect(selectionListenerCount).toBe(initialListenerCount + 2); // listeners attached again
 
       outline.nodes[0].detailTable.destroy();
-      expect(eventListeners.length).toBe(0); // every listener should be removed now
+      expect(node0.detailTable.events.count()).toBe(0); // every listener should be removed now
     });
 
     it('makes sure table does not update the menu parent for empty space menus', () => {

--- a/eclipse-scout-core/test/desktop/outline/SearchOutlineSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/SearchOutlineSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Column, EventListener, EventSupport, InitModelOf, Outline, PageWithTable, scout, SearchOutline, SearchPage, SearchState, Session, Table} from '../../../src/index';
+import {Column, InitModelOf, Outline, PageWithTable, scout, SearchOutline, SearchPage, SearchState, Session, Table} from '../../../src/index';
 
 describe('SearchOutline', () => {
   let session: Session;
@@ -323,12 +323,12 @@ describe('SearchOutline', () => {
       const searchPage = createSearchPage(outline, {text: 'SearchPage'});
 
       expect(searchPage.searchState.events.count('propertyChange:resultCount propertyChange:limited propertyChange:pending', outline._searchStateChangeHandler)).toBe(0);
-      expect((searchPage.searchState.events as SpecEventSupport)._eventListeners.filter(listener => listener.type === 'destroy' && listener.origFunc === outline._searchStateDestroyHandler).length).toBe(0);
+      expect(searchPage.searchState.events.count('destroy', outline._searchStateDestroyHandler)).toBe(0);
 
       outline.setSearchStates(new Set([searchPage.searchState]));
 
       expect(searchPage.searchState.events.count('propertyChange:resultCount propertyChange:limited propertyChange:pending', outline._searchStateChangeHandler)).toBe(1);
-      expect((searchPage.searchState.events as SpecEventSupport)._eventListeners.filter(listener => listener.type === 'destroy' && listener.origFunc === outline._searchStateDestroyHandler).length).toBe(1);
+      expect(searchPage.searchState.events.count('destroy', outline._searchStateDestroyHandler)).toBe(1);
     });
   });
 
@@ -340,12 +340,12 @@ describe('SearchOutline', () => {
       outline.setSearchStates(new Set([searchPage.searchState]));
 
       expect(searchPage.searchState.events.count('propertyChange:resultCount propertyChange:limited propertyChange:pending', outline._searchStateChangeHandler)).toBe(1);
-      expect((searchPage.searchState.events as SpecEventSupport)._eventListeners.filter(listener => listener.type === 'destroy' && listener.origFunc === outline._searchStateDestroyHandler).length).toBe(1);
+      expect(searchPage.searchState.events.count('destroy', outline._searchStateDestroyHandler)).toBe(1);
 
       outline.setSearchStates(new Set());
 
       expect(searchPage.searchState.events.count('propertyChange:resultCount propertyChange:limited propertyChange:pending', outline._searchStateChangeHandler)).toBe(0);
-      expect((searchPage.searchState.events as SpecEventSupport)._eventListeners.filter(listener => listener.type === 'destroy' && listener.origFunc === outline._searchStateDestroyHandler).length).toBe(0);
+      expect(searchPage.searchState.events.count('destroy', outline._searchStateDestroyHandler)).toBe(0);
     });
   });
 
@@ -558,9 +558,5 @@ describe('SearchOutline', () => {
     override _validateSearchQuery() {
       super._validateSearchQuery();
     }
-  }
-
-  class SpecEventSupport extends EventSupport {
-    declare _eventListeners: EventListener[];
   }
 });

--- a/eclipse-scout-core/test/events/EventSupportSpec.ts
+++ b/eclipse-scout-core/test/events/EventSupportSpec.ts
@@ -654,11 +654,11 @@ describe('EventSupport', () => {
     });
   });
 
-  describe('registerSubTypePredicate', () => {
+  describe('registerSubTypeProvider', () => {
 
     it('is used to execute specific listeners', () => {
       const eventSupport = new EventSupport();
-      eventSupport.registerSubTypePredicate('fancy', (event: FancyEvent, subType: string) => event?.subType === subType);
+      eventSupport.registerSubTypeProvider('fancy', (event: FancyEvent) => event.subType);
 
       let count = 0;
       let countFoo = 0;

--- a/eclipse-scout-core/test/events/EventSupportSpec.ts
+++ b/eclipse-scout-core/test/events/EventSupportSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,15 +7,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Event, EventListener, EventSupport} from '../../src/index';
+import {Event, EventSupport, scout} from '../../src/index';
 
 describe('EventSupport', () => {
 
-  let count: number, events: SpecEventSupport;
-
-  class SpecEventSupport extends EventSupport {
-    declare _eventListeners: EventListener[];
-  }
+  let count: number, events: EventSupport;
 
   function fooListener() {
     count++;
@@ -24,7 +20,7 @@ describe('EventSupport', () => {
   describe('on / trigger / off', () => {
 
     beforeEach(() => {
-      events = new SpecEventSupport();
+      events = new EventSupport();
       count = 0;
     });
 
@@ -47,10 +43,70 @@ describe('EventSupport', () => {
 
   });
 
+  describe('on', () => {
+
+    it('adds handler for given type', () => {
+      const eventSupport = new EventSupport();
+      const handler = () => {
+      };
+
+      expect(eventSupport.count(null, handler)).toBe(0);
+
+      eventSupport.on('foo', handler);
+      expect(eventSupport.count(null, handler)).toBe(1);
+
+      eventSupport.on('bar', handler);
+      expect(eventSupport.count(null, handler)).toBe(2);
+
+      eventSupport.on('lorem ipsum dolor', handler);
+      expect(eventSupport.count(null, handler)).toBe(3);
+    });
+
+    it('does not remove handler after event is triggered', () => {
+      const eventSupport = new EventSupport();
+      const handler = () => {
+      };
+
+      eventSupport.on('foo', handler);
+      eventSupport.on('bar', handler);
+      eventSupport.on('lorem ipsum dolor', handler);
+      expect(eventSupport.count(null, handler)).toBe(3);
+
+      eventSupport.trigger('foo');
+      eventSupport.trigger('foo');
+      eventSupport.trigger('bar');
+      eventSupport.trigger('ipsum');
+      expect(eventSupport.count(null, handler)).toBe(3);
+    });
+
+    it('adds a handler twice', () => {
+      const eventSupport = new EventSupport();
+      const handler = () => {
+      };
+
+      expect(eventSupport.count(null, handler)).toBe(0);
+
+      eventSupport.on('foo', handler);
+      expect(eventSupport.count(null, handler)).toBe(1);
+
+      eventSupport.on('foo', handler);
+      expect(eventSupport.count(null, handler)).toBe(2);
+
+      eventSupport.on('lorem ipsum dolor', handler);
+      expect(eventSupport.count(null, handler)).toBe(3);
+
+      eventSupport.on('lorem ipsum dolor', handler);
+      expect(eventSupport.count(null, handler)).toBe(4);
+
+      eventSupport.on('lorem', handler);
+      expect(eventSupport.count(null, handler)).toBe(5);
+    });
+  });
+
   describe('one', () => {
 
     beforeEach(() => {
-      events = new SpecEventSupport();
+      events = new EventSupport();
       count = 0;
     });
 
@@ -59,7 +115,7 @@ describe('EventSupport', () => {
       events.trigger('foo');
       events.trigger('foo');
       expect(count).toBe(1);
-      expect(events._eventListeners.length).toBe(0);
+      expect(events.count()).toBe(0);
     });
 
     it('event parameter passed to registered func', () => {
@@ -78,11 +134,74 @@ describe('EventSupport', () => {
 
     it('de-register function registered with one()', () => {
       events.one('foo', fooListener);
-      expect(events._eventListeners.length).toBe(1);
+      expect(events.count()).toBe(1);
       events.off('foo', fooListener);
-      expect(events._eventListeners.length).toBe(0);
+      expect(events.count()).toBe(0);
     });
 
+    it('adds handler for given type', () => {
+      const eventSupport = new EventSupport();
+      const handler = () => {
+      };
+
+      expect(eventSupport.count(null, handler)).toBe(0);
+
+      eventSupport.one('foo', handler);
+      expect(eventSupport.count(null, handler)).toBe(1);
+
+      eventSupport.one('bar', handler);
+      expect(eventSupport.count(null, handler)).toBe(2);
+
+      eventSupport.one('lorem ipsum dolor', handler);
+      expect(eventSupport.count(null, handler)).toBe(3);
+    });
+
+    it('removes handler after event is triggered', () => {
+      const eventSupport = new EventSupport();
+      const handler = () => {
+      };
+
+      eventSupport.one('foo', handler);
+      eventSupport.one('bar', handler);
+      eventSupport.one('lorem ipsum dolor', handler);
+      expect(eventSupport.count(null, handler)).toBe(3);
+
+      eventSupport.trigger('foo');
+      expect(eventSupport.count(null, handler)).toBe(2);
+
+      eventSupport.trigger('foo');
+      expect(eventSupport.count(null, handler)).toBe(2);
+
+      eventSupport.trigger('bar');
+      expect(eventSupport.count(null, handler)).toBe(1);
+
+      // removes all events that were registered together
+      eventSupport.trigger('ipsum');
+      expect(eventSupport.count(null, handler)).toBe(0);
+    });
+
+    it('adds a handler twice', () => {
+      const eventSupport = new EventSupport();
+      const handler = () => {
+      };
+
+      expect(eventSupport.count(null, handler)).toBe(0);
+
+      eventSupport.one('foo', handler);
+      expect(eventSupport.count(null, handler)).toBe(1);
+
+      eventSupport.one('foo', handler);
+      expect(eventSupport.count(null, handler)).toBe(2);
+
+      eventSupport.one('lorem ipsum dolor', handler);
+      expect(eventSupport.count(null, handler)).toBe(3);
+
+      eventSupport.one('lorem ipsum dolor', handler);
+      expect(eventSupport.count(null, handler)).toBe(4);
+
+      eventSupport.one('lorem', handler);
+      expect(eventSupport.count(null, handler)).toBe(5);
+    });
   });
 
   describe('off', () => {
@@ -116,7 +235,7 @@ describe('EventSupport', () => {
     }
 
     beforeEach(() => {
-      events = new SpecEventSupport();
+      events = new EventSupport();
       count = 0;
     });
 
@@ -130,7 +249,7 @@ describe('EventSupport', () => {
       events.one('asdf', fooListener6);
       events.one('asdf', fooListener7);
       events.off('foo');
-      expect(events._eventListeners.length).toBe(6);
+      expect(events.count()).toBe(6);
     });
 
     it('remove specific listener', () => {
@@ -143,7 +262,439 @@ describe('EventSupport', () => {
       events.one('asdf', fooListener6);
       events.one('asdf', fooListener7);
       events.off('foo', fooListener);
-      expect(events._eventListeners.length).toBe(7);
+      expect(events.count()).toBe(7);
+    });
+
+    it('removes handler', () => {
+      const eventSupport = new EventSupport();
+      const handler1 = () => {
+      };
+      const handler2 = () => {
+      };
+
+      eventSupport.on('foo', handler1);
+      eventSupport.on('foo', handler2);
+      eventSupport.on('bar', handler1);
+      eventSupport.on('bar', handler2);
+      eventSupport.on('lorem ipsum dolor', handler1);
+      eventSupport.on('lorem', handler1);
+      eventSupport.on('lorem', handler1);
+      eventSupport.on('lorem', handler1);
+      eventSupport.on('dolor', handler1);
+
+      expect(eventSupport.count(null, handler1)).toBe(7);
+      expect(eventSupport.count(null, handler2)).toBe(2);
+      expect(eventSupport.count('foo', handler1)).toBe(1);
+      expect(eventSupport.count('foo', handler2)).toBe(1);
+      expect(eventSupport.count('bar', handler1)).toBe(1);
+      expect(eventSupport.count('bar', handler2)).toBe(1);
+      expect(eventSupport.count('lorem ipsum dolor', handler1)).toBe(1);
+      expect(eventSupport.count('lorem', handler1)).toBe(4);
+      expect(eventSupport.count('ipsum', handler1)).toBe(1);
+      expect(eventSupport.count('dolor', handler1)).toBe(2);
+
+      eventSupport.off('foo', handler1);
+      expect(eventSupport.count(null, handler1)).toBe(6);
+      expect(eventSupport.count(null, handler2)).toBe(2);
+      expect(eventSupport.count('foo', handler1)).toBe(0);
+      expect(eventSupport.count('foo', handler2)).toBe(1);
+
+      eventSupport.off('foo', handler1);
+      expect(eventSupport.count(null, handler1)).toBe(6);
+      expect(eventSupport.count(null, handler2)).toBe(2);
+
+      eventSupport.off('bar');
+      expect(eventSupport.count(null, handler1)).toBe(5);
+      expect(eventSupport.count(null, handler2)).toBe(1);
+      expect(eventSupport.count('bar', handler1)).toBe(0);
+      expect(eventSupport.count('bar', handler2)).toBe(0);
+
+      eventSupport.off('ipsum', handler1);
+      expect(eventSupport.count(null, handler1)).toBe(5);
+      expect(eventSupport.count('lorem ipsum dolor', handler1)).toBe(1);
+      expect(eventSupport.count('lorem', handler1)).toBe(4);
+      expect(eventSupport.count('ipsum', handler1)).toBe(1);
+      expect(eventSupport.count('dolor', handler1)).toBe(2);
+
+      eventSupport.off('ipsum');
+      expect(eventSupport.count(null, handler1)).toBe(5);
+      expect(eventSupport.count('lorem ipsum dolor', handler1)).toBe(1);
+      expect(eventSupport.count('lorem', handler1)).toBe(4);
+      expect(eventSupport.count('ipsum', handler1)).toBe(1);
+      expect(eventSupport.count('dolor', handler1)).toBe(2);
+
+      // type need to match exactly
+      eventSupport.off('ipsum lorem dolor', handler1);
+      expect(eventSupport.count(null, handler1)).toBe(5);
+      expect(eventSupport.count('lorem ipsum dolor', handler1)).toBe(1);
+      expect(eventSupport.count('lorem', handler1)).toBe(4);
+      expect(eventSupport.count('ipsum', handler1)).toBe(1);
+      expect(eventSupport.count('dolor', handler1)).toBe(2);
+
+      eventSupport.off('lorem ipsum dolor', handler1);
+      expect(eventSupport.count(null, handler1)).toBe(4);
+      expect(eventSupport.count('lorem ipsum dolor', handler1)).toBe(0);
+      expect(eventSupport.count('lorem', handler1)).toBe(3);
+      expect(eventSupport.count('ipsum', handler1)).toBe(0);
+      expect(eventSupport.count('dolor', handler1)).toBe(1);
+
+      eventSupport.off(null, handler1);
+      expect(eventSupport.count(null, handler1)).toBe(0);
+      expect(eventSupport.count('lorem', handler1)).toBe(0);
+      expect(eventSupport.count('dolor', handler1)).toBe(0);
+    });
+  });
+
+  describe('when', () => {
+
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    it('is resolved on the next event', () => {
+      const eventSupport = new EventSupport();
+      let fooCount = 0;
+      let barCount = 0;
+
+      eventSupport.trigger('foo');
+      eventSupport.trigger('bar');
+      jasmine.clock().tick(10);
+      expect(fooCount).toBe(0);
+      expect(barCount).toBe(0);
+
+      eventSupport.when('foo').then(() => fooCount++);
+      eventSupport.when('bar').then(() => barCount++);
+
+      eventSupport.trigger('foo');
+      jasmine.clock().tick(10);
+      expect(fooCount).toBe(1);
+      expect(barCount).toBe(0);
+
+      eventSupport.trigger('bar');
+      jasmine.clock().tick(10);
+      expect(fooCount).toBe(1);
+      expect(barCount).toBe(1);
+
+      eventSupport.trigger('foo');
+      eventSupport.trigger('bar');
+      jasmine.clock().tick(10);
+      expect(fooCount).toBe(1);
+      expect(barCount).toBe(1);
+
+      eventSupport.when('foo').then(() => fooCount++);
+      eventSupport.when('bar').then(() => barCount++);
+
+      eventSupport.trigger('foo');
+      eventSupport.trigger('bar');
+      jasmine.clock().tick(10);
+      expect(fooCount).toBe(2);
+      expect(barCount).toBe(2);
+    });
+  });
+
+  describe('addListener', () => {
+
+    it('adds listener if it does not exist', () => {
+      const eventSupport = new EventSupport();
+      const listener1 = {
+        func: () => {
+        }
+      };
+      const listener2 = {
+        type: 'foo',
+        func: () => {
+        }
+      };
+      const listener3 = {
+        type: 'lorem ipsum dolor',
+        func: () => {
+        }
+      };
+
+      expect(eventSupport.count()).toBe(0);
+
+      eventSupport.addListener(listener1);
+      expect(eventSupport.count()).toBe(1);
+
+      eventSupport.addListener(listener1);
+      expect(eventSupport.count()).toBe(1);
+
+      eventSupport.addListener(listener2);
+      expect(eventSupport.count()).toBe(2);
+
+      eventSupport.addListener(listener2);
+      expect(eventSupport.count()).toBe(2);
+
+      eventSupport.addListener(listener3);
+      expect(eventSupport.count()).toBe(3);
+
+      eventSupport.addListener(listener3);
+      expect(eventSupport.count()).toBe(3);
+
+      // new instance
+      eventSupport.addListener({...listener3});
+      expect(eventSupport.count()).toBe(4);
+    });
+  });
+
+  describe('removeListener', () => {
+
+    it('removes listener if it does exist', () => {
+      const eventSupport = new EventSupport();
+      const listener1 = {
+        func: () => {
+        }
+      };
+      const listener2 = {
+        type: 'foo',
+        func: () => {
+        }
+      };
+      const listener3 = {
+        type: 'lorem ipsum dolor',
+        func: () => {
+        }
+      };
+
+      eventSupport.addListener(listener1);
+      eventSupport.addListener(listener2);
+      eventSupport.addListener(listener3);
+      eventSupport.addListener({...listener3});
+
+      expect(eventSupport.count()).toBe(4);
+
+      eventSupport.removeListener(listener1);
+      expect(eventSupport.count()).toBe(3);
+
+      eventSupport.removeListener(listener1);
+      expect(eventSupport.count()).toBe(3);
+
+      eventSupport.removeListener(listener2);
+      expect(eventSupport.count()).toBe(2);
+
+      eventSupport.removeListener(listener2);
+      expect(eventSupport.count()).toBe(2);
+
+      eventSupport.removeListener(listener3);
+      expect(eventSupport.count()).toBe(1);
+
+      eventSupport.removeListener(listener3);
+      expect(eventSupport.count()).toBe(1);
+
+      eventSupport.removeListener({...listener3});
+      expect(eventSupport.count()).toBe(1);
+    });
+  });
+
+  describe('count', () => {
+
+    it('gives total count if no argument is provided', () => {
+      const eventSupport = new EventSupport();
+      const handler1 = () => {
+      };
+      const handler2 = () => {
+      };
+
+      eventSupport.on('foo', handler1);
+      eventSupport.one('foo', handler2);
+
+      eventSupport.on('', handler2);
+      eventSupport.on(null, handler2);
+
+      eventSupport.on('lorem ipsum dolor', handler1);
+      eventSupport.on('ipsum', handler2);
+
+      expect(eventSupport.count()).toBe(6);
+    });
+
+    it('filters by type if type argument is provided', () => {
+      const eventSupport = new EventSupport();
+      const handler1 = () => {
+      };
+      const handler2 = () => {
+      };
+
+      eventSupport.on('foo', handler1);
+      eventSupport.one('foo', handler2);
+
+      eventSupport.on('', handler2);
+      eventSupport.on(null, handler2);
+
+      eventSupport.on('lorem ipsum dolor', handler1);
+      eventSupport.on('ipsum', handler2);
+
+      expect(eventSupport.count('foo')).toBe(2);
+      expect(eventSupport.count('bar')).toBe(0);
+      expect(eventSupport.count('lorem ipsum dolor')).toBe(1);
+      expect(eventSupport.count('lorem')).toBe(1);
+      expect(eventSupport.count('ipsum')).toBe(2);
+      expect(eventSupport.count('dolor')).toBe(1);
+    });
+
+    it('filters by func if func argument is provided', () => {
+      const eventSupport = new EventSupport();
+      const handler1 = () => {
+      };
+      const handler2 = () => {
+      };
+
+      eventSupport.on('foo', handler1);
+      eventSupport.one('foo', handler2);
+
+      eventSupport.on('', handler2);
+      eventSupport.on(null, handler2);
+
+      eventSupport.on('lorem ipsum dolor', handler1);
+      eventSupport.on('ipsum', handler2);
+
+      expect(eventSupport.count(null, handler1)).toBe(2);
+      expect(eventSupport.count(null, handler2)).toBe(4);
+    });
+
+    it('filters by type and func if both argument are provided', () => {
+      const eventSupport = new EventSupport();
+      const handler1 = () => {
+      };
+      const handler2 = () => {
+      };
+
+      eventSupport.on('foo', handler1);
+      eventSupport.one('foo', handler2);
+
+      eventSupport.on('', handler2);
+      eventSupport.on(null, handler2);
+
+      eventSupport.on('lorem ipsum dolor', handler1);
+      eventSupport.on('ipsum', handler2);
+
+      expect(eventSupport.count('foo', handler1)).toBe(1);
+      expect(eventSupport.count('foo', handler2)).toBe(1);
+      expect(eventSupport.count('bar', handler1)).toBe(0);
+      expect(eventSupport.count('bar', handler2)).toBe(0);
+      expect(eventSupport.count('lorem', handler1)).toBe(1);
+      expect(eventSupport.count('lorem', handler2)).toBe(0);
+      expect(eventSupport.count('ipsum', handler1)).toBe(1);
+      expect(eventSupport.count('ipsum', handler2)).toBe(1);
+      expect(eventSupport.count('dolor', handler1)).toBe(1);
+      expect(eventSupport.count('dolor', handler2)).toBe(0);
+    });
+  });
+
+  describe('types', () => {
+
+    it('returns a distinct list of types', () => {
+      const eventSupport = new EventSupport();
+      const handler1 = () => {
+      };
+      const handler2 = () => {
+      };
+
+      eventSupport.on('foo', handler1);
+      eventSupport.one('foo', handler2);
+      expect(eventSupport.types()).toEqual(['foo']);
+
+      eventSupport.on('', handler2);
+      expect(eventSupport.types()).toEqual(['foo']);
+
+      eventSupport.on(null, handler2);
+      expect(eventSupport.types()).toEqual(['foo']);
+
+      eventSupport.on('lorem ipsum dolor', handler1);
+      expect(eventSupport.types()).toEqual(['foo', 'lorem', 'ipsum', 'dolor']);
+
+      eventSupport.on('ipsum', handler2);
+      expect(eventSupport.types()).toEqual(['foo', 'lorem', 'ipsum', 'dolor']);
+    });
+  });
+
+  describe('trigger', () => {
+
+    it('triggers each listener once', () => {
+      const eventSupport = new EventSupport();
+      let count1 = 0;
+      let count2 = 0;
+      const handler1 = () => count1++;
+      const handler2 = () => count2++;
+
+      eventSupport.on('foo', handler1);
+      eventSupport.on('foo', handler2);
+
+      eventSupport.on('bar', handler2);
+
+      eventSupport.on('lorem ipsum dolor', handler1);
+      eventSupport.on('lorem', handler1);
+      eventSupport.on('ipsum dolor', handler2);
+
+      expect(count1).toBe(0);
+      expect(count2).toBe(0);
+
+      eventSupport.trigger('foo');
+      expect(count1).toBe(1);
+      expect(count2).toBe(1);
+
+      eventSupport.trigger('bar');
+      expect(count1).toBe(1);
+      expect(count2).toBe(2);
+
+      eventSupport.trigger('lorem');
+      expect(count1).toBe(3);
+      expect(count2).toBe(2);
+
+      eventSupport.trigger('ipsum');
+      expect(count1).toBe(4);
+      expect(count2).toBe(3);
+
+      eventSupport.trigger('dolor');
+      expect(count1).toBe(5);
+      expect(count2).toBe(4);
+    });
+  });
+
+  describe('registerSubTypePredicate', () => {
+
+    it('is used to execute specific listeners', () => {
+      const eventSupport = new EventSupport();
+      eventSupport.registerSubTypePredicate('fancy', (event: FancyEvent, subType: string) => event?.subType === subType);
+
+      let count = 0;
+      let countFoo = 0;
+      let countBar = 0;
+
+      eventSupport.on('fancy', e => count++);
+      eventSupport.on('fancy:foo', e => countFoo++);
+      eventSupport.on('fancy:bar', e => countBar++);
+
+      expect(count).toBe(0);
+      expect(countFoo).toBe(0);
+      expect(countBar).toBe(0);
+
+      eventSupport.trigger('fancy', new FancyEvent('not-existing'));
+      expect(count).toBe(1);
+      expect(countFoo).toBe(0);
+      expect(countBar).toBe(0);
+
+      eventSupport.trigger('fancy', new FancyEvent('foo'));
+      expect(count).toBe(2);
+      expect(countFoo).toBe(1);
+      expect(countBar).toBe(0);
+
+      eventSupport.trigger('fancy', new FancyEvent('bar'));
+      expect(count).toBe(3);
+      expect(countFoo).toBe(1);
+      expect(countBar).toBe(1);
     });
   });
 });
+
+class FancyEvent extends Event {
+  subType: string;
+
+  constructor(subType: string) {
+    super();
+    this.subType = scout.assertValue(subType);
+  }
+}

--- a/eclipse-scout-core/test/table/TableFooterSpec.ts
+++ b/eclipse-scout-core/test/table/TableFooterSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -43,13 +43,13 @@ describe('TableFooterSpec', () => {
       let table = helper.createTable(model);
       table.render();
       expect(table.footer).not.toBeUndefined();
-      let listenerCount = table.events._eventListeners.length;
+      let listenerCount = table.events.count();
 
       table.setTableStatusVisible(false);
       table.setTableStatusVisible(true);
 
       // Still same amount of listeners expected after footer visibility changed
-      expect(table.events._eventListeners.length).toBe(listenerCount);
+      expect(table.events.count()).toBe(listenerCount);
     });
 
   });

--- a/eclipse-scout-core/test/table/TableHeaderSpec.ts
+++ b/eclipse-scout-core/test/table/TableHeaderSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,13 +35,13 @@ describe('TableHeaderSpec', () => {
       let table = helper.createTable(model);
       table.render();
       expect(table.header).not.toBeUndefined();
-      let listenerCount = table.events._eventListeners.length;
+      let listenerCount = table.events.count();
 
       table.setHeaderVisible(false);
       table.setHeaderVisible(true);
 
       // Still same amount of listeners expected after header visibility changed
-      expect(table.events._eventListeners.length).toBe(listenerCount);
+      expect(table.events.count()).toBe(listenerCount);
     });
 
   });

--- a/eclipse-scout-core/test/widget/WidgetSpec.ts
+++ b/eclipse-scout-core/test/widget/WidgetSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1173,19 +1173,19 @@ describe('Widget', () => {
       expect(widget.parent).toBe(parent);
       expect(another.parent).toBe(parent);
 
-      let widgetListenerCount = widget.events._eventListeners.length;
-      let parentListenerCount = parent.events._eventListeners.length;
+      let widgetListenerCount = widget.events.count();
+      let parentListenerCount = parent.events.count();
       another.setParent(widget);
-      expect(parent.events._eventListeners.length).toBe(parentListenerCount - 1);
-      expect(widget.events._eventListeners.length).toBe(widgetListenerCount + 1);
+      expect(parent.events.count()).toBe(parentListenerCount - 1);
+      expect(widget.events.count()).toBe(widgetListenerCount + 1);
 
       another.setParent(parent);
-      expect(parent.events._eventListeners.length).toBe(parentListenerCount);
-      expect(widget.events._eventListeners.length).toBe(widgetListenerCount);
+      expect(parent.events.count()).toBe(parentListenerCount);
+      expect(widget.events.count()).toBe(widgetListenerCount);
 
       // Ensure parent destroy listener is removed on destroy
       another.destroy();
-      expect(parent.events._eventListeners.length).toBe(parentListenerCount - 1);
+      expect(parent.events.count()).toBe(parentListenerCount - 1);
     });
 
     it('triggers hierarchyChange event when parent changes', () => {


### PR DESCRIPTION
Store the registered events in a Map where the single event type a
listener is registered for is the key. So when an event is triggered
not all listeners need to be checked whether they need to be triggered
but only those with the correct types. This gives a huge performance
boost when dealing with huge amounts of listeners and triggered events.
Consider e.g. a hybrid action creating several thousands of widgets.
Typically, there will be a listener for each of these widgets and the
HybridManager will trigger a widgetAdd-event for each of these widgets.
Storing the listeners in an array like the former implementation led to
the array of several thousand listeners being processed for every of the
several thousand widgets which is O(n^2).

458889