### PR TITLE
Allow skipping of property resolving if it is not found

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/config/PropertiesUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/config/PropertiesUtilityTest.java
@@ -15,7 +15,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
+import java.util.function.BinaryOperator;
 
 import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.junit.Assert;
@@ -125,5 +127,32 @@ public class PropertiesUtilityTest {
       System.clearProperty(ATTR_STRING_KEY);
       System.clearProperty(attrOtherSystemPropertyKey);
     }
+  }
+
+  @Test
+  public void testResolveValue() {
+    Map<String, String> mappings = Map.of("attributeA", "valueA", "attributeB", "valueB", "combinedA", "${attributeA}${attributeB}", "combinedB", "${combinedB}", "combinedC", "${attributeA}${attributeC}");
+    BinaryOperator<String> variableReplacer = (p, k) -> mappings.get(k);
+
+    // Simple resolving
+    assertEquals("valueA", PropertiesUtility.resolveValue("key1", "${attributeA}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, true, false));
+    assertEquals("valueB", PropertiesUtility.resolveValue("key1", "${attributeB}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, true, false));
+
+    // Recursive resolving
+    assertEquals("valueAvalueB", PropertiesUtility.resolveValue("key1", "${attributeA}${attributeB}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, true, false));
+    assertEquals("valueAvalueB", PropertiesUtility.resolveValue("key1", "${combinedA}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, true, false));
+
+    // Unresolvable variables
+    assertThrows(IllegalArgumentException.class, () -> PropertiesUtility.resolveValue("key1", "${attributeC}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, true, false));
+    assertEquals("${attributeC}", PropertiesUtility.resolveValue("key1", "${attributeC}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, false, false));
+
+    // Loop detection
+    assertThrows(IllegalArgumentException.class, () -> PropertiesUtility.resolveValue("key1", "${combinedCB}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, true, false));
+
+    // Ignoring unresolvable variables
+    assertEquals("${attributeA}${attributeC}", PropertiesUtility.resolveValue("key1", "${attributeA}${attributeC}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, false, false));
+    assertEquals("${attributeA}${attributeC}", PropertiesUtility.resolveValue("key1", "${combinedC}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, false, false));
+    assertEquals("valueA${attributeC}", PropertiesUtility.resolveValue("key1", "${attributeA}${attributeC}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, false, true));
+    assertEquals("valueA${attributeC}", PropertiesUtility.resolveValue("key1", "${combinedC}", PropertiesUtility.DEFAULT_VARIABLE_PATTERN, variableReplacer, false, true));
   }
 }

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/PropertiesUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/config/PropertiesUtility.java
@@ -120,6 +120,26 @@ public class PropertiesUtility {
    */
   @SuppressWarnings("squid:S1149")
   public static String resolveValue(String propertyKey, String value, Pattern variablePattern, BinaryOperator<String> variableReplacer, boolean failOnProblems) {
+    return resolveValue(propertyKey, value, variablePattern, variableReplacer, failOnProblems, false);
+  }
+
+  /**
+   * Resolves all variables of format <code>${variableName}</code> in the given expression according to the current
+   * application context.
+   *
+   * @param propertyKey
+   *     The key of the property to resolve.
+   * @param value
+   *     The expression to resolve.
+   * @param variablePattern
+   *     The pattern for variables, such as <code>${var}</code>. The pattern must contain group(1) as the variable
+   *     name upon a match.
+   * @param variableReplacer
+   *     maps a variable name to its variable value
+   * @return A {@link String} where all variables have been replaced with their values.
+   */
+  @SuppressWarnings("squid:S1149")
+  public static String resolveValue(String propertyKey, String value, Pattern variablePattern, BinaryOperator<String> variableReplacer, boolean failOnProblems, boolean ignoreNotFoundValues) {
     Matcher m = variablePattern.matcher(value);
     boolean found = m.find();
     if (!found) {
@@ -134,12 +154,18 @@ public class PropertiesUtility {
         String variableName = m.group(1);
         String replacement = variableReplacer.apply(propertyKey, variableName);
         if (!StringUtility.hasText(replacement)) {
-          if (failOnProblems) {
-            throw new IllegalArgumentException("resolving expression '" + value + "': variable ${" + variableName + "} is not defined in the context.");
+          if (ignoreNotFoundValues) {
+            // Don't replace at all
+            replacement = m.group(0);
           }
           else {
-            LOG.debug("resolving expression '" + value + "': variable ${" + variableName + "} is not defined in the context.");
-            return t;
+            if (failOnProblems) {
+              throw new IllegalArgumentException("resolving expression '" + value + "': variable ${" + variableName + "} is not defined in the context.");
+            }
+            else {
+              LOG.debug("resolving expression '" + value + "': variable ${" + variableName + "} is not defined in the context.");
+              return t;
+            }
           }
         }
         if (replacement.contains(value)) {


### PR DESCRIPTION
If PropertiesUtility.resolveValue is called for the value "${attributeA}${attributeB}" and attributeB is not defined, the result is "${attributeA}${attributeB}". With this change "ignoreNotFoundValues" may be set to true and the result will be "valueA${attributeB}".