### PR TITLE
Don't handle key events if input is disabled

### DIFF
--- a/eclipse-scout-core/src/form/fields/datefield/DateField.ts
+++ b/eclipse-scout-core/src/form/fields/datefield/DateField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -805,6 +805,10 @@ export class DateField extends ValueField<Date, Date | string> implements DateFi
    * in _onDateFieldInput(), which is fired after 'keydown'.
    */
   protected _onDateFieldKeyDown(event: JQuery.KeyDownEvent) {
+    if (!this.enabledComputed) {
+      return;
+    }
+
     let delta = 0,
       diffYears = 0,
       diffMonths = 0,
@@ -1036,6 +1040,10 @@ export class DateField extends ValueField<Date, Date | string> implements DateFi
    * in _onTimeFieldInput(), which is fired after 'keydown'.
    */
   protected _onTimeFieldKeyDown(event: JQuery.KeyDownEvent) {
+    if (!this.enabledComputed) {
+      return;
+    }
+
     let delta = 0,
       diffHours = 0,
       diffMinutes = 0,

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.less
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.less
@@ -56,7 +56,7 @@
     width: 100%;
     padding-left: @text-field-padding-x;
 
-    &:focus {
+    &:focus:not(.disabled) {
       border-bottom-right-radius: @control-border-radius;
       border-bottom-left-radius: @control-border-radius;
     }
@@ -75,13 +75,9 @@
       &.has-error {
         border-bottom-color: @error-border-color;
       }
-    }
 
-    &.read-only {
-      border-bottom-color: @border-color;
-
-      &.has-error {
-        border-bottom-color: @error-border-color;
+      &.disabled {
+        border-bottom-color: @text-field-alternative-disabled-border-color;
       }
     }
   }
@@ -99,6 +95,7 @@
 
     &.disabled {
       background-color: @control-disabled-background-color;
+      border-color: @control-disabled-border-color;
     }
   }
 

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -196,8 +196,8 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
 
     if (!this.touchMode) {
       $field
-        .keyup(this._onFieldKeyUp.bind(this))
-        .keydown(this._onFieldKeyDown.bind(this))
+        .on('keydown', this._onFieldKeyDown.bind(this))
+        .on('keyup', this._onFieldKeyUp.bind(this))
         .on('input', this._onFieldInput.bind(this));
     }
     this.addField($field);
@@ -1205,6 +1205,10 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
   }
 
   protected _onFieldKeyUp(event: JQuery.KeyUpEvent) {
+    if (!this.enabledComputed) {
+      return;
+    }
+
     // Escape
     if (event.which === keys.ESC) {
       return;
@@ -1265,6 +1269,10 @@ export class SmartField<TValue> extends ValueField<TValue> implements SmartField
   }
 
   protected _onFieldKeyDown(event: JQuery.KeyDownEvent) {
+    if (!this.enabledComputed) {
+      return;
+    }
+
     this._updateUserWasTyping(event);
 
     // We must prevent default focus handling

--- a/eclipse-scout-core/src/form/fields/smartfield/SmartFieldMultiline.ts
+++ b/eclipse-scout-core/src/form/fields/smartfield/SmartFieldMultiline.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,8 +33,8 @@ export class SmartFieldMultiline<TValue> extends SmartField<TValue> {
 
     if (!this.touchMode) {
       $input
-        .keyup(this._onFieldKeyUp.bind(this))
-        .keydown(this._onFieldKeyDown.bind(this))
+        .on('keydown', this._onFieldKeyDown.bind(this))
+        .on('keyup', this._onFieldKeyUp.bind(this))
         .on('input', this._onFieldInput.bind(this));
     }
     this.addField($input);

--- a/eclipse-scout-core/src/form/fields/tagfield/TagField.ts
+++ b/eclipse-scout-core/src/form/fields/tagfield/TagField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -258,6 +258,10 @@ export class TagField extends ValueField<string[]> implements TagFieldModel {
   }
 
   protected _onInputKeydown(event: JQuery.KeyDownEvent) {
+    if (!this.enabledComputed) {
+      return;
+    }
+
     if (this._isNavigationKey(event) && this.popup) {
       this.popup.delegateKeyEvent(event);
     } else if (event.which === keys.ESC) {
@@ -275,6 +279,10 @@ export class TagField extends ValueField<string[]> implements TagFieldModel {
   }
 
   protected _onInputKeyup(event: JQuery.KeyUpEvent) {
+    if (!this.enabledComputed) {
+      return;
+    }
+
     // Prevent chooser popup from being opened again, after it has been closed by pressing ESC
     if (event.which === keys.ESC) {
       return;

--- a/eclipse-scout-core/src/keystroke/KeyStrokeManager.ts
+++ b/eclipse-scout-core/src/keystroke/KeyStrokeManager.ts
@@ -48,12 +48,12 @@ export class KeyStrokeManager extends EventEmitter implements KeyStrokeManagerMo
 
     if (this.swallowF1) {
       $container
-        .keydown(helpHandler)
-        .keyup(helpHandler);
+        .on('keydown', helpHandler)
+        .on('keyup', helpHandler);
     }
     $container
-      .keydown(backspaceHandler)
-      .keyup(backspaceHandler);
+      .on('keydown', backspaceHandler)
+      .on('keyup', backspaceHandler);
 
     if ('onhelp' in myWindow) {
       myWindow['onhelp'] = filters.returnFalse;

--- a/eclipse-scout-core/src/testing/form/fields/smartfield/SpecSmartField.ts
+++ b/eclipse-scout-core/src/testing/form/fields/smartfield/SpecSmartField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,10 @@ export class SpecSmartField extends SmartField<number> {
 
   override _readSearchText(): string {
     return super._readSearchText();
+  }
+
+  override _onFieldKeyDown(event: JQuery.KeyDownEvent) {
+    super._onFieldKeyDown(event);
   }
 
   override _onFieldKeyUp(event: JQuery.KeyUpEvent) {

--- a/eclipse-scout-core/test/form/fields/datefield/DateFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/datefield/DateFieldSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -652,6 +652,20 @@ describe('DateField', () => {
         dateField.acceptInput();
         expect(dates.isSameDay(dateField.value, dates.newDate())).toBe(true);
         expectTime(dateField.value, expectedTime.getHours(), expectedTime.getMinutes(), expectedTime.getSeconds());
+      });
+
+      it('does not open the picker if field is disabled', () => {
+        let dateField = scout.create(DateField, {
+          parent: session.desktop,
+          hasTime: true,
+          enabled: false
+        });
+        dateField.render();
+        JQueryTesting.triggerKeyDown(dateField.$dateField, keys.DOWN);
+        expect(dateField.popup).toBe(undefined);
+
+        JQueryTesting.triggerKeyDown(dateField.$timeField, keys.DOWN);
+        expect(dateField.popup).toBe(undefined);
       });
 
       it('selects the current date if picker is open and no date is selected', () => {

--- a/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.ts
+++ b/eclipse-scout-core/test/form/fields/smartfield/SmartFieldSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -902,10 +902,9 @@ describe('SmartField', () => {
       expect(field._userWasTyping).toBe(false);
 
       // send a regular key-press (no navigation)
-      // @ts-expect-error
-      field._onFieldKeyDown({
+      field._onFieldKeyDown($.Event('keydown', {
         which: keys.A
-      });
+      }) as JQuery.KeyDownEvent);
       expect(field._userWasTyping).toBe(true);
 
       // when the display text is set, reset the userWasTyping flag
@@ -918,6 +917,32 @@ describe('SmartField', () => {
       expect(field._userWasTyping).toBe(false);
     });
 
+    it('calls openPopup() when DOWN is pressed', () => {
+      field.render();
+      field.openPopup = browse => {
+        return null;
+      };
+
+      spyOn(field, 'openPopup');
+      field._onFieldKeyDown($.Event('keydown', {
+        which: keys.DOWN
+      }) as JQuery.KeyDownEvent);
+      expect(field.openPopup).toHaveBeenCalled();
+    });
+
+    it('does not call openPopup() if field is disabled and DOWN is pressed', () => {
+      field.setEnabled(false);
+      field.render();
+      field.openPopup = browse => {
+        return null;
+      };
+
+      spyOn(field, 'openPopup');
+      field._onFieldKeyDown($.Event('keydown', {
+        which: keys.DOWN
+      }) as JQuery.KeyDownEvent);
+      expect(field.openPopup).not.toHaveBeenCalled();
+    });
   });
 
   describe('_onFieldKeyUp', () => {
@@ -926,25 +951,51 @@ describe('SmartField', () => {
       field = createFieldWithLookupCall();
     });
 
+    it('calls openPopup() when character is pressed', () => {
+      field.render();
+      field.openPopup = browse => {
+        return null;
+      };
+
+      spyOn(field, 'openPopup');
+      field._onFieldKeyUp($.Event('keyup', {
+        which: keys.A
+      }) as JQuery.KeyUpEvent);
+      expect(field.openPopup).toHaveBeenCalled();
+    });
+
+    it('does not call openPopup() if field is disabled and character is pressed', () => {
+      field.setEnabled(false);
+      field.render();
+      field.openPopup = browse => {
+        return null;
+      };
+
+      spyOn(field, 'openPopup');
+      field._onFieldKeyUp($.Event('keyup', {
+        which: keys.A
+      }) as JQuery.KeyUpEvent);
+      expect(field.openPopup).not.toHaveBeenCalled();
+    });
+
     it('does not call openPopup() when TAB, CTRL or ALT has been pressed', () => {
       field.render();
       field.openPopup = browse => {
         return null;
       };
 
-      let keyEvents = [{
+      let keyEvents = [$.Event('keyup', {
         which: keys.TAB
-      }, {
+      }) as JQuery.KeyUpEvent, $.Event('keyup', {
         ctrlKey: true,
         which: keys.A
-      }, {
+      }) as JQuery.KeyUpEvent, $.Event('keyup', {
         altKey: true,
         which: keys.A
-      }];
+      }) as JQuery.KeyUpEvent];
 
       spyOn(field, 'openPopup');
       keyEvents.forEach(event => {
-        // @ts-expect-error
         field._onFieldKeyUp(event);
       });
       expect(field.openPopup).not.toHaveBeenCalled();
@@ -956,12 +1007,10 @@ describe('SmartField', () => {
       field._lookupByTextOrAll = () => {
         return null;
       };
-      let event = {
-        which: keys.A
-      };
       spyOn(field, '_lookupByTextOrAll').and.callThrough();
-      // @ts-expect-error
-      field._onFieldKeyUp(event);
+      field._onFieldKeyUp($.Event('keyup', {
+        which: keys.A
+      }) as JQuery.KeyUpEvent);
       expect(field._lookupByTextOrAll).toHaveBeenCalled();
     });
 
@@ -1221,8 +1270,7 @@ describe('SmartField', () => {
       field.render();
       field.$field.focus(); // must be focused, otherwise popup will not open
       field.$field.val('Bar');
-      // @ts-expect-error
-      field._onFieldKeyUp({});
+      field._onFieldKeyUp($.Event('keyup', {}) as JQuery.KeyUpEvent);
       jasmine.clock().tick(500);
       let popup = field.popup as SmartFieldPopup<any>;
       expect(popup.proposalChooser.content.rows[0].cells[0].text).toBe('Bar');

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/SmartFieldUIFacade.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/form/fields/smartfield/SmartFieldUIFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,9 @@ public class SmartFieldUIFacade<VALUE> implements ISmartFieldUIFacade<VALUE> {
 
   @Override
   public void setDisplayTextFromUI(String text) {
+    if (!m_smartField.isEnabledIncludingParents() || !m_smartField.isVisibleIncludingParents()) {
+      return;
+    }
     m_smartField.setDisplayText(text);
   }
 
@@ -42,11 +45,17 @@ public class SmartFieldUIFacade<VALUE> implements ISmartFieldUIFacade<VALUE> {
 
   @Override
   public void setLookupRowFromUI(ILookupRow<VALUE> lookupRow) {
+    if (!m_smartField.isEnabledIncludingParents() || !m_smartField.isVisibleIncludingParents()) {
+      return;
+    }
     m_smartField.setValueByLookupRow(lookupRow);
   }
 
   @Override
   public void setValueFromUI(VALUE value) {
+    if (!m_smartField.isEnabledIncludingParents() || !m_smartField.isVisibleIncludingParents()) {
+      return;
+    }
     m_smartField.setValue(value);
   }
 


### PR DESCRIPTION
Since ticket 423418, disabled inputs are set to readonly which makes them focusable by click and key events are triggered. This means, custom key handlers need to check the enabledComputed property to ensure the handlers do nothing if the input is disabled. KeyStrokes already do this by default, so they don't have to be adjusted.

458474