### PR TITLE
ClipboardField: restore InputFieldKeyStrokeContext

### DIFF
--- a/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.ts
+++ b/eclipse-scout-core/src/form/fields/clipboardfield/ClipboardField.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, BlobWithName, ClipboardFieldModel, Device, DragAndDropOptions, FatalMessageOptions, keys, mimeTypes, scout, Session, strings, ValueField} from '../../../index';
+import {arrays, BlobWithName, ClipboardFieldModel, Device, DragAndDropOptions, FatalMessageOptions, InputFieldKeyStrokeContext, keys, KeyStrokeContext, mimeTypes, scout, Session, strings, ValueField} from '../../../index';
 import $ from 'jquery';
 
 export class ClipboardField extends ValueField<string> implements ClipboardFieldModel {
@@ -62,6 +62,10 @@ export class ClipboardField extends ValueField<string> implements ClipboardField
     keys.BACKSPACE,
     keys.DELETE
   ];
+
+  protected override _createKeyStrokeContext(): KeyStrokeContext {
+    return new InputFieldKeyStrokeContext();
+  }
 
   protected override _render() {
     // We don't use makeDiv() here intentionally because the DIV created must


### PR DESCRIPTION
In the previous refactoring, the InputFieldKeyStrokeContext was removed from the ClipboardField, assuming it was unnecessary for a read-only field. However, this also removed some "stop propagation" flags, which are still needed to prevent outline keystrokes being triggered while the modal ClipboardForm is open. Restoring the context re-enables those flags and prevents unwanted keystroke handling.

378797