### PR TITLE
Fail build in case of webpack errors

### DIFF
--- a/eclipse-scout-cli/bin/scout-scripts.js
+++ b/eclipse-scout-cli/bin/scout-scripts.js
@@ -244,6 +244,7 @@ function createWebpackCompiler(configFilePath, args) {
 function logWebpack(err, stats, statsConfig) {
   if (err) {
     console.error(err);
+    process.exitCode = 2; // let the webpack build fail on errors
     return;
   }
   const info = stats.toJson();


### PR DESCRIPTION
Problem description:
If Webpack errors occur during a Scout project build, these errors are only logged in the console. Because of that the resulting build may be faulty, although the build pipeline was green.

Analysis:
Webpack logging is done in scout-script.js in

`function logWebpack(err, stats, statsConfig)`

In case of an error, only `console.error(err)` is executed.

The expected behaviour should be the same as the case where the stats object contains errors. In this case the build process will be terminated with` exitCode = -1`

Proposed solution:
To differentiate stats errors from the Webpack errors, the proposed solution uses a different `exitCode = -2.`

460777