### PR TITLE
Outline: don't fail on init in breadcrumb mode and search required

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.ts
+++ b/eclipse-scout-core/src/desktop/outline/Outline.ts
@@ -80,7 +80,7 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
     this.inBackground = false;
     this.iconId = null;
     this.iconVisible = false;
-    this.mediator = null;
+    this.mediator = this._createMediator();
     this.navigateButtonsVisible = true;
     this.navigateUpInProgress = false;
     this.outlineOverview = null;
@@ -127,7 +127,6 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
     this.addFilter(new DetailTableTreeFilter(), false);
     super._init(model);
 
-    this.mediator = this._createMediator();
     this._installLocalTreeListener();
 
     this.formController = scout.create(FormController, {

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
@@ -9,7 +9,7 @@
  */
 import {
   arrays, Column, Form, GroupBox, InitModelOf, MaxRowCountContributionDo, NumberColumn, NumberField, ObjectOrModel, Outline, Page, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl, SearchMenu,
-  SearchRequiredTableStatus, SmartColumn, StaticLookupCall, StringField, Table, TableReloadReason, TableRow, WidgetModel
+  SearchRequiredTableStatus, SmartColumn, StaticLookupCall, StringField, Table, TableReloadReason, TableRow, Tree, WidgetModel
 } from '../../../../src/index';
 import {OutlineSpecHelper, TableSpecHelper} from '../../../../src/testing/index';
 
@@ -760,6 +760,24 @@ describe('PageWithTable', () => {
       outline.selectNode(pageWithSearchRequiredWithoutDetailTable);
       expect(pageWithSearchRequiredWithoutDetailTable._loadTableData).not.toHaveBeenCalled();
       expect(pageWithSearchRequiredWithoutDetailTable.detailTable).toBe(null);
+    });
+
+    it('does not fail on init in breadcrumb mode if search required is true and expanded false', () => {
+      let outline = scout.create(Outline, {
+        parent: session.desktop,
+        displayStyle: Tree.DisplayStyle.BREADCRUMB,
+        nodes: [{
+          id: 'Node',
+          objectType: SpecPageWithTable,
+          detailTable: {
+            objectType: Table
+          },
+          searchRequired: true
+        }],
+        selectedNodes: ['Node']
+      });
+      expect(outline.selectedNode()).toBe(outline.nodes[0]);
+      expect(outline.selectedNode().expanded).toBe(true);
     });
   });
 });


### PR DESCRIPTION
If breadcrumb mode is active, the tree ensures the selected node is expanded. This calls ensureLoadChildren which resets the data on a page with table.

Resetting the table data calls deleteAllRows which triggers an event that needs to be propagated to the outline using the outline mediator. But the mediator has not been created yet so the initialization fails.

The error happens if a JS based table page with search required is selected and the browser reloaded.

It also happens when using the new page field with a Scout Classic outline. The display style is set to breadcrumb by the device transformer, even though the outline itself is never visible.

453872
446489