### PR TITLE
TreeAdapter: improve event filters

### DIFF
--- a/eclipse-scout-core/src/tree/TreeAdapter.ts
+++ b/eclipse-scout-core/src/tree/TreeAdapter.ts
@@ -74,8 +74,11 @@ export class TreeAdapter extends ModelAdapter {
   }
 
   protected _onWidgetNodesSelected(event: TreeNodesSelectedEvent) {
-    const selectedNodes = arrays.ensure(this.widget.selectedNodes)
+    const selectedNodes = this.widget.selectedNodes
       .filter(node => TreeAdapter.isRemote(node));
+    if (this.widget.selectedNodes.length && !selectedNodes.length) {
+      return;
+    }
     const nodeIds = this.widget.nodesToIds(selectedNodes);
     this._sendNodesSelected(nodeIds, event.debounce);
   }
@@ -94,7 +97,9 @@ export class TreeAdapter extends ModelAdapter {
   protected _onWidgetNodesChecked(event: TreeNodesCheckedEvent) {
     const nodes = arrays.ensure(event.nodes)
       .filter(node => TreeAdapter.isRemote(node));
-
+    if (!nodes.length) {
+      return;
+    }
     this._sendNodesChecked(nodes);
   }
 

--- a/eclipse-scout-core/test/tree/TreeAdapterSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeAdapterSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -689,13 +689,35 @@ describe('TreeAdapter', () => {
 
     it('nodesSelected', () => {
       tree.selectNodes([jsNode, hybridNode, remoteNode]);
-
       sendQueuedAjaxCalls();
       expect(jasmine.Ajax.requests.count()).toBe(1);
-
-      const request = mostRecentJsonRequest();
-      expect(request).toContainEventsExactly([
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
         new RemoteEvent(adapter.id, 'nodesSelected', {nodeIds: [hybridNode.id, remoteNode.id]})
+      ]);
+
+      tree.selectNodes([jsNode]);
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(1); // nothing is sent
+
+      tree.selectNodes([hybridNode]);
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(2);
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesSelected', {nodeIds: [hybridNode.id]})
+      ]);
+
+      tree.selectNodes([remoteNode]);
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(3);
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesSelected', {nodeIds: [remoteNode.id]})
+      ]);
+
+      tree.selectNodes([]);
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(4);
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesSelected', {nodeIds: []})
       ]);
     });
 
@@ -750,13 +772,53 @@ describe('TreeAdapter', () => {
       tree.checkable = true;
 
       tree.checkNodes([jsNode, hybridNode, remoteNode]);
-
       sendQueuedAjaxCalls();
       expect(jasmine.Ajax.requests.count()).toBe(1);
-
-      const request = mostRecentJsonRequest();
-      expect(request).toContainEventsExactly([
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
         new RemoteEvent(adapter.id, 'nodesChecked', {nodes: [{nodeId: hybridNode.id, checked: true}, {nodeId: remoteNode.id, checked: true}]})
+      ]);
+
+      tree.checkNodes([jsNode, hybridNode, remoteNode], {checked: false});
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(2);
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesChecked', {nodes: [{nodeId: hybridNode.id, checked: false}, {nodeId: remoteNode.id, checked: false}]})
+      ]);
+
+      tree.checkNodes([jsNode]);
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(2); // nothing is sent
+
+      tree.checkNodes([jsNode, hybridNode, remoteNode], {checked: false});
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(2); // nothing is sent
+
+      tree.checkNodes([hybridNode]);
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(3);
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesChecked', {nodes: [{nodeId: hybridNode.id, checked: true}]})
+      ]);
+
+      tree.checkNodes([jsNode, hybridNode, remoteNode], {checked: false});
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(4);
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesChecked', {nodes: [{nodeId: hybridNode.id, checked: false}]})
+      ]);
+
+      tree.checkNodes([remoteNode]);
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(5);
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesChecked', {nodes: [{nodeId: remoteNode.id, checked: true}]})
+      ]);
+
+      tree.checkNodes([jsNode, hybridNode, remoteNode], {checked: false});
+      sendQueuedAjaxCalls();
+      expect(jasmine.Ajax.requests.count()).toBe(6);
+      expect(mostRecentJsonRequest()).toContainEventsExactly([
+        new RemoteEvent(adapter.id, 'nodesChecked', {nodes: [{nodeId: remoteNode.id, checked: false}]})
       ]);
     });
   });


### PR DESCRIPTION
nodesSelected: The nodeSelected event is sent only for remote nodes (including hybrid ones). If there are only non-remote nodes selected an empty event was sent. This resulted in the root node being selected which prevents js only nodes from being selected in mobile mode. Therefore, do not send an event if there are only js nodes selected. nodesChecked: The nodesChecked event is sent only for remote nodes (including hybrid ones). But the event was sent even if it was empty. This did not lead to any unwanted behaviour as the UI server simply ignores empty nodesChecked events, but was unnecessary. Therefore, only send nodesChecked events if they contain nodes.

461141