### PR TITLE
PageWithTable: improve loading

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -423,9 +423,15 @@ export class PageWithTable extends Page implements PageWithTableModel {
     // Ensure the search form data is in sync with the search filter used to load the table data (e.g. required for getSearchFilterText())
     this._updateSearchData(searchFilter);
 
-    return this._loadTableData(searchFilter)
+    const promise = this._loadTableData(searchFilter)
       .then(data => this._onLoadTableDataDone(data, restoreSelectionInfo))
       .catch(error => this._onLoadTableDataFail(error, restoreSelectionInfo));
+
+    // Ensure loading of the detail table is set to false once all loading tasks have been completed.
+    // This includes loading the main table data but also column lookup calls.
+    this.detailTable.updateBuffer.pushPromise(promise);
+
+    return promise;
   }
 
   protected _updateSearchData(searchFilter: any) {
@@ -547,7 +553,6 @@ export class PageWithTable extends Page implements PageWithTableModel {
 
   protected _onLoadTableDataAlways(restoreSelectionInfo?: RestoreSelectionInfo) {
     this._restoreSelection(restoreSelectionInfo);
-    this.detailTable.setLoading(false);
   }
 
   /**

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -4254,7 +4254,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
    * @param type the type of the column to look for. The return value will be cast to that type. This parameter has no effect at runtime.
    * @returns the column for the requested ID or null if no column has been found.
    */
-  columnById<TColumn extends Column>(columnId: string, type: abstract new() => TColumn): TColumn;
+  columnById<TColumn extends Column<any>>(columnId: string, type: abstract new() => TColumn): TColumn;
   /**
    * Searches for a column with the given ID.
    *
@@ -4265,7 +4265,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
    * @returns the column for the requested ID or null if no column has been found.
    */
   columnById<TId extends string & keyof ColumnMapOf<this>>(columnId: TId): ColumnMapOf<this>[TId];
-  columnById<TId extends string & keyof ColumnMapOf<this>, TColumn extends Column>(columnId: TId, type?: abstract new() => TColumn): ColumnMapOf<this>[TId] | TColumn {
+  columnById<TId extends string & keyof ColumnMapOf<this>, TColumn extends Column<any>>(columnId: TId, type?: abstract new() => TColumn): ColumnMapOf<this>[TId] | TColumn {
     return arrays.find(this.columns, column => column.id === columnId) as ColumnMapOf<this>[TId];
   }
 

--- a/eclipse-scout-core/test/bookmark/BookmarkSupportSpec.ts
+++ b/eclipse-scout-core/test/bookmark/BookmarkSupportSpec.ts
@@ -138,8 +138,8 @@ describe('BookmarkSupport', () => {
       expect(page.detailTable).toBeInstanceOf(Table);
       expect(page.detailTable.loading).toBe(true);
       expect(page.detailTable.rows.length).toBe(0);
-      await page.ensureLoadChildren();
-      expect(page.detailTable.loading).toBe(false);
+      page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
       expect(page.detailTable.rows.length).toBe(8);
 
       // Change search filter
@@ -282,8 +282,8 @@ describe('BookmarkSupport', () => {
       expect(page.detailTable).toBeInstanceOf(Table);
       expect(page.detailTable.loading).toBe(true);
       expect(page.detailTable.rows.length).toBe(0);
-      await page.ensureLoadChildren();
-      expect(page.detailTable.loading).toBe(false);
+      page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
       expect(page.detailTable.rows.length).toBe(3);
 
       // -----

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  arrays, Column, Form, GroupBox, InitModelOf, MaxRowCountContributionDo, NumberColumn, NumberField, ObjectOrModel, Outline, Page, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl, SearchMenu,
+  arrays, Cell, Column, Deferred, Form, GroupBox, InitModelOf, MaxRowCountContributionDo, NumberColumn, NumberField, ObjectOrModel, Outline, Page, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl, SearchMenu,
   SearchRequiredTableStatus, SmartColumn, StaticLookupCall, StringField, Table, TableReloadReason, TableRow, Tree, WidgetModel
 } from '../../../../src/index';
 import {OutlineSpecHelper, TableSpecHelper} from '../../../../src/testing/index';
@@ -62,6 +62,10 @@ describe('PageWithTable', () => {
 
     override _loadTableData(searchFilter: any): JQuery.Promise<any> {
       return super._loadTableData(searchFilter);
+    }
+
+    override _resetTableData() {
+      super._resetTableData();
     }
 
     override _createChildPage(row: TableRow): Page {
@@ -660,6 +664,137 @@ describe('PageWithTable', () => {
     expect(usedFilter.numVal).toBe(2);
     expect(searchFormData.strVal).toBe('new');
     expect(searchFormData.numVal).toBe(2);
+  });
+
+  it('marks table loading until data is loaded', async () => {
+    jasmine.clock().uninstall();
+
+    const table = page.detailTable;
+
+    // await initial load, because page was selected
+    expect(table.loading).toBeTrue();
+    await table.when('propertyChange:loading');
+
+    page.setSearchRequired(true);
+    page._resetTableData();
+
+    let loadTableDataDeferred: Deferred<any>;
+    const resetLoadTableData = () => {
+      loadTableDataDeferred = new Deferred();
+      page._loadTableData = searchFilter => $.when(loadTableDataDeferred.promise());
+    };
+
+    let loadTableDataPromise: JQuery.Promise<any>;
+    const loadTableDataOrig = page.loadTableData.bind(page);
+    page.loadTableData = (reloadReason?: TableReloadReason) => {
+      loadTableDataPromise = loadTableDataOrig(reloadReason);
+      return loadTableDataPromise;
+    };
+
+    // column without deferred cell text
+
+    resetLoadTableData();
+    table.setColumns([{objectType: NumberColumn}]);
+    // modifying columns marks the table loading
+    expect(table.loading).toBeTrue();
+    await table.when('propertyChange:loading');
+
+    table.reload();
+    expect(table.loading).toBeTrue();
+
+    loadTableDataDeferred.resolve([{cells: [42]}]);
+    await loadTableDataPromise;
+    expect(table.loading).toBeFalse();
+
+    // column with deferred cell text
+
+    class DeferredSmartColumn extends SmartColumn<number> {
+
+      lastCellTextDeferred: Deferred<void> = null;
+      lastCellTextPromise: JQuery.Promise<string> = null;
+
+      protected override _init(model: InitModelOf<this>) {
+        super._init({
+          lookupCall: {
+            objectType: StaticLookupCall,
+            data: [
+              [13, 'foo'],
+              [42, 'bar']
+            ]
+          },
+          ...model
+        });
+      }
+
+      override setCellTextDeferred(promise: JQuery.Promise<string>, row: TableRow, cell: Cell<number>) {
+        this.lastCellTextDeferred = new Deferred();
+        this.lastCellTextPromise = promise.then(async text => {
+          await this.lastCellTextDeferred.promise();
+          return text;
+        });
+        super.setCellTextDeferred(this.lastCellTextPromise, row, cell);
+      }
+    }
+
+    page._resetTableData();
+    resetLoadTableData();
+    table.setColumns([{objectType: DeferredSmartColumn, id: 'DeferredSmartColumn'}]);
+    // modifying columns marks the table loading
+    expect(table.loading).toBeTrue();
+    await table.when('propertyChange:loading');
+    const deferredSmartColumn = table.columnById('DeferredSmartColumn', DeferredSmartColumn);
+
+    table.reload();
+    expect(table.loading).toBeTrue();
+
+    loadTableDataDeferred.resolve([{cells: [42]}]);
+    await loadTableDataPromise;
+    // still loading because of deferred cell text update
+    expect(table.loading).toBeTrue();
+
+    deferredSmartColumn.lastCellTextDeferred.resolve();
+    await deferredSmartColumn.lastCellTextPromise;
+    expect(table.loading).toBeFalse();
+
+    // double reload with column with deferred cell text
+
+    resetLoadTableData();
+    expect(table.loading).toBeFalse();
+
+    table.reload();
+    expect(table.loading).toBeTrue();
+
+    // fail if table marked loading=false before second cellText is updated
+    let cellText2Resolved = false;
+    table.when('propertyChange:loading').then(() => {
+      if (!cellText2Resolved) {
+        fail('Table was marked with loading=false before data and cell texts are loaded.');
+      }
+    });
+
+    loadTableDataDeferred.resolve([{cells: [42]}]);
+    await loadTableDataPromise;
+    // still loading because of deferred cell text update
+    expect(table.loading).toBeTrue();
+
+    resetLoadTableData();
+    table.reload();
+
+    // resolve cell text from first reload after second reload was triggered
+    deferredSmartColumn.lastCellTextDeferred.resolve();
+    await deferredSmartColumn.lastCellTextPromise;
+    // still loading because second reload was triggered already
+    expect(table.loading).toBeTrue();
+
+    loadTableDataDeferred.resolve([{cells: [13]}]);
+    await loadTableDataPromise;
+    // still loading because of deferred cell text update
+    expect(table.loading).toBeTrue();
+
+    deferredSmartColumn.lastCellTextDeferred.resolve();
+    cellText2Resolved = true;
+    await deferredSmartColumn.lastCellTextPromise;
+    expect(table.loading).toBeFalse();
   });
 
   describe('searchRequired', () => {


### PR DESCRIPTION
The PageWithTable marks its detailTable loading while it loads the data. Afterward, this flag is reset. This behaviour was implemented incorrectly as simply calling Table.setLoading does not ensure the table will stay loading during the whole time. The table itself contains a TableUpdateBuffer which holds promises and sets the table to loading=false after the last promise is resolved. Therefore, calling table.setLoading(true) without passing a promise to the TableUpdateBuffer may result in the table being loading=false before the page finished its loading, because in the meantime the last promise of the TableUpdateBuffer was resolved. Therefore, the PageWithTable now adds its load-promise to the TableUpdateBuffer and ensures that the table is marked with loading=true until the page finished loading. This also solves issues where rows and child pages are in an inconsistent state when the table was e.g. sorted. Consider a PageWithTable having at least one SmartColumn which resolves its cell text asynchronously. If this page is reloaded multiple times in a short period of time, the asynchronous cell text update of a former reload may finish while the latest page reload is still running. As the SmartColumn uses the TableUpdateBuffer this resulted in the table being marked loading=false before the latest page reload was finished. In addition, the TableUpdateBuffer ensures that e.g. the order of the rows is correct which will now sort rows of a previous reload (as the latest is not finished yet). If now the PageWithTable is an IJsPage that creates its child pages on the UI Server using the JsPageHelper the child pages created for the latest page reload may already be present. In this case the row order update is passed on to the Outline by the OutlineMediator which determines the new child page order using the rows and their linked pages. As the rows belong to a former page reload they are not linked to any pages and therefore, the OutlineMediator tries to update the child page order using an empty array. But as there are already child pages present the Outline throws an error because the order can not be updated correctly.
These issues are solved as the TableUpdateBuffer now waits until the page is loaded before e.g. updating the row order and if the page is loaded it is ensured that child pages and rows are linked correctly.

456855