### PR TITLE
Use fetchpriority=high for dynamically loaded scripts

### DIFF
--- a/eclipse-scout-core/src/jquery/jquery-scout.js
+++ b/eclipse-scout-core/src/jquery/jquery-scout.js
@@ -223,6 +223,7 @@ $.injectScript = (url, options) => {
   let $scriptTag = $(scriptTag)
     .attr('src', url)
     .attr('async', true)
+    .attr('fetchpriority', 'high')
     .on('load error', event => {
       if (options.removeTag) {
         myDocument.head.removeChild(scriptTag);


### PR DESCRIPTION
Modern browsers assign each request a priority. Scripts that are loaded dynamically by injecting an additional <script> tag into the DOM are assigned a low priority by default [1]. Under certain conditions, this will introduce significant but unnecessary delays (> 15s). This is problematic if the caller waits for the script completion.

Since request priorities are primarily relevant during the initial rendering of a HTML page, we can safely increase the priority hint for all scripts that are dynamically injected later using the central method $.injectScript() by setting the "fetchpriority" attribute [2] to "high".

[1] https://web.dev/articles/fetch-priority
[2] https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/fetchpriority

462323