### PR TITLE
Column: sort rows by cell value if sort codes are equal

### DIFF
--- a/eclipse-scout-core/src/table/columns/Column.ts
+++ b/eclipse-scout-core/src/table/columns/Column.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1029,11 +1029,14 @@ export class Column<TValue = string> extends PropertyEventEmitter implements Col
   }
 
   compare(row1: TableRow, row2: TableRow): number {
-    let cell1 = this.table.cell(this, row1),
-      cell2 = this.table.cell(this, row2);
+    let cell1 = this.table.cell(this, row1);
+    let cell2 = this.table.cell(this, row2);
 
     if (cell1.sortCode !== null || cell2.sortCode !== null) {
-      return comparators.NUMERIC.compare(cell1.sortCode, cell2.sortCode);
+      let c = comparators.NUMERIC.compare(cell1.sortCode, cell2.sortCode);
+      if (c) { // only return if sort codes are different, otherwise continue comparing by value
+        return c;
+      }
     }
 
     let valueA = this.cellValueOrText(row1);

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -1881,11 +1881,11 @@ describe('Table', () => {
       });
 
       it('sorts columns with sortcode', () => {
-        let model = helper.createModelSingleColumnByValues([0, 1, 2, 3, 4], 'NumberColumn');
+        let model = helper.createModelSingleColumnByValues([0, 1, 2, 3, 4, 5], 'NumberColumn');
         let table = helper.createTable(model);
         column0 = table.columns[0];
 
-        let sortCodes = [13, 0, 42, 7, null];
+        let sortCodes = [13, 0, 42, 7, null, null];
         table.rows.forEach((row, index) => {
           column0.cell(row).sortCode = sortCodes[index];
         });
@@ -1893,10 +1893,10 @@ describe('Table', () => {
         table.render();
 
         table.sort(column0, 'desc');
-        helper.assertValuesInCells(table.rows, 0, [2, 0, 3, 1, 4]);
+        helper.assertValuesInCells(table.rows, 0, [2, 0, 3, 1, 5, 4]);
 
         table.sort(column0, 'asc');
-        helper.assertValuesInCells(table.rows, 0, [4, 1, 3, 0, 2]);
+        helper.assertValuesInCells(table.rows, 0, [4, 5, 1, 3, 0, 2]);
       });
 
       it('sorts smart columns with sortcode', () => {
@@ -1935,6 +1935,13 @@ describe('Table', () => {
               text: '4',
               value: 4
             })
+          ]),
+          helper.createModelRow(null, [
+            scout.create(Cell, {
+              sortCode: null,
+              text: '5',
+              value: 5
+            })
           ])
         ];
 
@@ -1945,10 +1952,10 @@ describe('Table', () => {
         table.render();
 
         table.sort(column0, 'desc');
-        helper.assertValuesInCells(table.rows, 0, [2, 0, 3, 1, 4]);
+        helper.assertValuesInCells(table.rows, 0, [2, 0, 3, 1, 5, 4]);
 
         table.sort(column0, 'asc');
-        helper.assertValuesInCells(table.rows, 0, [4, 1, 3, 0, 2]);
+        helper.assertValuesInCells(table.rows, 0, [4, 5, 1, 3, 0, 2]);
       });
 
       it('uses non sort columns as fallback', () => {


### PR DESCRIPTION
Table cells can have an optional 'sortCode' property that is considered when comparing table rows. If at least one cell has a sortCode, they are compared by sort code first. However, if both sort codes are equal, the normal comparator should be applied to ensures a predictable, consistent row order.

454232