### PR TITLE
js build: remove source-map-loader

### DIFF
--- a/eclipse-scout-cli/package.json
+++ b/eclipse-scout-cli/package.json
@@ -42,7 +42,6 @@
     "babel-loader": "10.0.0",
     "typescript": "5.9.3",
     "ts-loader": "9.5.4",
-    "source-map-loader": "5.0.0",
     "copy-webpack-plugin": "13.0.1",
     "css-loader": "7.1.2",
     "jasmine-core": "5.13.0",

--- a/eclipse-scout-cli/scripts/webpack-defaults.js
+++ b/eclipse-scout-cli/scripts/webpack-defaults.js
@@ -210,12 +210,6 @@ module.exports = (env, args) => {
           loader: require.resolve('babel-loader'),
           options: babelOptions
         }]
-      }, {
-        test: /\.[c|m]?jsx?$/,
-        enforce: 'pre',
-        use: [{
-          loader: require.resolve('source-map-loader')
-        }]
       }]
     },
     plugins: [


### PR DESCRIPTION
The plugin is deprecated because it has been moved into Webpack core: https://github.com/webpack/webpack/pull/19824
https://github.com/webpack-contrib/source-map-loader

It looks like the plugin can just be removed and does not require any configuration because the source maps seem to be correct.

414053