### PR TITLE
Table: info-filter is hidden sometimes even if there is a filter

### DIFF
--- a/eclipse-scout-core/src/table/TableFooter.ts
+++ b/eclipse-scout-core/src/table/TableFooter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -506,6 +506,7 @@ export class TableFooter extends Widget implements TableFooterModel {
       $info.stop()
         // Save complete function so that layout may use it
         .data('animationComplete', complete)
+        .removeClass('hiding')
         .setVisible(true)
         .cssWidthToContentAnimated({
           progress: this.revalidateLayout.bind(this),


### PR DESCRIPTION
If a filter is removed and immediately added again, the info element showing that a filter is active is no longer visible because the class 'hiding' was not removed.

The bug was introduced with 90f5a66f4a4d96d8b021fb4c8f25aea296abb73f.

459973