### PR TITLE
Outline: improve lazy expanding

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/Outline.ts
+++ b/eclipse-scout-core/src/desktop/outline/Outline.ts
@@ -1281,9 +1281,10 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
   }
 
   /**
-   * Selects the given page.
+   * Selects the given page and, if necessary, scrolls it into the viewport to make it visible.
+   * Also expands the page if it is a node page and `expandDrillNode` is null or undefined.
    *
-   * @param drillNode The page to select. May be null, in which case nothing happens.
+   * @param drillNode The page to select. If it is null, nothing happens.
    * @param expandDrillNode Whether to automatically expand the drill node after selecting it.
    *        By default, this is `true` for node pages, `false` otherwise.
    */
@@ -1295,6 +1296,11 @@ export class Outline extends Tree implements DisplayParent, OutlineModel {
       // If the target node is a node page, expand it
       if (scout.nvl(expandDrillNode, drillNode.nodeType === Page.NodeType.NODES)) {
         this.expandNode(drillNode);
+      }
+
+      // Ensure selected node is visible
+      if (!this.scrollToSelection) {
+        this.revealSelection();
       }
     }
   }

--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -39,6 +39,7 @@ export class PageWithTable extends Page implements PageWithTableModel {
     this.nodeType = Page.NodeType.TABLE;
     this.inheritMenusFromParentTablePage = false;
     this.alwaysCreateChildPage = false;
+    this.lazyExpandingEnabled = true;
 
     this._reloadReason = null;
     this._tableRowDeleteHandler = this._onTableRowsDeleted.bind(this);

--- a/eclipse-scout-core/src/tree/Tree.ts
+++ b/eclipse-scout-core/src/tree/Tree.ts
@@ -2453,14 +2453,7 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
       let propertiesChanged: boolean;
       let oldNode = this.nodesMap[updatedNode.id];
 
-      // if same instance has been updated we must set the flag always to true
-      // because we cannot compare against an "old" node
-      if (updatedNode === oldNode) {
-        propertiesChanged = true;
-      } else {
-        propertiesChanged = this._applyUpdatedNodeProperties(oldNode, updatedNode);
-      }
-
+      propertiesChanged = this._applyUpdatedNodeProperties(oldNode, updatedNode);
       if (propertiesChanged) {
         this.applyFiltersForNode(oldNode);
         this._updateItemPath(false, oldNode.parentNode);
@@ -2490,6 +2483,16 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
    *          determine if the node has to be rendered again.
    */
   protected _applyUpdatedNodeProperties(oldNode: TreeNode, updatedNode: ObjectOrModel<TreeNode>): boolean {
+    // Make sure expandedLazy is reset to false when lazyExpanding is disabled (same code as in AbstractTreeNode.setLazyExpandingEnabled)
+    if (!updatedNode.lazyExpandingEnabled || !this.lazyExpandingEnabled) {
+      oldNode.expandedLazy = false;
+    }
+
+    // Always return true if the same instance has been updated because we cannot compare against an "old" node
+    if (updatedNode === oldNode) {
+      return true;
+    }
+
     // Note: We only update _some_ of the properties, because everything else will be handled
     // with separate events. --> See also: JsonTree.java/handleModelNodesUpdated()
     let propertiesChanged = false;
@@ -2503,10 +2506,6 @@ export class Tree extends Widget implements TreeModel, Filterable<TreeNode> {
     }
     if (oldNode.lazyExpandingEnabled !== updatedNode.lazyExpandingEnabled) {
       oldNode.lazyExpandingEnabled = updatedNode.lazyExpandingEnabled;
-      // Also make sure expandedLazy is reset to false when lazyExpanding is disabled (same code as in AbstractTreeNode.setLazyExpandingEnabled)
-      if (!updatedNode.lazyExpandingEnabled || !this.lazyExpandingEnabled) {
-        oldNode.expandedLazy = false;
-      }
       propertiesChanged = true;
     }
     return propertiesChanged;

--- a/eclipse-scout-core/test/desktop/outline/OutlineMediatorSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/OutlineMediatorSpec.ts
@@ -148,6 +148,7 @@ describe('OutlineMediator', () => {
   });
 
   it('tableRowsFiltered', () => {
+    page.setLazyExpandingEnabled(false);
     let modelRows = [
       tableHelper.createModelRow('0', ['Foo']),
       tableHelper.createModelRow('1', ['Bar'])

--- a/eclipse-scout-core/test/desktop/outline/pages/js/JsPageHelperSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/js/JsPageHelperSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1116,7 +1116,6 @@ class MyPageWithTable extends PageWithTable {
 
   protected override _jsonModel(): TreeNodeModel {
     return {
-      lazyExpandingEnabled: true,
       detailTable: {
         objectType: Table,
         columns: [

--- a/eclipse-scout-core/test/tree/TreeSpec.ts
+++ b/eclipse-scout-core/test/tree/TreeSpec.ts
@@ -464,8 +464,8 @@ describe('Tree', () => {
   describe('updateNodes', () => {
     let model: SpecTreeModel;
     let tree: SpecTree;
-    let node0;
-    let child0;
+    let node0: TreeNode;
+    let child0: TreeNode;
 
     beforeEach(() => {
       model = helper.createModelFixture(3, 3, false);
@@ -484,6 +484,41 @@ describe('Tree', () => {
       // we expect that _decorateNode has been called and updates the DOM of the tree
       let $treeNode = tree.$container.find('[data-nodeid="' + node0.id + '"]').first();
       expect($treeNode.attr('class')).toContain('leaf');
+    });
+
+    it('sets lazyExpanding to false if lazyExpandingEnabled is false', () => {
+      tree.render();
+
+      tree.nodes[0].setLazyExpandingEnabled(true);
+      tree.expandNode(tree.nodes[0]);
+      expect(tree.nodes[0].lazyExpandingEnabled).toBe(true);
+      expect(tree.nodes[0].expanded).toBe(true);
+      expect(tree.nodes[0].expandedLazy).toBe(true);
+
+      tree.nodes[0].setLazyExpandingEnabled(false);
+      tree.updateNode({
+        id: tree.nodes[0].id,
+        lazyExpandingEnabled: false
+      });
+      expect(tree.nodes[0].lazyExpandingEnabled).toBe(false);
+      expect(tree.nodes[0].expanded).toBe(true);
+      expect(tree.nodes[0].expandedLazy).toBe(false);
+    });
+
+    it('sets lazyExpanding to false if lazyExpandingEnabled is false even if node instance is the same', () => {
+      tree.render();
+
+      tree.nodes[0].setLazyExpandingEnabled(true);
+      tree.expandNode(tree.nodes[0]);
+      expect(tree.nodes[0].lazyExpandingEnabled).toBe(true);
+      expect(tree.nodes[0].expanded).toBe(true);
+      expect(tree.nodes[0].expandedLazy).toBe(true);
+
+      tree.nodes[0].setLazyExpandingEnabled(false);
+      tree.updateNode(node0);
+      expect(tree.nodes[0].lazyExpandingEnabled).toBe(false);
+      expect(tree.nodes[0].expanded).toBe(true);
+      expect(tree.nodes[0].expandedLazy).toBe(false);
     });
 
     describe('enabled update', () => {

--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/PageTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/PageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -133,11 +133,11 @@ public class PageTest {
   @Test
   public void testCollapseLazyNodeOnReload() {
     IDesktop desktop = TestEnvironmentClientSession.get().getDesktop();
-    desktop.setAvailableOutlines(Collections.singletonList(new LazyPageWithTableOutline()));
-    desktop.setOutline(LazyPageWithTableOutline.class);
+    desktop.setAvailableOutlines(Collections.singletonList(new PageWithTableOutline()));
+    desktop.setOutline(PageWithTableOutline.class);
     desktop.activateFirstPage();
     IOutline outline = desktop.getOutline();
-    LazyPageWithTable page = (LazyPageWithTable) outline.getActivePage();
+    PageWithTable page = (PageWithTable) outline.getActivePage();
 
     assertEquals(3, page.getChildNodeCount());
     assertFalse(page.isExpanded());
@@ -147,7 +147,7 @@ public class PageTest {
 
     // Drill down to child node -> page should be expanded lazily
 
-    outline.getUIFacade().setNodeSelectedAndExpandedFromUI(page.getChildNode(0));
+    outline.drillDown(page.getChildPage(0));
     assertTrue(page.isExpanded());
     assertTrue(page.isExpandedLazy());
 
@@ -237,15 +237,15 @@ public class PageTest {
     }
   }
 
-  class LazyPageWithTableOutline extends AbstractOutline {
+  class PageWithTableOutline extends AbstractOutline {
 
     @Override
     protected void execCreateChildPages(List<IPage<?>> pageList) {
-      pageList.add(new LazyPageWithTable());
+      pageList.add(new PageWithTable());
     }
   }
 
-  class LazyPageWithTable extends AbstractPageWithTable<LazyPageWithTable.Table> {
+  class PageWithTable extends AbstractPageWithTable<PageWithTable.Table> {
 
     @Override
     protected void execLoadData(SearchFilter filter) {
@@ -259,7 +259,8 @@ public class PageTest {
 
     @Override
     protected IPage<?> execCreateChildPage(ITableRow row) {
-      return new P_Page();
+      return new AbstractPageWithNodes() {
+      };
     }
 
     public class Table extends AbstractTable {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/bookmark/internal/BookmarkUtility.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/bookmark/internal/BookmarkUtility.java
@@ -720,7 +720,7 @@ public final class BookmarkUtility {
     }
     IPage<?> childPage = null;
     boolean loadChildren = !leafState;
-    if (tablePage.isChildrenDirty() || tablePage.isChildrenVolatile()) {
+    if (tablePage.isChildrenDirty()) {
       loadChildren = true;
       tablePage.setChildrenLoaded(false);
     }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTree.java
@@ -2843,7 +2843,7 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
           setTreeChanging(true);
           node = resolveNode(node);
           if (node != null && (node.isExpanded() != on || node.isExpandedLazy() != lazy)) {
-            if (on && (node.isChildrenDirty() || node.isChildrenVolatile())) {
+            if (on && node.isChildrenDirty()) {
               node.loadChildren();
             }
             setNodeExpanded(node, on, lazy);
@@ -2866,40 +2866,6 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
     }
 
     @Override
-    public void setNodeSelectedAndExpandedFromUI(ITreeNode node) {
-      try {
-        pushUIProcessor();
-        try {
-          setTreeChanging(true);
-          node = resolveNode(node);
-          if (node != null) {
-            if (node.isChildrenDirty() || node.isChildrenVolatile()) {
-              node.loadChildren();
-            }
-            setNodeExpanded(node, true);
-            selectNode(node, false);
-            if (!isScrollToSelection()) {
-              scrollToSelection();
-            }
-          }
-        }
-        finally {
-          setTreeChanging(false);
-        }
-      }
-      catch (RuntimeException e) {
-        if (node != null) {
-          throw BEANS.get(PlatformExceptionTranslator.class).translate(e)
-              .withContextInfo("cell", node.toPlainText());
-        }
-        throw e;
-      }
-      finally {
-        popUIProcessor();
-      }
-    }
-
-    @Override
     public void setNodesSelectedFromUI(List<ITreeNode> nodes) {
       try {
         pushUIProcessor();
@@ -2913,7 +2879,7 @@ public abstract class AbstractTree extends AbstractWidget implements ITree, ICon
 
           // load children for selection
           for (ITreeNode node : validNodes) {
-            if (node.isChildrenLoaded() && (node.isChildrenDirty() || node.isChildrenVolatile())) {
+            if (node.isChildrenLoaded() && node.isChildrenDirty()) {
               node.loadChildren();
             }
           }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTreeNode.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/AbstractTreeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -52,7 +52,6 @@ public abstract class AbstractTreeNode implements ITreeNode, ICellObserver, ICon
   private static final String DISPOSING = "DISPOSING";
   private static final String CHILDREN_DIRTY = "CHILDREN_DIRTY";
   private static final String CHILDREN_LOADED = "CHILDREN_LOADED";
-  private static final String CHILDREN_VOLATILE = "CHILDREN_VOLATILE";
   private static final String FILTER_ACCEPTED = "FILTER_ACCEPTED";
   private static final String LEAF = "LEAF";
   private static final String REJECTED_BY_USER = "REJECTED_BY_USER";
@@ -64,7 +63,7 @@ public abstract class AbstractTreeNode implements ITreeNode, ICellObserver, ICon
   private static final Logger LOG = LoggerFactory.getLogger(AbstractTreeNode.class);
   private static final NamedBitMaskHelper VISIBLE_BIT_HELPER = new NamedBitMaskHelper(IDimensions.VISIBLE, IDimensions.VISIBLE_GRANTED);
   private static final NamedBitMaskHelper ENABLED_BIT_HELPER = new NamedBitMaskHelper(IDimensions.ENABLED, IDimensions.ENABLED_GRANTED);
-  private static final NamedBitMaskHelper FLAGS_BIT_HELPER = new NamedBitMaskHelper(INITIALIZED, CHILDREN_DIRTY, CHILDREN_LOADED, CHILDREN_VOLATILE, FILTER_ACCEPTED, LEAF, REJECTED_BY_USER, DISPOSING);
+  private static final NamedBitMaskHelper FLAGS_BIT_HELPER = new NamedBitMaskHelper(INITIALIZED, CHILDREN_DIRTY, CHILDREN_LOADED, FILTER_ACCEPTED, LEAF, REJECTED_BY_USER, DISPOSING);
   private static final NamedBitMaskHelper EXPANDED_BIT_HELPER = new NamedBitMaskHelper(EXPANDED, EXPANDED_LAZY, INITIALLY_EXPANDED, LAZY_EXPANDING_ENABLED);
 
   private int m_initializing = 0; // >0 is true
@@ -107,8 +106,7 @@ public abstract class AbstractTreeNode implements ITreeNode, ICellObserver, ICon
 
   /**
    * Provides 8 boolean flags.<br>
-   * Currently used: {@link #CHILDREN_DIRTY}, {@link #CHILDREN_LOADED}, {@link #CHILDREN_VOLATILE},
-   * {@link #FILTER_ACCEPTED}, {@link #LEAF}, {@link #REJECTED_BY_USER}
+   * Currently used: {@link #CHILDREN_DIRTY}, {@link #CHILDREN_LOADED}, {@link #FILTER_ACCEPTED}, {@link #LEAF}, {@link #REJECTED_BY_USER}
    */
   private byte m_flags;
 
@@ -665,16 +663,6 @@ public abstract class AbstractTreeNode implements ITreeNode, ICellObserver, ICon
       enabled = ACCESS.check(p);
     }
     node.setEnabled(enabled, IDimensions.ENABLED_GRANTED);
-  }
-
-  @Override
-  public boolean isChildrenVolatile() {
-    return FLAGS_BIT_HELPER.isBitSet(CHILDREN_VOLATILE, m_flags);
-  }
-
-  @Override
-  public void setChildrenVolatile(boolean childrenVolatile) {
-    m_flags = FLAGS_BIT_HELPER.changeBit(CHILDREN_VOLATILE, childrenVolatile, m_flags);
   }
 
   @Override

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeNode.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -188,19 +188,6 @@ public interface ITreeNode extends IVisibleDimension, IEnabledDimension, IContex
    * mark a node as dirty
    */
   void setChildrenDirty(boolean b);
-
-  /**
-   * a node with volatile (rapidly and constantly changing) children is reloaded on ANY ui call to
-   * {@link ITreeUIFacade#setNodeExpandedFromUI(ITreeNode, boolean, boolean)}
-   * {@link ITreeUIFacade#setNodeSelectedAndExpandedFromUI(ITreeNode)}
-   * {@link ITreeUIFacade#setNodesSelectedFromUI(List)} default is false
-   */
-  boolean isChildrenVolatile();
-
-  /**
-   * mark node as containing volatile children
-   */
-  void setChildrenVolatile(boolean b);
 
   /**
    * @return true if node is enabled and enabled is granted

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeUIFacade.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/tree/ITreeUIFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,8 +23,6 @@ public interface ITreeUIFacade {
   void setNodesCheckedFromUI(List<ITreeNode> nodes, boolean on);
 
   void setNodeExpandedFromUI(ITreeNode node, boolean on, boolean lazy);
-
-  void setNodeSelectedAndExpandedFromUI(ITreeNode node);
 
   void setNodesSelectedFromUI(List<ITreeNode> nodes);
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/AbstractOutline.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/AbstractOutline.java
@@ -1094,4 +1094,28 @@ public abstract class AbstractOutline extends AbstractTree implements IOutline {
       jsPage.changeNode(cell);
     }
   }
+
+  @Override
+  public void drillDown(IPage page) {
+    if (page == null) {
+      return;
+    }
+
+    try {
+      setTreeChanging(true);
+      if (page.computeExpandOnDrillDown()) {
+        if (page.isChildrenDirty()) {
+          page.loadChildren();
+        }
+        setNodeExpanded(page, true);
+      }
+      selectNode(page, false);
+      if (!isScrollToSelection()) {
+        scrollToSelection();
+      }
+    }
+    finally {
+      setTreeChanging(false);
+    }
+  }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/IOutline.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/IOutline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import org.eclipse.scout.rt.client.ui.action.menu.TreeMenuType;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.basic.tree.ITree;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
+import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPageWithNodes;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPageWithTable;
 import org.eclipse.scout.rt.client.ui.form.IForm;
 import org.eclipse.scout.rt.platform.IOrdered;
@@ -235,4 +236,13 @@ public interface IOutline extends ITree, IOrdered, IDisplayParent, IVisibleDimen
    * @since 7.0
    */
   ClientRunContext createDisplayParentRunContext();
+
+  /**
+   * Selects the given page and, if necessary, scrolls it into the viewport to make it visible.
+   * Also expands the page if {@link IPage#computeExpandOnDrillDown()} returns <code>true</code>, which is the default for {@link IPageWithNodes}s.
+   *
+   * @param page
+   *     The page to select. If it is null, nothing happens.
+   */
+  void drillDown(IPage page);
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/OutlineMediator.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/OutlineMediator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,6 @@ import java.util.List;
 import org.eclipse.scout.rt.client.ui.basic.table.ITable;
 import org.eclipse.scout.rt.client.ui.basic.table.ITableRow;
 import org.eclipse.scout.rt.client.ui.basic.table.TableEvent;
-import org.eclipse.scout.rt.client.ui.basic.tree.ITree;
 import org.eclipse.scout.rt.client.ui.basic.tree.ITreeNode;
 import org.eclipse.scout.rt.client.ui.basic.tree.TreeEvent;
 import org.eclipse.scout.rt.client.ui.desktop.outline.pages.IPage;
@@ -125,12 +124,12 @@ public class OutlineMediator {
     if (e.isConsumed()) {
       return;
     }
-    ITreeNode node = page.getTreeNodeFor(e.getFirstRow());
-    if (node != null) {
+    IPage childPage = page.getPageFor(e.getFirstRow());
+    if (childPage != null) {
       e.consume();
-      ITree tree = page.getTree();
-      if (tree != null) {
-        tree.getUIFacade().setNodeSelectedAndExpandedFromUI(node);
+      IOutline outline = page.getOutline();
+      if (outline != null) {
+        outline.drillDown(childPage);
       }
     }
   }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPage.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1179,6 +1179,11 @@ public abstract class AbstractPage<T extends ITable> extends AbstractTreeNode im
     if (table != null) {
       table.deleteAllRows();
     }
+  }
+
+  @Override
+  public boolean computeExpandOnDrillDown() {
+    return false;
   }
 
   private void interceptReloadPage(String reloadReason) {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithNodes.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithNodes.java
@@ -355,6 +355,11 @@ public abstract class AbstractPageWithNodes extends AbstractPage<ITable> impleme
     return true;
   }
 
+  @Override
+  public boolean computeExpandOnDrillDown() {
+    return true;
+  }
+
   /**
    * inner table
    */

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/IPage.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/IPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -237,4 +237,9 @@ public interface IPage<T extends ITable> extends ITreeNode, ITypeWithClassId, ID
    * @see #pageActivatedNotify()
    */
   boolean hasBeenActivated();
+
+  /**
+   * Whether the page should be expanded on {@link IOutline#drillDown(IPage)}.
+   */
+  boolean computeExpandOnDrillDown();
 }


### PR DESCRIPTION
- Set lazyExpandingEnabled to true for Scout JS table pages   Scout JS based table pages should expand lazily by default to make it   consistent with Scout Classic table pages.
- Ensure correct expandedLazy state (Scout JS)   If lazyExpandingEnabled is disabled and the node updated,   expandedLazy state should be set to false as well.
- Don't expand table pages on drill down (Scout Classic)   Currently, a double click on a table row in the detail table of a page   always selects and expands the corresponding child page. This is fine   for node pages, but if a table is expanded that has   lazyExpandingEnabled set to true (default), a + is shown for the page   in the outline but no child page is visible. This is confusing and   also inconsistent to what the NavigateDown button does. This button   does the expanding only for node pages (see Outline.ts#drillDown).   Now, the Java based drillDown does the same as the JS based.
- Moved ITreeUIFacade.setNodeSelectedAndExpandedFromUI to IOutline   and renamed it to drillDown, because it is never called from ui.
- Added IPage.computeExpandOnDrillDown which returns true for node   pages.
- Removed unused property isChildrenVolatile/setChildrenVolatile of   ITreeNode.

337244