### PR TITLE
Fix error when checking for @ApiDocIgnore annotation on a bean with multiple subclasses

### DIFF
--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/doc/ApiDocGenerator.java
@@ -255,7 +255,7 @@ public class ApiDocGenerator {
 
   protected ApiDocIgnore getApiDocIgnoreAnnotation(Class<?> clazz) {
     // ask bean first: is faster and supports more features (inherited annotations from interfaces)
-    IBean<?> bean = BEANS.getBeanManager().optBean(clazz);
+    IBean<?> bean = BEANS.getBeanManager().uniqueBean(clazz);
     if (bean != null) {
       ApiDocIgnore ann = bean.getBeanAnnotation(ApiDocIgnore.class);
       if (ann != null) {


### PR DESCRIPTION
462170