### PR TITLE
Simplify usage of UserFilterStateMappers

### DIFF
--- a/eclipse-scout-core/src/prefs/TableUiPreferences.ts
+++ b/eclipse-scout-core/src/prefs/TableUiPreferences.ts
@@ -279,14 +279,11 @@ export class TableUiPreferences implements ObjectWithType {
     return table.filters
       .filter(filter => filter instanceof TableUserFilter)
       .map((filter: TableUserFilter) => {
-        for (let mapper of UserFilterStateMappers.all()) {
-          let filterState = mapper.tryToDo(table, filter);
-          if (filterState) {
-            return filterState;
-          }
+        let filterState = UserFilterStateMappers.toDo(table, filter);
+        if (!filterState) {
+          scout.create(ErrorHandler, {displayError: false, sendError: true}).handle(`Unable to map filter to data object [table=${table.id}, filterType=${filter?.filterType}, filterLabel=${filter?.createLabel()}`);
         }
-        scout.create(ErrorHandler, {displayError: false, sendError: true}).handle(`Unable to map filter to data object [table=${table.id}, filterType=${filter?.filterType}, filterLabel=${filter?.createLabel()}`);
-        return null;
+        return filterState;
       })
       .filter(Boolean);
   }

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -4548,14 +4548,12 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   applyUserFilterStates(userFilterStates: IUserFilterStateDo[]) {
     let newFilters = this.filters.filter(filter => !(filter instanceof TableUserFilter));
     arrays.ensure(userFilterStates).forEach(filterState => {
-      for (let mapper of UserFilterStateMappers.all()) {
-        let filter = mapper.tryFromDo(this, filterState);
-        if (filter) {
-          newFilters.push(filter);
-          return;
-        }
+      let filter = UserFilterStateMappers.fromDo(this, filterState);
+      if (!filter) {
+        scout.create(ErrorHandler, {displayError: false, logError: true}).handle(`No mapper found for user filter state: ${dataObjects.stringify(filterState)}`);
+        return;
       }
-      scout.create(ErrorHandler, {displayError: false, logError: true}).handle(`No mapper found for user filter state: ${dataObjects.stringify(filterState)}`);
+      newFilters.push(filter);
     });
     this.setFilters(newFilters);
   }

--- a/eclipse-scout-core/src/table/organizer/TableOrganizer.ts
+++ b/eclipse-scout-core/src/table/organizer/TableOrganizer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -166,8 +166,7 @@ export class TableOrganizer implements ObjectWithType {
   addColumn(column?: Column<any>): Promise<void> {
     if (this.table.isCustomizable()) {
       return this.table.customizer.addCustomColumn(column)
-        .then(() => {
-        }); // ignore return value
+        .then(() => undefined); // ignore return value
     }
     return this._showInvisibleColumnsForm(column);
   }
@@ -224,8 +223,7 @@ export class TableOrganizer implements ObjectWithType {
   modifyColumn(column: Column<any>): Promise<void> {
     if (this.table.isCustomizable() && this.table.customizer.isCustomizable(column)) {
       return this.table.customizer.modifyCustomColumn(column)
-        .then(() => {
-        }); // ignore return value
+        .then(() => undefined); // ignore return value
     }
     return Promise.resolve(); // non-customized columns cannot be modified
   }

--- a/eclipse-scout-core/src/table/userfilter/UserFilterStateMapper.ts
+++ b/eclipse-scout-core/src/table/userfilter/UserFilterStateMapper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,13 +11,6 @@ import {IUserFilterStateDo, Table, TableUserFilter} from '../../index';
 
 export abstract class UserFilterStateMapper<TFilter extends TableUserFilter = TableUserFilter, TFilterState extends IUserFilterStateDo = IUserFilterStateDo> {
 
-  tryToDo(table: Table, filter: TableUserFilter): IUserFilterStateDo {
-    if (this._acceptFilter(filter)) {
-      return this._toDo(table, filter);
-    }
-    return null;
-  }
-
   tryFromDo(table: Table, filterState: IUserFilterStateDo): TableUserFilter {
     if (this._acceptFilterState(filterState)) {
       return this._fromDo(table, filterState);
@@ -25,11 +18,20 @@ export abstract class UserFilterStateMapper<TFilter extends TableUserFilter = Ta
     return null;
   }
 
-  protected abstract _acceptFilter(filter: TableUserFilter): filter is TFilter;
-
   protected abstract _acceptFilterState(filterState: IUserFilterStateDo): filterState is TFilterState;
 
-  protected abstract _toDo(table: Table, filter: TFilter): TFilterState;
-
   protected abstract _fromDo(table: Table, filterState: TFilterState): TFilter;
+
+  // ----------
+
+  tryToDo(table: Table, filter: TableUserFilter): IUserFilterStateDo {
+    if (this._acceptFilter(filter)) {
+      return this._toDo(table, filter);
+    }
+    return null;
+  }
+
+  protected abstract _acceptFilter(filter: TableUserFilter): filter is TFilter;
+
+  protected abstract _toDo(table: Table, filter: TFilter): TFilterState;
 }

--- a/eclipse-scout-core/src/table/userfilter/UserFilterStateMappers.ts
+++ b/eclipse-scout-core/src/table/userfilter/UserFilterStateMappers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {ObjectRegistries, ObjectRegistry, UserFilterStateMapper} from '../../index';
+import {IUserFilterStateDo, ObjectRegistries, ObjectRegistry, Table, TableUserFilter, UserFilterStateMapper} from '../../index';
 
 /**
  * Central registry for all available {@link UserFilterStateMapper} instances.
@@ -20,5 +20,33 @@ export class UserFilterStateMappers extends ObjectRegistry<UserFilterStateMapper
 
   static all(): UserFilterStateMapper[] {
     return UserFilterStateMappers.get().all();
+  }
+
+  /**
+   * Loops through {@link all} registered mappers, calls {@link UserFilterStateMapper.tryFromDo}
+   * and returns the first non-null result.
+   */
+  static fromDo(table: Table, filterState: IUserFilterStateDo): TableUserFilter {
+    for (let mapper of UserFilterStateMappers.all()) {
+      let filter = mapper.tryFromDo(table, filterState);
+      if (filter) {
+        return filter;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Loops through {@link all} registered mappers, calls {@link UserFilterStateMapper.tryToDo}
+   * and returns the first non-null result.
+   */
+  static toDo(table: Table, filter: TableUserFilter): IUserFilterStateDo {
+    for (let mapper of UserFilterStateMappers.all()) {
+      let filterState = mapper.tryToDo(table, filter);
+      if (filterState) {
+        return filterState;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Add static convenience methods to loop through all registered mappers:
- fromDo()
- toDo()

Reorder methods to make code more readable.

456697