### PR TITLE
UiNotifications: don't fail on empty response

### DIFF
--- a/eclipse-scout-core/src/uinotification/UiNotificationPoller.ts
+++ b/eclipse-scout-core/src/uinotification/UiNotificationPoller.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -143,15 +143,24 @@ export class UiNotificationPoller extends PropertyEventEmitter {
   }
 
   protected _onSuccess(response: UiNotificationResponse) {
+    if (!response) {
+      this.setStatus(BackgroundJobPollingStatus.FAILURE);
+      scout.getSession()?.sendLogRequest(`UI notification poller got an empty response, call will be retried in ${UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL}ms.`, LogLevel.INFO);
+      this._schedulePoll(UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL);
+      return;
+    }
+
     if (response.error) {
       this._onSuccessError(response.error);
       return;
     }
+
     if (this.status === BackgroundJobPollingStatus.STOPPED) {
       // Don't do anything if poller was stopped in the meantime -> discard notifications
       // In case the poller will be started again, the discarded notifications will be sent again by the server
       return;
     }
+
     let notifications = response.notifications || [];
     $.log.isInfoEnabled() && $.log.info(`${notifications.length} UI notification(s) received.`);
     notifications = notifications.filter(notification => {
@@ -233,7 +242,7 @@ export class UiNotificationPoller extends PropertyEventEmitter {
     this.trigger('error', {error});
 
     App.get().errorHandler.analyzeError(error).then(errorInfo => {
-      scout.getSession()?.sendLogRequest(`UI notification poller failed, call will be retried in ${UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL} ms.\nError message:\n${errorInfo.log}\n()`, LogLevel.INFO);
+      scout.getSession()?.sendLogRequest(`UI notification poller failed, call will be retried in ${UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL}ms.\nError message:\n${errorInfo.log}\n()`, LogLevel.INFO);
     });
 
     this._schedulePoll(UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL);

--- a/eclipse-scout-core/test/uinotification/uiNotificationsSpec.ts
+++ b/eclipse-scout-core/test/uinotification/uiNotificationsSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -839,7 +839,70 @@ describe('uiNotifications', () => {
       expect(poller.status).toBe(BackgroundJobPollingStatus.RUNNING);
     });
 
-    it('automatically restarts on response error if other topics are subscribed', () => {
+    it('automatically restarts on polling response error', () => {
+      uiNotifications.subscribe('aaa', () => undefined);
+
+      let response = scout.create(UiNotificationResponse, {
+        notifications: [{
+          id: '100',
+          topic: 'aaa',
+          nodeId: 'node1',
+          creationTime: '2023-09-16 21:44:13.000',
+          subscriptionStart: true
+        }]
+      });
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        responseText: JSON.stringify(response.toPojo())
+      });
+
+      // Subscription was successful, start polling
+      jasmine.clock().tick(1);
+
+      let poller = pollers().get('main');
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 500
+      });
+      jasmine.clock().tick(1);
+      expect(poller.status).toBe(BackgroundJobPollingStatus.FAILURE);
+
+      jasmine.clock().tick(UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL + 1000);
+      expect(poller.status).toBe(BackgroundJobPollingStatus.RUNNING);
+    });
+
+    it('automatically restarts on empty polling response', () => {
+      uiNotifications.subscribe('aaa', () => undefined);
+
+      let response = scout.create(UiNotificationResponse, {
+        notifications: [{
+          id: '100',
+          topic: 'aaa',
+          nodeId: 'node1',
+          creationTime: '2023-09-16 21:44:13.000',
+          subscriptionStart: true
+        }]
+      });
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        responseText: JSON.stringify(response.toPojo())
+      });
+
+      // Subscription was successful, start polling
+      jasmine.clock().tick(1);
+
+      let poller = pollers().get('main');
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200
+        // no response text
+      });
+      jasmine.clock().tick(1);
+      expect(poller.status).toBe(BackgroundJobPollingStatus.FAILURE);
+
+      jasmine.clock().tick(UiNotificationPoller.RESPONSE_ERROR_RETRY_INTERVAL + 1000);
+      expect(poller.status).toBe(BackgroundJobPollingStatus.RUNNING);
+    });
+
+    it('automatically restarts if subscription fails and other topics are subscribed', () => {
       uiNotifications.subscribe('aaa', () => undefined);
 
       let response = scout.create(UiNotificationResponse, {


### PR DESCRIPTION
If the server sends an empty response, the success handler throws a null pointer exception and the polling stops. From now on, no error will occur and the polling will resume after the
RESPONSE_ERROR_RETRY_INTERVAL.

452409