### PR TITLE
Set open-uri action of PDF files to 'download'

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/OpenUriHelper.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/OpenUriHelper.java
@@ -90,7 +90,7 @@ public class OpenUriHelper {
   }
 
   protected IOpenUriAction getOpenUriActionPdf() {
-    return OpenUriAction.OPEN;
+    return OpenUriAction.DOWNLOAD;
   }
 
   protected IOpenUriAction getOpenUriActionDefault() {


### PR DESCRIPTION
Some browsers (e.g., Chrome) don't persist preview files and re-fetch them when saved locally. Since our resource expires after 1 minute, we download the PDF directly first to ensure it isn't lost during preview.

462735