### PR TITLE
Refactored client notification dispatching

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/cache/CacheClientNotificationHandler.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/cache/CacheClientNotificationHandler.java
@@ -14,6 +14,8 @@ import org.eclipse.scout.rt.platform.cache.InvalidateCacheNotification;
 import org.eclipse.scout.rt.shared.cache.CacheNotificationHandler;
 import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationAddress;
 import org.eclipse.scout.rt.shared.notification.INotificationHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Client {@link CacheNotificationHandler} that additionally informs any session listeners.
@@ -21,6 +23,8 @@ import org.eclipse.scout.rt.shared.notification.INotificationHandler;
  * @since 5.2
  */
 public class CacheClientNotificationHandler extends AbstractObservableNotificationHandler<InvalidateCacheNotification> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CacheClientNotificationHandler.class);
 
   private final INotificationHandler<InvalidateCacheNotification> m_basicHandler;
 
@@ -34,6 +38,7 @@ public class CacheClientNotificationHandler extends AbstractObservableNotificati
 
   @Override
   public void handleNotification(InvalidateCacheNotification notification, IClientNotificationAddress address) {
+    LOG.debug("Received InvalidateCacheNotification for cache {}", notification.getCacheId());
     // invalidate caches first
     m_basicHandler.handleNotification(notification);
     super.handleNotification(notification, address);

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/clientnotification/ClientNotificationPoller.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/clientnotification/ClientNotificationPoller.java
@@ -66,6 +66,7 @@ public class ClientNotificationPoller {
   private IFuture<Void> m_livenessFuture;
   private volatile long m_pollerStaleTimeMillis;
   private volatile long m_lastPollRequest;
+  private volatile boolean m_nodeRegistered;
 
   @PostConstruct
   public void start() {
@@ -91,9 +92,17 @@ public class ClientNotificationPoller {
 
   protected void startPoller() {
     touch(); // reset timestamp of last poll request to eliminate timing issues (poller must run before liveness check)
-    m_pollerFuture = Jobs.schedule(new P_NotificationPoller(this::touch), Jobs.newInput()
+    m_pollerFuture = Jobs.schedule(new P_NotificationPoller(this::ensureNodeRegistered, this::touch), Jobs.newInput()
         .withRunContext(createRunContext())
         .withName(ClientNotificationPoller.class.getSimpleName()));
+  }
+
+  protected void ensureNodeRegistered() {
+    if (!m_nodeRegistered) {
+      BEANS.optional(IClientNotificationService.class).ifPresent(svc -> svc.registerNode(NodeId.current()));
+      m_nodeRegistered = true;
+      LOG.info("Registered node {}", NodeId.current());
+    }
   }
 
   protected void stopPoller() {
@@ -104,6 +113,14 @@ public class ClientNotificationPoller {
     LOG.debug("Stopping client notification poller [clientNodeId={}].", IIds.toString(NodeId.current()));
     m_pollerFuture.cancel(true);
     m_pollerFuture = null;
+  }
+
+  protected void unregisterNode() {
+    if (m_nodeRegistered) {
+      createRunContext().run(() -> BEANS.optional(IClientNotificationService.class).ifPresent(svc -> svc.unregisterNode(NodeId.current())));
+      m_nodeRegistered = false;
+      LOG.info("Unregistered node {}", NodeId.current());
+    }
   }
 
   protected RunContext createRunContext() {
@@ -128,9 +145,11 @@ public class ClientNotificationPoller {
 
   private static final class P_NotificationPoller implements IRunnable {
 
+    private final Runnable m_ensureNodeRegistered;
     private final Runnable m_livenessCheck;
 
-    public P_NotificationPoller(Runnable livenessCheck) {
+    public P_NotificationPoller(Runnable ensureNodeRegistered, Runnable livenessCheck) {
+      m_ensureNodeRegistered = ensureNodeRegistered;
       m_livenessCheck = livenessCheck;
     }
 
@@ -149,6 +168,7 @@ public class ClientNotificationPoller {
               .withParentRunMonitor(outerRunMonitor)
               .run(() -> {
                 try {
+                  m_ensureNodeRegistered.run();
                   LOG.debug("Getting notifications from backend [clientNodeId={}]", IIds.toString(NodeId.current()));
                   handleMessagesReceived(BEANS.get(IClientNotificationService.class).getNotifications(NodeId.current()));
                 }
@@ -239,8 +259,7 @@ public class ClientNotificationPoller {
       if (event.getState() == State.PlatformStopping) {
         ClientNotificationPoller poller = BEANS.get(ClientNotificationPoller.class);
         poller.stop();
-        poller.createRunContext().run(() -> BEANS.optional(IClientNotificationService.class)
-            .ifPresent(svc -> svc.unregisterNode(NodeId.current())));
+        poller.unregisterNode();
       }
     }
   }

--- a/org.eclipse.scout.rt.server.session/src/main/java/org/eclipse/scout/rt/server/session/ServerSessionLifecycleHandler.java
+++ b/org.eclipse.scout.rt.server.session/src/main/java/org/eclipse/scout/rt/server/session/ServerSessionLifecycleHandler.java
@@ -11,10 +11,8 @@ package org.eclipse.scout.rt.server.session;
 
 import static org.eclipse.scout.rt.platform.util.Assertions.*;
 
-import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.server.context.ServerRunContext;
-import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,13 +21,11 @@ public class ServerSessionLifecycleHandler implements IServerSessionLifecycleHan
   private static final Logger LOG = LoggerFactory.getLogger(ServerSessionLifecycleHandler.class);
 
   private final String m_scoutSessionId;
-  private final NodeId m_clientNodeId; // may be null
   private final ServerRunContext m_serverRunContextForSessionStart;
 
   public ServerSessionLifecycleHandler(String scoutSessionId, ServerRunContext serverRunContextForSessionStart) {
     m_scoutSessionId = assertNotNullOrEmpty(scoutSessionId, "sessionId must not be null or empty");
     m_serverRunContextForSessionStart = assertNotNull(serverRunContextForSessionStart, "serverRunContext must not be null");
-    m_clientNodeId = serverRunContextForSessionStart.getClientNodeId();
   }
 
   @Override
@@ -46,9 +42,6 @@ public class ServerSessionLifecycleHandler implements IServerSessionLifecycleHan
     }
 
     assertEqual(session.getId(), getId()); // ensure mapping between the actual session and the id used in the caches matches
-    if (m_clientNodeId != null) {
-      BEANS.get(IClientNotificationService.class).registerNode(m_clientNodeId);
-    }
     return session;
   }
 

--- a/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/server/clientnotification/TestingClientNotificationRegistryPlatformListener.java
+++ b/org.eclipse.scout.rt.server.test/src/main/java/org/eclipse/scout/rt/server/clientnotification/TestingClientNotificationRegistryPlatformListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.clientnotification;
+
+import org.eclipse.scout.rt.platform.PlatformEvent;
+import org.eclipse.scout.rt.platform.Replace;
+import org.eclipse.scout.rt.server.clientnotification.ClientNotificationRegistry.ClientNotificationRegistryPlatformListener;
+
+/**
+ * Testing implementation of {@link ClientNotificationRegistry.ClientNotificationRegistryPlatformListener} suppressing start and stop of cleanup job.
+ */
+@Replace
+public class TestingClientNotificationRegistryPlatformListener extends ClientNotificationRegistryPlatformListener {
+  @Override
+  public void stateChanged(PlatformEvent event) {
+    // NOP do not init/shutdown ClientNotificationRegistry
+  }
+}

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationNodeQueueTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationNodeQueueTest.java
@@ -18,10 +18,13 @@ import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.job.IFuture;
 import org.eclipse.scout.rt.platform.job.Jobs;
+import org.eclipse.scout.rt.server.clientnotification.ClientNotificationProperties.NodeQueueCapacity;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationAddress;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
+import org.eclipse.scout.rt.testing.platform.mock.MockConfigPropertyRule;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -30,13 +33,18 @@ import org.junit.runner.RunWith;
  */
 @RunWith(PlatformTestRunner.class)
 public class ClientNotificationNodeQueueTest {
+
   private ClientNotificationNodeQueue m_queue;
+
   private static final int MAX_TEST_CAPACITY = 10;
+
+  @Rule
+  public MockConfigPropertyRule<Integer> m_nodeQueueCapacityPropertyRule = new MockConfigPropertyRule<>(NodeQueueCapacity.class, MAX_TEST_CAPACITY);
 
   @Before
   public void setup() {
-    m_queue = new ClientNotificationNodeQueue(MAX_TEST_CAPACITY);
-    m_queue.setNodeId(NodeId.of("testNodeId"));
+    m_queue = new ClientNotificationNodeQueue();
+    m_queue.init(NodeId.of("testNodeId"));
   }
 
   @Test
@@ -57,8 +65,8 @@ public class ClientNotificationNodeQueueTest {
     IFuture<List<ClientNotificationMessage>> res = Jobs.schedule(() -> m_queue.getNotifications(10, 100, TimeUnit.MILLISECONDS), Jobs.newInput()
         .withRunContext(RunContexts.copyCurrent()));
     ClientNotificationAddress allNodes = ClientNotificationAddress.createAllNodesAddress();
-    m_queue.put(new ClientNotificationMessage(allNodes, "test", true, "cid"));
-    m_queue.put(new ClientNotificationMessage(allNodes, "test2", true, "cid"));
+    m_queue.put(new ClientNotificationMessage(allNodes, "test", "cid"));
+    m_queue.put(new ClientNotificationMessage(allNodes, "test2", "cid"));
     List<ClientNotificationMessage> notifications = res.awaitDoneAndGet();
     assertEquals(2, notifications.size());
     assertEquals("test", notifications.get(0).getNotification());
@@ -76,7 +84,7 @@ public class ClientNotificationNodeQueueTest {
   private void putTestNotifications(int count) {
     ClientNotificationAddress allNodes = ClientNotificationAddress.createAllNodesAddress();
     for (int i = 0; i < count; i++) {
-      m_queue.put(new ClientNotificationMessage(allNodes, "test" + i, true, "cid"));
+      m_queue.put(new ClientNotificationMessage(allNodes, "test" + i, "cid"));
     }
   }
 }

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryClusterHandlerTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryClusterHandlerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.clientnotification;
+
+import static org.mockito.Mockito.*;
+
+import org.eclipse.scout.rt.dataobject.id.NodeId;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.server.clientnotification.ClientNotificationRegistryClusterNotification.Event;
+import org.eclipse.scout.rt.testing.platform.mock.BeanMock;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Testcases for {@link ClientNotificationRegistryClusterHandler}
+ */
+@RunWith(PlatformTestRunner.class)
+public class ClientNotificationRegistryClusterHandlerTest {
+
+  protected static final NodeId MOCK_CLIENT_ID = NodeId.of("mockClientId");
+
+  @BeanMock
+  protected ClientNotificationRegistry m_registry;
+
+  @Test
+  public void testRegister() {
+    ClientNotificationRegistryClusterHandler handler = BEANS.get(ClientNotificationRegistryClusterHandler.class);
+    handler.handleNotification(new ClientNotificationRegistryClusterNotification(Event.NODE_REGISTERED, MOCK_CLIENT_ID));
+    verify(m_registry).registerNode(MOCK_CLIENT_ID, false);
+    verifyNoMoreInteractions(m_registry);
+  }
+
+  @Test
+  public void testUnregister() {
+    ClientNotificationRegistryClusterHandler handler = BEANS.get(ClientNotificationRegistryClusterHandler.class);
+    handler.handleNotification(new ClientNotificationRegistryClusterNotification(Event.NODE_UNREGISTERED, MOCK_CLIENT_ID));
+    verify(m_registry).unregisterNode(MOCK_CLIENT_ID, false);
+    verifyNoMoreInteractions(m_registry);
+  }
+}

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.server.commons.servlet.IHttpServletRoundtrip;
 import org.eclipse.scout.rt.server.context.ServerRunContexts;
@@ -45,8 +46,8 @@ public class ClientNotificationRegistryTest {
   @Test
   public void testNotificationsForAllNodes() {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-    reg.registerNode(NodeId.of("testNodeId"));
-    reg.registerNode(NodeId.of("testNodeId2"));
+    reg.registerNode(NodeId.of("testNodeId"), true);
+    reg.registerNode(NodeId.of("testNodeId2"), true);
     reg.putForAllNodes(TEST_NOTIFICATION);
     List<ClientNotificationMessage> notificationsNode1 = consumeNoWait(reg, NodeId.of("testNodeId"));
     List<ClientNotificationMessage> notificationsNode2 = consumeNoWait(reg, NodeId.of("testNodeId2"));
@@ -60,7 +61,7 @@ public class ClientNotificationRegistryTest {
   @Test
   public void testNotificationsUnregisteredSingleSession() {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-    reg.registerNode(NodeId.of("testNodeId"));
+    reg.registerNode(NodeId.of("testNodeId"), true);
     reg.putForUser(TEST_USER, TEST_NOTIFICATION);
     List<ClientNotificationMessage> notificationsNode = consumeNoWait(reg, NodeId.of("testNodeId"));
     assertEquals(1, notificationsNode.size());
@@ -72,7 +73,7 @@ public class ClientNotificationRegistryTest {
   @Test
   public void testMultipleNotifications() {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-    reg.registerNode(TEST_NODE);
+    reg.registerNode(TEST_NODE, true);
     reg.putForUser(TEST_USER, TEST_NOTIFICATION);
     reg.putForUser(TEST_USER, "notification2");
 
@@ -85,7 +86,7 @@ public class ClientNotificationRegistryTest {
   @Test
   public void testNotificationsForAllSessions() {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-    reg.registerNode(NodeId.of("testNodeId"));
+    reg.registerNode(NodeId.of("testNodeId"), true);
     reg.putForAllSessions(TEST_NOTIFICATION);
     List<ClientNotificationMessage> notificationsNode = consumeNoWait(reg, NodeId.of("testNodeId"));
     assertEquals(1, notificationsNode.size());
@@ -102,10 +103,10 @@ public class ClientNotificationRegistryTest {
         .withApplicationScoped(true));
     try {
       ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-      reg.registerNode(NodeId.of("testNodeId"));
+      reg.registerNode(NodeId.of("testNodeId"), false);
       reg.publish(Collections.emptySet());
       assertEquals(Collections.emptyList(), consumeNoWait(reg, NodeId.of("testNodeId")));
-      Mockito.verifyNoInteractions(mockClusterSyncService);
+      Mockito.verifyNoMoreInteractions(mockClusterSyncService);
     }
     finally {
       BeanTestingHelper.get().unregisterBean(bean);
@@ -123,14 +124,17 @@ public class ClientNotificationRegistryTest {
         .withApplicationScoped(true));
     try {
       ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-      reg.registerNode(NodeId.of("testNodeId"));
-      reg.registerNode(NodeId.of("testNodeId2"));
-      reg.putForAllNodes(TEST_NOTIFICATION, false);
+      reg.registerNode(NodeId.of("testNodeId"), false);
+      reg.registerNode(NodeId.of("testNodeId2"), false);
+      RunContexts.empty().run(() -> {
+        //noinspection deprecation
+        reg.putTransactionalForAllNodesWithoutClusterNotification(TEST_NOTIFICATION);
+      });
       List<ClientNotificationMessage> notificationsNode1 = consumeNoWait(reg, NodeId.of("testNodeId"));
       List<ClientNotificationMessage> notificationsNode2 = consumeNoWait(reg, NodeId.of("testNodeId2"));
       assertSingleTestNotification(notificationsNode1);
       assertSingleTestNotification(notificationsNode2);
-      Mockito.verifyNoInteractions(mockClusterSyncService);
+      Mockito.verifyNoMoreInteractions(mockClusterSyncService);
     }
     finally {
       BeanTestingHelper.get().unregisterBean(bean);
@@ -140,8 +144,8 @@ public class ClientNotificationRegistryTest {
   @Test
   public void registeredNodeAvailable() {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-    reg.registerNode(TEST_NODE);
-    assertTrue(reg.getRegisteredNodeIds().contains(TEST_NODE));
+    reg.registerNode(TEST_NODE, true);
+    assertTrue(reg.getRegisteredClientNodeIds().contains(TEST_NODE));
   }
 
   /**
@@ -150,7 +154,7 @@ public class ClientNotificationRegistryTest {
   @Test
   public void registeredNodeInitialsNotAvailable() {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-    assertFalse(reg.getRegisteredNodeIds().contains(TEST_NODE));
+    assertFalse(reg.getRegisteredClientNodeIds().contains(TEST_NODE));
   }
 
   /**
@@ -159,9 +163,9 @@ public class ClientNotificationRegistryTest {
   @Test
   public void registeredNodeNotAvailable_afterUnregister() {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-    reg.registerNode(TEST_NODE);
-    reg.unregisterNode(TEST_NODE);
-    assertFalse(reg.getRegisteredNodeIds().contains(TEST_NODE));
+    reg.registerNode(TEST_NODE, true);
+    reg.unregisterNode(TEST_NODE, true);
+    assertFalse(reg.getRegisteredClientNodeIds().contains(TEST_NODE));
   }
 
   /**
@@ -170,8 +174,8 @@ public class ClientNotificationRegistryTest {
   @Test
   public void testNodeAvailable_AfterUnregisterSession() {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-    reg.registerNode(TEST_NODE);
-    assertTrue(reg.getRegisteredNodeIds().contains(TEST_NODE));
+    reg.registerNode(TEST_NODE, true);
+    assertTrue(reg.getRegisteredClientNodeIds().contains(TEST_NODE));
   }
 
   /**
@@ -180,8 +184,9 @@ public class ClientNotificationRegistryTest {
   @Test
   public void testQueueRemovedAfterTimeout() throws InterruptedException {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(10);
-    reg.registerNode(TEST_NODE);
+    reg.registerNode(TEST_NODE, true);
     Thread.sleep(100);
+    reg.cleanupDeadNodes();
     reg.putForAllNodes("notification");
     List<ClientNotificationMessage> consumed = consumeNoWait(reg, TEST_NODE);
     assertTrue(consumed.isEmpty());
@@ -193,7 +198,7 @@ public class ClientNotificationRegistryTest {
   @Test
   public void testQueueNotRemovedIfConsumed() throws InterruptedException {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(100);
-    reg.registerNode(TEST_NODE);
+    reg.registerNode(TEST_NODE, true);
     for (int i = 0; i < 100; i++) {
       Thread.sleep(10);
       consumeNoWait(reg, TEST_NODE);
@@ -220,8 +225,8 @@ public class ClientNotificationRegistryTest {
           .withClientNotificationCollector(collector)
           .run(() -> {
             ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-            reg.registerNode(currentNode);
-            reg.registerNode(otherNode);
+            reg.registerNode(currentNode, true);
+            reg.registerNode(otherNode, true);
 
             reg.putTransactionalForUser(TEST_USER, TEST_NOTIFICATION);
             commit();
@@ -252,8 +257,8 @@ public class ClientNotificationRegistryTest {
     collector.consume();
     ServerRunContexts.copyCurrent().withClientNodeId(currentNode).withClientNotificationCollector(collector).run(() -> {
       ClientNotificationRegistry reg = new ClientNotificationRegistry(TEST_QUEUE_EXPIRE_TIMEOUT);
-      reg.registerNode(currentNode);
-      reg.registerNode(otherNode);
+      reg.registerNode(currentNode, true);
+      reg.registerNode(otherNode, true);
       reg.putTransactionalForUser(TEST_USER, TEST_NOTIFICATION);
       commit();
       //no notifications for current request (piggyback)

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/clustersync/ClientNotificationClusterNotificationTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/clustersync/ClientNotificationClusterNotificationTest.java
@@ -65,7 +65,7 @@ public class ClientNotificationClusterNotificationTest {
     m_svc.enable();
     ClientNotificationTestRegistry reg = new ClientNotificationTestRegistry();
     m_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(ClientNotificationRegistry.class, reg)));
-    reg.registerNode(TEST_NODE);
+    reg.registerNode(TEST_NODE, false);
   }
 
   @After
@@ -82,7 +82,7 @@ public class ClientNotificationClusterNotificationTest {
     IMessage<IClusterNotificationMessage> momMsg = mock(IMessage.class);
 
     ClientNotificationAddress address = ClientNotificationAddress.createAllNodesAddress();
-    ClientNotificationMessage message = new ClientNotificationMessage(address, "test", true, "cid");
+    ClientNotificationMessage message = new ClientNotificationMessage(address, "test", "cid");
     ArrayList<ClientNotificationMessage> messages = new ArrayList<>();
     messages.add(message);
     when(momMsg.getTransferObject()).thenReturn(new ClusterNotificationMessage(new ClientNotificationClusterNotification(messages), m_testProps));
@@ -95,8 +95,8 @@ public class ClientNotificationClusterNotificationTest {
 
   public class ClientNotificationTestRegistry extends ClientNotificationRegistry {
     @Override
-    public void registerNode(NodeId nodeId) {
-      super.registerNode(nodeId);
+    public void registerNode(NodeId clientNodeId, boolean distributeOverCluster) {
+      super.registerNode(clientNodeId, distributeOverCluster);
     }
   }
 

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/code/CodeServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/code/CodeServiceTest.java
@@ -10,7 +10,6 @@
 package org.eclipse.scout.rt.server.services.common.code;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
 
 import java.io.Serial;
@@ -78,7 +77,8 @@ public class CodeServiceTest {
     codeService.reloadCodeType(SomeCodeType.class);
 
     ArgumentCaptor<InvalidateCacheNotification> notification = ArgumentCaptor.forClass(InvalidateCacheNotification.class);
-    verify(m_clientNotificationReg).putTransactionalForAllNodes(notification.capture(), anyBoolean());
+    //noinspection deprecation
+    verify(m_clientNotificationReg).putTransactionalForAllNodesWithoutClusterNotification(notification.capture());
 
     Set<Class<? extends ICodeType<?, ?>>> codeTypeClasses = ((CodeTypeCacheEntryFilter) notification.getValue().getFilter()).getCodeTypeClasses();
     assertEquals("CodeType list in the notification size", 1, codeTypeClasses.size());
@@ -95,7 +95,8 @@ public class CodeServiceTest {
     codeService.reloadCodeTypes(list);
 
     ArgumentCaptor<InvalidateCacheNotification> notification = ArgumentCaptor.forClass(InvalidateCacheNotification.class);
-    verify(m_clientNotificationReg).putTransactionalForAllNodes(notification.capture(), anyBoolean());
+    //noinspection deprecation
+    verify(m_clientNotificationReg).putTransactionalForAllNodesWithoutClusterNotification(notification.capture());
 
     Set<Class<? extends ICodeType<?, ?>>> codeTypeClasses = ((CodeTypeCacheEntryFilter) notification.getValue().getFilter()).getCodeTypeClasses();
     assertEquals("CodeType list in the notification size", 2, codeTypeClasses.size());
@@ -109,7 +110,7 @@ public class CodeServiceTest {
    * {@link CodeService#invalidateCodeType(Class)}
    */
   @Test
-  public void testInvlidateCodeType() {
+  public void testInvalidateCodeType() {
     ICodeService codeService = BEANS.get(ICodeService.class);
     codeService.getCodeType(SomeCodeType.class);
     // verify that execLoadCodes has been invoked and reset flag, so that next execLoadCodes can be detected
@@ -119,7 +120,8 @@ public class CodeServiceTest {
 
     // check notification
     ArgumentCaptor<InvalidateCacheNotification> notification = ArgumentCaptor.forClass(InvalidateCacheNotification.class);
-    verify(m_clientNotificationReg).putTransactionalForAllNodes(notification.capture(), anyBoolean());
+    //noinspection deprecation
+    verify(m_clientNotificationReg).putTransactionalForAllNodesWithoutClusterNotification(notification.capture());
 
     Set<Class<? extends ICodeType<?, ?>>> codeTypeClasses = ((CodeTypeCacheEntryFilter) notification.getValue().getFilter()).getCodeTypeClasses();
     assertEquals("CodeType list in the notification size", 1, codeTypeClasses.size());
@@ -167,7 +169,7 @@ public class CodeServiceTest {
    * {@link CodeService#invalidateCodeTypes(List)}
    */
   @Test
-  public void testInvlidateCodeTypes() {
+  public void testInvalidateCodeTypes() {
     ICodeService codeService = BEANS.get(ICodeService.class);
 
     List<Class<? extends ICodeType<?, ?>>> list = new ArrayList<>();
@@ -176,7 +178,8 @@ public class CodeServiceTest {
     codeService.invalidateCodeTypes(list);
 
     ArgumentCaptor<InvalidateCacheNotification> notification = ArgumentCaptor.forClass(InvalidateCacheNotification.class);
-    verify(m_clientNotificationReg).putTransactionalForAllNodes(notification.capture(), anyBoolean());
+    //noinspection deprecation
+    verify(m_clientNotificationReg).putTransactionalForAllNodesWithoutClusterNotification(notification.capture());
 
     Set<Class<? extends ICodeType<?, ?>>> codeTypeClasses = ((CodeTypeCacheEntryFilter) notification.getValue().getFilter()).getCodeTypeClasses();
     assertEquals("CodeType list in the notification size", 2, codeTypeClasses.size());

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/cache/ClientNotificationServerCacheWrapper.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/cache/ClientNotificationServerCacheWrapper.java
@@ -15,6 +15,8 @@ import org.eclipse.scout.rt.platform.cache.ICache;
 import org.eclipse.scout.rt.platform.cache.ICacheEntryFilter;
 import org.eclipse.scout.rt.platform.cache.InvalidateCacheNotification;
 import org.eclipse.scout.rt.server.clientnotification.ClientNotificationRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Cache wrapper used to notify clients about invalidate operations.
@@ -26,6 +28,8 @@ import org.eclipse.scout.rt.server.clientnotification.ClientNotificationRegistry
  */
 public final class ClientNotificationServerCacheWrapper<K, V> extends AbstractCacheWrapper<K, V> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ClientNotificationServerCacheWrapper.class);
+
   public ClientNotificationServerCacheWrapper(ICache<K, V> delegate) {
     super(delegate);
   }
@@ -33,8 +37,11 @@ public final class ClientNotificationServerCacheWrapper<K, V> extends AbstractCa
   @Override
   public void invalidate(ICacheEntryFilter<K, V> filter, boolean propagate) {
     super.invalidate(filter, propagate);
-    // always send invalidate operations from a server to clients and do not check on the propagate property
+    // always send invalidate operations from a server to all clients and do not check on the propagate property
+    LOG.debug("Propagate InvalidateCacheNotification for cache '{}' to UI nodes", getCacheId());
     InvalidateCacheNotification notification = new InvalidateCacheNotification(getCacheId(), filter);
-    BEANS.get(ClientNotificationRegistry.class).putTransactionalForAllNodes(notification, false);
+    // Do not re-distribute this message to other cluster nodes, since this was already published by ClusterNotificationCacheWrapper before
+    //noinspection deprecation
+    BEANS.get(ClientNotificationRegistry.class).putTransactionalForAllNodesWithoutClusterNotification(notification);
   }
 }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/cache/ClusterNotificationCacheWrapper.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/cache/ClusterNotificationCacheWrapper.java
@@ -16,6 +16,8 @@ import org.eclipse.scout.rt.platform.cache.ICacheEntryFilter;
 import org.eclipse.scout.rt.platform.cache.InvalidateCacheNotification;
 import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.server.services.common.clustersync.IClusterSynchronizationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Cache wrapper used to distribute invalidate operations within a server cluster.
@@ -23,6 +25,8 @@ import org.eclipse.scout.rt.server.services.common.clustersync.IClusterSynchroni
  * @since 5.2
  */
 public class ClusterNotificationCacheWrapper<K, V> extends AbstractCacheWrapper<K, V> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterNotificationCacheWrapper.class);
 
   public ClusterNotificationCacheWrapper(ICache<K, V> delegate) {
     super(delegate);
@@ -34,9 +38,11 @@ public class ClusterNotificationCacheWrapper<K, V> extends AbstractCacheWrapper<
     if (propagate) {
       InvalidateCacheNotification notification = new InvalidateCacheNotification(getCacheId(), filter);
       if (ITransaction.CURRENT.get() != null) {
+        LOG.debug("Publish InvalidateCacheNotification for cache '{}' transactional to other backend nodes", getCacheId());
         BEANS.get(IClusterSynchronizationService.class).publishTransactional(notification);
       }
       else {
+        LOG.debug("Publish InvalidateCacheNotification for cache '{}' to other backend nodes", getCacheId());
         BEANS.get(IClusterSynchronizationService.class).publish(notification);
       }
     }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/cache/ServerCacheBuilder.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/cache/ServerCacheBuilder.java
@@ -23,7 +23,8 @@ public class ServerCacheBuilder<K, V> extends CacheBuilder<K, V> {
     if (isShared()) {
       cache = new ClientNotificationServerCacheWrapper<>(cache);
     }
-    // it is important, that the ClusterNotificationCacheWrapper is added after the client notification cache wrapper
+    // It is important, that the ClusterNotificationCacheWrapper is added after the client notification cache wrapper
+    // in order to first publish cache invalidation to backend cluster and afterward publish the notification for all UI nodes
     if (isClusterEnabled()) {
       cache = new ClusterNotificationCacheWrapper<>(cache);
     }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/AbstractClientNotificationNodeQueue.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/AbstractClientNotificationNodeQueue.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.clientnotification;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.scout.rt.dataobject.id.NodeId;
+import org.eclipse.scout.rt.platform.config.CONFIG;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.FinalValue;
+import org.eclipse.scout.rt.platform.util.date.DateUtility;
+import org.eclipse.scout.rt.server.clientnotification.ClientNotificationProperties.NodeQueueCapacity;
+import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
+import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract implementation of a queue for a client node, that keeps track of notifications for that node.
+ */
+public abstract class AbstractClientNotificationNodeQueue implements IClientNotificationNodeQueue {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractClientNotificationNodeQueue.class);
+
+  protected final FinalValue<NodeId> m_clientNodeId = new FinalValue<>();
+
+  protected final AtomicLong m_lastConsumeAccess;
+
+  public AbstractClientNotificationNodeQueue() {
+    m_lastConsumeAccess = new AtomicLong(System.currentTimeMillis());
+  }
+
+  @Override
+  public void init(NodeId clientNodeId) {
+    m_clientNodeId.set(clientNodeId);
+  }
+
+  @Override
+  public NodeId getClientNodeId() {
+    return m_clientNodeId.get();
+  }
+
+  @Override
+  public void put(ClientNotificationMessage notification) {
+    put(List.of(notification));
+  }
+
+  @Override
+  public void put(Collection<? extends ClientNotificationMessage> notifications) {
+    List<ClientNotificationMessage> relevantNotifications = getRelevantNotifications(notifications);
+    putDroppingOld(relevantNotifications);
+  }
+
+  /**
+   * Put notifications into queue and drop the oldest ones, if capacity is reached.
+   */
+  protected void putDroppingOld(Collection<? extends ClientNotificationMessage> notifications) {
+    List<ClientNotificationMessage> droppedNotifications = new ArrayList<>();
+    for (ClientNotificationMessage message : notifications) {
+      LOG.debug("Put notification {} to queue. [clientNodeId={}]", message.getNotification().getClass().getSimpleName(), getClientNodeId());
+      boolean inserted = offer(message);
+      while (!inserted) {
+        ClientNotificationMessage removed = poll();
+        if (removed != null) {
+          droppedNotifications.add(removed);
+        }
+        inserted = offer(message);
+      }
+    }
+    if (!droppedNotifications.isEmpty()) {
+      Function<Stream<? extends ClientNotificationMessage>, String> infoExtractor = s -> s
+          .map(m -> m.getNotification().getClass().getSimpleName() + " -> " + m.getAddress().prettyPrint())
+          .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+          .entrySet().stream()
+          .sorted(Entry.<String, Long> comparingByValue().reversed())
+          .map(e -> e.getKey() + " (" + e.getValue() + "x)")
+          .collect(Collectors.joining(", ", "[", "]"));
+
+      LOG.error("Notification queue capacity reached. Added {}, removed oldest {} notification messages. [clientNodeId={}, lastConsumeAccess={}, newNotifications={}, droppedNotifications={}]",
+          notifications.size(), droppedNotifications.size(), getClientNodeId(), getLastConsumeAccessFormatted(), infoExtractor.apply(notifications.stream()), infoExtractor.apply(droppedNotifications.stream()));
+
+      if (LOG.isDebugEnabled()) {
+        Function<Stream<? extends ClientNotificationMessage>, String> detailInfoExtractor = s -> s
+            .map(m -> m.toString())
+            .collect(Collectors.joining("\n    ", "\n    ", ""));
+
+        LOG.debug("Notification queue capacity reached. Details:\n  newNotifications={}\n  droppedNotifications={}",
+            detailInfoExtractor.apply(notifications.stream()), detailInfoExtractor.apply(droppedNotifications.stream()),
+            new Exception("stacktrace for further analysis"));
+      }
+    }
+  }
+
+  /**
+   * @return time since messages have last been consumed
+   */
+  @Override
+  public long getLastConsumeAccess() {
+    return m_lastConsumeAccess.get();
+  }
+
+  @Override
+  public String getLastConsumeAccessFormatted() {
+    return DateUtility.format(new Date(getLastConsumeAccess()), "yyyy-MM-dd HH:mm:ss.SSS");
+  }
+
+  @Override
+  public List<ClientNotificationMessage> consume(int maxAmount, long maxWaitTime, TimeUnit unit) {
+    m_lastConsumeAccess.set(System.currentTimeMillis());
+
+    List<ClientNotificationMessage> result = getNotifications(maxAmount, maxWaitTime, unit);
+    LOG.debug("Consumed {} notifications. [clientNodeId={}]", result.size(), getClientNodeId());
+    return result;
+  }
+
+  protected List<ClientNotificationMessage> getNotifications(int maxAmount, long maxWaitTime, TimeUnit unit) {
+    List<ClientNotificationMessage> collected = new LinkedList<>();
+    try {
+      //blocking wait to get first message
+      ClientNotificationMessage next = poll(maxWaitTime, unit);
+      if (next != null) {
+        collected.add(next);
+      }
+
+      //add more available notifications
+      //with short wait timeout to not go back with one notification when some are about to pop up.
+      int timeout = 234; // 0 for no reschedule
+      while (next != null && collected.size() < maxAmount) {
+        next = poll(timeout, TimeUnit.MILLISECONDS);
+        if (next != null) {
+          collected.add(next);
+        }
+      }
+    }
+    catch (InterruptedException e) {
+      LOG.info("Interrupted while waiting for client notification messages", e);
+    }
+    return collected;
+  }
+
+  protected List<ClientNotificationMessage> getRelevantNotifications(Collection<? extends ClientNotificationMessage> notificationInput) {
+    return notificationInput.stream()
+        .filter(msg -> isRelevant(msg.getAddress()))
+        .collect(toList());
+  }
+
+  protected boolean isRelevant(IClientNotificationAddress address) {
+    return address.isNotifyAllSessions()
+        || address.isNotifyAllNodes()
+        || CollectionUtility.hasElements(address.getSessionIds())
+        || CollectionUtility.hasElements(address.getUserIds());
+  }
+
+  /**
+   * @return capacity of queue. If maximum capacity is reached, messages are dropped.
+   */
+  protected int getConfiguredCapacity() {
+    return CONFIG.getPropertyValue(NodeQueueCapacity.class);
+  }
+
+  /**
+   * Inserts the specified notification into the queue.
+   */
+  protected abstract boolean offer(ClientNotificationMessage notification);
+
+  /**
+   * Retrieves and removes the head of the queue or returns {@code null} if this queue is empty.
+   */
+  protected abstract ClientNotificationMessage poll();
+
+  /**
+   * Retrieves and removes the head of the queue, waiting up to the specified wait time if necessary
+   * for an element to become available or returns {@code null} if this queue is empty.
+   */
+  protected abstract ClientNotificationMessage poll(long timeout, TimeUnit unit) throws InterruptedException;
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationClusterHandler.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationClusterHandler.java
@@ -25,6 +25,6 @@ public class ClientNotificationClusterHandler implements INotificationHandler<Cl
   @Override
   public void handleNotification(ClientNotificationClusterNotification notification) {
     Collection<? extends ClientNotificationMessage> messages = notification.getClientNotificationMessages();
-    BEANS.get(ClientNotificationRegistry.class).publishWithoutClusterNotification(messages);
+    BEANS.get(ClientNotificationRegistry.class).publishWithoutClusterNotification(messages, null);
   }
 }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationCoalescer.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationCoalescer.java
@@ -27,7 +27,13 @@ import org.eclipse.scout.rt.server.notification.NotificationCoalescer;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
 import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationAddress;
 
+/**
+ * TODO Cleanup implementation when {@link ClientNotificationMessage#isDistributeOverCluster()} is cleaned up.
+ * This requires an updated client notification dispatching to ensure all Scout backends (cluster nodes) are able to dispatch
+ * any client notification for an arbitrary client node.
+ */
 @ApplicationScoped
+@SuppressWarnings("deprecation")
 public class ClientNotificationCoalescer {
 
   public List<ClientNotificationMessage> coalesce(List<ClientNotificationMessage> inNotifications) {
@@ -38,7 +44,7 @@ public class ClientNotificationCoalescer {
     messagesPerDistributeAndAddress.put(false, new HashMap<>());
     for (ClientNotificationMessage message : notificationsNoDuplicates) {
       Map<IClientNotificationAddress, List<ClientNotificationMessage>> messagesPerAddress = messagesPerDistributeAndAddress.get(message.isDistributeOverCluster());
-      List<ClientNotificationMessage> messages = messagesPerAddress.computeIfAbsent(message.getAddress(), k -> new ArrayList<>());
+      List<ClientNotificationMessage> messages = messagesPerAddress.computeIfAbsent(message.getAddress(), _ -> new ArrayList<>());
       messages.add(message);
     }
     List<ClientNotificationMessage> result = new ArrayList<>();

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationNodeQueue.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationNodeQueue.java
@@ -9,174 +9,42 @@
  */
 package org.eclipse.scout.rt.server.clientnotification;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map.Entry;
 import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.eclipse.scout.rt.dataobject.id.NodeId;
-import org.eclipse.scout.rt.platform.Bean;
-import org.eclipse.scout.rt.platform.config.CONFIG;
-import org.eclipse.scout.rt.platform.util.CollectionUtility;
-import org.eclipse.scout.rt.platform.util.FinalValue;
-import org.eclipse.scout.rt.platform.util.date.DateUtility;
-import org.eclipse.scout.rt.server.clientnotification.ClientNotificationProperties.NodeQueueCapacity;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
-import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationAddress;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * A queue for a client node, that keeps track of notifications for that node.
+ * A queue implementation for a client node, that keeps track of notifications for that node.
+ * This implementation is based on a {@link BlockingQueue}
  */
-@Bean
-public class ClientNotificationNodeQueue {
-  private static final Logger LOG = LoggerFactory.getLogger(ClientNotificationNodeQueue.class);
+public class ClientNotificationNodeQueue extends AbstractClientNotificationNodeQueue {
 
-  private final FinalValue<NodeId> m_nodeId = new FinalValue<>();
-
-  private final int m_capacity;
-  private final BlockingDeque<ClientNotificationMessage> m_notifications;
-  private final AtomicLong m_lastConsumeAccess;
+  protected final BlockingDeque<ClientNotificationMessage> m_queue;
 
   public ClientNotificationNodeQueue() {
-    this(CONFIG.getPropertyValue(NodeQueueCapacity.class));
+    m_queue = new LinkedBlockingDeque<>(getConfiguredCapacity());
   }
 
-  public ClientNotificationNodeQueue(int capacity) {
-    m_capacity = capacity;
-    m_notifications = new LinkedBlockingDeque<>(capacity);
-    m_lastConsumeAccess = new AtomicLong(System.currentTimeMillis());
+  @Override
+  protected ClientNotificationMessage poll() {
+    return m_queue.poll();
   }
 
-  public void setNodeId(NodeId nodeId) {
-    m_nodeId.set(nodeId);
+  @Override
+  protected ClientNotificationMessage poll(long timeout, TimeUnit unit) throws InterruptedException {
+    return m_queue.poll(timeout, unit);
   }
 
-  public NodeId getNodeId() {
-    return m_nodeId.get();
+  @Override
+  protected boolean offer(ClientNotificationMessage notification) {
+    return m_queue.offer(notification);
   }
 
-  /**
-   * @return capacity of queue. If maximum capacity is reached, messages are dropped.
-   */
-  public int getCapacity() {
-    return m_capacity;
-  }
-
-  public void put(ClientNotificationMessage notification) {
-    put(CollectionUtility.arrayList(notification));
-  }
-
-  public void put(Collection<? extends ClientNotificationMessage> notificationInput) {
-    List<ClientNotificationMessage> notifications = getRelevantNotifications(notificationInput);
-    putDroppingOld(notifications);
-  }
-
-  /**
-   * Put notifications into queue and drop the oldest ones, if capacity is reached.
-   */
-  private void putDroppingOld(Collection<? extends ClientNotificationMessage> notifications) {
-    List<ClientNotificationMessage> droppedNotifications = new ArrayList<>();
-    for (ClientNotificationMessage message : notifications) {
-      boolean inserted = m_notifications.offer(message);
-      while (!inserted) {
-        ClientNotificationMessage removed = m_notifications.poll();
-        if (removed != null) {
-          droppedNotifications.add(removed);
-        }
-        inserted = m_notifications.offer(message);
-      }
-    }
-    if (!droppedNotifications.isEmpty()) {
-      Function<Stream<? extends ClientNotificationMessage>, String> infoExtractor = s -> s
-          .map(m -> m.getNotification().getClass().getSimpleName() + " -> " + m.getAddress().prettyPrint())
-          .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
-          .entrySet().stream()
-          .sorted(Entry.<String, Long> comparingByValue().reversed())
-          .map(e -> e.getKey() + " (" + e.getValue() + "x)")
-          .collect(Collectors.joining(", ", "[", "]"));
-
-      LOG.error("Notification queue capacity reached. Added {}, removed oldest {} notification messages. [clientNodeId={}, lastConsumeAccess={}, newNotifications={}, droppedNotifications={}]",
-          notifications.size(), droppedNotifications.size(), getNodeId(), getLastConsumeAccessFormatted(), infoExtractor.apply(notifications.stream()), infoExtractor.apply(droppedNotifications.stream()));
-
-      if (LOG.isDebugEnabled()) {
-        Function<Stream<? extends ClientNotificationMessage>, String> detailInfoExtractor = s -> s
-            .map(m -> m.toString())
-            .collect(Collectors.joining("\n    ", "\n    ", ""));
-
-        LOG.debug("Notification queue capacity reached. Details:\n  newNotifications={}\n  droppedNotifications={}",
-            detailInfoExtractor.apply(notifications.stream()), detailInfoExtractor.apply(droppedNotifications.stream()),
-            new Exception("stacktrace for further analysis"));
-      }
-    }
-  }
-
-  /**
-   * @return time since messages have last been consumed
-   */
-  public long getLastConsumeAccess() {
-    return m_lastConsumeAccess.get();
-  }
-
-  public String getLastConsumeAccessFormatted() {
-    return DateUtility.format(new Date(getLastConsumeAccess()), "yyyy-MM-dd HH:mm:ss.SSS");
-  }
-
-  public List<ClientNotificationMessage> consume(int maxAmount, long maxWaitTime, TimeUnit unit) {
-    m_lastConsumeAccess.set(System.currentTimeMillis());
-
-    List<ClientNotificationMessage> result = getNotifications(maxAmount, maxWaitTime, unit);
-    LOG.debug("consumed {} notifications. [clientNodeId={}]", result.size(), getNodeId());
-    return result;
-  }
-
-  protected List<ClientNotificationMessage> getNotifications(int maxAmount, long maxWaitTime, TimeUnit unit) {
-    List<ClientNotificationMessage> collected = new LinkedList<>();
-    try {
-      //blocking wait to get first message
-      ClientNotificationMessage next = m_notifications.poll(maxWaitTime, unit);
-      if (next != null) {
-        collected.add(next);
-      }
-
-      //add more available notifications
-      //with short wait timeout to not go back with one notification when some are about to pop up.
-      int timeout = 234; // 0 for no reschedule
-      while (next != null && collected.size() < maxAmount) {
-        next = m_notifications.poll(timeout, TimeUnit.MILLISECONDS);
-        if (next != null) {
-          collected.add(next);
-        }
-      }
-    }
-    catch (InterruptedException e) {
-      LOG.info("Interrupted while waiting for client notification messages", e);
-    }
-    return collected;
-  }
-
-  private List<ClientNotificationMessage> getRelevantNotifications(Collection<? extends ClientNotificationMessage> notificationInput) {
-    return notificationInput.stream()
-        .filter(msg -> isRelevant(msg.getAddress()))
-        .collect(toList());
-  }
-
-  public boolean isRelevant(IClientNotificationAddress address) {
-    return address.isNotifyAllSessions()
-        || address.isNotifyAllNodes()
-        || CollectionUtility.hasElements(address.getSessionIds())
-        || CollectionUtility.hasElements(address.getUserIds());
+  @Override
+  public long size() {
+    return m_queue.size();
   }
 }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationProperties.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationProperties.java
@@ -23,7 +23,7 @@ public final class ClientNotificationProperties {
 
     @Override
     public Integer getDefaultValue() {
-      return 10000;
+      return 10_000;
     }
 
     @Override
@@ -41,12 +41,12 @@ public final class ClientNotificationProperties {
 
     @Override
     public Integer getDefaultValue() {
-      return 10000;
+      return 10_000;
     }
 
     @Override
     public String description() {
-      return "The maximum amount of time in millisecons a consumer blocks while waiting for new notifications. The default is 10 seconds.";
+      return "The maximum amount of time in milliseconds a consumer blocks while waiting for new notifications. The default is 10 seconds.";
     }
 
     @Override
@@ -91,6 +91,26 @@ public final class ClientNotificationProperties {
     @Override
     public String getKey() {
       return "scout.clientnotification.notificationQueueExpireTime";
+    }
+  }
+
+  public static class NotificationQueueCleanupTime extends AbstractPositiveIntegerConfigProperty {
+
+    @Override
+    public Integer getDefaultValue() {
+      return 15 * 60 * 1000;
+    }
+
+    @Override
+    public String description() {
+      return """
+          Cleanup interval for job checking for old queues which may exist if a client node does not properly unregister (e.g. due to a crash).
+          The default value is 15 minutes.""";
+    }
+
+    @Override
+    public String getKey() {
+      return "scout.clientnotification.notificationQueueCleanupTime";
     }
   }
 }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistry.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistry.java
@@ -10,6 +10,7 @@
 package org.eclipse.scout.rt.server.clientnotification;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,12 +25,23 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.IPlatform.State;
+import org.eclipse.scout.rt.platform.IPlatformListener;
+import org.eclipse.scout.rt.platform.Order;
+import org.eclipse.scout.rt.platform.PlatformEvent;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.context.CorrelationId;
+import org.eclipse.scout.rt.platform.exception.ExceptionHandler;
+import org.eclipse.scout.rt.platform.job.FixedDelayScheduleBuilder;
+import org.eclipse.scout.rt.platform.job.IFuture;
+import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.StringUtility;
+import org.eclipse.scout.rt.server.clientnotification.ClientNotificationProperties.NotificationQueueCleanupTime;
 import org.eclipse.scout.rt.server.clientnotification.ClientNotificationProperties.NotificationQueueExpireTime;
+import org.eclipse.scout.rt.server.clientnotification.ClientNotificationRegistryClusterNotification.Event;
+import org.eclipse.scout.rt.server.context.ServerRunContexts;
 import org.eclipse.scout.rt.server.services.common.clustersync.IClusterSynchronizationService;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationAddress;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
@@ -38,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link ClientNotificationRegistry} is the registry for all notifications. It keeps a
- * {@link ClientNotificationNodeQueue} for each notification node (usually a client node). The
+ * {@link IClientNotificationNodeQueue} for each notification node (usually a client node). The
  * {@link ClientNotificationService} consumes the notifications per node. The consumption of the notifications waits for
  * a given timeout for notifications. If no notifications are scheduled within this timeout the lock will be released
  * and returns without any notifications. In case a notification gets scheduled during this timeout the request will be
@@ -47,13 +59,29 @@ import org.slf4j.LoggerFactory;
 @ApplicationScoped
 public class ClientNotificationRegistry {
   private static final Logger LOG = LoggerFactory.getLogger(ClientNotificationRegistry.class);
-  private final Map<NodeId, ClientNotificationNodeQueue> m_notificationQueues = new HashMap<>();
+
+  /**
+   * Indicates the order of the client notification registry's {@link IPlatformListener} to shut down itself upon entering
+   * platform state {@link State#PlatformStopping}. Any listener depending on client notification registry facility must be
+   * configured with an order less than {@code #DESTROY_ORDER}.
+   */
+  public static final int DESTROY_ORDER = 5_700;
+
+  /**
+   * Map of UI server {@link NodeId} to corresponding {@link IClientNotificationNodeQueue}.
+   */
+  protected final Map<NodeId, IClientNotificationNodeQueue> m_notificationQueues = new HashMap<>();
 
   /**
    * If no message is consumed for a certain amount of time [ms], queues are removed to avoid overflows. This may
    * happen, if a node does not properly unregister (e.g. due to a crash).
    */
-  private final int m_queueExpireTime;
+  protected final int m_queueExpireTime;
+
+  /**
+   * Handle to dead node cleanup job.
+   */
+  protected IFuture<Void> m_cleanupJobFuture;
 
   public ClientNotificationRegistry() {
     this(Assertions.assertNotNull(CONFIG.getPropertyValue(NotificationQueueExpireTime.class)));
@@ -64,19 +92,46 @@ public class ClientNotificationRegistry {
   }
 
   /**
-   * This method should only be accessed from {@link ClientNotificationService}
+   * Initialize {@link ClientNotificationRegistry}.
+   *
+   * @see ClientNotificationRegistryPlatformListener
    */
-  protected void registerNode(NodeId nodeId) {
-    getOrCreateQueue(nodeId);
+  protected void init() {
+    startCleanupJob();
   }
 
   /**
-   * This method should only be accessed from {@link ClientNotificationService}
+   * Shutdown {@link ClientNotificationRegistry}.
+   *
+   * @see ClientNotificationRegistryPlatformListener
    */
-  protected void unregisterNode(NodeId nodeId) {
-    synchronized (m_notificationQueues) {
-      LOG.info("Removing queue of unregistered node [clientNodeId={}]", nodeId);
-      m_notificationQueues.remove(nodeId);
+  protected void shutdown() {
+    stopCleanupJob();
+  }
+
+  /**
+   * This method should only be accessed from {@link ClientNotificationService} and {@link ClientNotificationRegistryClusterHandler}.
+   */
+  protected void registerNode(NodeId clientNodeId, boolean distributeOverCluster) {
+    LOG.debug("Register node [clientNodeId={}, distributeOverCluster={}]", clientNodeId, distributeOverCluster);
+    getOrCreateQueue(clientNodeId);
+    if (distributeOverCluster) {
+      // Distribute cluster notification even if no new queue was created on this cluster node to ensure all cluster nodes are kept in sync
+      // Publishing cluster message outside lock for m_notificationQueues
+      publishClusterMessage(new ClientNotificationRegistryClusterNotification(Event.NODE_REGISTERED, clientNodeId));
+    }
+  }
+
+  /**
+   * This method should only be accessed from {@link ClientNotificationService} and {@link ClientNotificationRegistryClusterHandler}.
+   */
+  protected void unregisterNode(NodeId clientNodeId, boolean distributeOverCluster) {
+    LOG.debug("Unregister node [clientNodeId={}, distributeOverCluster={}]", clientNodeId, distributeOverCluster);
+    removeQueue(clientNodeId);
+    if (distributeOverCluster) {
+      // Distribute cluster notification even if no new queue was created on this cluster node to ensure all cluster nodes are kept in sync
+      // Publishing cluster message outside lock for m_notificationQueues
+      publishClusterMessage(new ClientNotificationRegistryClusterNotification(Event.NODE_UNREGISTERED, clientNodeId));
     }
   }
 
@@ -91,164 +146,153 @@ public class ClientNotificationRegistry {
    *     time unit for maxWaitTime
    */
   protected List<ClientNotificationMessage> consume(NodeId notificationNodeId, int maxAmount, int maxWaitTime, TimeUnit unit) {
-    ClientNotificationNodeQueue queue = getOrCreateQueue(notificationNodeId);
+    IClientNotificationNodeQueue queue = getOrCreateQueue(notificationNodeId);
     return queue.consume(maxAmount, maxWaitTime, unit);
   }
 
-  protected ClientNotificationNodeQueue getOrCreateQueue(NodeId nodeId) {
-    Assertions.assertNotNull(nodeId);
+  protected IClientNotificationNodeQueue getOrCreateQueue(NodeId clientNodeId) {
+    Assertions.assertNotNull(clientNodeId);
     synchronized (m_notificationQueues) {
-      return m_notificationQueues.computeIfAbsent(nodeId, this::createNewQueue);
+      return m_notificationQueues.computeIfAbsent(clientNodeId, this::createNewQueue);
     }
   }
 
-  protected ClientNotificationNodeQueue createNewQueue(NodeId nodeId) {
-    ClientNotificationNodeQueue queue = BEANS.get(ClientNotificationNodeQueue.class);
-    queue.setNodeId(nodeId);
+  protected IClientNotificationNodeQueue createNewQueue(NodeId clientNodeId) {
+    IClientNotificationNodeQueue queue = BEANS.get(IClientNotificationNodeQueue.class);
+    queue.init(clientNodeId);
+    LOG.info("Created queue for node [clientNodeId={}]", clientNodeId);
     return queue;
   }
 
+  protected void removeQueue(NodeId clientNodeId) {
+    synchronized (m_notificationQueues) {
+      LOG.info("Removing queue of unregistered node [clientNodeId={}]", clientNodeId);
+      m_notificationQueues.remove(clientNodeId);
+    }
+  }
+
   /**
-   * Nodes that have been registered with {@link #registerNode(NodeId)}
+   * Nodes that have been registered with {@link #registerNode(NodeId, boolean)}
    */
-  public Set<NodeId> getRegisteredNodeIds() {
+  public Set<NodeId> getRegisteredClientNodeIds() {
     synchronized (m_notificationQueues) {
       return new HashSet<>(m_notificationQueues.keySet());
     }
   }
 
-  // put methods
+  // -------- non-transactional put methods --------
+
+  /**
+   * The notification will be distributed to all sessions of the given {@code userId}.
+   */
   public void putForUser(String userId, Serializable notification) {
-    putForUser(userId, notification, true);
+    putForUsers(Collections.singleton(userId), notification);
   }
 
   /**
-   * The notification will be distributed to all sessions of the given userId.
-   *
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
+   * The notification will be distributed to all sessions of the given {@code userIds}.
    */
-  public void putForUser(String userId, Serializable notification, boolean distributeOverCluster) {
-    putForUsers(Collections.singleton(userId), notification, distributeOverCluster);
-  }
-
   public void putForUsers(Set<String> userIds, Serializable notification) {
-    putForUsers(userIds, notification, true);
+    publish(ClientNotificationAddress.createUserAddress(userIds), notification);
   }
 
   /**
-   * The notification will be distributed to all sessions of the given userIds.
-   *
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
+   * The notification will be distributed to the session addressed with the unique {@code sessionId}.
    */
-  public void putForUsers(Set<String> userIds, Serializable notification, boolean distributeOverCluster) {
-    publish(ClientNotificationAddress.createUserAddress(userIds), notification, distributeOverCluster);
-  }
-
   public void putForSession(String sessionId, Serializable notification) {
-    putForSession(sessionId, notification, true);
-  }
-
-  /**
-   * The notification will be distributed to the session addressed with the unique sessionId.
-   *
-   * @param sessionId
-   *     the addressed session
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
-   */
-  public void putForSession(String sessionId, Serializable notification, boolean distributeOverCluster) {
     if (StringUtility.isNullOrEmpty(sessionId)) {
       return;
     }
-    publish(ClientNotificationAddress.createSessionAddress(Collections.singleton(sessionId)), notification, distributeOverCluster);
-  }
-
-  public void putForAllSessions(Serializable notification) {
-    putForAllSessions(notification, true);
+    publish(ClientNotificationAddress.createSessionAddress(Collections.singleton(sessionId)), notification);
   }
 
   /**
    * This notification will be distributed to all sessions.
-   *
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
    */
-  public void putForAllSessions(Serializable notification, boolean distributeOverCluster) {
-    publish(ClientNotificationAddress.createAllSessionsAddress(), notification, distributeOverCluster);
+  public void putForAllSessions(Serializable notification) {
+    publish(ClientNotificationAddress.createAllSessionsAddress(), notification);
   }
 
+  /**
+   * This notification will be distributed to client nodes (e.g. UI server nodes).
+   */
   public void putForAllNodes(Serializable notification) {
-    putForAllNodes(notification, true);
+    publish(ClientNotificationAddress.createAllNodesAddress(), notification);
   }
 
   /**
-   * This notification will be distributed to client nodes.
-   *
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
+   * Publishes given notification to given {@code address}.
    */
-  public void putForAllNodes(Serializable notification, boolean distributeOverCluster) {
-    publish(ClientNotificationAddress.createAllNodesAddress(), notification, distributeOverCluster);
-  }
-
   public void publish(ClientNotificationAddress address, Serializable notification) {
-    publish(address, notification, true);
+    publish(Collections.singleton(new ClientNotificationMessage(address, notification, CorrelationId.CURRENT.get())));
   }
 
-  public void publish(ClientNotificationAddress address, Serializable notification, boolean distributeOverCluster) {
-    publish(Collections.singleton(new ClientNotificationMessage(address, notification, distributeOverCluster, CorrelationId.CURRENT.get())));
-  }
-
+  /**
+   * Publishes given notifications for UI servers and as cluster notification for the other backends.
+   */
   public void publish(Collection<? extends ClientNotificationMessage> messages) {
-    publishWithoutClusterNotification(messages, null);
-    publishClusterInternal(messages);
-  }
-
-  public void publish(Collection<? extends ClientNotificationMessage> messages, NodeId excludedUiNodeId) {
-    publishWithoutClusterNotification(messages, excludedUiNodeId);
-    publishClusterInternal(messages);
+    publish(messages, null);
   }
 
   /**
-   * Publish without triggering cluster notification
-   */
-  public void publishWithoutClusterNotification(Collection<? extends ClientNotificationMessage> messages) {
-    publishWithoutClusterNotification(messages, null);
-  }
-
-  /**
-   * Publish without triggering cluster notification
+   * Publishes given notifications for UI servers and as cluster notification for the other backends excluding client node {@code excludedClientNodeId}.
    *
-   * @param excludedUiNodeId
-   *     may be <code>null</code>
+   * @param excludedClientNodeId
+   *     may be {@code null}
    */
-  public void publishWithoutClusterNotification(Collection<? extends ClientNotificationMessage> messages, NodeId excludedUiNodeId) {
+  public void publish(Collection<? extends ClientNotificationMessage> messages, NodeId excludedClientNodeId) {
+    publishWithoutClusterNotification(messages, excludedClientNodeId);
+    publishClusterInternal(messages);
+  }
+
+  /**
+   * Publish given notifications for UI servers excluding client node {@code excludedClientNodeId} and without triggering cluster notification for other backends.
+   *
+   * @param excludedClientNodeId
+   *     may be {@code null}
+   */
+  protected void publishWithoutClusterNotification(Collection<? extends ClientNotificationMessage> messages, NodeId excludedClientNodeId) {
     synchronized (m_notificationQueues) {
-      Iterator<ClientNotificationNodeQueue> iter = m_notificationQueues.values().iterator();
-      while (iter.hasNext()) {
-        ClientNotificationNodeQueue queue = iter.next();
-        if (!queue.getNodeId().equals(excludedUiNodeId)) {
+      for (IClientNotificationNodeQueue queue : m_notificationQueues.values()) {
+        if (!queue.getClientNodeId().equals(excludedClientNodeId)) {
           queue.put(messages);
-          if (isQueueExpired(queue)) {
-            LOG.info("Removing expired queue [clientNodeId={}, lastConsumeAccess={}]", queue.getNodeId(), queue.getLastConsumeAccessFormatted());
-            iter.remove();
-          }
         }
       }
     }
   }
 
-  protected boolean isQueueExpired(ClientNotificationNodeQueue queue) {
-    long now = System.currentTimeMillis();
-    long lastAccess = queue.getLastConsumeAccess();
-    return (now - lastAccess) > m_queueExpireTime;
+  /**
+   * Publish client notification messages to other backend cluster nodes. Message not foreseen for cluster distributions are filtered.
+   */
+  protected void publishClusterInternal(Collection<? extends ClientNotificationMessage> messages) {
+    Collection<ClientNotificationMessage> filteredMessages = new LinkedList<>();
+    for (ClientNotificationMessage message : messages) {
+      //noinspection deprecation
+      if (message.isDistributeOverCluster()) {
+        filteredMessages.add(message);
+      }
+    }
+    // do not publish empty messages
+    if (filteredMessages.isEmpty()) {
+      return;
+    }
+    publishClusterMessage(new ClientNotificationClusterNotification(filteredMessages));
   }
 
-  public void putTransactionalForUser(String userId, Serializable notification) {
-    putTransactionalForUser(userId, notification, true);
+  /**
+   * Publish cluster message to other backend cluster nodes.
+   */
+  protected void publishClusterMessage(Serializable message) {
+    try {
+      IClusterSynchronizationService service = BEANS.get(IClusterSynchronizationService.class);
+      service.publish(message);
+    }
+    catch (RuntimeException e) {
+      LOG.error("Failed to publish cluster notification", e);
+    }
   }
+
+  // -------- transactional put methods --------
 
   /**
    * To put a notifications with transactional behavior. The notification will be processed on successful commit of the
@@ -257,15 +301,9 @@ public class ClientNotificationRegistry {
    *
    * @param userId
    *     the addressed user
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
    */
-  public void putTransactionalForUser(String userId, Serializable notification, boolean distributeOverCluster) {
-    putTransactionalForUsers(Collections.singleton(userId), notification, distributeOverCluster);
-  }
-
-  public void putTransactionalForUsers(Set<String> userIds, Serializable notification) {
-    putTransactionalForUsers(userIds, notification, true);
+  public void putTransactionalForUser(String userId, Serializable notification) {
+    putTransactionalForUsers(Collections.singleton(userId), notification);
   }
 
   /**
@@ -275,15 +313,9 @@ public class ClientNotificationRegistry {
    *
    * @param userIds
    *     the addressed user
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
    */
-  public void putTransactionalForUsers(Set<String> userIds, Serializable notification, boolean distributeOverCluster) {
-    putTransactional(ClientNotificationAddress.createUserAddress(userIds), notification, distributeOverCluster);
-  }
-
-  public void putTransactionalForSession(String sessionId, Serializable notification) {
-    putTransactionalForSession(sessionId, notification, true);
+  public void putTransactionalForUsers(Set<String> userIds, Serializable notification) {
+    putTransactional(ClientNotificationAddress.createUserAddress(userIds), notification);
   }
 
   /**
@@ -293,54 +325,53 @@ public class ClientNotificationRegistry {
    *
    * @param sessionId
    *     the addressed session
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
    */
-  public void putTransactionalForSession(String sessionId, Serializable notification, boolean distributeOverCluster) {
+  public void putTransactionalForSession(String sessionId, Serializable notification) {
     if (StringUtility.isNullOrEmpty(sessionId)) {
       return;
     }
-    putTransactional(ClientNotificationAddress.createSessionAddress(Collections.singleton(sessionId)), notification, distributeOverCluster);
-  }
-
-  public void putTransactionalForAllSessions(Serializable notification) {
-    putTransactionalForAllSessions(notification, true);
+    putTransactional(ClientNotificationAddress.createSessionAddress(Collections.singleton(sessionId)), notification);
   }
 
   /**
    * To put a notifications with transactional behavior. The notification will be processed on successful commit of the
    * {@link ITransaction} surrounding the server call. This notification will be distributed to all sessions.
-   *
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
    */
-  public void putTransactionalForAllSessions(Serializable notification, boolean distributeOverCluster) {
-    putTransactional(ClientNotificationAddress.createAllSessionsAddress(), notification, distributeOverCluster);
-  }
-
-  public void putTransactionalForAllNodes(Serializable notification) {
-    putTransactionalForAllNodes(notification, true);
+  public void putTransactionalForAllSessions(Serializable notification) {
+    putTransactional(ClientNotificationAddress.createAllSessionsAddress(), notification);
   }
 
   /**
    * To put a notifications with transactional behavior. The notification will be processed on successful commit of the
    * {@link ITransaction} surrounding the server call. This notification will be distributed to all client nodes.
-   *
-   * @param distributeOverCluster
-   *     flag to distribute notification over whole cluster
    */
-  public void putTransactionalForAllNodes(Serializable notification, boolean distributeOverCluster) {
-    putTransactional(ClientNotificationAddress.createAllNodesAddress(), notification, distributeOverCluster);
+  public void putTransactionalForAllNodes(Serializable notification) {
+    putTransactional(ClientNotificationAddress.createAllNodesAddress(), notification);
   }
 
+  /**
+   * To put a notifications with transactional behavior. The notification will be processed on successful commit of the
+   * {@link ITransaction} surrounding the server call. <p>
+   * <b>This notification will be distributed to all client nodes known to this backend but will not be distributed within cluster to other backend nodes</b>.
+   *
+   * @deprecated This method will be removed in a future release. Use {@link #putTransactional(ClientNotificationAddress, Serializable)} instead and publish message to all client nodes.
+   */
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  public void putTransactionalForAllNodesWithoutClusterNotification(Serializable notification) {
+    putTransactional(new ClientNotificationMessage(ClientNotificationAddress.createAllNodesAddress(), notification, false, CorrelationId.CURRENT.get()));
+  }
+
+  /**
+   * Publishes the given notification transactional to given {@code address}.
+   */
   public void putTransactional(ClientNotificationAddress address, Serializable notification) {
-    putTransactional(address, notification, true);
+    putTransactional(new ClientNotificationMessage(address, notification, CorrelationId.CURRENT.get()));
   }
 
-  public void putTransactional(ClientNotificationAddress address, Serializable notification, boolean distributeOverCluster) {
-    putTransactional(new ClientNotificationMessage(address, notification, distributeOverCluster, CorrelationId.CURRENT.get()));
-  }
-
+  /**
+   * Publishes the given notification transactional to given {@code address}.
+   */
   public void putTransactional(ClientNotificationMessage message) {
     ITransaction transaction = Assertions.assertNotNull(ITransaction.CURRENT.get(), "No transaction found on current calling context to register transactional client notification {}", message);
     try {
@@ -357,26 +388,67 @@ public class ClientNotificationRegistry {
     }
   }
 
-  /**
-   * Publish messages to other cluster nodes. Message not foreseen for cluster distributions are filtered.
-   */
-  protected void publishClusterInternal(Collection<? extends ClientNotificationMessage> messages) {
-    Collection<ClientNotificationMessage> filteredMessages = new LinkedList<>();
-    for (ClientNotificationMessage message : messages) {
-      if (message.isDistributeOverCluster()) {
-        filteredMessages.add(message);
+  // -------- Cleanup nodes methods --------
+
+  protected void startCleanupJob() {
+    int cleanupInterval = Assertions.assertNotNull(CONFIG.getPropertyValue(NotificationQueueCleanupTime.class));
+    m_cleanupJobFuture = Jobs.schedule(this::cleanupDeadNodes, Jobs.newInput()
+        .withRunContext(ServerRunContexts.empty())
+        .withName(ClientNotificationRegistry.class.getSimpleName() + "-cleanup")
+        .withExceptionHandling(BEANS.get(ExceptionHandler.class), true)
+        .withExecutionTrigger(Jobs.newExecutionTrigger()
+            .withSchedule(FixedDelayScheduleBuilder.repeatForever(cleanupInterval, TimeUnit.MILLISECONDS))));
+  }
+
+  protected void cleanupDeadNodes() {
+    List<IClientNotificationNodeQueue> expiredQueues = new ArrayList<>();
+    synchronized (m_notificationQueues) {
+      LOG.debug("Running job to cleanup queues for dead nodes. Available queues {}", m_notificationQueues.keySet());
+      Iterator<IClientNotificationNodeQueue> iter = m_notificationQueues.values().iterator();
+      while (iter.hasNext()) {
+        IClientNotificationNodeQueue queue = iter.next();
+        if (isQueueExpired(queue.getLastConsumeAccess())) {
+          LOG.info("Removing expired queue [clientNodeId={}, lastConsumeAccess={}]", queue.getClientNodeId(), queue.getLastConsumeAccessFormatted());
+          expiredQueues.add(queue);
+          iter.remove();
+        }
       }
     }
-    // do not publish empty messages
-    if (filteredMessages.isEmpty()) {
+
+    for (IClientNotificationNodeQueue queue : expiredQueues) {
+      LOG.info("Disposing expired queue [clientNodeId={}, lastConsumeAccess={}]", queue.getClientNodeId(), queue.getLastConsumeAccessFormatted());
+      queue.dispose();
+    }
+  }
+
+  protected boolean isQueueExpired(long lastAccess) {
+    long now = System.currentTimeMillis();
+    return (now - lastAccess) > m_queueExpireTime;
+  }
+
+  protected void stopCleanupJob() {
+    if (m_cleanupJobFuture == null) {
       return;
     }
-    try {
-      IClusterSynchronizationService service = BEANS.get(IClusterSynchronizationService.class);
-      service.publish(new ClientNotificationClusterNotification(filteredMessages));
-    }
-    catch (RuntimeException e) {
-      LOG.error("Failed to publish client notification", e);
+    LOG.info("Stopping ClientNotification cleanup job");
+    m_cleanupJobFuture.cancel(true);
+    m_cleanupJobFuture = null;
+  }
+
+  /**
+   * {@link IPlatformListener} to initialize and shutdown this {@link ClientNotificationRegistry} upon platform state change.
+   */
+  @Order(DESTROY_ORDER)
+  public static class ClientNotificationRegistryPlatformListener implements IPlatformListener {
+    @Override
+    public void stateChanged(final PlatformEvent event) {
+      if (event.getState() == State.PlatformStarted) {
+        BEANS.get(ClientNotificationRegistry.class).init();
+      }
+
+      if (event.getState() == State.PlatformStopping) {
+        BEANS.get(ClientNotificationRegistry.class).shutdown();
+      }
     }
   }
 }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryClusterHandler.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryClusterHandler.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.clientnotification;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.shared.notification.INotificationHandler;
+
+public class ClientNotificationRegistryClusterHandler implements INotificationHandler<ClientNotificationRegistryClusterNotification> {
+
+  @Override
+  public void handleNotification(ClientNotificationRegistryClusterNotification notification) {
+    switch (notification.getEvent()) {
+      case NODE_REGISTERED -> BEANS.get(ClientNotificationRegistry.class).registerNode(notification.getClientNodeId(), false);
+      case NODE_UNREGISTERED -> BEANS.get(ClientNotificationRegistry.class).unregisterNode(notification.getClientNodeId(), false);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryClusterNotification.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryClusterNotification.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.clientnotification;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import org.eclipse.scout.rt.dataobject.id.NodeId;
+
+/**
+ * Cluster notification indicating that a client node registered or unregistered for client notifications in a Scout backend.
+ */
+public class ClientNotificationRegistryClusterNotification implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  public enum Event {
+    NODE_REGISTERED,
+    NODE_UNREGISTERED,
+  }
+
+  private final Event m_event;
+  private final NodeId m_clientNodeId;
+
+  public ClientNotificationRegistryClusterNotification(Event event, NodeId clientNodeId) {
+    m_event = event;
+    m_clientNodeId = clientNodeId;
+  }
+
+  public Event getEvent() {
+    return m_event;
+  }
+
+  public NodeId getClientNodeId() {
+    return m_clientNodeId;
+  }
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationService.java
@@ -31,17 +31,17 @@ public class ClientNotificationService implements IClientNotificationService {
   }
 
   @Override
-  public void registerNode(NodeId nodeId) {
-    BEANS.get(ClientNotificationRegistry.class).registerNode(nodeId);
+  public void registerNode(NodeId clientNodeId) {
+    BEANS.get(ClientNotificationRegistry.class).registerNode(clientNodeId, true);
   }
 
   @Override
-  public void unregisterNode(NodeId nodeId) {
-    BEANS.get(ClientNotificationRegistry.class).unregisterNode(nodeId);
+  public void unregisterNode(NodeId clientNodeId) {
+    BEANS.get(ClientNotificationRegistry.class).unregisterNode(clientNodeId, true);
   }
 
   @Override
-  public List<ClientNotificationMessage> getNotifications(NodeId nodeId) {
-    return BEANS.get(ClientNotificationRegistry.class).consume(nodeId, m_maxNotifications, m_blockingTimeout, TimeUnit.MILLISECONDS);
+  public List<ClientNotificationMessage> getNotifications(NodeId clientNodeId) {
+    return BEANS.get(ClientNotificationRegistry.class).consume(clientNodeId, m_maxNotifications, m_blockingTimeout, TimeUnit.MILLISECONDS);
   }
 }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationTransactionMember.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationTransactionMember.java
@@ -73,7 +73,7 @@ public class ClientNotificationTransactionMember extends AbstractTransactionMemb
       m_notificationRegistry.publish(notifications, Assertions.assertNotNull(IClientNodeId.CURRENT.get(), "Missing 'client node id' on current calling context"));
     }
     else {
-      // if we cannot 'piggy-back' the notifications to the current request (e.g. for rest-calls), we hold the notifications back until the transaction is released
+      // if we cannot 'piggyback' the notifications to the current request (e.g. for rest-calls), we hold the notifications back until the transaction is released
       // to ensure the notifications are sent after all transaction-members are committed.
       m_notificationsToPublish = notifications;
     }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/IClientNotificationNodeQueue.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/IClientNotificationNodeQueue.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.server.clientnotification;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.scout.rt.dataobject.id.NodeId;
+import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
+
+/**
+ * Interface for a client notification queue for a client node, that keeps track of notifications for that node.
+ */
+@Bean
+public interface IClientNotificationNodeQueue {
+
+  /**
+   * Initialize node queue for given {@code clientNodeId}.
+   */
+  void init(NodeId clientNodeId);
+
+  /**
+   * @return {@link NodeId} associated with this queue.
+   */
+  NodeId getClientNodeId();
+
+  /**
+   * Put notification into queue.
+   */
+  void put(ClientNotificationMessage notification);
+
+  /**
+   * Put notifications into queue.
+   */
+  void put(Collection<? extends ClientNotificationMessage> notifications);
+
+  /**
+   * @return list of next notifications up to a limit of given {@code maxAmount}. Waits for given {@code maxWaitTime} if no messages are available.
+   */
+  List<ClientNotificationMessage> consume(int maxAmount, long maxWaitTime, TimeUnit unit);
+
+  /**
+   * @return timestamp of last message consume invocation.
+   */
+  long getLastConsumeAccess();
+
+  /**
+   * @return formatted timestamp of last message consume invocation.
+   */
+  String getLastConsumeAccessFormatted();
+
+  /**
+   * @return size of queue.
+   */
+  long size();
+
+  /**
+   * Disposes this object and releases any associated resources.
+   */
+  default void dispose() {
+  }
+}

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/clientnotification/ClientNotificationMessage.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/clientnotification/ClientNotificationMessage.java
@@ -14,15 +14,27 @@ import java.io.Serializable;
 
 import org.eclipse.scout.rt.platform.util.ToStringBuilder;
 
+/**
+ * TODO Cleanup implementation and remove {@link ClientNotificationMessage#isDistributeOverCluster()} flag.
+ * This requires an updated client notification dispatching to ensure all Scout backends (cluster nodes) are able to dispatch
+ * any client notification for an arbitrary client node.
+ */
 public class ClientNotificationMessage implements Serializable {
   @Serial
   private static final long serialVersionUID = 1L;
 
   private final IClientNotificationAddress m_address;
   private final Serializable m_notification;
+  /**
+   * @deprecated This flag is deprecated and will be removed in a future release.
+   * Publishing client notifications without distributing the notification to all backend cluster nodes will no longer be supported in the future (e.g. m_distributeOverCluster will always be true).
+   */
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
   private final boolean m_distributeOverCluster;
   private final String m_correlationId;
 
+  @Deprecated
   public ClientNotificationMessage(final IClientNotificationAddress address, final Serializable notification, final boolean distributeOverCluster, final String correlationId) {
     m_address = address;
     m_notification = notification;
@@ -30,10 +42,20 @@ public class ClientNotificationMessage implements Serializable {
     m_correlationId = correlationId;
   }
 
+  public ClientNotificationMessage(final IClientNotificationAddress address, final Serializable notification, final String correlationId) {
+    this(address, notification, true, correlationId);
+  }
+
   public IClientNotificationAddress getAddress() {
     return m_address;
   }
 
+  /**
+   * @deprecated This flag is deprecated and will be removed in a future release.
+   * Publishing client notifications without distributing the notification to all backend cluster nodes will no longer be supported in the future (e.g. m_distributeOverCluster will always be true).
+   */
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
   public boolean isDistributeOverCluster() {
     return m_distributeOverCluster;
   }

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/clientnotification/IClientNotificationService.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/clientnotification/IClientNotificationService.java
@@ -27,25 +27,25 @@ public interface IClientNotificationService {
   /**
    * Register a session with the corresponding user and client node
    *
-   * @param nodeId
+   * @param clientNodeId
    *     unique id of the client node
    */
-  void registerNode(NodeId nodeId);
+  void registerNode(NodeId clientNodeId);
 
   /**
    * Unregister a node with all its registered session and users.
    *
-   * @param nodeId
+   * @param clientNodeId
    *     unique id of the client node
    */
-  void unregisterNode(NodeId nodeId);
+  void unregisterNode(NodeId clientNodeId);
 
   /**
    * Receive new notifications relevant for the given node
    *
-   * @param nodeId
+   * @param clientNodeId
    *     unique id of the client node
    * @return list of new notification messages never <code>null</code>
    */
-  List<ClientNotificationMessage> getNotifications(NodeId nodeId);
+  List<ClientNotificationMessage> getNotifications(NodeId clientNodeId);
 }


### PR DESCRIPTION
This change is a preparation step for a stateless Scout backend.
The dispatching of client notifications was refactored to be (partly)
prepared for handling requests from arbitrary UI server nodes.

Changes
- Ensure ClientNotificationPoller is registered/unregistered for client
  notification in backend.
- Extracted AbstractClientNotificationNodeQueue and
  IClientNotificationNodeQueue for ClientNotificationNodeQueue
- ClientNotificationRegistry: Removed possibility to publish messages
  only for 'own' known UI nodes without publishing to other backend
  nodes and therefore publish client notifications for all UI nodes
- Exclusion is ClientNotificationServerCacheWrapper which uses
  special (legacy) putTransactionalForAllNodesWithoutClusterNotification
  method

443924