### PR TITLE
Use fetchpriority=high for dynamically loaded webpack modules

### DIFF
--- a/eclipse-scout-cli/scripts/webpack-defaults.js
+++ b/eclipse-scout-cli/scripts/webpack-defaults.js
@@ -210,7 +210,14 @@ module.exports = (env, args) => {
           loader: require.resolve('babel-loader'),
           options: babelOptions
         }]
-      }]
+      }],
+      // Use 'fetchpriority=high' for dynamic imports
+      // https://webpack.js.org/configuration/module/#moduleparserjavascriptdynamicimportfetchpriority
+      parser: {
+        javascript: {
+          dynamicImportFetchPriority: 'high'
+        }
+      }
     },
     plugins: [
       new WatchIgnorePlugin({paths: [/\.d\.ts$/]}),


### PR DESCRIPTION
Modern browsers assign each request a priority. Scripts that are loaded dynamically by injecting an additional <script> tag into the DOM are assigned a low priority by default [1]. Under certain conditions, this will introduce significant but unnecessary delays (> 15s). This is problematic if the caller waits for the script completion.

Since request priorities are primarily relevant during the initial rendering of an HTML page, we can safely increase the priority hint for all modules that are dynamically loaded later via import() by setting the "fetchpriority" attribute to "high" [2].

[1] https://web.dev/articles/fetch-priority
[2] https://webpack.js.org/configuration/module/#moduleparserjavascriptdynamicimportfetchpriority

462323