### PR TITLE
Increase Http2 Stream Idle Timeout from 30s (jetty default) -> 40s

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
@@ -87,6 +87,7 @@ import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCoo
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionCookieConfigSecureProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationSessionTimeoutProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationStopTimeoutProperty;
+import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationStreamIdleTimeoutProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationThreadPoolMaxSizeProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationUseTlsProperty;
 import org.eclipse.scout.rt.app.handler.ScoutJettyErrorHandler;
@@ -236,6 +237,7 @@ public class Application {
 
     HttpConnectionFactory http11 = new HttpConnectionFactory(httpsConfig);
     HTTP2ServerConnectionFactory http2 = new HTTP2ServerConnectionFactory(httpsConfig);
+    http2.setStreamIdleTimeout(CONFIG.getPropertyValue(ScoutApplicationStreamIdleTimeoutProperty.class));
 
     ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
     alpn.setDefaultProtocol(http11.getProtocol());

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
@@ -670,4 +670,22 @@ public final class ApplicationProperties {
       return "The server stop timeout in milliseconds to allow a proper shutdown. Default value is " + getDefaultValue() + ".";
     }
   }
+
+  public static class ScoutApplicationStreamIdleTimeoutProperty extends AbstractPositiveLongConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.app.jetty.stream.idletimeout";
+    }
+
+    @Override
+    public Long getDefaultValue() {
+      return TimeUnit.SECONDS.toMillis(40);
+    }
+
+    @Override
+    public String description() {
+      return "The HTTP2 stream idle timeout in milliseconds. Default value is " + getDefaultValue() + ".";
+    }
+  }
 }

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
@@ -675,7 +675,7 @@ public final class ApplicationProperties {
 
     @Override
     public String getKey() {
-      return "scout.app.jetty.stream.idletimeout";
+      return "scout.app.jetty.stream.idleTimeout";   
     }
 
     @Override

--- a/org.eclipse.scout.rt/pom.xml
+++ b/org.eclipse.scout.rt/pom.xml
@@ -128,7 +128,7 @@
     <scout.base.version>26.2.0</scout.base.version>
     <base.version>${scout.base.version}</base.version>
     <org.eclipse.scout.rt.version>${project.version}</org.eclipse.scout.rt.version>
-    <jetty.version>12.1.9</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.32</logback.version>
     <jackson.version>2.21.2</jackson.version>


### PR DESCRIPTION
Update jetty to 12.1.10 and introduce property to configure stream idle timeout.

After update to 12.1.9, we experienced
infrequent ERR_HTTP2_PROTOCOL_ERROR
which might be due to race conditions introduced by inconvenient timeout defaults from both browser and server.

Tests suggest that increasing the stream idle timeout helped eliminate the errors.

453441