### PR TITLE
Limit valid filenames to 250 bytes instead of 250 characters

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/FileUtilityTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/FileUtilityTest.java
@@ -214,12 +214,27 @@ public class FileUtilityTest {
         FileUtility
             .toValidFilename(
                 "someReallyLongName01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123456789.01234567890123.doc"));
+    assertEquals(
+        "♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  .♍  ☀  ♯",
+        FileUtility
+            .toValidFilename(
+                "♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯.♍  ☀  ♯"));
 
     assertEquals("_.txt", FileUtility.toValidFilename("...txt"));
     assertEquals("_.txt", FileUtility.toValidFilename("..txt"));
     assertEquals("_.txt", FileUtility.toValidFilename(" .txt"));
     assertEquals("_.txt", FileUtility.toValidFilename("  .txt"));
     assertEquals("_.txt", FileUtility.toValidFilename(" _.txt"));
+  }
+
+  @Test
+  public void testTruncateToBytes() {
+    assertNull(FileUtility.truncateToBytes(null, 100, UTF_8));
+    assertEquals("♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯", FileUtility.truncateToBytes("♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯", 100, UTF_8));
+
+    String truncated = FileUtility.truncateToBytes("♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕", 100, UTF_8);
+    assertEquals("♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ☤  ♍  ☀  ♯  ♕  ☢  ☣  ☠  ", truncated);
+    assertEquals(100, truncated.getBytes(UTF_8).length);
   }
 
   @Test

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/FileUtility.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/FileUtility.java
@@ -18,8 +18,11 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -539,11 +542,15 @@ public final class FileUtility {
    * <p>
    * Never returns an empty String or null.
    * <p>
-   * Chops filename to max length of 250 characters.
+   * Chops filename to max length of 250 bytes.
    *
    * @since 5.1
    */
   public static String toValidFilename(final String filename) {
+    return toValidFilename(filename, StandardCharsets.UTF_8);
+  }
+
+  public static String toValidFilename(final String filename, Charset charset) {
     if (filename == null) {
       return DEFAULT_FILENAME;
     }
@@ -593,18 +600,36 @@ public final class FileUtility {
     s = StringUtility.join(".", filenameParts);
     s = PAT_FILENAME_TRIM.matcher(s).replaceAll("");
 
-    // on some operating systems, the name may not be longer than 250 characters
-    if (s.length() > 250) {
+    // on some operating systems, the name may not be longer than 250 bytes
+    if (s.getBytes(charset).length > 250) {
       int dot = s.lastIndexOf('.');
       String suffix = (dot > 0 ? s.substring(dot) : "");
       //suffix is at most 32 chars
       if (suffix.length() > 32) {
         suffix = "";
       }
-      s = s.substring(0, 250 - suffix.length()) + suffix;
+      s = truncateToBytes(s, 250 - suffix.getBytes(charset).length, charset) + suffix;
     }
 
     return s;
+  }
+
+  /**
+   * Truncates a string to max number of bytes.
+   */
+  public static String truncateToBytes(String input, int maxBytes, Charset charset) {
+    if (input == null) {
+      return null;
+    }
+    CharsetEncoder encoder = charset.newEncoder();
+
+    ByteBuffer byteBuffer = ByteBuffer.allocate(maxBytes);
+
+    CharBuffer charBuffer = CharBuffer.wrap(input);
+    encoder.encode(charBuffer, byteBuffer, true);
+
+    byteBuffer.flip();
+    return charset.decode(byteBuffer).toString();
   }
 
   /**


### PR DESCRIPTION
On Linux the maximum filename length is 255 bytes. Multi‑byte characters can make a name longer than 250 bytes even though it's under 250 characters.

Replace character count limit (250 chars) with byte count limit (250 bytes)

414521