### PR TITLE
TileTableField: wrong selection colors for inverted style

### DIFF
--- a/eclipse-scout-core/src/table/Table.less
+++ b/eclipse-scout-core/src/table/Table.less
@@ -15,8 +15,11 @@
   position: relative;
   --table-row-margin-x: @table-row-margin-x;
   --table-row-padding-y: @table-row-padding-y;
+  --table-row-active-background-color: @table-row-active-background-color;
   --table-aggregate-row-padding-y-small: @table-aggregate-padding-y-small;
   --table-aggregate-row-padding-y-large: @table-aggregate-padding-y-large;
+  --focus-row-selected-background-color: @item-selection-background-color;
+  --focus-row-selected-border-color: @item-selection-border-color;
 
   &.perma-focus > .table-data,
   & > .table-data:is(:focus, .focused) {
@@ -24,10 +27,10 @@
 
     & > .table-row {
       &.selected {
-        background-color: @item-selection-background-color;
+        background-color: var(--focus-row-selected-background-color);
 
         &::after {
-          border-color: @item-selection-border-color;
+          border-color: var(--focus-row-selected-border-color);
         }
       }
     }
@@ -244,7 +247,7 @@
 
 .table-row {
   &:active {
-    background-color: @table-row-active-background-color;
+    background-color: var(--table-row-active-background-color);
   }
 
   &:is(.selected, .focused)::after {

--- a/eclipse-scout-core/src/tile/fields/tablefield/TileTableField.less
+++ b/eclipse-scout-core/src/tile/fields/tablefield/TileTableField.less
@@ -116,17 +116,9 @@
 
 .tile.dashboard {
   &.inverted > .table-field > .table {
-
-    &:focus,
-    &.focused {
-      & > .table-data > .table-row.selected {
-        background-color: @tile-table-default-inverted-selection-background-color;
-
-        &::after {
-          border-color: @tile-table-default-inverted-selection-border-color;
-        }
-      }
-    }
+    --focus-row-selected-background-color: @tile-table-default-inverted-selection-background-color;
+    --focus-row-selected-border-color: @tile-table-default-inverted-selection-border-color;
+    --table-row-active-background-color: transparent;
 
     & > .table-header {
       border-bottom-color: @tile-table-default-inverted-border-color;
@@ -140,20 +132,12 @@
       }
     }
 
-    & > .table-data {
-      & > .table-row {
-        &:active {
-          background-color: transparent;
-        }
+    & > .table-data > .table-row > .table-cell {
+      color: @tile-default-inverted-color;
+      border-bottom-color: @tile-table-default-inverted-border-color;
 
-        & > .table-cell {
-          color: @tile-default-inverted-color;
-          border-bottom-color: @tile-table-default-inverted-border-color;
-
-          & > .font-icon {
-            color: @tile-default-inverted-color;
-          }
-        }
+      & > .font-icon {
+        color: @tile-default-inverted-color;
       }
     }
 
@@ -167,17 +151,9 @@
   }
 
   &.color-alternative.inverted > .table-field > .table {
-
-    &:focus,
-    &.focused {
-      & > .table-data > .table-row.selected {
-        background-color: @tile-table-alternative-inverted-selection-background-color;
-
-        &::after {
-          border-color: @tile-table-alternative-inverted-selection-border-color;
-        }
-      }
-    }
+    --focus-row-selected-background-color: @tile-table-alternative-inverted-selection-background-color;
+    --focus-row-selected-border-color: @tile-table-alternative-inverted-selection-border-color;
+    --table-row-active-background-color: transparent;
 
     & > .table-header {
       border-bottom-color: @tile-table-default-inverted-border-color;
@@ -191,20 +167,12 @@
       }
     }
 
-    & > .table-data {
-      & > .table-row {
-        &:active {
-          background-color: transparent;
-        }
+    & > .table-data > .table-row > .table-cell {
+      color: @tile-alternative-inverted-color;
+      border-bottom-color: @tile-table-default-inverted-border-color;
 
-        & > .table-cell {
-          color: @tile-alternative-inverted-color;
-          border-bottom-color: @tile-table-default-inverted-border-color;
-
-          & > .font-icon {
-            color: @tile-alternative-inverted-color;
-          }
-        }
+      & > .font-icon {
+        color: @tile-alternative-inverted-color;
       }
     }
 


### PR DESCRIPTION
Since 26.1, table-data has the focus, not the table itself.

Added css variables similar to Tree.less to simplify customizing.

464390