### PR TITLE
Simplify System.getEndpointUrl

### DIFF
--- a/eclipse-scout-core/src/code/CodeTypeCache.ts
+++ b/eclipse-scout-core/src/code/CodeTypeCache.ts
@@ -48,7 +48,7 @@ export class CodeTypeCache extends EventEmitter implements ObjectModel<CodeTypeC
    * Loads code types from the main system using the url configuration of that {@link System}.
    */
   bootstrapSystem(): JQuery.Promise<void> {
-    const url = systems.getOrCreate().getEndpointUrl('codes', 'codes');
+    const url = systems.getOrCreate().getEndpointUrl('codes');
     return this.bootstrap(url);
   }
 

--- a/eclipse-scout-core/src/security/access.ts
+++ b/eclipse-scout-core/src/security/access.ts
@@ -32,7 +32,7 @@ export const access = {
    * Loads permissions from the main system using the url configuration of that {@link System}.
    */
   bootstrapSystem(): JQuery.Promise<void> {
-    const url = systems.getOrCreate().getEndpointUrl('permissions', 'permissions');
+    const url = systems.getOrCreate().getEndpointUrl('permissions');
     return access.bootstrap(url);
   },
 

--- a/eclipse-scout-core/src/system/System.ts
+++ b/eclipse-scout-core/src/system/System.ts
@@ -66,18 +66,18 @@ export class System implements SystemModel, ObjectWithType {
   }
 
   /**
-   * Sets the URL relative to the base URL of this system for a named endpoint.
-   * @param endpointName The endpoint identifier for which the relative URL should be updated.
+   * Sets the URL relative to the base URL of this system for an endpoint.
+   * @param defaultEndpointUrl The default endpoint for which the relative URL should be updated.
    * @param endpointUrl The new endpoint url relative to the {@link baseUrl} of this system.
    */
-  setEndpointUrl(endpointName: string, endpointUrl: string) {
-    if (!endpointName) {
+  setEndpointUrl(defaultEndpointUrl: string, endpointUrl: string) {
+    if (!defaultEndpointUrl) {
       return;
     }
     if (endpointUrl) {
-      this._endpointUrls.set(endpointName, endpointUrl);
+      this._endpointUrls.set(defaultEndpointUrl, endpointUrl);
     } else {
-      this._endpointUrls.delete(endpointName);
+      this._endpointUrls.delete(defaultEndpointUrl);
     }
   }
 
@@ -85,29 +85,33 @@ export class System implements SystemModel, ObjectWithType {
    * @returns the endpoints to load config properties.
    */
   getConfigEndpointUrls(): string[] {
-    let urls = [];
-    let defaultBackendUrl = 'config-properties';
+    const urls = [];
     if (this.hasUiBackend) {
       urls.push('res/config-properties.json');
-      defaultBackendUrl = null; // by default only fetch from UI server. Only use both if explicitly requested
     }
-    let backendConfigResource = this.getEndpointUrl('config-properties', defaultBackendUrl);
-    if (backendConfigResource) {
-      urls.push(backendConfigResource);
+
+    // by default only fetch from UI server. Only use both if explicitly requested
+    const defaultBackendUrl = 'config-properties';
+    if (!this.hasUiBackend || this._endpointUrls.has(defaultBackendUrl)) {
+      const backendUrl = this.getEndpointUrl(defaultBackendUrl);
+      if (backendUrl) {
+        urls.push(backendUrl);
+      }
     }
     return urls;
   }
 
   /**
-   * @returns The full URL including the {@link baseUrl} to the endpoint with given name. The result is always without trailing slash.
+   * @param endpointUrl The default relative url to use, if no custom url is specified.
+   * @returns The full URL including the {@link baseUrl} to the endpoint with given url. The result is always without trailing slash.
    */
-  getEndpointUrl(endpointName: string, defaultEndpoint?: string): string {
-    let customizedEndpointUrl = this._endpointUrls.get(endpointName);
-    let relEndpointUrl = customizedEndpointUrl || defaultEndpoint;
-    if (!relEndpointUrl) {
+  getEndpointUrl(endpointUrl: string): string {
+    let customizedEndpointUrl = this._endpointUrls.get(endpointUrl);
+    let url = customizedEndpointUrl || endpointUrl;
+    if (!url) {
       return null;
     }
-    return this._concatPath(this.baseUrl, relEndpointUrl);
+    return this._concatPath(this.baseUrl, url);
   }
 
   protected _concatPath(a: string, b: string): string {

--- a/eclipse-scout-core/src/uinotification/UiNotificationSystem.ts
+++ b/eclipse-scout-core/src/uinotification/UiNotificationSystem.ts
@@ -101,7 +101,7 @@ export class UiNotificationSystem implements UiNotificationSystemModel, ObjectWi
     let poller = this.poller;
     if (topics.length > 0 && !poller) {
       // First topic added -> create poller
-      let endpointUrl = systems.getOrCreate(this.name).getEndpointUrl('ui-notifications', 'ui-notifications');
+      let endpointUrl = systems.getOrCreate(this.name).getEndpointUrl('ui-notifications');
       poller = scout.create(UiNotificationPoller, {
         system: this,
         url: endpointUrl

--- a/eclipse-scout-core/test/system/SystemSpec.ts
+++ b/eclipse-scout-core/test/system/SystemSpec.ts
@@ -27,14 +27,10 @@ describe('System', () => {
       expect(system.name).toBe('test');
       expect(system.baseUrl).toBe('abc/');
       expect(system.hasUiBackend).toBeTrue();
-      expect(system.getEndpointUrl('a')).toBeNull();
-      expect(system.getEndpointUrl('a', 'def')).toBe('abc/def');
-      expect(system.getEndpointUrl('b')).toBeNull();
+      expect(system.getEndpointUrl('a')).toBe('abc/a');
+      expect(system.getEndpointUrl('b')).toBe('abc/b');
       expect(system.getEndpointUrl('c')).toBe('abc/rel');
-      expect(system.getEndpointUrl('c', 'whatEver')).toBe('abc/rel');
-      expect(system.getEndpointUrl('d', 'whatEver')).toBe('abc/rel2');
-      expect(system.getEndpointUrl('notExisting')).toBeNull();
-      expect(system.getEndpointUrl('notExisting', '/default/')).toBe('abc/default');
+      expect(system.getEndpointUrl('notExisting')).toBe('abc/notExisting');
     });
 
     it('uses defaults for system name', () => {
@@ -43,7 +39,7 @@ describe('System', () => {
       expect(system.name).toBe('test');
       expect(system.baseUrl).toBe('api');
       expect(system.hasUiBackend).toBeFalse();
-      expect(system.getEndpointUrl('a', 'def')).toBe('api/def');
+      expect(system.getEndpointUrl('a')).toBe('api/a');
       expect(system.getConfigEndpointUrls()).toEqual(['api/config-properties']);
     });
 
@@ -53,7 +49,7 @@ describe('System', () => {
       expect(system.name).toBe(System.MAIN_SYSTEM);
       expect(system.baseUrl).toBe('api');
       expect(system.hasUiBackend).toBeTrue();
-      expect(system.getEndpointUrl('a', 'def')).toBe('api/def');
+      expect(system.getEndpointUrl('a')).toBe('api/a');
       expect(system.getConfigEndpointUrls()).toEqual(['res/config-properties.json']);
     });
   });
@@ -62,14 +58,11 @@ describe('System', () => {
     it('updates endpoint in map', () => {
       let system = new System();
       system.init({name: System.MAIN_SYSTEM});
-      expect(system.getEndpointUrl('a', 'def')).toBe('api/def');
-      expect(system.getEndpointUrl('a')).toBeNull();
+      expect(system.getEndpointUrl('a')).toBe('api/a');
       system.setEndpointUrl('a', 'a-url');
-      expect(system.getEndpointUrl('a', 'def')).toBe('api/a-url');
       expect(system.getEndpointUrl('a')).toBe('api/a-url');
       system.setEndpointUrl('a', null);
-      expect(system.getEndpointUrl('a', 'def')).toBe('api/def');
-      expect(system.getEndpointUrl('a')).toBeNull();
+      expect(system.getEndpointUrl('a')).toBe('api/a');
     });
   });
 

--- a/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonRestClient.ts
+++ b/scout-hellojs-app/src/main/resources/archetype-resources/__rootArtifactId__.ui/src/main/js/person/PersonRestClient.ts
@@ -6,7 +6,7 @@ export class PersonRestClient extends AbstractRestClient {
   static DATA_TYPE = 'person';
 
   constructor() {
-    super(PersonRestClient.DATA_TYPE, systems.getOrCreate().getEndpointUrl('persons', 'persons') + '/');
+    super(PersonRestClient.DATA_TYPE, systems.getOrCreate().getEndpointUrl('persons') + '/');
   }
 
   /**


### PR DESCRIPTION
endpointName is used in case there is no default URl and no explicit URL This allows the default URL to be the endpointName directly and prevents its duplication in this case.

456584