### PR TITLE
Add abortable loading for PageWithTable

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  arrays, AutoLeafPageWithNodes, BookmarkSupport, BookmarkTableRowIdentifierDo, dataObjects, DoEntity, Event, EventHandler, Form, InitModelOf, LimitedResultInfoContributionDo, ObjectOrModel, Page, PageWithTableEventMap, PageWithTableModel,
-  PropertyChangeEvent, scout, SearchFilterTextBuilder, SearchFormTableControl, SearchRequiredTableStatus, Status, Table, TableAllRowsDeletedEvent, TableControl, TableMaxResultsHelper, TableOrganizerMenu, TableReloadEvent, TableReloadReason,
-  TableRow, TableRowActionEvent, TableRowOrderChangedEvent, TableRowsDeletedEvent, TableRowsInsertedEvent, TableRowsUpdatedEvent
+  abortableContext, AbortablePromise, AbortError, arrays, AutoLeafPageWithNodes, BookmarkSupport, BookmarkTableRowIdentifierDo, dataObjects, DoEntity, Event, EventHandler, Form, InitModelOf, LimitedResultInfoContributionDo, ObjectOrModel,
+  Page, PageWithTableEventMap, PageWithTableModel, PropertyChangeEvent, scout, SearchFilterTextBuilder, SearchFormTableControl, SearchRequiredTableStatus, Status, Table, TableAllRowsDeletedEvent, TableControl, TableMaxResultsHelper,
+  TableOrganizerMenu, TableReloadEvent, TableReloadReason, TableRow, TableRowActionEvent, TableRowOrderChangedEvent, TableRowsDeletedEvent, TableRowsInsertedEvent, TableRowsUpdatedEvent
 } from '../../../index';
 import $ from 'jquery';
 
@@ -23,6 +23,10 @@ export class PageWithTable extends Page implements PageWithTableModel {
   searchFilterCompleted = false;
 
   protected _reloadReason: TableReloadReason;
+  /**
+   * {@link AbortController} to abort loading.
+   */
+  protected _abortController: AbortController;
   protected _tableRowDeleteHandler: EventHandler<TableRowsDeletedEvent | TableAllRowsDeletedEvent>;
   protected _tableRowInsertHandler: EventHandler<TableRowsInsertedEvent>;
   protected _tableRowUpdateHandler: EventHandler<TableRowsUpdatedEvent>;
@@ -58,6 +62,11 @@ export class PageWithTable extends Page implements PageWithTableModel {
       this.setAlwaysCreateChildPage(true);
       this.setLeaf(false);
     }
+  }
+
+  protected override _destroy() {
+    this._abortController?.abort();
+    super._destroy();
   }
 
   setAlwaysCreateChildPage(alwaysCreateChildPage: boolean) {
@@ -104,6 +113,10 @@ export class PageWithTable extends Page implements PageWithTableModel {
 
     table.on('propertyChange:tableControls', this._tableControlsChangeHandler);
     this._addSearchFormTableControlListeners(this._findSearchFormTableControl(table));
+
+    // make loading support abortable
+    table.loadingSupport?.setAbortable(true);
+    table.loadingSupport?.setAbortHandler(() => this._abortController?.abort());
 
     // Ensure _initDetailTableUiPreferences is only called after _initDetailTable has been completed (including subclasses).
     this.one('propertyChange:detailTable', event => {
@@ -237,6 +250,8 @@ export class PageWithTable extends Page implements PageWithTableModel {
       return;
     }
     if (this.searchRequired) {
+      // abort current load
+      this._abortController?.abort();
       this.detailTable.deleteAllRows();
       this.setSearchFilterCompleted(false);
       // Reset table status (otherwise, a previous message such as "limited result" message would remain visible)
@@ -420,7 +435,24 @@ export class PageWithTable extends Page implements PageWithTableModel {
     // Ensure the search form data is in sync with the search filter used to load the table data (e.g. required for getSearchFilterText())
     this._updateSearchData(searchFilter);
 
-    const promise = this._loadTableData(searchFilter)
+    // abort previous load and create new AbortController for current load
+    this._abortController?.abort();
+    this._abortController = new AbortController();
+
+    const promise = $
+      .when(
+        // Create an abortable context and wrap this._loadTableData(searchFilter) in an AbortablePromise.
+        // With this the load is abortable and results in an AbortError when the AbortController is aborted.
+        // All Abortables that are registered in the current abortable context during this._loadTableData(searchFilter) (e.g. ajax calls) are aborted as well.
+        abortableContext.runInContext(
+          () => {
+            const abortablePromise = AbortablePromise.of(this._loadTableData(searchFilter));
+            abortableContext.registerAbortableInCurrentContext(abortablePromise);
+            return abortablePromise;
+          },
+          this._abortController
+        )
+      )
       .then(data => this._onLoadTableDataDone(data, restoreSelectionInfo))
       .catch(error => this._onLoadTableDataFail(error, restoreSelectionInfo));
 
@@ -489,6 +521,39 @@ export class PageWithTable extends Page implements PageWithTableModel {
    *
    * To return static data, use a resolved promise: `return $.resolvedPromise({...});`
    *
+   * Loading table data is executed in an {@link abortableContext} to support abortable loading.
+   * For a typical implementation where data is loaded via rest, the call is registered automatically.
+   *
+   * @example simple implementation of `_loadTableData(searchFilter)`
+   * ```ts
+   * protected override _loadTableData(searchFilter: any): JQuery.Promise<any> {
+   *   return ajax.postDataObject('api/foo/list', this._withMaxRowCountContribution(searchFilter));
+   * }
+   * ```
+   *
+   * As only synchronously created calls are registered automatically, implementations that make several calls subsequently
+   * must create new abortable contexts for each asynchronously created rest call to ensure all calls are aborted correctly.
+   * If this is not done, the {@link PageWithTable} will still behave correctly, i.e. will not show resulting data when loading was aborted.
+   * So creating a new abortable context for a subsequent call is not necessary for the user experience but prevents unnecessary calls being made.
+   * To create such a new abortable context all implementations can use the protected member {@link _abortController}.
+   *
+   * @example implementation of `_loadTableData(searchFilter)` using multiple and asynchronously created rest calls
+   * ```ts
+   * protected override _loadTableData(searchFilter: any): JQuery.Promise<any> {
+   *   return $.when(this._loadTableDataAsync(searchFilter));
+   * }
+   *
+   * protected async _loadTableDataAsync(searchFilter: any): Promise<any> {
+   *   const abortController = this._abortController;
+   *   const searchRestrictions = await ajax.postDataObject('search-api/util/build-search-restrictions', this._withMaxRowCountContribution(searchFilter));
+   *   const foos = await abortableContext.runInContext(
+   *     () => ajax.postDataObject('api/foo/list', {searchRestrictions}),
+   *     abortController
+   *   );
+   *   return foos;
+   * }
+   * ```
+   *
    * @param searchFilter The search filter as exported by the search form or null.
    */
   protected _loadTableData(searchFilter: any): JQuery.Promise<any> {
@@ -547,6 +612,10 @@ export class PageWithTable extends Page implements PageWithTableModel {
     }
 
     try {
+      if (error instanceof AbortError) {
+        // load was aborted by the user -> no need to set any error status
+        return;
+      }
       this.detailTable.setTableStatus(Status.error({
         message: this.session.text('ErrorWhileLoadingData')
       }));

--- a/eclipse-scout-core/src/focus/FocusManager.ts
+++ b/eclipse-scout-core/src/focus/FocusManager.ts
@@ -222,9 +222,18 @@ export class FocusManager implements FocusManagerOptions {
     if (this._glassPaneDisplayParents.indexOf(scout.widget(element)) >= 0) {
       return true;
     }
-    // Checks whether the element is a child of a glasspane target.
+    // Checks whether the element is a child of a glasspane target but not of the last glasspane itself.
     // If so, the some-iterator returns immediately with true.
-    return targets.some($glassPaneTarget => $(element).closest($glassPaneTarget).length !== 0);
+    return targets.some($glassPaneTarget => {
+      const $element = $(element);
+      if ($element.closest($glassPaneTarget).length === 0) {
+        // not child of the glasspane target -> not covert
+        return false;
+      }
+      const $lastGlasspane = $glassPaneTarget.children('.glasspane').last();
+      // child of the glasspane target, check whether the element is a child of the last glasspane otherwise it is covert
+      return $element.closest($lastGlasspane).length === 0;
+    });
   }
 
   /**

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -70,6 +70,7 @@ export * from './aria/TreeGridAriaRules';
 export * from './aria/ListBoxAriaRules';
 export * from './aria/HorizontalListBoxAriaRules';
 export * from './aria/VoidGridAriaRules';
+export * from './util/abortableContext';
 export * from './util/arrays';
 export * from './util/BinaryResource';
 export * from './util/CallModel';

--- a/eclipse-scout-core/src/session/Session.ts
+++ b/eclipse-scout-core/src/session/Session.ts
@@ -740,7 +740,8 @@ export class Session extends EventEmitter implements SessionModel, ModelAdapterL
 
   protected _callAjax(callOptions: InitModelOf<AjaxCall>): JQuery.Promise<RemoteResponse> {
     let defaultOptions = {
-      retryIntervals: [100, 500, 500, 500]
+      retryIntervals: [100, 500, 500, 500],
+      registerInAbortableContext: false
     };
     let ajaxCall = scout.create(AjaxCall, $.extend(defaultOptions, callOptions, this.ajaxCallOptions));
     this.registerAjaxCall(ajaxCall);

--- a/eclipse-scout-core/src/util/Call.ts
+++ b/eclipse-scout-core/src/util/Call.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, CallModel, InitModelOf, objects, ObjectWithType, scout, strings} from '../index';
+import {abortableContext, arrays, CallModel, InitModelOf, objects, ObjectWithType, scout, strings} from '../index';
 import $ from 'jquery';
 
 /**
@@ -35,6 +35,7 @@ export abstract class Call implements CallModel, ObjectWithType {
   uniqueName: string;
   logPrefix: string;
   result: any;
+  registerInAbortableContext = true;
 
   constructor() {
     this.initialized = false;
@@ -74,6 +75,10 @@ export abstract class Call implements CallModel, ObjectWithType {
     // Assign a unique name to the call to help distinguish different calls in the log
     this.uniqueName = scout.nvl(this.type, 'call') + '-' + (Call.GLOBAL_SEQ++) + strings.box(' ', this.name, '');
 
+    // register in current abortable context if auto-register-flag is set
+    if (this.registerInAbortableContext) {
+      abortableContext.registerAbortableInCurrentContext(this);
+    }
     this.initialized = true;
   }
 

--- a/eclipse-scout-core/src/util/CallModel.ts
+++ b/eclipse-scout-core/src/util/CallModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,4 +47,8 @@ export interface CallModel extends ObjectModel<Call> {
    * All log messages are prefixed with this string. It contains the uniqueName and the current state (e.g. callCounter)
    */
   logPrefix?: string;
+  /**
+   * Whether the call is registered in the current {@link abortableContext} during initialization or not. Default is `true`.
+   */
+  registerInAbortableContext?: boolean;
 }

--- a/eclipse-scout-core/src/util/abortableContext.ts
+++ b/eclipse-scout-core/src/util/abortableContext.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {Abortable, scout} from '../index';
+
+let currentAbortController: AbortController;
+
+export const abortableContext = {
+
+  /**
+   * Runs the given callback in an abortable context.
+   * All {@link Abortable}s registered during the callback using {@link registerAbortableInCurrentContext} are aborted when the provided {@link AbortController} is aborted.
+   * If the code is already running in an abortable context, the given {@link AbortController} is registered as {@link Abortable} in the current context.
+   * As a result, nested abortable contexts are aborted when the outer {@link AbortController} is aborted.
+   */
+  runInContext<T>(callback: () => T, abortController: AbortController): T {
+    // assert parameters
+    scout.assertParameter('callback', callback);
+    scout.assertParameter('abortController', abortController);
+
+    // register new AbortController in current context -> nested contexts will be aborted when the outer context is aborted
+    abortableContext.registerAbortableInCurrentContext(abortController);
+
+    // throw AbortError if the AbortController has already been aborted
+    if (abortController.signal.aborted) {
+      throw new AbortError();
+    }
+
+    // run callback using the given AbortController and reset to current one afterward
+    const oldAbortController = currentAbortController;
+    try {
+      currentAbortController = abortController;
+      return callback();
+    } finally {
+      currentAbortController = oldAbortController;
+    }
+  },
+
+  /**
+   * Registers an {@link Abortable} in the current abortable context. The abortable is linked to the current {@link AbortController} (see {@link runInContext}) and is aborted when the controller is aborted.
+   */
+  registerAbortableInCurrentContext(abortable: Abortable) {
+    // no AbortController present -> nothing to register
+    if (!currentAbortController) {
+      return;
+    }
+
+    // abort Abortable directly if the current AbortController has already been aborted
+    if (currentAbortController.signal.aborted) {
+      abortable.abort();
+      return;
+    }
+
+    // add listener to abort Abortable when AbortController is aborted
+    currentAbortController.signal.addEventListener('abort', () => abortable.abort());
+  }
+};
+
+/**
+ * Marker class for aborted computations.
+ */
+export class AbortError {
+  objectType: string;
+
+  constructor() {
+    this.objectType = 'AbortError';
+  }
+}

--- a/eclipse-scout-core/src/util/promises.ts
+++ b/eclipse-scout-core/src/util/promises.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Abortable, objects, PromiseCreator} from '../index';
+import {Abortable, AbortError, objects, PromiseCreator} from '../index';
 import $ from 'jquery';
 
 export const promises = {
@@ -202,7 +202,7 @@ export class AbortablePromise<T> extends Promise<T> implements Abortable {
   /**
    * Creates an {@link AbortablePromise} from the given ES6 promise.
    */
-  static of<T>(promise: Promise<T>): AbortablePromise<T> {
+  static of<T>(promise: PromiseLike<T>): AbortablePromise<T> {
     if (!promise) {
       return;
     }
@@ -214,16 +214,5 @@ export class AbortablePromise<T> extends Promise<T> implements Abortable {
    */
   abort() {
     this._reject(new AbortError());
-  }
-}
-
-/**
- * Marker class for aborted promises.
- */
-export class AbortError {
-  objectType: string;
-
-  constructor() {
-    this.objectType = 'AbortError';
   }
 }

--- a/eclipse-scout-core/src/widget/LoadingSupport.less
+++ b/eclipse-scout-core/src/widget/LoadingSupport.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,4 +11,23 @@
   // bottom/right: 0 of the regular glasspane does not work if glasspane is not at scrollTop/Left: 0
   width: 100%;
   height: 100%;
+
+  & > .loading-indicator {
+    --cancel-button-margin-top: 26px;
+
+    &:has(> .action.cancel-button) {
+      translate: 0 calc((-@logical-grid-row-height - var(--cancel-button-margin-top)) / 2);
+    }
+
+    & > .action.cancel-button {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      translate: -50%;
+      margin-top: var(--cancel-button-margin-top);
+      padding: 6px 16px;
+      border: 0;
+      pointer-events: auto;
+    }
+  }
 }

--- a/eclipse-scout-core/src/widget/LoadingSupport.ts
+++ b/eclipse-scout-core/src/widget/LoadingSupport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,14 +7,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {GlassPane, LoadingSupportOptions, scout, WidgetSupport} from '../index';
+import {Action, GlassPane, LoadingSupportOptions, scout, WidgetSupport} from '../index';
 
 export class LoadingSupport extends WidgetSupport {
   loadingIndicatorDelay: number;
   withGlassPane: boolean;
+  abortable = false;
+  abortHandler: () => void = null;
   protected _$loadingIndicator: JQuery;
   protected _loadingIndicatorTimeoutId: number;
   protected _glassPane: GlassPane;
+  protected _cancelAction: Action;
   protected _containerScrollHandler: (event: JQuery.ScrollEvent) => void;
 
   /**
@@ -24,6 +27,8 @@ export class LoadingSupport extends WidgetSupport {
     super(options);
     this.loadingIndicatorDelay = scout.nvl(options.loadingIndicatorDelay, 250); // ms
     this.withGlassPane = scout.nvl(options.withGlassPane, false);
+    this.abortable = scout.nvl(options.abortable, this.abortable);
+    this.abortHandler = scout.nvl(options.abortHandler, this.abortHandler);
 
     this._$loadingIndicator = null;
     this._loadingIndicatorTimeoutId = null;
@@ -32,6 +37,14 @@ export class LoadingSupport extends WidgetSupport {
 
   setLoadingIndicatorDelay(loadingIndicatorDelay: number) {
     this.loadingIndicatorDelay = loadingIndicatorDelay;
+  }
+
+  setAbortable(abortable: boolean) {
+    this.abortable = abortable;
+  }
+
+  setAbortHandler(abortHandler: () => void) {
+    this.abortHandler = abortHandler;
   }
 
   protected override _ensure$Container() {
@@ -92,6 +105,20 @@ export class LoadingSupport extends WidgetSupport {
     // Create loading indicator
     let $indicatorParent = this._glassPane ? this._glassPane.$container : this.$container;
     this._$loadingIndicator = $indicatorParent.appendDiv('loading-indicator');
+    if (this.abortable) {
+      // LoadingSupport is abortable -> add cancel button
+      this._cancelAction = scout.create(Action, {
+        parent: this.widget,
+        text: this.widget.session.text('Cancel'),
+        cssClass: 'button cancel-button'
+      });
+      this._cancelAction.one('action', event => {
+        // button was clicked -> remove button after a short delay and call abortHandler
+        setTimeout(() => this._cancelAction.remove(), 100);
+        this.abortHandler?.();
+      });
+      this._cancelAction.render(this._$loadingIndicator);
+    }
   }
 
   protected _removeLoadingIndicator() {
@@ -119,6 +146,7 @@ export class LoadingSupport extends WidgetSupport {
     }
     this.$container?.off('scroll', this._containerScrollHandler);
     this._glassPane?.destroy();
+    this._cancelAction?.destroy();
   }
 
   protected _onContainerScroll(event: JQuery.ScrollEvent) {

--- a/eclipse-scout-core/src/widget/LoadingSupportOptions.ts
+++ b/eclipse-scout-core/src/widget/LoadingSupportOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,4 +21,16 @@ export interface LoadingSupportOptions extends WidgetSupportOptions {
    * Default is false.
    */
   withGlassPane?: boolean;
+  /**
+   * Whether the loading support is abortable.
+   *
+   * If the loading support is abortable a cancel button will be rendered together with the loading indicator.
+   *
+   * Default is `false`.
+   */
+  abortable?: boolean;
+  /**
+   * Handler that is called when loading is aborted (see {@link abortable}).
+   */
+  abortHandler?: () => void;
 }

--- a/eclipse-scout-core/test/bookmark/BookmarkSupportSpec.ts
+++ b/eclipse-scout-core/test/bookmark/BookmarkSupportSpec.ts
@@ -147,7 +147,7 @@ describe('BookmarkSupport', () => {
       searchForm.widget('TextField').setValue('n'); // 'Green', 'Magenta', 'Cyan'
       searchForm.widget('SearchMenu').doAction();
       await page.detailTable.when('reload');
-      await page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
       expect(page.detailTable.rows.length).toBe(3);
       expect(page.detailTable.visibleRows.length).toBe(3);
 
@@ -736,7 +736,7 @@ describe('BookmarkSupport', () => {
       let searchForm = page.getSearchForm() as SpecSearchForm;
       searchForm.widget('ResetMenu').doAction();
       await page.detailTable.when('reload');
-      await page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
 
       expect(table.columns.length).toBe(5);
       expect(table.visibleColumns().length).toBe(4);
@@ -1076,7 +1076,7 @@ describe('BookmarkSupport', () => {
       searchForm1.widget('TextField').setValue('le');
       searchForm1.widget('SearchMenu').doAction();
       await page1.detailTable.when('reload');
-      await page1.ensureLoadChildren();
+      await page1.detailTable.when('propertyChange:loading');
       expect(page1.detailTable.rows.length).toBe(3);
       expect(page1.detailTable.rows[0].getKeyValues()).toEqual([FRUIT_1_KEY]);
       expect(page1.detailTable.rows[1].getKeyValues()).toEqual([FRUIT_3_KEY]);
@@ -1475,6 +1475,8 @@ describe('BookmarkSupport', () => {
       // Selected table page changed
       selectedPage.setChildrenLoaded(false);
       await BookmarkSupport.get(session).activateBookmarkPath(activateBookmarkPathParam);
+      expect(selectedPage.detailTable.loading).toBeTrue();
+      await selectedPage.detailTable.when('propertyChange:loading');
       expect(nodesInsertedEvents.length).toBe(1);
       expect(nodesInsertedEvents[0].parentNode).toBe(selectedPage);
     });
@@ -1497,7 +1499,7 @@ describe('BookmarkSupport', () => {
       searchForm.widget('TextField').setValue('bl'); // Matches 'Black' and 'Blue'
       searchForm.widget('SearchMenu').doAction();
       await page.detailTable.when('reload');
-      await page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
       expect(page.detailTable.rows.length).toBe(2);
 
       // -----
@@ -1638,7 +1640,7 @@ describe('BookmarkSupport', () => {
       searchForm.widget('TextField').setValue('bl'); // Matches 'Black' and 'Blue'
       searchForm.widget('SearchMenu').doAction();
       await page.detailTable.when('reload');
-      await page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
       expect(page.detailTable.rows.length).toBe(2);
 
       // -----
@@ -1781,7 +1783,7 @@ describe('BookmarkSupport', () => {
       searchForm.widget('TextField').setValue('bl'); // Matches 'Black' and 'Blue'
       searchForm.widget('SearchMenu').doAction();
       await page.detailTable.when('reload');
-      await page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
       expect(page.detailTable.rows.length).toBe(2);
 
       // -----
@@ -1872,7 +1874,7 @@ describe('BookmarkSupport', () => {
       searchForm.widget('TextField').setValue('bl'); // Matches 'Black' and 'Blue'
       searchForm.widget('SearchMenu').doAction();
       await page.detailTable.when('reload');
-      await page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
       expect(page.detailTable.rows.length).toBe(2);
 
       // -----
@@ -1963,7 +1965,7 @@ describe('BookmarkSupport', () => {
       searchForm.widget('TextField').setValue('bl'); // Matches 'Black' and 'Blue'
       searchForm.widget('SearchMenu').doAction();
       await page.detailTable.when('reload');
-      await page.ensureLoadChildren();
+      await page.detailTable.when('propertyChange:loading');
       expect(page.detailTable.rows.length).toBe(2);
 
       let bookmark = scout.create(BookmarkDo, {
@@ -2133,6 +2135,7 @@ describe('BookmarkSupport', () => {
 
       searchForm.widget('ResetMenu').doAction();
       await searchForm.when('reset');
+      await page.detailTable.when('propertyChange:loading');
       expect(searchForm.widget('TextField').value).toBe(null); // <--
 
       page.detailTable.resetToInitialUiPreferences();

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
@@ -5,11 +5,15 @@
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
- * SPDX-License-Identifier: EPL-2.0
+ * AI Disclosure: This file was partially AI-generated.
+ * The AI-generated portions are made available under CC0-1.0
+ * and not subject to the project's licence.
+ *
+ * SPDX-License-Identifier: EPL-2.0 and CC0-1.0
  */
 import {
-  arrays, Cell, Column, Deferred, Form, GroupBox, InitModelOf, MaxRowCountContributionDo, NumberColumn, NumberField, ObjectOrModel, Outline, Page, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl, SearchMenu,
-  SearchRequiredTableStatus, SmartColumn, StaticLookupCall, StringField, Table, TableReloadReason, TableRow, Tree, WidgetModel
+  AbortError, arrays, Cell, Column, Deferred, Form, GroupBox, InitModelOf, MaxRowCountContributionDo, NumberColumn, NumberField, ObjectOrModel, Outline, Page, PageWithNodes, PageWithTable, ResetMenu, scout, SearchFormTableControl,
+  SearchMenu, SearchRequiredTableStatus, SmartColumn, StaticLookupCall, StringField, Table, TableReloadReason, TableRow, Tree, WidgetModel
 } from '../../../../src/index';
 import {OutlineSpecHelper, TableSpecHelper} from '../../../../src/testing/index';
 
@@ -37,15 +41,10 @@ describe('PageWithTable', () => {
     outline.render();
     outline.selectNode(page);
     page.detailTable.render();
-
-    jasmine.clock().install();
-  });
-
-  afterEach(() => {
-    jasmine.clock().uninstall();
   });
 
   class SpecPageWithTable extends PageWithTable {
+    declare _abortController: AbortController;
     override _reloadReason: TableReloadReason = null;
 
     override _createSearchFilter(): any {
@@ -150,7 +149,7 @@ describe('PageWithTable', () => {
     expect(maxRowCountContributionDo._type).toBe('scout.MaxRowCountContribution');
   });
 
-  it('row limits are imported', () => {
+  it('row limits are imported', async () => {
     page._loadTableData = searchFilter => {
       return $.resolvedPromise({
         _contributions: [{
@@ -163,13 +162,13 @@ describe('PageWithTable', () => {
     };
     page._transformTableDataToTableRows = data => undefined;
     page.detailTable.reload();
-    jasmine.clock().tick(10);
+    await page.detailTable.when('propertyChange:loading');
     expect(page.detailTable.maxRowCount).toBe(456);
     expect(page.detailTable.estimatedRowCount).toBe(1111);
     expect(page.detailTable.tableStatus.message).toBe('[undefined text: MaxOutlineRowWarningWithEstimatedRowCount]');
   });
 
-  it('stores reload reason', () => {
+  it('stores reload reason', async () => {
     page._loadTableData = searchFilter => {
       return $.resolvedPromise({
         _contributions: [{
@@ -182,19 +181,19 @@ describe('PageWithTable', () => {
     };
     page._transformTableDataToTableRows = data => undefined;
     page.detailTable.reload();
-    jasmine.clock().tick(10);
+    await page.detailTable.when('propertyChange:loading');
     page.detailTable.footer._compactStyle = false;
     page.detailTable.footer._infoLoadAction.doAction();
-    jasmine.clock().tick(10);
+    await page.detailTable.when('propertyChange:loading');
     expect(page._reloadReason).toEqual(Table.ReloadReason.OVERRIDE_ROW_LIMIT);
 
     // reload reason must stay on next reloads. otherwise the override gets lost. Keep it until a new reason is provided.
     page.detailTable.reload();
-    jasmine.clock().tick(10);
+    await page.detailTable.when('propertyChange:loading');
     expect(page._reloadReason).toEqual(Table.ReloadReason.OVERRIDE_ROW_LIMIT);
   });
 
-  it('should handle errors in _onLoadTableDataDone', () => {
+  it('should handle errors in _onLoadTableDataDone', async () => {
     page._loadTableData = searchFilter => $.resolvedPromise([{
       rowId: 1,
       parentRow: 666, // does not exist -> causes an error in Table.js#insertRows
@@ -202,7 +201,7 @@ describe('PageWithTable', () => {
     }]);
     expect(page.detailTable.tableStatus).toBe(undefined);
     page.detailTable.reload();
-    jasmine.clock().tick(3);
+    await page.detailTable.when('propertyChange:loading');
 
     // expect error to be set as tableStatus
     let keys = Object.keys(page.detailTable.tableStatus);
@@ -260,7 +259,6 @@ describe('PageWithTable', () => {
       }
     }
 
-    jasmine.clock().uninstall();
     let lookupCall = new DummyLookupCall();
     lookupCall.init({session: session});
     let samplePage = new SamplePageWithTable();
@@ -295,7 +293,7 @@ describe('PageWithTable', () => {
       .catch(fail);
   });
 
-  it('restores the selection after reload if possible', () => {
+  it('restores the selection after reload if possible', async () => {
     const tablePage = scout.create(SpecPageWithTable, {
       parent: outline,
       detailTable: {
@@ -344,7 +342,7 @@ describe('PageWithTable', () => {
     expect(outline.selectedNode()).toBe(tablePage);
 
     table.reload();
-    jasmine.clock().tick(3);
+    await table.when('propertyChange:loading');
     expect(outline.selectedNode()).toBe(tablePage);
 
     table.selectRow(table.getRowByKey([2]));
@@ -355,13 +353,13 @@ describe('PageWithTable', () => {
     expect(outline.selectedNode().text).toBe('Row 2');
 
     table.reload();
-    jasmine.clock().tick(3);
+    await table.when('propertyChange:loading');
     expect(outline.selectedNode()).toBe(tablePage.childNodes[2]);
     expect(outline.selectedNode().text).toBe('Row 2');
 
     searchIds = [1, 3];
     table.reload();
-    jasmine.clock().tick(3);
+    await table.when('propertyChange:loading');
     expect(outline.selectedNode()).toBe(tablePage);
 
     table.selectRow(table.getRowByKey([3]));
@@ -372,7 +370,7 @@ describe('PageWithTable', () => {
     searchIds = [0, 2, 3];
     data[3][1] = 'Updated row 3';
     table.reload();
-    jasmine.clock().tick(3);
+    await table.when('propertyChange:loading');
     expect(outline.selectedNode()).toBe(tablePage.childNodes[2]);
     expect(outline.selectedNode().text).toBe('Updated row 3');
 
@@ -380,11 +378,11 @@ describe('PageWithTable', () => {
     expect(outline.selectedNode()).toBe(page);
 
     table.reload();
-    jasmine.clock().tick(3);
+    await table.when('propertyChange:loading');
     expect(outline.selectedNode()).toBe(page);
   });
 
-  it('childPages text is updated from the summary columns of the table', () => {
+  it('childPages text is updated from the summary columns of the table', async () => {
     const tablePage = scout.create(SpecPageWithTable, {
       parent: outline,
       detailTable: tableHelper.createTable(tableHelper.createModel(tableHelper.createModelColumns(5), []))
@@ -399,7 +397,7 @@ describe('PageWithTable', () => {
 
     const table = tablePage.detailTable;
     table.reload();
-    jasmine.clock().tick(3);
+    await table.when('propertyChange:loading');
 
     const [pageAbc, page123] = table.rows.map(r => r.page);
 
@@ -421,7 +419,7 @@ describe('PageWithTable', () => {
     expect(page123.text).toBe('1 4 5');
   });
 
-  it('updates childrenLoaded flag', () => {
+  it('updates childrenLoaded flag', async () => {
     let page = scout.create(SpecPageWithTable, {
       parent: outline,
       detailTable: {
@@ -432,7 +430,7 @@ describe('PageWithTable', () => {
     expect(page.childrenLoaded).toBe(false);
 
     outline.selectNode(page);
-    jasmine.clock().tick(1);
+    await page.detailTable.when('propertyChange:loading');
     let detailTable = page.detailTable;
     expect(detailTable).toBeTruthy();
 
@@ -443,7 +441,7 @@ describe('PageWithTable', () => {
     expect(page.childrenLoaded).toBe(true); // same as before, because reloading the table does not call loadChildren()
     expect(detailTable.loading).toBe(true);
 
-    jasmine.clock().tick(1);
+    await page.detailTable.when('propertyChange:loading');
     expect(page.childrenLoaded).toBe(true);
     expect(detailTable.loading).toBe(false);
 
@@ -451,13 +449,12 @@ describe('PageWithTable', () => {
     expect(page.childrenLoaded).toBe(false); // <--
     expect(detailTable.loading).toBe(true);
 
-    jasmine.clock().tick(1);
+    await page.detailTable.when('propertyChange:loading');
     expect(page.childrenLoaded).toBe(true);
     expect(detailTable.loading).toBe(false);
   });
 
   it('reloads its data if childrenLoaded is false and selected on outline change', async () => {
-    jasmine.clock().uninstall();
     let page = scout.create(SpecPageWithTable, {
       parent: outline,
       detailTable: {
@@ -537,7 +534,7 @@ describe('PageWithTable', () => {
     expect(observedTestValue).toBe(2);
   });
 
-  it('collapses lazy expanded nodes on reload', () => {
+  it('collapses lazy expanded nodes on reload', async () => {
     class LazyPageWithTable extends PageWithTable {
       constructor() {
         super();
@@ -580,7 +577,7 @@ describe('PageWithTable', () => {
     });
     outline.insertNode(page);
     outline.selectNode(page);
-    jasmine.clock().tick(1);
+    await page.detailTable.when('propertyChange:loading');
 
     expect(page.childNodes.length).toBe(3);
     expect(page.expanded).toBe(false);
@@ -603,7 +600,7 @@ describe('PageWithTable', () => {
 
     outline.selectNode(page);
     page.detailTable.reload();
-    jasmine.clock().tick(1);
+    await page.detailTable.when('propertyChange:loading');
 
     expect(page.childNodes.length).toBe(3);
     expect(page.expanded).toBe(false);
@@ -618,7 +615,7 @@ describe('PageWithTable', () => {
     expect(page.expandedLazy).toBe(false);
 
     page.detailTable.reload();
-    jasmine.clock().tick(1);
+    await page.detailTable.when('propertyChange:loading');
     expect(page.childNodes.length).toBe(3);
     expect(page.expanded).toBe(true);
     expect(page.expandedLazy).toBe(false);
@@ -626,7 +623,6 @@ describe('PageWithTable', () => {
 
   describe('getSearchFilterText', () => {
     it('only considers the texts of the actual search filter', async () => {
-      jasmine.clock().uninstall();
       page.detailTable.setTableControls([{
         objectType: SearchFormTableControl,
         form: {
@@ -660,7 +656,6 @@ describe('PageWithTable', () => {
   });
 
   it('keeps the search form data and used search filter in sync', async () => {
-    jasmine.clock().uninstall();
     page.detailTable.setTableControls([{
       objectType: SearchFormTableControl,
       form: {
@@ -700,8 +695,6 @@ describe('PageWithTable', () => {
   });
 
   it('marks table loading until data is loaded', async () => {
-    jasmine.clock().uninstall();
-
     const table = page.detailTable;
 
     // await initial load, because page was selected
@@ -946,6 +939,118 @@ describe('PageWithTable', () => {
       });
       expect(outline.selectedNode()).toBe(outline.nodes[0]);
       expect(outline.selectedNode().expanded).toBe(true);
+    });
+  });
+
+  describe('abortController', () => {
+
+    it('is aborted on destroy', () => {
+      page.detailTable.reload();
+
+      const abortController = page._abortController;
+      expect(abortController).toBeDefined();
+      expect(abortController.signal.aborted).toBeFalse();
+
+      page.destroy();
+      expect(abortController.signal.aborted).toBeTrue();
+    });
+
+    it('is aborted by the loadingSupport of the detailTable', () => {
+      expect(page.detailTable.loadingSupport.abortable).toBeTrue();
+      expect(page.detailTable.loadingSupport.abortHandler).toBeDefined();
+
+      page.detailTable.reload();
+
+      const abortController = page._abortController;
+      expect(abortController.signal.aborted).toBeFalse();
+
+      page.detailTable.loadingSupport.abortHandler();
+      expect(abortController.signal.aborted).toBeTrue();
+    });
+
+    it('is aborted when the searchForm is reset and searchRequired=true', () => {
+      page.setSearchRequired(true);
+
+      page.detailTable.reload();
+
+      const abortController = page._abortController;
+      expect(abortController.signal.aborted).toBeFalse();
+
+      page._resetTableData();
+      expect(abortController.signal.aborted).toBeTrue();
+    });
+
+    it('is aborted before a new load is executed', () => {
+      page.detailTable.reload();
+
+      const firstAbortController = page._abortController;
+      expect(firstAbortController.signal.aborted).toBeFalse();
+
+      page.detailTable.reload();
+
+      expect(firstAbortController.signal.aborted).toBeTrue();
+      const secondAbortController = page._abortController;
+      expect(secondAbortController).not.toBe(firstAbortController);
+      expect(secondAbortController.signal.aborted).toBeFalse();
+    });
+
+    it('aborts the current load resulting in an AbortError', async () => {
+      page.detailTable.insertColumn({id: 'StringColumn', objectType: Column});
+      page._loadTableData = () => $.resolvedPromise([
+        {cells: ['foo']},
+        {cells: ['bar']}
+      ]);
+
+      page.detailTable.reload();
+      await page.detailTable.when('propertyChange:loading');
+
+      expect(page.detailTable.rows.length).toBe(2);
+      expect(page.detailTable.rows.map(row => page.detailTable.columnById('StringColumn').cellValue(row))).toEqual(['foo', 'bar']);
+
+      page._loadTableData = () => $.resolvedPromise([
+        {cells: ['lorem']},
+        {cells: ['ipsum']},
+        {cells: ['dolor']}
+      ]);
+
+      page.detailTable.reload();
+
+      const deferred = new Deferred<void>();
+      page.one('error', ({error}) => {
+        expect(error).toBeInstanceOf(AbortError);
+        deferred.resolve();
+      });
+      page._abortController.abort();
+
+      await deferred.promise();
+      await page.detailTable.when('propertyChange:loading');
+
+      expect(page.detailTable.rows.length).toBe(2);
+      expect(page.detailTable.rows.map(row => page.detailTable.columnById('StringColumn').cellValue(row))).toEqual(['foo', 'bar']);
+      expect(page.detailTable.tableStatus).toBeNull();
+    });
+
+    it('does nothing when aborted after the load is finished', async () => {
+      page.detailTable.insertColumn({id: 'StringColumn', objectType: Column});
+      page._loadTableData = () => $.resolvedPromise([
+        {cells: ['foo']},
+        {cells: ['bar']}
+      ]);
+
+      page.detailTable.reload();
+      await page.detailTable.when('propertyChange:loading');
+
+      expect(page.detailTable.rows.length).toBe(2);
+      expect(page.detailTable.rows.map(row => page.detailTable.columnById('StringColumn').cellValue(row))).toEqual(['foo', 'bar']);
+      expect(page.detailTable.tableStatus).toBeNull();
+
+      page.one('error', ({error}) => {
+        fail(error);
+      });
+      page._abortController.abort();
+
+      page.detailTable.reload();
+      await page.detailTable.when('propertyChange:loading');
     });
   });
 });

--- a/eclipse-scout-core/test/focus/FocusManagerSpec.ts
+++ b/eclipse-scout-core/test/focus/FocusManagerSpec.ts
@@ -5,7 +5,11 @@
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
- * SPDX-License-Identifier: EPL-2.0
+ * AI Disclosure: This file was partially AI-generated.
+ * The AI-generated portions are made available under CC0-1.0
+ * and not subject to the project's licence.
+ *
+ * SPDX-License-Identifier: EPL-2.0 and CC0-1.0
  */
 import {FocusManagerSpecHelper, FormSpecHelper, JQueryTesting} from '../../src/testing/index';
 import {Button, FocusManager, FocusRule, GlassPane, scout} from '../../src/index';
@@ -535,6 +539,79 @@ describe('FocusManager', () => {
 
       expectMouseDownToPreventDefault(false);
       JQueryTesting.triggerMouseDown($input3);
+    });
+  });
+
+  describe('isElementCovertByGlassPane', () => {
+
+    it('returns false when there are no glass pane targets', () => {
+      let $element = session.$entryPoint.appendDiv();
+      expect(focusManager.isElementCovertByGlassPane($element)).toBeFalse();
+    });
+
+    it('returns false when the element is not inside any glass pane target', () => {
+      let $coveredContainer = session.$entryPoint.appendDiv();
+      let $uncoveredElement = session.$entryPoint.appendDiv();
+
+      let glassPane = scout.create(GlassPane, {parent: session.desktop});
+      glassPane.render($coveredContainer);
+
+      expect(focusManager.isElementCovertByGlassPane($uncoveredElement)).toBeFalse();
+    });
+
+    it('returns true when the element is inside a glass pane target', () => {
+      let $container = session.$entryPoint.appendDiv();
+      let $element = $container.appendDiv();
+
+      expect(focusManager.isElementCovertByGlassPane($element)).toBeFalse();
+
+      let glassPane = scout.create(GlassPane, {parent: session.desktop});
+      glassPane.render($container);
+
+      expect(focusManager.isElementCovertByGlassPane($element)).toBeTrue();
+    });
+
+    it('returns false when the element is a child of the glass pane itself', () => {
+      let $container = session.$entryPoint.appendDiv();
+
+      let glassPane = scout.create(GlassPane, {parent: session.desktop});
+      glassPane.render($container);
+      let $insideGlassPane = glassPane.$container.appendDiv();
+
+      expect(focusManager.isElementCovertByGlassPane($insideGlassPane)).toBeFalse();
+    });
+
+    it('returns true when the element belongs to a glass pane display parent', () => {
+      // A registered glass pane target is required so the method does not return early
+      let $container = session.$entryPoint.appendDiv();
+      let glassPane = scout.create(GlassPane, {parent: session.desktop});
+      glassPane.render($container);
+
+      expect(focusManager.isElementCovertByGlassPane(session.desktop.$container)).toBeFalse();
+
+      focusManager.registerGlassPaneDisplayParent(session.desktop);
+      expect(focusManager.isElementCovertByGlassPane(session.desktop.$container)).toBeTrue();
+    });
+
+    it('uses the filter to limit which glass pane targets are considered', () => {
+      let $container1 = session.$entryPoint.appendDiv();
+      let $container2 = session.$entryPoint.appendDiv();
+      let $element1 = $container1.appendDiv();
+      let $element2 = $container2.appendDiv();
+
+      let glassPane1 = scout.create(GlassPane, {parent: session.desktop});
+      let glassPane2 = scout.create(GlassPane, {parent: session.desktop});
+      glassPane1.render($container1);
+      glassPane2.render($container2);
+
+      // Without filter: both elements are covered
+      expect(focusManager.isElementCovertByGlassPane($element1)).toBeTrue();
+      expect(focusManager.isElementCovertByGlassPane($element2)).toBeTrue();
+
+      // With filter: only container2 is considered -> only element2 is covered
+      const filter = ($target: JQuery) => $target[0] === $container2[0];
+      expect(focusManager.isElementCovertByGlassPane($element1, filter)).toBeFalse();
+      expect(focusManager.isElementCovertByGlassPane($element2, filter)).toBeTrue();
     });
   });
 });

--- a/eclipse-scout-core/test/util/abortableContextSpec.ts
+++ b/eclipse-scout-core/test/util/abortableContextSpec.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * AI Disclosure: This file was partially AI-generated.
+ * The AI-generated portions are made available under CC0-1.0
+ * and not subject to the project's licence.
+ *
+ * SPDX-License-Identifier: EPL-2.0 and CC0-1.0
+ */
+
+import {Abortable, abortableContext, AbortError} from '../../src';
+
+describe('abortableContext', () => {
+
+  describe('runInContext', () => {
+
+    it('asserts that callback is not null', () => {
+      expect(() =>
+        abortableContext.runInContext(
+          null,
+          new AbortController()
+        )
+      ).toThrowError('Missing required parameter \'callback\'');
+    });
+
+    it('asserts that abortController is not null', () => {
+      expect(() =>
+        abortableContext.runInContext(
+          () => {
+          },
+          null
+        )
+      ).toThrowError('Missing required parameter \'abortController\'');
+    });
+
+    it('runs the callback and returns its result', () => {
+      const controller = new AbortController();
+      const result = abortableContext.runInContext(() => 42, controller);
+      expect(result).toBe(42);
+    });
+
+    it('aborts registered abortables when the controller is aborted', () => {
+      const controller = new AbortController();
+      const abortable = new SimpleAbortable();
+
+      abortableContext.runInContext(
+        () => abortableContext.registerAbortableInCurrentContext(abortable),
+        controller
+      );
+
+      expect(abortable.aborted).toBeFalse();
+      controller.abort();
+      expect(abortable.aborted).toBeTrue();
+    });
+
+    it('runs the callback synchronously so asynchronous registered abortables are not aborted', async () => {
+      const controller = new AbortController();
+      const synchronousAbortable = new SimpleAbortable();
+      const asynchronousAbortable = new SimpleAbortable();
+      await abortableContext.runInContext(
+        async () => {
+          abortableContext.registerAbortableInCurrentContext(synchronousAbortable);
+          await Promise.resolve();
+          abortableContext.registerAbortableInCurrentContext(asynchronousAbortable);
+        },
+        controller
+      );
+
+      expect(synchronousAbortable.aborted).toBeFalse();
+      expect(asynchronousAbortable.aborted).toBeFalse();
+      controller.abort();
+      expect(synchronousAbortable.aborted).toBeTrue();
+      expect(asynchronousAbortable.aborted).toBeFalse();
+    });
+
+    it('restores the previous context after the callback', () => {
+      const outerController = new AbortController();
+      const innerController = new AbortController();
+      const outerAbortable = new SimpleAbortable();
+
+      abortableContext.runInContext(
+        () => {
+          abortableContext.runInContext(
+            () => {
+            },
+            innerController
+          );
+          // outer context must be active again here
+          abortableContext.registerAbortableInCurrentContext(outerAbortable);
+        },
+        outerController
+      );
+
+      innerController.abort();
+      expect(outerAbortable.aborted).toBeFalse();
+    });
+
+    it('restores the previous context even if the callback throws', () => {
+      const outerController = new AbortController();
+      const innerController = new AbortController();
+      const outerAbortable = new SimpleAbortable();
+
+      abortableContext.runInContext(
+        () => {
+          try {
+            abortableContext.runInContext(
+              () => {
+                throw new Error('test error');
+              },
+              innerController
+            );
+          } catch (e) {
+            // swallow inner error
+          }
+          // outer context must be active again here
+          abortableContext.registerAbortableInCurrentContext(outerAbortable);
+        },
+        outerController
+      );
+
+      outerController.abort();
+      expect(outerAbortable.aborted).toBeTrue();
+    });
+
+    it('throws an AbortError if the controller is already aborted', () => {
+      const controller = new AbortController();
+      controller.abort();
+      expect(() =>
+        abortableContext.runInContext(
+          () => {
+          },
+          controller
+        )
+      ).toThrow(new AbortError());
+    });
+
+    it('does not execute the callback if the controller is already aborted', () => {
+      const controller = new AbortController();
+      controller.abort();
+      let called = false;
+      try {
+        abortableContext.runInContext(() => {
+          called = true;
+        }, controller);
+      } catch (e) {
+        // expected AbortError
+      }
+      expect(called).toBeFalse();
+    });
+
+    it('registers the controller in the outer context so that aborting the outer controller also aborts the inner one', () => {
+      const outerController = new AbortController();
+      const innerController = new AbortController();
+      const innerAbortable = new SimpleAbortable();
+
+      abortableContext.runInContext(
+        () => {
+          abortableContext.runInContext(
+            () => abortableContext.registerAbortableInCurrentContext(innerAbortable),
+            innerController
+          );
+        },
+        outerController
+      );
+
+      expect(innerAbortable.aborted).toBeFalse();
+      outerController.abort();
+      expect(innerAbortable.aborted).toBeTrue();
+    });
+  });
+
+  describe('registerAbortableInCurrentContext', () => {
+
+    it('does nothing when there is no active context', () => {
+      const controller = new AbortController();
+      const abortable = new SimpleAbortable();
+
+      abortableContext.registerAbortableInCurrentContext(abortable);
+
+      controller.abort();
+      expect(abortable.aborted).toBeFalse();
+    });
+
+    it('aborts the abortable immediately when the current context is already aborted', () => {
+      const controller = new AbortController();
+      const abortable = new SimpleAbortable();
+
+      abortableContext.runInContext(
+        () => {
+          controller.abort(); // abort while inside the context, otherwise abortableContext.runInContext throws an AbortError
+          abortableContext.registerAbortableInCurrentContext(abortable);
+        },
+        controller
+      );
+
+      expect(abortable.aborted).toBeTrue();
+    });
+
+    it('registers the abortable to be aborted when the current context is later aborted', () => {
+      const controller = new AbortController();
+      const abortable = new SimpleAbortable();
+
+      abortableContext.runInContext(
+        () => abortableContext.registerAbortableInCurrentContext(abortable),
+        controller
+      );
+
+      expect(abortable.aborted).toBeFalse();
+      controller.abort();
+      expect(abortable.aborted).toBeTrue();
+    });
+
+    it('registers multiple abortables in the same context', () => {
+      const controller = new AbortController();
+      const abortable1 = new SimpleAbortable();
+      const abortable2 = new SimpleAbortable();
+
+      abortableContext.runInContext(
+        () => {
+          abortableContext.registerAbortableInCurrentContext(abortable1);
+          abortableContext.registerAbortableInCurrentContext(abortable2);
+        },
+        controller
+      );
+
+      expect(abortable1.aborted).toBeFalse();
+      expect(abortable2.aborted).toBeFalse();
+      controller.abort();
+      expect(abortable1.aborted).toBeTrue();
+      expect(abortable2.aborted).toBeTrue();
+    });
+  });
+
+  class SimpleAbortable implements Abortable {
+
+    aborted = false;
+
+    abort() {
+      this.aborted = true;
+    }
+  }
+});


### PR DESCRIPTION
Introduce an abortableContext. This context can be used to run a
callback with a global AbortController set. Abortables can be registered
in the current context and are aborted when the AbortController is
aborted. Running something using an already aborted AbortController
results in an AbortError. When a new inner context is opened while there
is already on outer context present, the AbortController of the inner
context is registered in the outer context to ensure nested contexts are
aborted when the outer AbortController is aborted.
The LoadingSupport now has an abortable-flag and an abortHandler. If it
is abortable a Cancel-button is rendered together with the loading
indicator. When this button is clicked the abortHandler is executed.
A new property autoRegisterAsAbortable was introduced for Call. If set
a Call registers itself in the current abortable context. The default of
this flag is false, but it is true for all AjaxCalls created using
ajax.ts.
The PageWithTable creates an abortableContext to load its data (i.e.
_loadTableData(searchFilter)). As this method is implemented by
subclasses and returns a JQuery promise this promise is wrapped in an
AbortablePromise to support abortable loading for all instances without
a migration. All Abortables registered synchronously in the current
abortable context during _loadTableData(searchFilter) are aborted when
loading the PageWithTable is aborted. These Abortables are e.g.
AjaxCalls created using ajax.ts. When an implementation performs more
complex logic, e.g. does multiple calls sequentially, the implementation
must ensure that all subsequent calls are again run in an
abortableContext using the AbortController of the PageWithTable.

427785

Assisted-by: Sonnet 4.6, Haiku 4.5 (Claude Code)