### PR TITLE
Show info about missing permission on AccessForbiddenException

### DIFF
--- a/eclipse-scout-core/src/ErrorHandler.ts
+++ b/eclipse-scout-core/src/ErrorHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -521,14 +521,15 @@ export class ErrorHandler implements ErrorHandlerModel, ObjectWithType {
       code = errorInfo.errorDo.errorCode;
     }
     let body = status.message || session.optText('ui.UnexpectedProblem', 'Unexpected problem');
-    if (code) {
-      body += ' (' + session.optText('ui.ErrorCodeX', 'Code ' + code, code) + ').';
-    }
     let html = null;
+    let $container = session.desktop?.$container || session.$entryPoint;
+    if (code) {
+      let codeText = session.optText('ErrorCode', 'Code');
+      html = $container.makeDiv('error-popup-code', codeText + ': ' + code)[0].outerHTML;
+    }
     if (errorInfo?.errorDo?.correlationId) {
-      let $container = session.desktop?.$container || session.$entryPoint;
       let correlationIdText = session.optText('CorrelationId', 'Correlation ID');
-      html = $container.makeDiv('error-popup-correlation-id', correlationIdText + ': ' + errorInfo.errorDo.correlationId)[0].outerHTML;
+      html = (html ?? '') + $container.makeDiv('error-popup-correlation-id', correlationIdText + ': ' + errorInfo.errorDo.correlationId)[0].outerHTML;
     }
 
     return {

--- a/eclipse-scout-core/src/main.less
+++ b/eclipse-scout-core/src/main.less
@@ -467,6 +467,12 @@ noscript {
   }
 }
 
+.error-popup-code {
+  #scout.user-select(text);
+  #scout.font-text-small();
+  color: @disabled-color;
+}
+
 .error-popup-correlation-id {
   #scout.user-select(text);
   #scout.font-text-small();

--- a/eclipse-scout-core/test/ErrorHandlerSpec.ts
+++ b/eclipse-scout-core/test/ErrorHandlerSpec.ts
@@ -260,8 +260,8 @@ describe('ErrorHandler', () => {
       });
       expect(msgBoxModel).toEqual({
         header: undefined,
-        body: 'status msg (Code 100).',
-        html: null,
+        body: 'status msg',
+        html: '<div class="error-popup-code">Code: 100</div>',
         severity: Status.Severity.INFO,
         iconId: 'testicon',
         hiddenText: 'log',
@@ -288,10 +288,10 @@ describe('ErrorHandler', () => {
       }) as MessageBoxModel;
       expect(msgBoxModel).toEqual({
         header: 'title',
-        body: 'message (Code Y789).',
+        body: 'message',
         severity: Status.Severity.WARNING,
         hiddenText: 'log',
-        html: '<div class="error-popup-correlation-id">Correlation ID: Corr567</div>',
+        html: '<div class="error-popup-code">Code: Y789</div><div class="error-popup-correlation-id">Correlation ID: Corr567</div>',
         iconId: null,
         yesButtonText: 'Ok'
       });
@@ -315,9 +315,9 @@ describe('ErrorHandler', () => {
       }) as MessageBoxModel;
       expect(msgBoxModel).toEqual({
         header: 'title',
-        body: 'message (Code Y789).',
+        body: 'message',
         severity: Status.Severity.WARNING,
-        html: '<div class="error-popup-correlation-id">Correlation ID: Corr567</div>',
+        html: '<div class="error-popup-code">Code: Y789</div><div class="error-popup-correlation-id">Correlation ID: Corr567</div>',
         hiddenText: 'log',
         iconId: null,
         yesButtonText: 'Ok'

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/exceptionhandler/ErrorPopup.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/services/common/exceptionhandler/ErrorPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.scout.rt.client.session.ClientSessionProvider;
 import org.eclipse.scout.rt.client.ui.messagebox.IMessageBox;
 import org.eclipse.scout.rt.client.ui.messagebox.MessageBoxes;
+import org.eclipse.scout.rt.dataobject.exception.AccessForbiddenException;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.Platform;
 import org.eclipse.scout.rt.platform.context.CorrelationId;
@@ -169,6 +170,10 @@ public class ErrorPopup {
    * @return <code>true</code> if the error was handled by this method and the parsing is finished.
    */
   protected boolean parseError(Throwable t) {
+    if (t instanceof AccessForbiddenException) {
+      parseAccessForbiddenException((AccessForbiddenException) t);
+      return true;
+    }
     if (t instanceof VetoException) {
       parseVetoException((VetoException) t);
       return true;
@@ -200,6 +205,24 @@ public class ErrorPopup {
     return t instanceof RemoteSystemUnavailableException ||
         t instanceof SocketException ||
         t instanceof UnknownHostException;
+  }
+
+  protected void parseAccessForbiddenException(AccessForbiddenException afe) {
+    m_header = afe.getStatus().getTitle();
+    if (afe.getHtmlMessage() != null) {
+      m_body = null;
+      m_html = afe.getHtmlMessage();
+    }
+    else if (afe.getStatus().getBody() != null) {
+      m_body = afe.getStatus().getBody();
+      if (afe.getPermissionCode() != null) {
+        m_html = HTML.div(StringUtility.box(TEXTS.get("ErrorCode") + ": ", afe.getPermissionCode(), ""))
+            .cssClass("error-popup-code");
+      }
+      else {
+        m_html = null;
+      }
+    }
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/exception/AccessForbiddenException.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/exception/AccessForbiddenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,10 @@
 package org.eclipse.scout.rt.dataobject.exception;
 
 import java.io.Serial;
+import java.security.Permission;
+import java.util.Optional;
 
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.exception.IProcessingStatus;
 import org.eclipse.scout.rt.platform.exception.VetoException;
 
@@ -23,6 +26,13 @@ public class AccessForbiddenException extends VetoException {
   @Serial
   private static final long serialVersionUID = 1L;
 
+  /**
+   * Optional code representing the {@link Permission} that caused the access check to fail.
+   * <p>
+   * This code is shown in the error popup (e.g. "Code: XYZ") to inform the user which permission is missing.
+   */
+  private String m_permissionCode;
+
   public AccessForbiddenException() {
     super();
   }
@@ -33,6 +43,24 @@ public class AccessForbiddenException extends VetoException {
 
   public AccessForbiddenException(IProcessingStatus status) {
     super(status);
+  }
+
+  public String getPermissionCode() {
+    return m_permissionCode;
+  }
+
+  public AccessForbiddenException withPermission(Permission permission) {
+    withPermissionCode(Optional.ofNullable(permission)
+        .map(p -> BEANS.optional(IPermissionCodeHelper.class)
+            .map(helper -> helper.getPermissionCode(p))
+            .orElse(p.getName()))
+        .orElse(null));
+    return this;
+  }
+
+  public AccessForbiddenException withPermissionCode(final String permissionCode) {
+    m_permissionCode = permissionCode;
+    return this;
   }
 
   @Override

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/exception/IPermissionCodeHelper.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/exception/IPermissionCodeHelper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.dataobject.exception;
+
+import java.security.Permission;
+
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+@ApplicationScoped
+public interface IPermissionCodeHelper {
+
+  /**
+   * Returns a hashed permission code to be shown on an error message
+   */
+  String getPermissionCode(Permission permission);
+}

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts.properties
@@ -100,6 +100,7 @@ Enabled=Activated
 EndDate=End date
 Error=Error
 ErrorAndRetryTextDefault=An error has occurred.
+ErrorCode=Code
 ErrorCodeX=Code {0}
 ErrorTitleSecurity=Access error
 ErrorWhileLoadingData=Failed to load the data.

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_de.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_de.properties
@@ -100,6 +100,7 @@ Enabled=Aktiviert
 EndDate=Enddatum
 Error=Fehler
 ErrorAndRetryTextDefault=Ein Fehler ist aufgetreten.
+ErrorCode=Code
 ErrorCodeX=Code {0}
 ErrorTitleSecurity=Zugriffsfehler
 ErrorWhileLoadingData=Fehler beim Laden der Daten

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_es.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_es.properties
@@ -86,6 +86,7 @@ Enabled=Activado
 EndDate=Fecha de finalización
 Error=Error
 ErrorAndRetryTextDefault=Ha ocurrido un error durante la transferencia de datos.
+ErrorCode=Código
 ErrorCodeX=Código {0}
 ErrorTitleSecurity=Acceso denegado
 ErrorWhileLoadingData=Error al cargar los datos.

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_fr.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_fr.properties
@@ -100,6 +100,7 @@ Enabled=Activé
 EndDate=Date de fin
 Error=Erreur
 ErrorAndRetryTextDefault=Une erreur est apparue
+ErrorCode=Code
 ErrorCodeX=Code {0}
 ErrorTitleSecurity=Erreur d'accès
 ErrorWhileLoadingData=Erreur lors du chargement des données

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_it.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_it.properties
@@ -100,6 +100,7 @@ Enabled=Attivato
 EndDate=Data di fine
 Error=Errore
 ErrorAndRetryTextDefault=Si è verificato un errore.
+ErrorCode=Codice
 ErrorCodeX=Codice {0}
 ErrorTitleSecurity=Errore di accesso
 ErrorWhileLoadingData=Caricamento dati fallito

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_ja.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_ja.properties
@@ -86,6 +86,7 @@ Enabled=活動
 EndDate=終了日
 Error=エラー
 ErrorAndRetryTextDefault=問題が生じました
+ErrorCode=コード
 ErrorCodeX=コード {0}
 ErrorTitleSecurity=アクセスが拒否されました
 ErrorWhileLoadingData=データの読み込みに失敗しました。

--- a/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_nl.properties
+++ b/org.eclipse.scout.rt.nls/src/main/resources/org/eclipse/scout/rt/nls/texts/ScoutTexts_nl.properties
@@ -85,6 +85,7 @@ Enabled=Geactiveerd
 EndDate=Einddatum
 Error=Fout
 ErrorAndRetryTextDefault=Een fout is opgetreden tijdens gegevensoverbrenging
+ErrorCode=Code
 ErrorCodeX=Code {0}
 ErrorTitleSecurity=Toegang geweigerd
 ErrorWhileLoadingData=Laden van gegevens mislukt.

--- a/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/exception/DefaultExceptionMapperTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/exception/DefaultExceptionMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -142,6 +142,19 @@ public class DefaultExceptionMapperTest {
       assertEquals(exception.getStatus().getTitle(), error.getTitle());
       assertEquals(exception.getStatus().getBody(), error.getMessage());
       assertEquals(exception.getStatus().getCode(), error.getErrorCodeAsInt());
+    }
+  }
+
+  @Test
+  public void testToResponseAccessForbiddenException_permissionCode() {
+    AccessForbiddenExceptionMapper mapper = new AccessForbiddenExceptionMapper();
+    AccessForbiddenException exception = new AccessForbiddenException("foo {}", "bar", new Exception()).withTitle("hagbard").withPermissionCode("fooPermission");
+    try (Response response = mapper.toResponse(exception)) {
+      assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+      ErrorDo error = response.readEntity(ErrorResponse.class).getError();
+      assertEquals(exception.getStatus().getTitle(), error.getTitle());
+      assertEquals(exception.getStatus().getBody(), error.getMessage());
+      assertEquals(exception.getPermissionCode(), error.getErrorCode());
     }
   }
 

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/proxy/ErrorDoRestClientExceptionTransformer.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/client/proxy/ErrorDoRestClientExceptionTransformer.java
@@ -52,10 +52,14 @@ public class ErrorDoRestClientExceptionTransformer extends AbstractEntityRestCli
   protected RuntimeException transformClientError(RuntimeException e, Response response, BiFunction<String, RuntimeException, VetoException> vetoExceptionFactory) {
     return safeTransformEntityErrorResponse(e, response, () -> {
       ErrorDo error = response.readEntity(ErrorResponse.class).getError();
-      return vetoExceptionFactory.apply(error.getMessage(), e)
+      VetoException vetoException = vetoExceptionFactory.apply(error.getMessage(), e)
           .withTitle(error.getTitle())
           .withCode(error.getErrorCodeAsInt())
           .withSeverity(error.getSeverityAsInt());
+      if (vetoException instanceof AccessForbiddenException afe) {
+        afe.withPermissionCode(error.getErrorCode());
+      }
+      return vetoException;
     }, () -> {
       StatusType statusInfo = response.getStatusInfo();
       return vetoExceptionFactory.apply(statusInfo.getReasonPhrase(), e);

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/AbstractVetoExceptionMapper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/AbstractVetoExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,8 @@ public abstract class AbstractVetoExceptionMapper<E extends VetoException> exten
 
   @Override
   public Response toResponseImpl(E exception) {
-    LOG.info("{}: {}", exception.getClass().getSimpleName(), exception.getMessage());
+    //noinspection LoggingPlaceholderCountMatchesArgumentCount
+    LOG.info("{}: {}", exception.getClass().getSimpleName(), exception.getMessage(), LOG.isDebugEnabled() ? exception : null);
     return createErrorResponseBuilder(exception).build();
   }
 

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/AccessForbiddenExceptionMapper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/AccessForbiddenExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,11 @@ public class AccessForbiddenExceptionMapper extends AbstractVetoExceptionMapper<
 
   @Override
   protected ErrorResponseBuilder createErrorResponseBuilder(AccessForbiddenException exception) {
-    return super.createErrorResponseBuilder(exception)
+    ErrorResponseBuilder errorResponseBuilder = super.createErrorResponseBuilder(exception)
         .withHttpStatus(Response.Status.FORBIDDEN);
+    if (exception.getPermissionCode() != null) {
+      errorResponseBuilder.withErrorCode(exception.getPermissionCode());
+    }
+    return errorResponseBuilder;
   }
 }

--- a/org.eclipse.scout.rt.security.test/src/test/java/org/eclipse/scout/rt/security/PermissionCodeHelperTest.java
+++ b/org.eclipse.scout.rt.security.test/src/test/java/org/eclipse/scout/rt/security/PermissionCodeHelperTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.security;
+
+import static org.junit.Assert.*;
+
+import java.io.Serial;
+import java.security.BasicPermission;
+import java.security.Permission;
+
+import org.eclipse.scout.rt.dataobject.exception.IPermissionCodeHelper;
+import org.eclipse.scout.rt.security.fixture.AFixturePermission;
+import org.eclipse.scout.rt.security.fixture.DFixturePermission;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for {@link PermissionCodeHelper}
+ */
+@RunWith(PlatformTestRunner.class)
+public class PermissionCodeHelperTest {
+
+  private final IPermissionCodeHelper m_helper = new PermissionCodeHelper();
+
+  @Test
+  public void testGetPermissionCode_nullPermission() {
+    assertNull(m_helper.getPermissionCode(null));
+  }
+
+  @Test
+  public void testGetPermissionCode_regularPermission() {
+    Permission perm = new BasicPermission("myPermission") {
+      @Serial
+      private static final long serialVersionUID = 1L;
+    };
+    assertEquals("acf16cd7c4", m_helper.getPermissionCode(perm));
+  }
+
+  @Test
+  public void testGetPermissionCode_iPermission() {
+    assertEquals("21b4f4bd9e", m_helper.getPermissionCode(new AFixturePermission()));
+    assertEquals("2ac968752f", m_helper.getPermissionCode(new DFixturePermission()));
+  }
+}

--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/ACCESS.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/ACCESS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,6 +49,19 @@ public final class ACCESS {
   }
 
   /**
+   * Throws an exception if {@link #check(Permission)} fails for the given permission.
+   *
+   * @param accessCheckFailedMessage
+   *     A message which should be displayed to the user in case the permission check failed.
+   *     If <code>null</code>, {@link IPermission#getAccessCheckFailedMessage()} is used.
+   * @throws AccessForbiddenException
+   *     thrown if access is not granted
+   */
+  public static void checkAndThrow(Permission permission, String accessCheckFailedMessage) {
+    BEANS.get(AccessSupport.class).checkAndThrow(permission, accessCheckFailedMessage);
+  }
+
+  /**
    * @return true if access for any given permission is granted
    */
   public static boolean checkAny(Permission... permissions) {
@@ -89,14 +102,14 @@ public final class ACCESS {
   }
 
   /**
-   * This methods returns the granted {@link PermissionLevel} for a given permission instance {@code permission}.
+   * This method returns the granted {@link PermissionLevel} for a given permission instance {@code permission}.
    * <ul>
    * <li>{@link PermissionLevel#UNDEFINED} if {@code permission} is {@code null} or in general 'not an
    * {@link IPermission}'
    * <li>{@link PermissionLevel#NONE} if no level at all is granted to {@code permission}
    * <li>{@link PermissionLevel} if the level can be determined exactly.
    * <li>{@link PermissionLevel#UNDEFINED} if there are multiple granted permission levels possible and there is not
-   * enough data in the permission contained to determine the result more closer.
+   * enough data in the permission contained to determine the result closer.
    * </ul>
    *
    * @return non null {@link PermissionLevel}

--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/AccessSupport.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/AccessSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ import org.eclipse.scout.rt.dataobject.exception.AccessForbiddenException;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.text.TEXTS;
+import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,9 +32,13 @@ public class AccessSupport {
   }
 
   public void checkAndThrow(Permission p) {
+    checkAndThrow(p, null);
+  }
+
+  public void checkAndThrow(Permission p, String accessCheckFailedMessage) {
     if (!check(p)) {
       LOG.debug("checkAndThrow(p) failed, throwing exception");
-      throw getAccessCheckFailedException(p);
+      throw getAccessCheckFailedException(p, accessCheckFailedMessage);
     }
   }
 
@@ -83,15 +88,21 @@ public class AccessSupport {
   }
 
   public AccessForbiddenException getAccessCheckFailedException(Permission p) {
-    if (p instanceof IPermission) {
-      return getAccessCheckFailedException((IPermission) p);
-    }
-    return getDefaultAccessCheckFailedException()
-        .withContextInfo("permission", "{}", p);
+    return getAccessCheckFailedException(p, null);
   }
 
-  protected AccessForbiddenException getAccessCheckFailedException(IPermission p) {
-    return new AccessForbiddenException(p.getAccessCheckFailedMessage())
+  public AccessForbiddenException getAccessCheckFailedException(Permission p, String accessCheckFailedMessage) {
+    if (p instanceof IPermission) {
+      return getAccessCheckFailedException((IPermission) p, accessCheckFailedMessage)
+          .withPermission(p);
+    }
+    return getDefaultAccessCheckFailedException()
+        .withContextInfo("permission", "{}", p)
+        .withPermission(p);
+  }
+
+  protected AccessForbiddenException getAccessCheckFailedException(IPermission p, String accessCheckFailedMessage) {
+    return new AccessForbiddenException(StringUtility.isNullOrEmpty(accessCheckFailedMessage) ? p.getAccessCheckFailedMessage() : accessCheckFailedMessage)
         .withContextInfo("permission", "{}", p);
   }
 

--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/PermissionCodeHelper.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/PermissionCodeHelper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Permission;
+
+import org.eclipse.scout.rt.api.data.security.PermissionId;
+import org.eclipse.scout.rt.dataobject.exception.IPermissionCodeHelper;
+import org.eclipse.scout.rt.platform.security.SecurityUtility;
+import org.eclipse.scout.rt.platform.util.HexUtility;
+
+/**
+ * The permission code is calculated by hashing the permission name using {@link SecurityUtility#hash}
+ * and then encoding it to hex and shortening it.
+ */
+public class PermissionCodeHelper implements IPermissionCodeHelper {
+
+  @Override
+  public String getPermissionCode(Permission permission) {
+    if (permission == null) {
+      return null;
+    }
+    if (permission instanceof IPermission p) {
+      return getPermissionCode(p);
+    }
+    return hash(permission.getName());
+  }
+
+  protected String getPermissionCode(IPermission permission) {
+    return hashPermissionId(permission.getId());
+  }
+
+  protected String hashPermissionId(PermissionId permissionId) {
+    return hash(permissionId.unwrap());
+  }
+
+  protected String hash(String text) {
+    if (text == null) {
+      return null;
+    }
+    return encodeAndShorten(SecurityUtility.hash(text.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  protected String encodeAndShorten(byte[] hash) {
+    return HexUtility.encode(hash).substring(0, 10);
+  }
+}

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceOperationInvoker.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceOperationInvoker.java
@@ -264,6 +264,7 @@ public class ServiceOperationInvoker {
     Throwable p;
     if (t instanceof AccessForbiddenException afe) {
       p = copyVetoException(afe, AccessForbiddenException::new);
+      ((AccessForbiddenException) p).withPermissionCode(afe.getPermissionCode());
       afe.getContextInfos().stream()
           .filter(contextInfo -> contextInfo.startsWith("permission="))
           .map(contextInfo -> StringUtility.substring(contextInfo, 11))


### PR DESCRIPTION
On a permission check an AccessForbiddenException is thrown. A message is shown to the user with a message like "You are not authorized to execute this action". But the user does not know which permission is missing.

This change adds an error code to the error popup on an AccessForbiddenException to give the user a hint which permission is missing.

326455