### PR TITLE
Allow setting CssClass on TableRow without setting it on all Cells

### DIFF
--- a/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/internal/InternalTableRowTest.java
+++ b/org.eclipse.scout.rt.client.test/src/test/java/org/eclipse/scout/rt/client/ui/basic/table/internal/InternalTableRowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -59,6 +59,27 @@ public class InternalTableRowTest {
     ir.setCssClass("test");
     assertEquals("test", ir.getCssClass());
     assertEquals("test", ir.getCell(0).getCssClass());
+  }
+
+  @Test
+  public void testPropagateCssClassToCells() {
+    TestTable table = new TestTable();
+    ITableRow row = table.createRow();
+    row.setCssClass("CssClassOnRow");
+    assertEquals("CssClassOnRow", row.getCssClass());
+    // setting a css class will set css class on cell as well
+    assertEquals("CssClassOnRow", row.getCellForUpdate(0).getCssClass());
+    // set css class on the cell to a different one
+    row.getCellForUpdate(0).setCssClass("CssClassOnCell");
+    assertEquals("CssClassOnCell", row.getCellForUpdate(0).getCssClass());
+    // get internal table row and ensure that the css classes for the row and the cell match
+    InternalTableRow ir = new InternalTableRow(table, row);
+    assertEquals("CssClassOnRow", ir.getCssClass());
+    assertEquals("CssClassOnCell", ir.getCellForUpdate(0).getCssClass());
+    // set css class on row but do not propagate to cells
+    ir.setCssClass("ChangedCssClassOnRow", false);
+    assertEquals("ChangedCssClassOnRow", ir.getCssClass());
+    assertEquals("CssClassOnCell", ir.getCellForUpdate(0).getCssClass());
   }
 
   @Test

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/ITableRow.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/ITableRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -172,6 +172,8 @@ public interface ITableRow {
    * Convenience method for setting css class on all cells of this row
    */
   void setCssClass(String cssClass);
+
+  void setCssClass(String cssClass, boolean propagateCssClassToCells);
 
   String getCssClass();
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableRow.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/TableRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -448,9 +448,16 @@ public class TableRow implements ITableRow {
 
   @Override
   public void setCssClass(String cssClass) {
+    setCssClass(cssClass, true);
+  }
+
+  @Override
+  public void setCssClass(String cssClass, boolean propagateCssClassToCells) {
     m_cssClass = cssClass;
-    for (Cell m_cell : m_cells) {
-      m_cell.setCssClass(cssClass);
+    if (propagateCssClassToCells) {
+      for (Cell m_cell : m_cells) {
+        m_cell.setCssClass(cssClass);
+      }
     }
   }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/internal/InternalTableRow.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/internal/InternalTableRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -59,7 +59,7 @@ public class InternalTableRow extends TableRow implements ICellObserver {
     }
     // copy status and properties
     setStatus(row.getStatus());
-    setCssClass(row.getCssClass());
+    setCssClass(row.getCssClass(), false);
     setIconId(row.getIconId());
     // set table at end to avoid events before the row is even attached
     m_table = table;


### PR DESCRIPTION
If you want to apply a CSS class to a TableRow, there are cases where you don't want that CSS class to be inherited by all cells. This adjustment makes that possible.

459443