### PR TITLE
Make local lookup calls search the whole text

### DIFF
--- a/eclipse-scout-core/src/lookup/StaticLookupCall.ts
+++ b/eclipse-scout-core/src/lookup/StaticLookupCall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -144,13 +144,12 @@ export class StaticLookupCall<TKey> extends LookupCall<TKey> implements StaticLo
   }
 
   _createSearchPattern(text: string): RegExp {
-    // Implementation copied from LocalLookupCall.java
+    // Implementation copied from LookupHelper.createTextSearchPattern to match LocalLookupCall.java
 
     const WILDCARD = '*';
     const WILDCARD_PLACEHOLDER = '@wildcard@';
 
     text = strings.nvl(text);
-    text = text.toLowerCase();
     text = text.replace(new RegExp(strings.quote(WILDCARD), 'g'), WILDCARD_PLACEHOLDER);
     text = strings.quote(text);
 
@@ -163,10 +162,13 @@ export class StaticLookupCall<TKey> extends LookupCall<TKey> implements StaticLo
     if (!strings.endsWith(text, WILDCARD_PLACEHOLDER)) {
       text += WILDCARD_PLACEHOLDER;
     }
+    if (!strings.startsWith(text, WILDCARD_PLACEHOLDER)) {
+      text = WILDCARD_PLACEHOLDER + text;
+    }
 
     text = text.replace(new RegExp(strings.quote(WILDCARD_PLACEHOLDER), 'g'), '.*');
 
-    return new RegExp('^' + text + '$', 's'); // s = DOT_ALL
+    return new RegExp('^' + text + '$', 'siu'); // s = DOT_ALL, i = CASE_INSENSITIVE, u = UNICODE_CASE
   }
 
   protected override _getByKey(key: TKey): JQuery.Promise<LookupResult<TKey>> {

--- a/eclipse-scout-core/test/lookup/StaticLookupCallSpec.ts
+++ b/eclipse-scout-core/test/lookup/StaticLookupCallSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,7 +88,10 @@ describe('StaticLookupCall', () => {
     lookupCall.getByText('f').then(result => expectLookupRows(result).toEqual(['Foo']));
     jasmine.clock().tick(500);
 
-    lookupCall.getByText('a').then(result => expectLookupRows(result).toEqual([]));
+    lookupCall.getByText('a').then(result => expectLookupRows(result).toEqual(['Bar', 'Baz']));
+    jasmine.clock().tick(500);
+
+    lookupCall.getByText('O').then(result => expectLookupRows(result).toEqual(['Foo']));
     jasmine.clock().tick(500);
 
     lookupCall.getByText('*a').then(result => expectLookupRows(result).toEqual(['Bar', 'Baz']));

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/lookup/LookupHelper.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/lookup/LookupHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -330,7 +330,7 @@ public class LookupHelper {
       return truePredicate();
     }
     Assertions.assertNotNull(textAccessor, "textAccessor is required");
-    Pattern pattern = createTextSearchPattern(textPattern);
+    Pattern pattern = createTextSearchPattern(textPattern, WILDCARD);
     return data -> {
       if (data == null) {
         return false;
@@ -362,15 +362,25 @@ public class LookupHelper {
 
   /**
    * Text lookup pattern
+   * <p>
+   * When changing this method, update StaticLookupCall._createSearchPattern as well.
    */
-  protected Pattern createTextSearchPattern(String text) {
+  public Pattern createTextSearchPattern(String text, String wildcard) {
     if (text == null) {
       text = "";
     }
-    text = text.replace(WILDCARD, WILDCARD_REPLACE);
+    text = text.replace(wildcard, WILDCARD_REPLACE);
     text = StringUtility.escapeRegexMetachars(text);
+
+    // replace repeating wildcards to prevent regex DoS
+    String duplicateWildcards = WILDCARD_REPLACE.concat(WILDCARD_REPLACE);
+    while (text.contains(duplicateWildcards)) {
+      text = text.replace(duplicateWildcards, WILDCARD_REPLACE);
+    }
+
     text = text.replace(WILDCARD_REPLACE, MATCH_ALL_REGEX);
-    if (!text.contains(MATCH_ALL_REGEX)) {
+
+    if (!text.endsWith(MATCH_ALL_REGEX)) {
       text = text + MATCH_ALL_REGEX;
     }
     if (!text.startsWith(MATCH_ALL_REGEX)) {

--- a/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCallTest.java
+++ b/org.eclipse.scout.rt.shared.test/src/test/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -92,7 +92,9 @@ public class LocalLookupCallTest {
     runGetDataByTextFiltered(8, null, null);
     runGetDataByTextFiltered(4, "*or*", null);
     runGetDataByTextFiltered(4, "*or*", "*");
-    runGetDataByTextFiltered(3, "*or", null);
+    runGetDataByTextFiltered(4, "*or", null);
+    runGetDataByTextFiltered(4, "or*", null);
+    runGetDataByTextFiltered(4, "or", null);
     runGetDataByTextFiltered(2, "ip", null);
     runGetDataByTextFiltered(0, "foo", null);
     runGetDataByTextFiltered(1, "ipi", null);
@@ -100,6 +102,8 @@ public class LocalLookupCallTest {
     runGetDataByTextFiltered(8, "", null);
     runGetDataByTextFiltered(0, "°", null);
     runGetDataByTextFiltered(1, "*?*", null);
+    runGetDataByTextFiltered(1, "?*", null);
+    runGetDataByTextFiltered(1, "?", null);
     runGetDataByTextFiltered(1, "*\\*", null);
   }
 
@@ -107,16 +111,20 @@ public class LocalLookupCallTest {
   public void testGetDataByTextFilteredCustomWildcard() {
     runGetDataByTextFiltered(8, null, "°");
     runGetDataByTextFiltered(4, "°or°", "°");
-    runGetDataByTextFiltered(3, "°or", "°");
+    runGetDataByTextFiltered(4, "°or", "°");
+    runGetDataByTextFiltered(4, "or°", "°");
+    runGetDataByTextFiltered(4, "or", "°");
     runGetDataByTextFiltered(2, "ip", "°");
     runGetDataByTextFiltered(0, "foo", "°");
     runGetDataByTextFiltered(1, "ipi", "°");
     runGetDataByTextFiltered(8, "°", "°");
     runGetDataByTextFiltered(8, "", "°");
-    runGetDataByTextFiltered(0, "*", "°");
+    runGetDataByTextFiltered(2, "*", "°");
     runGetDataByTextFiltered(2, "°*°", "°");
     runGetDataByTextFiltered(1, "text with°*°", "°");
     runGetDataByTextFiltered(1, "°?°", "°");
+    runGetDataByTextFiltered(1, "?°", "°");
+    runGetDataByTextFiltered(1, "?", "°");
     runGetDataByTextFiltered(1, "°\\°", "°");
   }
 

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCall.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/services/lookup/LocalLookupCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,12 +19,13 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.eclipse.scout.rt.dataobject.lookup.LookupHelper;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.annotations.ConfigOperation;
 import org.eclipse.scout.rt.platform.classid.ClassId;
 import org.eclipse.scout.rt.platform.util.BooleanUtility;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
-import org.eclipse.scout.rt.platform.util.StringUtility;
 import org.eclipse.scout.rt.platform.util.TriState;
 
 /**
@@ -40,8 +41,6 @@ public class LocalLookupCall<T> extends LookupCall<T> {
   private static final long serialVersionUID = 0L;
 
   private boolean m_hierarchicalLookup;
-
-  private static final String WILDCARD_PLACEHOLDER = "@wildcard@";
 
   @Override
   @SuppressWarnings("squid:S1185") // method is required to satisfy LookupCall quality checks that require equals to be overridden
@@ -82,25 +81,7 @@ public class LocalLookupCall<T> extends LookupCall<T> {
   }
 
   protected Pattern createSearchPattern(String s) {
-    if (s == null) {
-      s = "";
-    }
-    s = s.replace(getWildcard(), WILDCARD_PLACEHOLDER);
-    s = s.toLowerCase();
-    s = StringUtility.escapeRegexMetachars(s);
-
-    // replace repeating wildcards to prevent regex DoS
-    String duplicateWildcards = WILDCARD_PLACEHOLDER.concat(WILDCARD_PLACEHOLDER);
-    while (s.contains(duplicateWildcards)) {
-      s = s.replace(duplicateWildcards, WILDCARD_PLACEHOLDER);
-    }
-
-    if (!s.contains(WILDCARD_PLACEHOLDER)) {
-      s = s.concat(WILDCARD_PLACEHOLDER);
-    }
-
-    s = s.replace(WILDCARD_PLACEHOLDER, ".*");
-    return Pattern.compile(s, Pattern.DOTALL);
+    return BEANS.get(LookupHelper.class).createTextSearchPattern(s, getWildcard());
   }
 
   @Override


### PR DESCRIPTION
For local lookup calls, wildcards are inserted at the beginning and end
of the lookup text so that the whole text is searched instead of only
the beginning.

420317