### PR TITLE
Ensure widget scroll methods trigger if widget is not rendered

### DIFF
--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -2361,6 +2361,10 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
   }
 
   scrollToTop(options?: ScrollOptions) {
+    if (!this.rendered) {
+      this.session.layoutValidator.schedulePostValidateFunction(this.scrollToTop.bind(this));
+      return;
+    }
     if (this.getDelegateScrollable()) {
       this.getDelegateScrollable().scrollToTop();
       return;
@@ -2369,14 +2373,15 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
     if (!$scrollable) {
       return;
     }
-    if (!this.rendered) {
-      this.session.layoutValidator.schedulePostValidateFunction(this.scrollToTop.bind(this));
-      return;
-    }
+    this.scrollTop = null; // Prevent scrollTop from being restored by _renderScrollTop during rendering
     scrollbars.scrollTop($scrollable, 0, options);
   }
 
   scrollToBottom(options?: ScrollOptions) {
+    if (!this.rendered) {
+      this.session.layoutValidator.schedulePostValidateFunction(this.scrollToBottom.bind(this));
+      return;
+    }
     if (this.getDelegateScrollable()) {
       this.getDelegateScrollable().scrollToBottom();
       return;
@@ -2385,10 +2390,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
     if (!$scrollable) {
       return;
     }
-    if (!this.rendered) {
-      this.session.layoutValidator.schedulePostValidateFunction(this.scrollToBottom.bind(this));
-      return;
-    }
+    this.scrollTop = null; // Prevent scrollTop from being restored by _renderScrollTop during rendering
     scrollbars.scrollToBottom($scrollable, options);
   }
 

--- a/eclipse-scout-core/test/widget/WidgetSpec.ts
+++ b/eclipse-scout-core/test/widget/WidgetSpec.ts
@@ -2270,6 +2270,164 @@ describe('Widget', () => {
     });
   });
 
+  describe('scrollToTop', () => {
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    it('scrolls to top if widget is rendered', () => {
+      let widget = new ScrollableWidget();
+      widget.init({
+        parent: parent,
+        session: session
+      });
+
+      // ensure widget is already rendered
+      widget.render(session.$entryPoint);
+
+      // scroll to some position (other than top-most position)
+      widget.$container[0].scrollTop = 40;
+      widget.$container.trigger('scroll');
+      jasmine.clock().tick(500);
+      expect(widget.scrollTop).toBe(40);
+
+      // ensure scroll to top works properly
+      widget.scrollToTop();
+      widget.$container.trigger('scroll');
+      expect(widget.scrollTop).toBe(0);
+    });
+
+    it('scrolls to top after layouting if widget is not yet rendered', () => {
+      let widget = new ScrollableWidget();
+      widget.init({
+        parent: parent,
+        session: session
+      });
+
+      // call method before widget is rendered -> should be called after layouting is finished
+      widget.scrollToTop();
+
+      // render widget and change scroll position
+      widget.render(session.$entryPoint);
+      widget.$container[0].scrollTop = 40;
+      widget.$container.trigger('scroll');
+      jasmine.clock().tick(500);
+      expect(widget.scrollTop).toBe(40);
+
+      // trigger layouting and ensure scroll to top is executed
+      widget.revalidateLayoutTree();
+      widget.$container.trigger('scroll');
+      jasmine.clock().tick(500);
+      expect(widget.scrollTop).toBe(0);
+    });
+
+    it('removes previous scroll top position and is applied on render after remove', () => {
+      let widget = new ScrollableWidget();
+      widget.init({
+        parent: parent,
+        session: session
+      });
+      widget.render(session.$entryPoint);
+      widget.$container[0].scrollTop = 40;
+      widget.$container.trigger('scroll');
+      jasmine.clock().tick(500);
+      expect(widget.scrollTop).toBe(40);
+
+      // remove widget (scroll top would be applied after re-rendering)
+      widget.remove();
+
+      // trigger scroll to top
+      widget.scrollToTop();
+
+      // re-render (previous scroll top position should not be applied)
+      widget.render(session.$entryPoint);
+      widget.revalidateLayoutTree(); // Scroll top will be rendered after the layout
+      expect(widget.$container[0].scrollTop).toBe(0);
+    });
+  });
+
+  describe('scrollToBottom', () => {
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    it('scrolls to bottom if widget is rendered', () => {
+      let widget = new ScrollableWidget();
+      widget.init({
+        parent: parent,
+        session: session
+      });
+
+      // ensure widget is already rendered
+      widget.render(session.$entryPoint);
+      widget.$container[0].scrollTop = 0;
+      widget.$container.trigger('scroll');
+      jasmine.clock().tick(500);
+      expect(widget.scrollTop).toBe(0);
+
+      // ensure scroll to bottom works properly
+      widget.scrollToBottom();
+      widget.$container.trigger('scroll');
+      expect(widget.scrollTop).toBeGreaterThan(0);
+    });
+
+    it('scrolls to bottom after layouting if widget is not yet rendered', () => {
+      let widget = new ScrollableWidget();
+      widget.init({
+        parent: parent,
+        session: session
+      });
+
+      // call method before widget is rendered -> should be called after layouting is finished
+      widget.scrollToBottom();
+
+      // render widget and change scroll position
+      widget.render(session.$entryPoint);
+      widget.$container[0].scrollTop = 0;
+      widget.$container.trigger('scroll');
+      jasmine.clock().tick(500);
+      expect(widget.scrollTop).toBe(0);
+
+      // trigger layouting and ensure scroll to bottom is executed
+      widget.revalidateLayoutTree();
+      widget.$container.trigger('scroll');
+      jasmine.clock().tick(500);
+      expect(widget.scrollTop).toBeGreaterThan(0);
+    });
+
+    it('removes previous scroll top position and is applied on render after remove', () => {
+      let widget = new ScrollableWidget();
+      widget.init({
+        parent: parent,
+        session: session
+      });
+      widget.render(session.$entryPoint);
+      widget.$container[0].scrollTop = 10;
+      widget.$container.trigger('scroll');
+      jasmine.clock().tick(500);
+      expect(widget.scrollTop).toBe(10);
+
+      // remove widget (scroll top would be applied after re-rendering)
+      widget.remove();
+
+      // trigger scroll to bottom
+      widget.scrollToBottom();
+
+      // re-render (previous scroll top position should not be applied)
+      widget.render(session.$entryPoint);
+      widget.revalidateLayoutTree(); // Scroll top will be rendered after the layout
+      expect(widget.$container[0].scrollTop).toBeGreaterThan(10);
+    });
+  });
+
   describe('isEveryParentVisible', () => {
 
     let parentWidget1, parentWidget2, parentWidget3, testWidget;


### PR DESCRIPTION
When a widget is not rendered yet and one of the methods scrollToTop or scrollToBottom is called, the scroll should be applied after rendering and layouting the widget.
Ensure that a post-validate-function is properly registered for scrolling if the widget is not rendered yet.

468419