### PR TITLE
DateColumn: improve columnDateGroupTypeChanged event

### DIFF
--- a/eclipse-scout-core/src/table/columns/DateColumn.ts
+++ b/eclipse-scout-core/src/table/columns/DateColumn.ts
@@ -101,10 +101,12 @@ export class DateColumn extends Column<Date> implements DateColumnModel {
   }
 
   protected _setGroupType(groupType: DateGroupType) {
-    this._setProperty('groupType', groupType);
+    const changed = this._setProperty('groupType', groupType);
     this._updateGroupTypeAxis();
-    // Trigger event to update ui preferences and sync to java model
-    this.table.trigger('columnDateGroupTypeChanged', {column: this});
+    if (changed) {
+      // Trigger event to update ui preferences and sync to java model
+      this.table.trigger('columnDateGroupTypeChanged', {column: this});
+    }
   }
 
   protected _updateGroupTypeAxis() {

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/table/JsonTable.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/json/table/JsonTable.java
@@ -838,6 +838,10 @@ public class JsonTable<T extends ITable> extends AbstractJsonWidget<T> implement
   protected void handleColumnAggregationFunctionChanged(JsonEvent event) {
     addTableEventFilterCondition(TableEvent.TYPE_COLUMN_AGGREGATION_CHANGED);
     IColumn<?> column = extractColumn(event.getData());
+    if (column == null) {
+      LOG.info("Requested column with ID {} doesn't exist. Skip aggregationFunctionChanged event.", event.getData().optString(PROP_COLUMN_ID, null));
+      return;
+    }
     Assertions.assertInstance(column, INumberColumn.class, "Aggregation can only be specified on numeric columns");
     getModel().getUIFacade().fireAggregationFunctionChanged((INumberColumn<?>) column, event.getData().getString("aggregationFunction"));
   }
@@ -845,6 +849,10 @@ public class JsonTable<T extends ITable> extends AbstractJsonWidget<T> implement
   protected void handleColumnBackgroundEffectChanged(JsonEvent event) {
     addTableEventFilterCondition(TableEvent.TYPE_COLUMN_BACKGROUND_EFFECT_CHANGED);
     IColumn<?> column = extractColumn(event.getData());
+    if (column == null) {
+      LOG.info("Requested column with ID {} doesn't exist. Skip columnBackgroundEffectChanged event.", event.getData().optString(PROP_COLUMN_ID, null));
+      return;
+    }
     Assertions.assertInstance(column, INumberColumn.class, "BackgroundEffect can only be specified on numeric columns");
     getModel().getUIFacade().setColumnBackgroundEffect((INumberColumn<?>) column, event.getData().optString("backgroundEffect", null));
   }
@@ -852,6 +860,10 @@ public class JsonTable<T extends ITable> extends AbstractJsonWidget<T> implement
   protected void handleUiColumnDateGroupTypeChanged(JsonEvent event) {
     addTableEventFilterCondition(TableEvent.TYPE_COLUMN_DATE_GROUP_TYPE_CHANGED);
     IColumn<?> column = extractColumn(event.getData());
+    if (column == null) {
+      LOG.info("Requested column with ID {} doesn't exist. Skip columnDateGroupTypeChanged event.", event.getData().optString(PROP_COLUMN_ID, null));
+      return;
+    }
     IDateColumn dateColumn = Assertions.assertInstance(column, IDateColumn.class, "DateGroupType can only be specified on date columns");
     DateGroupType groupType = BEANS.get(EnumResolver.class).resolve(DateGroupType.class, event.getData().optString("groupType", null));
     getModel().getUIFacade().setDateGroupTypeFromUI(dateColumn, groupType);


### PR DESCRIPTION
The columnDateGroupTypeChanged event is triggered by the DateColumn when the groupType is set in order to notify e.g. the UI server about a changed groupType. When the DateColumn is initialized the event was sent even if the value did not change which led to unnecessary events. This was changed so the event is only sent when the value changes. In addition, improve the JsonTable and only process the columnDateGroupTypeChanged if the column still exists. This may happen when a user changes the groupType while a model job e.g. adds columns to the table. These added columns lead to a columnStructureChanged event which disposes and rebuilds all JsonColumns. If the columnDateGroupTypeChanged for the old column is processed afterward simply log an info that no column can be found. Do the same for the events aggregationFunctionChanged and columnBackgroundEffectChanged of the NumberColumn.

469083