### PR TITLE
Add dataObjectVisitors

### DIFF
--- a/eclipse-scout-core/src/dataobject/BaseDoEntity.ts
+++ b/eclipse-scout-core/src/dataobject/BaseDoEntity.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Constructor, dataObjects, DeepPartial, DoContributionClassOrType, InitModelOf, objectFactoryHints, objects, ObjectType} from '../index';
+import {Constructor, dataObjects, DataObjectVisitor, dataObjectVisitors, DeepPartial, DoContributionClassOrType, InitModelOf, objectFactoryHints, objects, ObjectType} from '../index';
 import $ from 'jquery';
 
 /**
@@ -103,5 +103,12 @@ export class BaseDoEntity {
    */
   equals(obj: any) {
     return objects.equalsRecursive(this, obj, true /* prevent stackoverflow as this is called in equals */);
+  }
+
+  /**
+   * Visits this {@link BaseDoEntity} using {@link dataObjectVisitors.forEachRecWhile}.
+   */
+  visit<T>(visitor: DataObjectVisitor<T>, type?: Constructor<T>) {
+    dataObjectVisitors.forEachRecWhile(this, type, visitor);
   }
 }

--- a/eclipse-scout-core/src/dataobject/dataObjectVisitors.ts
+++ b/eclipse-scout-core/src/dataobject/dataObjectVisitors.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {arrays, BaseDoEntity, Constructor, objects, scout, strings, TreeVisitResult} from '../index';
+
+export const dataObjectVisitors = {
+
+  /**
+   * Visits all nodes and calls on each element matching the given type the provided consumer.
+   * If a node matches, child nodes of this node are not visited.
+   */
+  forEach<T>(root: any, type: Constructor<T>, consumer: (node: T) => void) {
+    dataObjectVisitors.forEachIf(root, (type ? c => c instanceof type : c => true) as (candidate) => candidate is T, consumer);
+  },
+
+  /**
+   * Visits all nodes and calls on each element matching the given type the provided consumer.
+   * If a node matches, child nodes of this node are also visited.
+   */
+  forEachRec<T>(root: any, type: Constructor<T>, consumer: (node: T) => void) {
+    dataObjectVisitors.forEachIfRec(root, (type ? c => c instanceof type : c => true) as (candidate) => candidate is T, consumer);
+  },
+
+  /**
+   * Visits all nodes and calls on each element matching the given type the provided visitor.
+   * If a node matches, the resulting {@link TreeVisitResult} of the given visitor determines how the visitor proceeds.
+   */
+  forEachRecWhile<T>(root: any, type: Constructor<T>, visitor: DataObjectVisitor<T>) {
+    dataObjectVisitors.forEachIfRecWhile(root, (type ? c => c instanceof type : c => true) as (candidate) => candidate is T, visitor);
+  },
+
+  /**
+   * Visits all nodes and calls on each element matching the given type predicate the provided consumer.
+   * If a node matches, child nodes of this node are not visited.
+   */
+  forEachIf<T>(root: any, typePredicate: (candidate) => candidate is T, consumer: (node: T) => void) {
+    dataObjectVisitors.forEachIfRecWhile(root, typePredicate, node => {
+      consumer(node);
+      return TreeVisitResult.SKIP_SUBTREE;
+    });
+  },
+
+  /**
+   * Visits all nodes and calls on each element matching the given type predicate the provided consumer.
+   * If a node matches, child nodes of this node are also visited.
+   */
+  forEachIfRec<T>(root: any, typePredicate: (candidate) => candidate is T, consumer: (node: T) => void) {
+    dataObjectVisitors.forEachIfRecWhile(root, typePredicate, node => {
+      consumer(node);
+      return TreeVisitResult.CONTINUE;
+    });
+  },
+
+  /**
+   * Visits all nodes and calls on each element matching the given type predicate the provided visitor.
+   * If a node matches, the resulting {@link TreeVisitResult} of the given visitor determines how the visitor proceeds.
+   */
+  forEachIfRecWhile<T>(root: any, typePredicate: (candidate) => candidate is T, visitor: DataObjectVisitor<T>) {
+    if (!typePredicate) {
+      typePredicate = (c => true) as (candidate) => candidate is T;
+    }
+    scout.create(DataObjectVisitHelper).visit(root, (node, context) => {
+      if (typePredicate(node)) {
+        return visitor(node, context);
+      }
+      return TreeVisitResult.CONTINUE;
+    });
+  }
+};
+
+/**
+ * Helper class to visit data objects (depth first, pre-order).
+ * <p>
+ * {@link dataObjectVisitors} will be in most cases sufficient.
+ */
+export class DataObjectVisitHelper {
+
+  /**
+   * Visits the given node and all of its children using the visitor.
+   */
+  visit(node: any, visitor: DataObjectVisitor<any>) {
+    this._visit(node, scout.create(DataObjectVisitorContext), visitor);
+  }
+
+  protected _visit(node: any, context: DataObjectVisitorContext, visitor: DataObjectVisitor<any>): TreeVisitResult {
+    if (objects.isNullOrUndefined(node)) {
+      return TreeVisitResult.CONTINUE;
+    }
+
+    if (node instanceof Set || objects.isArray(node)) {
+      return this._visitNode(node, context, visitor, (n, c, v) => this._visitSetOrArray(n, c, v));
+    }
+
+    if (node instanceof Map) {
+      return this._visitNode(node, context, visitor, (n, c, v) => this._visitMap(n, c, v));
+    }
+
+    if (node instanceof BaseDoEntity) {
+      return this._visitNode(node, context, visitor, (n, c, v) => this._visitBaseDoEntity(n, c, v));
+    }
+
+    if (objects.isObject(node)) {
+      return this._visitNode(node, context, visitor, (n, c, v) => this._visitObject(n, c, v));
+    }
+
+    return this._visitNode(node, context, visitor, (n, c, v) => this._visitAny(n, c, v));
+  }
+
+  /**
+   * Visits the given node using the visitor.
+   * If this results in {@link TreeVisitResult.TERMINATE} visiting is terminated.
+   * If it does not result in {@link TreeVisitResult.SKIP_SUBTREE} the children of the given node are visited using the given chain.
+   */
+  protected _visitNode<T>(node: T, context: DataObjectVisitorContext, visitor: DataObjectVisitor<any>, chain: (n: T, c: DataObjectVisitorContext, v: DataObjectVisitor<any>) => TreeVisitResult): TreeVisitResult {
+    if (context.containsParent(node)) {
+      throw new Error('Unable to visit node. Reference cycle detected.');
+    }
+
+    const visitResult = visitor(node, context);
+    if (visitResult === TreeVisitResult.TERMINATE) {
+      return TreeVisitResult.TERMINATE;
+    }
+
+    if (visitResult !== TreeVisitResult.SKIP_SUBTREE) {
+      context.pushParent(node);
+      const chainVisitResult = chain(node, context, visitor);
+      context.popParent();
+      return chainVisitResult;
+    }
+
+    return TreeVisitResult.CONTINUE;
+  }
+
+  /**
+   * Visits all elements of a {@link Set} or an {@link Array} using the visitor.
+   */
+  protected _visitSetOrArray(setOrArray: Set<any> | Array<any>, context: DataObjectVisitorContext, visitor: DataObjectVisitor<any>): TreeVisitResult {
+    for (const element of setOrArray) {
+      if (this._visit(element, context, visitor) === TreeVisitResult.TERMINATE) {
+        return TreeVisitResult.TERMINATE;
+      }
+    }
+    return TreeVisitResult.CONTINUE;
+  }
+
+  /**
+   * Visits all keys and values of a {@link Map} using the visitor.
+   */
+  protected _visitMap(map: Map<any, any>, context: DataObjectVisitorContext, visitor: DataObjectVisitor<any>): TreeVisitResult {
+    for (const [key, value] of map) {
+      if (this._visit(key, context, visitor) === TreeVisitResult.TERMINATE) {
+        return TreeVisitResult.TERMINATE;
+      }
+      if (this._visit(value, context, visitor) === TreeVisitResult.TERMINATE) {
+        return TreeVisitResult.TERMINATE;
+      }
+    }
+    return TreeVisitResult.CONTINUE;
+  }
+
+  /**
+   * Visits all values and all contributions of a {@link BaseDoEntity} using the visitor.
+   */
+  protected _visitBaseDoEntity(baseDoEntity: BaseDoEntity, context: DataObjectVisitorContext, visitor: DataObjectVisitor<any>): TreeVisitResult {
+    if (this._visitSetOrArray(
+      Object
+        .keys(baseDoEntity)
+        .filter(key => !strings.startsWith(key, '_'))
+        .map(key => baseDoEntity[key]),
+      context,
+      visitor
+    ) === TreeVisitResult.TERMINATE) {
+      return TreeVisitResult.TERMINATE;
+    }
+    return this._visitSetOrArray(baseDoEntity.getContributions(), context, visitor);
+  }
+
+  /**
+   * Visits all values of an {@link object} using the visitor.
+   */
+  protected _visitObject(obj: object, context: DataObjectVisitorContext, visitor: DataObjectVisitor<any>): TreeVisitResult {
+    return this._visitSetOrArray(Object.values(obj), context, visitor);
+  }
+
+  /**
+   * Visits no child of the given element. Hook for subclasses.
+   */
+  protected _visitAny(node: any, context: DataObjectVisitorContext, visitor: DataObjectVisitor<any>): TreeVisitResult {
+    return TreeVisitResult.CONTINUE;
+  }
+}
+
+export type DataObjectVisitor<T> = (node: T, context: DataObjectVisitorContext) => TreeVisitResult;
+
+export class DataObjectVisitorContext {
+
+  protected _parents = [];
+
+  get parents(): any[] {
+    return [...this._parents];
+  }
+
+  parent(index = 0): any {
+    return this._parents[this._parents.length - 1 - index];
+  }
+
+  containsParent(parent: any): boolean {
+    return arrays.contains(this._parents, parent);
+  }
+
+  pushParent(parent: any) {
+    this._parents.push(parent);
+  }
+
+  popParent(): any {
+    return this._parents.pop();
+  }
+}

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -137,6 +137,7 @@ export * from './dataobject/serialize/DataObjectDeserializer';
 export * from './dataobject/serialize/DataObjectSerializer';
 export * from './dataobject/serialize/DoTypeResolver';
 export * from './dataobject/dataObjects';
+export * from './dataobject/dataObjectVisitors';
 export * from './dataobject/BaseDoEntity';
 export * from './dataobject/ValueDo';
 export * from './ajax/ajax';

--- a/eclipse-scout-core/test/dataobject/dataObjectVisitorsSpec.ts
+++ b/eclipse-scout-core/test/dataobject/dataObjectVisitorsSpec.ts
@@ -1,0 +1,823 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {BaseDoEntity, DataObjectVisitHelper, dataObjectVisitors, numbers, scout, TreeVisitResult, typeName} from '../../src';
+
+describe('dataObjectVisitors', () => {
+
+  describe('forEach', () => {
+
+    it('visits only requested types', () => {
+      let visitedNodes = [];
+      const consumer = node => visitedNodes.push(node);
+      const mixedTypes = {
+        a: 1,
+        b: true,
+        c: 'some',
+        f: scout.create(FooDo, {foo: 'FOO'}),
+        l: scout.create(LoremDo, {lorem: 'LOREM'})
+      };
+
+      dataObjectVisitors.forEach(mixedTypes, null, consumer);
+      expect(visitedNodes).toEqual([mixedTypes]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEach(mixedTypes, FooDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(FooDo, {foo: 'FOO'})]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEach(mixedTypes, LoremDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(LoremDo, {lorem: 'LOREM'})]);
+    });
+
+    it('does visit non matched objects recursively', () => {
+      const visitedNodes = [];
+      const consumer = node => visitedNodes.push(node);
+      const lorem = scout.create(LoremDo, {foo: scout.create(FooDo)});
+
+      dataObjectVisitors.forEach(lorem, FooDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(FooDo)]);
+    });
+
+    it('does not visit matched objects recursively', () => {
+      const visitedFoos = [];
+      const consumer = (foo: FooDo) => visitedFoos.push(foo.foo);
+      const lorem = scout.create(LoremDo, {
+        foo: scout.create(FooDo, {
+          foo: 'FOO1',
+          lorem: scout.create(LoremDo, {
+            foo: scout.create(FooDo, {
+              foo: 'FOO2'
+            })
+          })
+        })
+      });
+
+      dataObjectVisitors.forEach(lorem, FooDo, consumer);
+      expect(visitedFoos).toEqual(['FOO1']);
+    });
+  });
+
+  describe('forEachRec', () => {
+
+    it('visits only requested types', () => {
+      let visitedNodes = [];
+      const consumer = node => visitedNodes.push(node);
+      const mixedTypes = {
+        a: 1,
+        b: true,
+        c: 'some',
+        f: scout.create(FooDo, {foo: 'FOO'}),
+        l: scout.create(LoremDo, {lorem: 'LOREM'})
+      };
+
+      dataObjectVisitors.forEachRec(mixedTypes, null, consumer);
+      expect(visitedNodes).toEqual([mixedTypes, 1, true, 'some', scout.create(FooDo, {foo: 'FOO'}), 'FOO', scout.create(LoremDo, {lorem: 'LOREM'}), 'LOREM']);
+
+      visitedNodes = [];
+
+      dataObjectVisitors.forEachRec(mixedTypes, FooDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(FooDo, {foo: 'FOO'})]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachRec(mixedTypes, LoremDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(LoremDo, {lorem: 'LOREM'})]);
+    });
+
+    it('does visit non matched objects recursively', () => {
+      const visitedNodes = [];
+      const consumer = node => visitedNodes.push(node);
+      const lorem = scout.create(LoremDo, {foo: scout.create(FooDo)});
+
+      dataObjectVisitors.forEachRec(lorem, FooDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(FooDo)]);
+    });
+
+    it('does visit matched objects recursively', () => {
+      const visitedFoos = [];
+      const consumer = (foo: FooDo) => visitedFoos.push(foo.foo);
+      const lorem = scout.create(LoremDo, {
+        foo: scout.create(FooDo, {
+          foo: 'FOO1',
+          lorem: scout.create(LoremDo, {
+            foo: scout.create(FooDo, {
+              foo: 'FOO2'
+            })
+          })
+        })
+      });
+
+      dataObjectVisitors.forEachRec(lorem, FooDo, consumer);
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2']);
+    });
+  });
+
+  describe('forEachRecWhile', () => {
+
+    it('visits only requested types', () => {
+      let visitedNodes = [];
+      const visitor = node => {
+        visitedNodes.push(node);
+        return TreeVisitResult.CONTINUE;
+      };
+      const mixedTypes = {
+        a: 1,
+        b: true,
+        c: 'some',
+        f: scout.create(FooDo, {foo: 'FOO'}),
+        l: scout.create(LoremDo, {lorem: 'LOREM'})
+      };
+
+      dataObjectVisitors.forEachRecWhile(mixedTypes, null, visitor);
+      expect(visitedNodes).toEqual([mixedTypes, 1, true, 'some', scout.create(FooDo, {foo: 'FOO'}), 'FOO', scout.create(LoremDo, {lorem: 'LOREM'}), 'LOREM']);
+
+      visitedNodes = [];
+
+      dataObjectVisitors.forEachRecWhile(mixedTypes, FooDo, visitor);
+      expect(visitedNodes).toEqual([scout.create(FooDo, {foo: 'FOO'})]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachRecWhile(mixedTypes, LoremDo, visitor);
+      expect(visitedNodes).toEqual([scout.create(LoremDo, {lorem: 'LOREM'})]);
+    });
+
+    it('does visit non matched objects recursively', () => {
+      const visitedNodes = [];
+      const visitor = node => {
+        visitedNodes.push(node);
+        return TreeVisitResult.CONTINUE;
+      };
+      const lorem = scout.create(LoremDo, {foo: scout.create(FooDo)});
+
+      dataObjectVisitors.forEachRecWhile(lorem, FooDo, visitor);
+      expect(visitedNodes).toEqual([scout.create(FooDo)]);
+    });
+
+    it('visits matched objects like the visitor demands', () => {
+      let visitedFoos = [];
+      const lorem = scout.create(LoremDo, {
+        foo: scout.create(FooDo, {
+          foo: 'FOO1',
+          lorem: scout.create(LoremDo, {
+            foo: scout.create(FooDo, {
+              foo: 'FOO2',
+              lorem: scout.create(LoremDo, {
+                foo: scout.create(FooDo, {
+                  foo: 'FOO3'
+                })
+              })
+            })
+          })
+        })
+      });
+      const foos = [scout.create(FooDo, {foo: 'FOO1'}), scout.create(FooDo, {foo: 'FOO2'}), scout.create(FooDo, {foo: 'FOO3'})];
+
+      dataObjectVisitors.forEachRecWhile(
+        lorem,
+        FooDo,
+        foo => {
+          visitedFoos.push(foo.foo);
+          return foo.foo === 'FOO2' ? TreeVisitResult.SKIP_SUBTREE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2']);
+
+      visitedFoos = [];
+      dataObjectVisitors.forEachRecWhile(
+        lorem,
+        FooDo,
+        foo => {
+          visitedFoos.push(foo.foo);
+          return foo.foo === 'FOO2' ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2']);
+
+      visitedFoos = [];
+      dataObjectVisitors.forEachRecWhile(
+        foos,
+        FooDo,
+        foo => {
+          visitedFoos.push(foo.foo);
+          return foo.foo === 'FOO2' ? TreeVisitResult.SKIP_SUBTREE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2', 'FOO3']);
+
+      visitedFoos = [];
+      dataObjectVisitors.forEachRecWhile(
+        foos,
+        FooDo,
+        foo => {
+          visitedFoos.push(foo.foo);
+          return foo.foo === 'FOO2' ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2']);
+    });
+  });
+
+  describe('forEachIf', () => {
+
+    it('visits only requested types', () => {
+      let visitedNodes = [];
+      const consumer = node => visitedNodes.push(node);
+      const mixedTypes = {
+        a: 1,
+        b: true,
+        c: 'some',
+        f: scout.create(FooDo, {foo: 'FOO'}),
+        l: scout.create(LoremDo, {lorem: 'LOREM'})
+      };
+
+      dataObjectVisitors.forEachIf(mixedTypes, null, consumer);
+      expect(visitedNodes).toEqual([mixedTypes]);
+
+      visitedNodes = [];
+
+      dataObjectVisitors.forEachIf(mixedTypes, c => numbers.isNumber(c), consumer);
+      expect(visitedNodes).toEqual([1]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIf(mixedTypes, c => typeof c === 'boolean', consumer);
+      expect(visitedNodes).toEqual([true]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIf(mixedTypes, c => typeof c === 'string', consumer);
+      expect(visitedNodes).toEqual(['some', 'FOO', 'LOREM']);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIf(mixedTypes, c => c instanceof FooDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(FooDo, {foo: 'FOO'})]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIf(mixedTypes, c => c instanceof LoremDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(LoremDo, {lorem: 'LOREM'})]);
+    });
+
+    it('does visit non matched objects recursively', () => {
+      const visitedNodes = [];
+      const consumer = node => visitedNodes.push(node);
+      const lorem = scout.create(LoremDo, {foo: scout.create(FooDo)});
+
+      dataObjectVisitors.forEachIf(lorem, c => c instanceof FooDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(FooDo)]);
+    });
+
+    it('does not visit matched objects recursively', () => {
+      const visitedFoos = [];
+      const consumer = (foo: FooDo) => visitedFoos.push(foo.foo);
+      const lorem = scout.create(LoremDo, {
+        foo: scout.create(FooDo, {
+          foo: 'FOO1',
+          lorem: scout.create(LoremDo, {
+            foo: scout.create(FooDo, {
+              foo: 'FOO2'
+            })
+          })
+        })
+      });
+
+      dataObjectVisitors.forEachIf(lorem, c => c instanceof FooDo, consumer);
+      expect(visitedFoos).toEqual(['FOO1']);
+    });
+  });
+
+  describe('forEachIfRec', () => {
+
+    it('visits only requested types', () => {
+      let visitedNodes = [];
+      const consumer = node => visitedNodes.push(node);
+      const mixedTypes = {
+        a: 1,
+        b: true,
+        c: 'some',
+        f: scout.create(FooDo, {foo: 'FOO'}),
+        l: scout.create(LoremDo, {lorem: 'LOREM'})
+      };
+
+      dataObjectVisitors.forEachIfRec(mixedTypes, null, consumer);
+      expect(visitedNodes).toEqual([mixedTypes, 1, true, 'some', scout.create(FooDo, {foo: 'FOO'}), 'FOO', scout.create(LoremDo, {lorem: 'LOREM'}), 'LOREM']);
+
+      visitedNodes = [];
+
+      dataObjectVisitors.forEachIfRec(mixedTypes, c => numbers.isNumber(c), consumer);
+      expect(visitedNodes).toEqual([1]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIfRec(mixedTypes, c => typeof c === 'boolean', consumer);
+      expect(visitedNodes).toEqual([true]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIfRec(mixedTypes, c => typeof c === 'string', consumer);
+      expect(visitedNodes).toEqual(['some', 'FOO', 'LOREM']);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIfRec(mixedTypes, c => c instanceof FooDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(FooDo, {foo: 'FOO'})]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIfRec(mixedTypes, c => c instanceof LoremDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(LoremDo, {lorem: 'LOREM'})]);
+    });
+
+    it('does visit non matched objects recursively', () => {
+      const visitedNodes = [];
+      const consumer = node => visitedNodes.push(node);
+      const lorem = scout.create(LoremDo, {foo: scout.create(FooDo)});
+
+      dataObjectVisitors.forEachIfRec(lorem, c => c instanceof FooDo, consumer);
+      expect(visitedNodes).toEqual([scout.create(FooDo)]);
+    });
+
+    it('does visit matched objects recursively', () => {
+      const visitedFoos = [];
+      const consumer = (foo: FooDo) => visitedFoos.push(foo.foo);
+      const lorem = scout.create(LoremDo, {
+        foo: scout.create(FooDo, {
+          foo: 'FOO1',
+          lorem: scout.create(LoremDo, {
+            foo: scout.create(FooDo, {
+              foo: 'FOO2'
+            })
+          })
+        })
+      });
+
+      dataObjectVisitors.forEachIfRec(lorem, c => c instanceof FooDo, consumer);
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2']);
+    });
+  });
+
+  describe('forEachIfRecWhile', () => {
+
+    it('visits only requested types', () => {
+      let visitedNodes = [];
+      const visitor = node => {
+        visitedNodes.push(node);
+        return TreeVisitResult.CONTINUE;
+      };
+      const mixedTypes = {
+        a: 1,
+        b: true,
+        c: 'some',
+        f: scout.create(FooDo, {foo: 'FOO'}),
+        l: scout.create(LoremDo, {lorem: 'LOREM'})
+      };
+
+      dataObjectVisitors.forEachIfRecWhile(mixedTypes, null, visitor);
+      expect(visitedNodes).toEqual([mixedTypes, 1, true, 'some', scout.create(FooDo, {foo: 'FOO'}), 'FOO', scout.create(LoremDo, {lorem: 'LOREM'}), 'LOREM']);
+
+      visitedNodes = [];
+
+      dataObjectVisitors.forEachIfRecWhile(mixedTypes, c => numbers.isNumber(c), visitor);
+      expect(visitedNodes).toEqual([1]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIfRecWhile(mixedTypes, c => typeof c === 'boolean', visitor);
+      expect(visitedNodes).toEqual([true]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIfRecWhile(mixedTypes, c => typeof c === 'string', visitor);
+      expect(visitedNodes).toEqual(['some', 'FOO', 'LOREM']);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIfRecWhile(mixedTypes, c => c instanceof FooDo, visitor);
+      expect(visitedNodes).toEqual([scout.create(FooDo, {foo: 'FOO'})]);
+
+      visitedNodes = [];
+      dataObjectVisitors.forEachIfRecWhile(mixedTypes, c => c instanceof LoremDo, visitor);
+      expect(visitedNodes).toEqual([scout.create(LoremDo, {lorem: 'LOREM'})]);
+    });
+
+    it('does visit non matched objects recursively', () => {
+      const visitedNodes = [];
+      const visitor = node => {
+        visitedNodes.push(node);
+        return TreeVisitResult.CONTINUE;
+      };
+      const lorem = scout.create(LoremDo, {foo: scout.create(FooDo)});
+
+      dataObjectVisitors.forEachIfRecWhile(lorem, c => c instanceof FooDo, visitor);
+      expect(visitedNodes).toEqual([scout.create(FooDo)]);
+    });
+
+    it('visits matched objects like the visitor demands', () => {
+      let visitedFoos = [];
+      const lorem = scout.create(LoremDo, {
+        foo: scout.create(FooDo, {
+          foo: 'FOO1',
+          lorem: scout.create(LoremDo, {
+            foo: scout.create(FooDo, {
+              foo: 'FOO2',
+              lorem: scout.create(LoremDo, {
+                foo: scout.create(FooDo, {
+                  foo: 'FOO3'
+                })
+              })
+            })
+          })
+        })
+      });
+      const foos = [scout.create(FooDo, {foo: 'FOO1'}), scout.create(FooDo, {foo: 'FOO2'}), scout.create(FooDo, {foo: 'FOO3'})];
+
+      dataObjectVisitors.forEachIfRecWhile(
+        lorem,
+        c => c instanceof FooDo,
+        foo => {
+          visitedFoos.push(foo.foo);
+          return foo.foo === 'FOO2' ? TreeVisitResult.SKIP_SUBTREE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2']);
+
+      visitedFoos = [];
+      dataObjectVisitors.forEachIfRecWhile(
+        lorem,
+        c => c instanceof FooDo,
+        foo => {
+          visitedFoos.push(foo.foo);
+          return foo.foo === 'FOO2' ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2']);
+
+      visitedFoos = [];
+      dataObjectVisitors.forEachIfRecWhile(
+        foos,
+        c => c instanceof FooDo,
+        foo => {
+          visitedFoos.push(foo.foo);
+          return foo.foo === 'FOO2' ? TreeVisitResult.SKIP_SUBTREE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2', 'FOO3']);
+
+      visitedFoos = [];
+      dataObjectVisitors.forEachIfRecWhile(
+        foos,
+        c => c instanceof FooDo,
+        foo => {
+          visitedFoos.push(foo.foo);
+          return foo.foo === 'FOO2' ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedFoos).toEqual(['FOO1', 'FOO2']);
+    });
+  });
+
+  describe('DataObjectVisitHelper', () => {
+
+    it('does not visit null or undefined', () => {
+      let visitedNodes = [];
+      const visitor = node => {
+        visitedNodes.push(node);
+        return TreeVisitResult.CONTINUE;
+      };
+
+      const helper = scout.create(DataObjectVisitHelper);
+
+      helper.visit(null, visitor);
+      expect(visitedNodes).toEqual([]);
+      helper.visit(undefined, visitor);
+      expect(visitedNodes).toEqual([]);
+
+      helper.visit(0, visitor);
+      expect(visitedNodes).toEqual([0]);
+
+      visitedNodes = [];
+      helper.visit(false, visitor);
+      expect(visitedNodes).toEqual([false]);
+
+      visitedNodes = [];
+      helper.visit('', visitor);
+      expect(visitedNodes).toEqual(['']);
+    });
+
+    it('visits primitives', () => {
+      let visitedNodes = [];
+      const visitor = node => {
+        visitedNodes.push(node);
+        return TreeVisitResult.CONTINUE;
+      };
+
+      const helper = scout.create(DataObjectVisitHelper);
+
+      helper.visit(42, visitor);
+      expect(visitedNodes).toEqual([42]);
+
+      visitedNodes = [];
+      helper.visit(true, visitor);
+      expect(visitedNodes).toEqual([true]);
+
+      visitedNodes = [];
+      helper.visit('foo', visitor);
+      expect(visitedNodes).toEqual(['foo']);
+    });
+
+    it('visits a Set and all of its elements', () => {
+      const visitedNodes = new Set();
+      const helper = scout.create(DataObjectVisitHelper);
+      const set = new Set([7, 13, 42]);
+
+      helper.visit(
+        set,
+        node => {
+          visitedNodes.add(node);
+          return TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual(new Set([set, 7, 13, 42]));
+
+      visitedNodes.clear();
+      helper.visit(
+        set,
+        node => {
+          visitedNodes.add(node);
+          return TreeVisitResult.SKIP_SUBTREE;
+        }
+      );
+      expect(visitedNodes).toEqual(new Set([set]));
+
+      visitedNodes.clear();
+      helper.visit(
+        set,
+        node => {
+          visitedNodes.add(node);
+          return node === 13 ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual(new Set([set, 7, 13]));
+    });
+
+    it('visits an array and all of its elements', () => {
+      let visitedNodes = [];
+      const helper = scout.create(DataObjectVisitHelper);
+      const array = [7, 13, 42];
+
+      helper.visit(
+        array,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([array, 7, 13, 42]);
+
+      visitedNodes = [];
+      helper.visit(
+        array,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.SKIP_SUBTREE;
+        }
+      );
+      expect(visitedNodes).toEqual([array]);
+
+      visitedNodes = [];
+      helper.visit(
+        array,
+        node => {
+          visitedNodes.push(node);
+          return node === 13 ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([array, 7, 13]);
+    });
+
+    it('visits a Map and all of its elements', () => {
+      let visitedNodes = [];
+      const helper = scout.create(DataObjectVisitHelper);
+      const map = new Map([
+        ['foo', 7],
+        ['bar', 13]
+      ]);
+
+      helper.visit(
+        map,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([map, 'foo', 7, 'bar', 13]);
+
+      visitedNodes = [];
+      helper.visit(
+        map,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.SKIP_SUBTREE;
+        }
+      );
+      expect(visitedNodes).toEqual([map]);
+
+      visitedNodes = [];
+      helper.visit(
+        map,
+        node => {
+          visitedNodes.push(node);
+          return node === 7 ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([map, 'foo', 7]);
+
+      visitedNodes = [];
+      helper.visit(
+        map,
+        node => {
+          visitedNodes.push(node);
+          return node === 'bar' ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([map, 'foo', 7, 'bar']);
+    });
+
+    it('visits a BaseDoEntity and all of its elements', () => {
+      let visitedNodes = [];
+      const helper = scout.create(DataObjectVisitHelper);
+      const foo = scout.create(FooDo, {foo: 'FOO', bar: 42});
+
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo, 'FOO', 42]);
+
+      visitedNodes = [];
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.SKIP_SUBTREE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo]);
+
+      visitedNodes = [];
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return node === 'FOO' ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo, 'FOO']);
+
+      const lorem = scout.create(LoremDo, {lorem: 'LOREM', ipsum: 13, dolor: true});
+      foo.addContribution(lorem);
+
+      visitedNodes = [];
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo, 'FOO', 42, lorem, 'LOREM', 13, true]);
+
+      visitedNodes = [];
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return node === lorem ? TreeVisitResult.SKIP_SUBTREE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo, 'FOO', 42, lorem]);
+
+      visitedNodes = [];
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return node === 13 ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo, 'FOO', 42, lorem, 'LOREM', 13]);
+    });
+
+    it('visits a pojo and all of its elements', () => {
+      let visitedNodes = [];
+      const helper = scout.create(DataObjectVisitHelper);
+      const foo = {foo: 'FOO', bar: 42};
+
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo, 'FOO', 42]);
+
+      visitedNodes = [];
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return TreeVisitResult.SKIP_SUBTREE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo]);
+
+      visitedNodes = [];
+      helper.visit(
+        foo,
+        node => {
+          visitedNodes.push(node);
+          return node === 'FOO' ? TreeVisitResult.TERMINATE : TreeVisitResult.CONTINUE;
+        }
+      );
+      expect(visitedNodes).toEqual([foo, 'FOO']);
+    });
+
+    it('keeps track of the parents while visiting', () => {
+      const visitedContextParents = [];
+      const visitor = (node, context) => {
+        visitedContextParents.push(context.parents);
+        return TreeVisitResult.CONTINUE;
+      };
+
+      const helper = scout.create(DataObjectVisitHelper);
+
+      const foo = scout.create(FooDo, {foo: 'FOO'});
+      const lorem = scout.create(LoremDo, {lorem: 'LOREM', foo});
+      const set = new Set([true, lorem]);
+      const map = new Map<string, BaseDoEntity>([
+        ['foo', foo],
+        ['lorem', lorem]
+      ]);
+      const object = {
+        n: 42,
+        set,
+        map
+      };
+
+      helper.visit(object, visitor);
+      expect(visitedContextParents).toEqual([
+        [], // <- object
+        [object],
+        [object], // <- set
+        [object, set],
+        [object, set], // <- lorem
+        [object, set, lorem],
+        [object, set, lorem], // <- foo
+        [object, set, lorem, foo],
+        [object], // <- map
+        [object, map],
+        [object, map], // <- foo
+        [object, map, foo],
+        [object, map],
+        [object, map], // <- lorem
+        [object, map, lorem],
+        [object, map, lorem], // <- foo
+        [object, map, lorem, foo]
+      ]);
+    });
+
+    it('detects reference cycles', () => {
+      const visitedNodes = [];
+      const visitor = node => {
+        visitedNodes.push(node);
+        return TreeVisitResult.CONTINUE;
+      };
+
+      const helper = scout.create(DataObjectVisitHelper);
+
+      const foo = scout.create(FooDo, {foo: 'FOO'});
+      const lorem = scout.create(LoremDo, {lorem: 'LOREM', foo});
+      foo.lorem = lorem;
+
+      expect(() => helper.visit(foo, visitor)).toThrowError('Unable to visit node. Reference cycle detected.');
+
+      expect(visitedNodes).toEqual([foo, 'FOO', lorem, 'LOREM']);
+    });
+  });
+
+  @typeName('scout.Foo')
+  class FooDo extends BaseDoEntity {
+    foo: string;
+    bar: number;
+    lorem: LoremDo;
+  }
+
+  @typeName('scout.Lorem')
+  class LoremDo extends BaseDoEntity {
+    lorem: string;
+    ipsum: number;
+    dolor: boolean;
+    foo: FooDo;
+  }
+});


### PR DESCRIPTION
Data objects can now be visited in Scout JS using dataObjectVisitors. The visitor will traverse sets, arrays, maps, objects and BaseDoEntities and will be executed on all of these elements and their children.

418622