### PR TITLE
scoutInstall: enable scout overrides again after pnpm install/update

### DIFF
--- a/eclipse-scout-releng/scripts/install/scoutInstall.ts
+++ b/eclipse-scout-releng/scripts/install/scoutInstall.ts
@@ -47,18 +47,30 @@ export async function scoutInstall(dir: string, options: UpdateOptions = {update
     await disableScoutOverrides(dir);
   }
 
-  // update
-  console.log('Perform \'pnpm update\'\n');
-  await pnpm.fork(dir, 'update', '--no-save', ...commonPnpmArguments);
-  console.log();
+  try {
+    // update
+    console.log('Perform \'pnpm update\'\n');
+    await pnpm.fork(dir, 'update', '--no-save', ...commonPnpmArguments);
+    console.log();
+  } finally {
+    // enable overrides again
+    if (options.updateMode === updateMode.ALL) {
+      await enableScoutOverrides(dir);
+    }
+  }
 
   // 'pnpm install' updates all non overridden dependencies that do not fulfill the required version
   // -> disable scout overrides and call 'pnpm install' depending on the updateMode
   if (options.updateMode === updateMode.REQUIRED) {
     await disableScoutOverrides(dir);
-    console.log('Perform \'pnpm install\'\n');
-    await pnpm.fork(dir, 'install', ...commonPnpmArguments);
-    console.log();
+    try {
+      console.log('Perform \'pnpm install\'\n');
+      await pnpm.fork(dir, 'install', ...commonPnpmArguments);
+      console.log();
+    } finally {
+      // enable overrides again
+      await enableScoutOverrides(dir);
+    }
   }
 
   if (options.updateMode !== updateMode.SNAPSHOTS) {
@@ -76,6 +88,16 @@ export async function disableScoutOverrides(dir: string): Promise<void> {
   console.log(`Disable scout overrides in '${dir}'\n`);
   const wsYaml = await PnpmWorkspaceYaml.parse(dir);
   wsYaml.removeScoutOverrides();
+  await wsYaml.flush();
+}
+
+/**
+ * Enables scout overrides of the `pnpm-workspace.yaml` in the given directory (see {@link PnpmWorkspaceYaml.addScoutOverrides}).
+ */
+export async function enableScoutOverrides(dir: string): Promise<void> {
+  console.log(`Enable scout overrides in '${dir}'\n`);
+  const wsYaml = await PnpmWorkspaceYaml.parse(dir);
+  wsYaml.addScoutOverrides();
   await wsYaml.flush();
 }
 

--- a/eclipse-scout-releng/scripts/util/PnpmWorkspaceYaml.ts
+++ b/eclipse-scout-releng/scripts/util/PnpmWorkspaceYaml.ts
@@ -19,6 +19,8 @@ import files from './files.ts';
 const PNPM_WORKSPACE_REGEX = /^pnpm-workspace(-.*)?\.yaml$/;
 const PNPM_WORKSPACE_FILE_EXTENSION = '.yaml';
 
+const SCOUT_OVERRIDES_ANCHOR = 'scout-overrides';
+
 /**
  * This class contains all information of a `pnpm-workspace.yaml`.
  **/
@@ -143,13 +145,36 @@ export class PnpmWorkspaceYaml {
   }
 
   /**
+   * Adds a link to the scout overrides to the overrides.
+   */
+  addScoutOverrides() {
+    const existingScout = this.doc.get('scout') as YAML.YAMLMap;
+    if (!existingScout) {
+      // there is no scout block -> nothing to link
+      return;
+    }
+
+    const existingScoutOverrides = existingScout.get('overrides') as YAML.YAMLMap;
+    if (!existingScout) {
+      // there are no scout overrides -> nothing to link
+      return;
+    }
+
+    if (!existingScoutOverrides.anchor) {
+      // no anchor present -> add anchor
+      existingScoutOverrides.anchor = SCOUT_OVERRIDES_ANCHOR;
+    }
+
+    this._ensureScoutOverridesAlias(existingScout, existingScoutOverrides);
+  }
+
+  /**
    * Updates scout overrides in this `pnpm-workspace.yaml` and links them into the overrides.
    */
   updateScoutOverrides(newScoutOverrides: Record<string, string>) {
     // create new scout overrides block
-    const scoutOverridesAnchorName = 'scout-overrides';
     const scoutOverrides = new YAML.YAMLMap();
-    scoutOverrides.anchor = scoutOverridesAnchorName;
+    scoutOverrides.anchor = SCOUT_OVERRIDES_ANCHOR;
     Object.entries(newScoutOverrides).forEach(([name, override]) => scoutOverrides.set(name, override));
 
     // replace scout block and include overrides
@@ -158,13 +183,13 @@ export class PnpmWorkspaceYaml {
     this.doc.set('scout', scout);
 
     // ensure scout-overrides block is linked in overrides using an alias
-    this._ensureScoutOverridesAlias(scout, scoutOverrides, scoutOverridesAnchorName);
+    this._ensureScoutOverridesAlias(scout, scoutOverrides);
   }
 
   /**
    * Ensures the scout overrides are included in the overrides.
    */
-  protected _ensureScoutOverridesAlias(scout: YAML.YAMLMap, scoutOverrides: YAML.YAMLMap, scoutOverridesAnchorName: string) {
+  protected _ensureScoutOverridesAlias(scout: YAML.YAMLMap, scoutOverrides: YAML.YAMLMap) {
     const mergeKey = '<<';
     const existingOverrides = this.doc.get('overrides') as YAML.YAMLMap;
     if (existingOverrides?.items?.length) {
@@ -174,21 +199,21 @@ export class PnpmWorkspaceYaml {
         // merge key is present and points to an alias
         const alias = first.value as YAML.Alias;
         // check if the alias points to the scout overrides
-        if (alias?.source === scoutOverridesAnchorName) {
+        if (alias?.source === SCOUT_OVERRIDES_ANCHOR) {
           return;
         }
       }
 
       // merge key is missing, not at the beginning or does not point to the correct alias -> add at the beginning or move to the beginning
       const existingOverridesItems = existingOverrides.items;
-      const scoutOverridesMergeKeyIndex = existingOverridesItems.findIndex((pair: YAML.Pair<YAML.Scalar>) => pair.key?.value === mergeKey && pair.value instanceof YAML.Alias && pair.value.source === scoutOverridesAnchorName);
+      const scoutOverridesMergeKeyIndex = existingOverridesItems.findIndex((pair: YAML.Pair<YAML.Scalar>) => pair.key?.value === mergeKey && pair.value instanceof YAML.Alias && pair.value.source === SCOUT_OVERRIDES_ANCHOR);
       if (scoutOverridesMergeKeyIndex > -1) {
         existingOverridesItems.splice(scoutOverridesMergeKeyIndex, 1);
       }
       existingOverrides.items = [
         new YAML.Pair(
           new YAML.Scalar(mergeKey),
-          this.doc.createAlias(scoutOverrides, scoutOverridesAnchorName)
+          this.doc.createAlias(scoutOverrides, SCOUT_OVERRIDES_ANCHOR)
         ),
         ...existingOverrides.items
       ];
@@ -207,7 +232,7 @@ export class PnpmWorkspaceYaml {
       // create new overrides block including the alias
       // it is added at the end and therefore after the
       const newOverrides = {};
-      newOverrides[mergeKey] = this.doc.createAlias(scoutOverrides, scoutOverridesAnchorName);
+      newOverrides[mergeKey] = this.doc.createAlias(scoutOverrides, SCOUT_OVERRIDES_ANCHOR);
       this.doc.set('overrides', newOverrides);
     }
   }

--- a/eclipse-scout-releng/test/install/scoutInstall.test.ts
+++ b/eclipse-scout-releng/test/install/scoutInstall.test.ts
@@ -263,6 +263,164 @@ describe('scoutInstall', () => {
         assert.equal(updateAllScoutOverridesMock.mock.callCount(), 0);
       });
     });
+
+    it('ensures scout overrides are re-enabled in REQUIRED mode if pnpm update fails', async () => {
+      await withPnpmWorkspaceYaml(async dir => {
+        pnpmForkMock.mock.mockImplementation(async (workingDir: string, ...args: string[]) => {
+          if (args[0] === 'update') {
+            throw 'Pnpm update fails';
+          }
+        });
+
+        try {
+          await scoutInstall(dir, {updateMode: updateMode.REQUIRED});
+        } catch (e) {
+          // nop
+        }
+
+        assert.equal(
+          await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf8'),
+          'packages:\n' +
+          '  - pkg-a\n' +
+          'scout:\n' +
+          '  overrides: &scout-overrides\n' +
+          '    lodash: 4.17.21\n' +
+          'overrides:\n' +
+          '  <<: *scout-overrides\n'
+        );
+      });
+    });
+
+    it('ensures scout overrides are re-enabled in ALL mode if pnpm update fails', async () => {
+      await withPnpmWorkspaceYaml(async dir => {
+        pnpmForkMock.mock.mockImplementation(async (workingDir: string, ...args: string[]) => {
+          if (args[0] === 'update') {
+            throw 'Pnpm update fails';
+          }
+        });
+
+        try {
+          await scoutInstall(dir, {updateMode: updateMode.ALL});
+        } catch (e) {
+          // nop
+        }
+
+        assert.equal(
+          await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf8'),
+          'packages:\n' +
+          '  - pkg-a\n' +
+          'scout:\n' +
+          '  overrides: &scout-overrides\n' +
+          '    lodash: 4.17.21\n' +
+          'overrides:\n' +
+          '  <<: *scout-overrides\n'
+        );
+      });
+    });
+
+    it('ensures scout overrides are re-enabled in SNAPSHOTS mode if pnpm update fails', async () => {
+      await withPnpmWorkspaceYaml(async dir => {
+        pnpmForkMock.mock.mockImplementation(async (workingDir: string, ...args: string[]) => {
+          if (args[0] === 'update') {
+            throw 'Pnpm update fails';
+          }
+        });
+
+        try {
+          await scoutInstall(dir, {updateMode: updateMode.SNAPSHOTS});
+        } catch (e) {
+          // nop
+        }
+
+        assert.equal(
+          await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf8'),
+          'packages:\n' +
+          '  - pkg-a\n' +
+          'scout:\n' +
+          '  overrides: &scout-overrides\n' +
+          '    lodash: 4.17.21\n' +
+          'overrides:\n' +
+          '  <<: *scout-overrides\n'
+        );
+      });
+    });
+
+    it('ensures scout overrides are re-enabled in REQUIRED mode if pnpm install fails', async () => {
+      await withPnpmWorkspaceYaml(async dir => {
+        pnpmForkMock.mock.mockImplementation(async (workingDir: string, ...args: string[]) => {
+          if (args[0] === 'install') {
+            throw 'Pnpm install fails';
+          }
+        });
+
+        try {
+          await scoutInstall(dir, {updateMode: updateMode.REQUIRED});
+        } catch (e) {
+          // nop
+        }
+
+        assert.equal(
+          await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf8'),
+          'packages:\n' +
+          '  - pkg-a\n' +
+          'scout:\n' +
+          '  overrides: &scout-overrides\n' +
+          '    lodash: 4.17.21\n' +
+          'overrides:\n' +
+          '  <<: *scout-overrides\n'
+        );
+      });
+    });
+
+    it('ensures scout overrides are re-enabled in REQUIRED mode if updating overrides fails', async () => {
+      await withPnpmWorkspaceYaml(async dir => {
+        updateAllScoutOverridesMock.mock.mockImplementation(async (lockfileDir: string, convergenceLogLevel?: DependencyConvergenceLogLevel) => {
+          throw 'Updating overrides fails';
+        });
+
+        try {
+          await scoutInstall(dir, {updateMode: updateMode.REQUIRED});
+        } catch (e) {
+          // nop
+        }
+
+        assert.equal(
+          await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf8'),
+          'packages:\n' +
+          '  - pkg-a\n' +
+          'scout:\n' +
+          '  overrides: &scout-overrides\n' +
+          '    lodash: 4.17.21\n' +
+          'overrides:\n' +
+          '  <<: *scout-overrides\n'
+        );
+      });
+    });
+
+    it('ensures scout overrides are re-enabled in ALL mode if updating overrides fails', async () => {
+      await withPnpmWorkspaceYaml(async dir => {
+        updateAllScoutOverridesMock.mock.mockImplementation(async (lockfileDir: string, convergenceLogLevel?: DependencyConvergenceLogLevel) => {
+          throw 'Updating overrides fails';
+        });
+
+        try {
+          await scoutInstall(dir, {updateMode: updateMode.ALL});
+        } catch (e) {
+          // nop
+        }
+
+        assert.equal(
+          await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf8'),
+          'packages:\n' +
+          '  - pkg-a\n' +
+          'scout:\n' +
+          '  overrides: &scout-overrides\n' +
+          '    lodash: 4.17.21\n' +
+          'overrides:\n' +
+          '  <<: *scout-overrides\n'
+        );
+      });
+    });
   });
 });
 

--- a/eclipse-scout-releng/test/util/PnpmWorkspaceYaml.test.ts
+++ b/eclipse-scout-releng/test/util/PnpmWorkspaceYaml.test.ts
@@ -258,6 +258,173 @@ describe('PnpmWorkspaceYaml', () => {
     });
   });
 
+  describe('addScoutOverrides', () => {
+
+    it('does nothing when scout block is absent', async () => {
+      await withPnpmWorkspaceYaml(
+        'packages:\n' +
+        '  - pkg-a\n' +
+        'overrides:\n' +
+        '  lodash: 4.17.21\n',
+        async pnpmWorkspaceYaml => {
+          pnpmWorkspaceYaml.addScoutOverrides();
+
+          await pnpmWorkspaceYaml.flush();
+          const content = await fs.readFile(pnpmWorkspaceYaml.path, 'utf8');
+          assert.equal(
+            content,
+            'packages:\n' +
+            '  - pkg-a\n' +
+            'overrides:\n' +
+            '  lodash: 4.17.21\n'
+          );
+        }
+      );
+    });
+
+    it('adds anchor to scout overrides and creates overrides with merge key when no overrides section exists', async () => {
+      await withPnpmWorkspaceYaml(
+        'packages:\n' +
+        '  - pkg-a\n' +
+        'scout:\n' +
+        '  overrides:\n' +
+        '    express: 4.18.0\n',
+        async pnpmWorkspaceYaml => {
+          pnpmWorkspaceYaml.addScoutOverrides();
+
+          await pnpmWorkspaceYaml.flush();
+          const content = await fs.readFile(pnpmWorkspaceYaml.path, 'utf8');
+          assert.equal(
+            content,
+            'packages:\n' +
+            '  - pkg-a\n' +
+            'scout:\n' +
+            '  overrides: &scout-overrides\n' +
+            '    express: 4.18.0\n' +
+            'overrides:\n' +
+            '  <<: *scout-overrides\n'
+          );
+        }
+      );
+    });
+
+    it('adds anchor to scout overrides and merge key to existing overrides', async () => {
+      await withPnpmWorkspaceYaml(
+        'packages:\n' +
+        '  - pkg-a\n' +
+        'scout:\n' +
+        '  overrides:\n' +
+        '    express: 4.18.0\n' +
+        'overrides:\n' +
+        '  lodash: 4.17.21\n',
+        async pnpmWorkspaceYaml => {
+          pnpmWorkspaceYaml.addScoutOverrides();
+
+          await pnpmWorkspaceYaml.flush();
+          const content = await fs.readFile(pnpmWorkspaceYaml.path, 'utf8');
+          assert.equal(
+            content,
+            'packages:\n' +
+            '  - pkg-a\n' +
+            'scout:\n' +
+            '  overrides: &scout-overrides\n' +
+            '    express: 4.18.0\n' +
+            'overrides:\n' +
+            '  <<: *scout-overrides\n' +
+            '  lodash: 4.17.21\n'
+          );
+        }
+      );
+    });
+
+    it('is a no-op when merge key already correctly links to scout overrides', async () => {
+      await withPnpmWorkspaceYaml(
+        'packages:\n' +
+        '  - pkg-a\n' +
+        'scout:\n' +
+        '  overrides: &scout-overrides\n' +
+        '    express: 4.18.0\n' +
+        'overrides:\n' +
+        '  <<: *scout-overrides\n',
+        async pnpmWorkspaceYaml => {
+          pnpmWorkspaceYaml.addScoutOverrides();
+
+          await pnpmWorkspaceYaml.flush();
+          const content = await fs.readFile(pnpmWorkspaceYaml.path, 'utf8');
+          assert.equal(
+            content,
+            'packages:\n' +
+            '  - pkg-a\n' +
+            'scout:\n' +
+            '  overrides: &scout-overrides\n' +
+            '    express: 4.18.0\n' +
+            'overrides:\n' +
+            '  <<: *scout-overrides\n'
+          );
+        }
+      );
+    });
+
+    it('moves merge key to beginning when present but not first in overrides', async () => {
+      await withPnpmWorkspaceYaml(
+        'packages:\n' +
+        '  - pkg-a\n' +
+        'scout:\n' +
+        '  overrides: &scout-overrides\n' +
+        '    express: 4.18.0\n' +
+        'overrides:\n' +
+        '  lodash: 4.17.21\n' +
+        '  <<: *scout-overrides\n',
+        async pnpmWorkspaceYaml => {
+          pnpmWorkspaceYaml.addScoutOverrides();
+
+          await pnpmWorkspaceYaml.flush();
+          const content = await fs.readFile(pnpmWorkspaceYaml.path, 'utf8');
+          assert.equal(
+            content,
+            'packages:\n' +
+            '  - pkg-a\n' +
+            'scout:\n' +
+            '  overrides: &scout-overrides\n' +
+            '    express: 4.18.0\n' +
+            'overrides:\n' +
+            '  <<: *scout-overrides\n' +
+            '  lodash: 4.17.21\n'
+          );
+        }
+      );
+    });
+
+    it('moves overrides after scout when overrides precedes scout block', async () => {
+      await withPnpmWorkspaceYaml(
+        'packages:\n' +
+        '  - pkg-a\n' +
+        'overrides:\n' +
+        '  lodash: 4.17.21\n' +
+        'scout:\n' +
+        '  overrides:\n' +
+        '    express: 4.18.0\n',
+        async pnpmWorkspaceYaml => {
+          pnpmWorkspaceYaml.addScoutOverrides();
+
+          await pnpmWorkspaceYaml.flush();
+          const content = await fs.readFile(pnpmWorkspaceYaml.path, 'utf8');
+          assert.equal(
+            content,
+            'packages:\n' +
+            '  - pkg-a\n' +
+            'scout:\n' +
+            '  overrides: &scout-overrides\n' +
+            '    express: 4.18.0\n' +
+            'overrides:\n' +
+            '  <<: *scout-overrides\n' +
+            '  lodash: 4.17.21\n'
+          );
+        }
+      );
+    });
+  });
+
   describe('updateScoutOverrides', () => {
 
     it('creates scout block with the given overrides and overrides using a merge key when no overrides exist', async () => {


### PR DESCRIPTION
If scoutInstall fails e.g. because of and error while updating the overrides the scout overrides must not stay disabled because otherwise re-running scoutInstall will result in a full update of all dependencies. Therefore, re-enable the scout overrides again after the pnpm calls they have been disabled for.

359390

Assisted-by: Sonnet 4.6, Haiku 4.5 (Claude Code)