### PR TITLE
Form: don't scroll to a focused widget when rendering

### DIFF
--- a/eclipse-scout-core/src/filechooser/FileChooser.ts
+++ b/eclipse-scout-core/src/filechooser/FileChooser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -85,12 +85,7 @@ export class FileChooser extends Widget implements FileChooserModel {
     this.keyStrokeContext.registerKeyStrokes([
       new FocusAdjacentElementKeyStroke(this.session, this),
       new ClickActiveElementKeyStroke(this, [keys.SPACE, keys.ENTER]),
-      new CloseKeyStroke(this, (() => {
-        if (!this.cancelButton) {
-          return null;
-        }
-        return this.cancelButton.$container;
-      }))
+      new CloseKeyStroke(this, () => this.cancelButton?.$container)
     ]);
   }
 
@@ -208,9 +203,7 @@ export class FileChooser extends Widget implements FileChooserModel {
       this.cancel();
       return;
     }
-    if (this.cancelButton && this.cancelButton.$container && this.session.focusManager.requestFocus(this.cancelButton.$container)) {
-      this.cancelButton.doAction();
-    }
+    this.cancelButton?.doAction();
   }
 
   cancel() {
@@ -224,9 +217,7 @@ export class FileChooser extends Widget implements FileChooserModel {
    * Destroys the file chooser and unlinks it from the display parent.
    */
   protected _close() {
-    if (this.displayParent) {
-      this.displayParent.fileChooserController.unregisterAndRemove(this);
-    }
+    this.displayParent?.fileChooserController.unregisterAndRemove(this);
     this.destroy();
   }
 

--- a/eclipse-scout-core/src/focus/FocusManager.ts
+++ b/eclipse-scout-core/src/focus/FocusManager.ts
@@ -291,22 +291,23 @@ export class FocusManager implements FocusManagerOptions {
     }
   }
 
-  requestFocusIfReady(element: HTMLElement | JQuery, filter?: () => boolean): boolean {
-    return this.requestFocus(element, filter, {onlyIfReady: true});
+  /**
+   * @see requestFocus
+   * @see RequestFocusOptions.onlyIfReady
+   */
+  requestFocusIfReady(element: HTMLElement | JQuery, options?: FocusContextFocusOptions): boolean {
+    options = options || {};
+    return this.requestFocus(element, {...options, onlyIfReady: true});
   }
 
   /**
    * Requests the focus for the given element, but only if being a valid focus location.
    *
-   * @param element
-   *        the element to focus, or null to focus the context's first focusable element matching the given filter.
-   * @param filter
-   *        filter that controls which element should be focused, or null to accept all focusable candidates.
-   * @param options
-   *        options to customize the focus request.
+   * @param element the element to focus. The method returns false if the element is null, undefined or not focusable.
+   * @param options options to customize the focus request.
    * @returns true if focus was gained, false otherwise.
    */
-  requestFocus(element: HTMLElement | JQuery, filter?: () => boolean, options?: RequestFocusOptions): boolean {
+  requestFocus(element: HTMLElement | JQuery, options?: RequestFocusOptions): boolean {
     options = options || {};
     let $element = $.ensure(element);
     if (!$element.is(':focusable')) {
@@ -319,7 +320,7 @@ export class FocusManager implements FocusManagerOptions {
       if (scout.nvl(options.onlyIfReady, false) && !context.prepared) {
         return false;
       }
-      context.validateAndSetFocus(htmlElement, filter, options);
+      context.validateAndSetFocus(htmlElement, null, options);
     }
 
     return focusUtils.isActiveElement(htmlElement);

--- a/eclipse-scout-core/src/form/Form.ts
+++ b/eclipse-scout-core/src/form/Form.ts
@@ -1630,30 +1630,26 @@ export class Form extends Widget implements FormModel, DisplayParent {
   }
 
   renderInitialFocus() {
-    let focused = false;
     if (this.restoreFocus()) {
       // If the form is re-rendered, the last focused element should be focused again
       return;
     }
+
+    // If the widget to be focused is outside the view area, the browser tries to scroll the widget into view.
+    // This may sometimes be desired, but if a form opens, the user typically expects to see the top of the form.
+    // Furthermore, if the scroll area contains large (not absolutely positioned) content, it can happen that the browsers scrolls the content even though the focused widget already is in the view area.
+    // This is probably because the focus happens while the form is not layouted yet. So actually, automatic scrolling to the focused widget when the form is not layouted yet does not work reliably.
+    // Because of this, preventScroll is set to true. If it is necessary to scroll to a specific widget, Widget.reveal() can be used.
     if (this.initialFocus) {
-      focused = this.initialFocus.focus();
+      this.initialFocus.focus({preventScroll: true});
     } else {
       // If no explicit focus is requested, try to focus the first focusable element.
       // Do it only if the focus is not already on an element in the form (e.g. focus could have been requested explicitly by a child element)
       // And only if the context belonging to that element is ready. Not ready means, some other widget (probably an outer container) is still preparing the context and will do the initial focus later
       if (!this.$container.isOrHas(this.$container.activeElement())) {
         let focusManager = this.session.focusManager;
-        focused = focusManager.requestFocusIfReady(focusManager.findFirstFocusableElement(this.$container));
+        focusManager.requestFocusIfReady(focusManager.findFirstFocusableElement(this.$container), {preventScroll: true});
       }
-    }
-    if (focused) {
-      // If the focus widget is outside the view area the browser tries to scroll the widget into view.
-      // If the scroll area contains large (not absolutely positioned) content it can happen that the browsers scrolls the content even though the focused widget already is in the view area.
-      // This is probably because the focus happens while the form is not layouted yet. We should actually refactor this and do the focusing after layouting, but this would be a bigger change.
-      // The current workaround is to revert the scrolling done by the browser. Automatic scrolling to the focused widget when the form is not layouted does not work anyway.
-      let $scrollParent = this.$container.activeElement().scrollParent();
-      $scrollParent.scrollTop(0);
-      $scrollParent.scrollLeft(0);
     }
   }
 

--- a/eclipse-scout-core/src/messagebox/MessageBox.ts
+++ b/eclipse-scout-core/src/messagebox/MessageBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -66,7 +66,7 @@ export class MessageBox extends Widget implements MessageBoxModel {
     this.noButton = null;
     this.cancelButton = null;
     this.abortButton = null;
-    this.inheritAccessibility = false; // do not inherit enabled-state by default. Otherwise the MessageBox cannot be closed anymore
+    this.inheritAccessibility = false; // do not inherit enabled-state by default. Otherwise, the MessageBox cannot be closed anymore
     this.$content = null;
     this.$header = null;
     this.$body = null;
@@ -108,12 +108,7 @@ export class MessageBox extends Widget implements MessageBoxModel {
       new ClickActiveElementKeyStroke(this, [
         keys.SPACE, keys.ENTER
       ]),
-      new AbortKeyStroke(this, () => {
-        if (this.abortButton) {
-          return this.abortButton.$container;
-        }
-        return null;
-      })
+      new AbortKeyStroke(this, () => this.abortButton?.$container)
     ]);
   }
 
@@ -241,9 +236,7 @@ export class MessageBox extends Widget implements MessageBoxModel {
   }
 
   protected _renderHiddenText() {
-    if (this.$hiddenText) {
-      this.$hiddenText.remove();
-    }
+    this.$hiddenText?.remove();
     if (this.hiddenText) {
       this.$hiddenText = this.$content.appendElement('<!-- \n' + this.hiddenText.replace(/<!--|-->/g, '') + '\n -->');
     }
@@ -353,19 +346,15 @@ export class MessageBox extends Widget implements MessageBoxModel {
    * Destroys the message box and unlinks it from the display parent.
    */
   close() {
-    if (this.displayParent) {
-      this.displayParent.messageBoxController.unregisterAndRemove(this);
-    }
+    this.displayParent?.messageBoxController.unregisterAndRemove(this);
     this.destroy();
   }
 
   /**
-   * Aborts the message box by using the default abort button. Used by the ESC key stroke.
+   * Aborts the message box by using the default abort button. Used by the ESC keystroke.
    */
   abort() {
-    if (this.abortButton && this.abortButton.$container && this.session.focusManager.requestFocus(this.abortButton.$container)) {
-      this.abortButton.doAction();
-    }
+    this.abortButton?.doAction();
   }
 
   protected override _attach() {

--- a/eclipse-scout-core/src/widget/Widget.ts
+++ b/eclipse-scout-core/src/widget/Widget.ts
@@ -2183,7 +2183,7 @@ export class Widget extends PropertyEventEmitter implements WidgetModel, ObjectW
       this.session.layoutValidator.schedulePostValidateFunction(this.focus.bind(this, options));
       return false;
     }
-    return this.session.focusManager.requestFocus(this.get$Focusable(), null, options);
+    return this.session.focusManager.requestFocus(this.get$Focusable(), options);
   }
 
   /**

--- a/eclipse-scout-core/test/focus/FocusManagerSpec.ts
+++ b/eclipse-scout-core/test/focus/FocusManagerSpec.ts
@@ -171,6 +171,11 @@ describe('FocusManager', () => {
       focusManager.uninstallFocusContext($container1);
     });
 
+    it('returns false if the element is null or undefined', () => {
+      expect(focusManager.requestFocus(null)).toBe(false);
+      expect(focusManager.requestFocus(undefined)).toBe(false);
+    });
+
     it('activates the context of the element if the element to focus is not in the active context', () => {
       let $container1 = createDivWithTwoInputs().appendTo(session.$entryPoint);
       let $container2 = createDivWithTwoInputs().appendTo(session.$entryPoint);


### PR DESCRIPTION
The form already tried to prevent scrolling by resetting scroll positions to 0. This does not work anymore since 26.1 if the widget to be focused is a very large table, because the table data now has the focus instead of the table, which means the scrollParent() returns the table data instead of the group box body. So scroll positions were reset for the wrong object.
Instead of only considering the actual parents (scrollParent() returns the element itself if it is scrollable, which is not expected here), we use the preventScroll option because it is now widely supported by the browsers.

453283