### PR TITLE
Improve permission code calculation by hashing the ID signature

### DIFF
--- a/org.eclipse.scout.rt.security.test/src/test/java/org/eclipse/scout/rt/security/PermissionCodeHelperTest.java
+++ b/org.eclipse.scout.rt.security.test/src/test/java/org/eclipse/scout/rt/security/PermissionCodeHelperTest.java
@@ -16,9 +16,12 @@ import java.security.BasicPermission;
 import java.security.Permission;
 
 import org.eclipse.scout.rt.dataobject.exception.IPermissionCodeHelper;
+import org.eclipse.scout.rt.dataobject.id.IdCodec.IdSignaturePasswordProperty;
 import org.eclipse.scout.rt.security.fixture.AFixturePermission;
 import org.eclipse.scout.rt.security.fixture.DFixturePermission;
+import org.eclipse.scout.rt.testing.platform.mock.MockConfigPropertyRule;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,6 +32,9 @@ import org.junit.runner.RunWith;
 public class PermissionCodeHelperTest {
 
   private final IPermissionCodeHelper m_helper = new PermissionCodeHelper();
+
+  @Rule
+  public MockConfigPropertyRule<String> m_idSignaturePasswordPropertyRule = new MockConfigPropertyRule<>(IdSignaturePasswordProperty.class, "myPassword");
 
   @Test
   public void testGetPermissionCode_nullPermission() {
@@ -46,7 +52,7 @@ public class PermissionCodeHelperTest {
 
   @Test
   public void testGetPermissionCode_iPermission() {
-    assertEquals("21b4f4bd9e", m_helper.getPermissionCode(new AFixturePermission()));
-    assertEquals("2ac968752f", m_helper.getPermissionCode(new DFixturePermission()));
+    assertEquals("2712551d2f", m_helper.getPermissionCode(new AFixturePermission()));
+    assertEquals("23a6330c80", m_helper.getPermissionCode(new DFixturePermission()));
   }
 }

--- a/org.eclipse.scout.rt.security.test/src/test/java/org/eclipse/scout/rt/security/PermissionsTest.java
+++ b/org.eclipse.scout.rt.security.test/src/test/java/org/eclipse/scout/rt/security/PermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.scout.rt.dataobject.exception.AccessForbiddenException;
+import org.eclipse.scout.rt.dataobject.id.IdCodec.IdSignaturePasswordProperty;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
@@ -37,10 +38,12 @@ import org.eclipse.scout.rt.security.fixture.TestPermissionLevels;
 import org.eclipse.scout.rt.security.fixture.UFixturePermission;
 import org.eclipse.scout.rt.security.fixture.UJFixturePermission;
 import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.eclipse.scout.rt.testing.platform.mock.MockConfigPropertyRule;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -59,6 +62,9 @@ public class PermissionsTest {
 
   private AccessSupport m_support;
   private final List<IBean<?>> m_beans = new ArrayList<>();
+
+  @Rule
+  public MockConfigPropertyRule<String> m_idSignaturePasswordPropertyRule = new MockConfigPropertyRule<>(IdSignaturePasswordProperty.class, "myPassword");
 
   @Before
   public void before() {

--- a/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/PermissionCodeHelper.java
+++ b/org.eclipse.scout.rt.security/src/main/java/org/eclipse/scout/rt/security/PermissionCodeHelper.java
@@ -12,16 +12,22 @@ package org.eclipse.scout.rt.security;
 import java.nio.charset.StandardCharsets;
 import java.security.Permission;
 
-import org.eclipse.scout.rt.api.data.security.PermissionId;
 import org.eclipse.scout.rt.dataobject.exception.IPermissionCodeHelper;
+import org.eclipse.scout.rt.dataobject.id.IId;
+import org.eclipse.scout.rt.dataobject.id.IdCodec;
 import org.eclipse.scout.rt.platform.security.SecurityUtility;
 import org.eclipse.scout.rt.platform.util.HexUtility;
+import org.eclipse.scout.rt.platform.util.LazyValue;
 
 /**
- * The permission code is calculated by hashing the permission name using {@link SecurityUtility#hash}
- * and then encoding it to hex and shortening it.
+ * Creates a short (10‑char) permission code.
+ * <p>
+ * If the {@link Permission} implements {@link IPermission}, the signature of the permission's {@link IPermission#getId() ID}
+ * is hashed; otherwise the permission name is hashed.
  */
 public class PermissionCodeHelper implements IPermissionCodeHelper {
+
+  protected final LazyValue<IdCodec> m_idCodec = new LazyValue<>(IdCodec.class);
 
   @Override
   public String getPermissionCode(Permission permission) {
@@ -35,11 +41,13 @@ public class PermissionCodeHelper implements IPermissionCodeHelper {
   }
 
   protected String getPermissionCode(IPermission permission) {
-    return hashPermissionId(permission.getId());
+    return hash(permission.getId());
   }
 
-  protected String hashPermissionId(PermissionId permissionId) {
-    return hash(permissionId.unwrap());
+  protected String hash(IId id) {
+    String idString = m_idCodec.get().toUnqualified(id);
+    String signature = m_idCodec.get().createSignature(idString);
+    return hash(signature);
   }
 
   protected String hash(String text) {

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceOperationInvokerTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceOperationInvokerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import org.eclipse.scout.rt.dataobject.exception.AccessForbiddenException;
+import org.eclipse.scout.rt.dataobject.id.IdCodec.IdSignaturePasswordProperty;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.exception.ProcessingException;
 import org.eclipse.scout.rt.security.AccessSupport;
@@ -29,8 +30,10 @@ import org.eclipse.scout.rt.shared.services.common.ping.IPingService;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelResponse;
 import org.eclipse.scout.rt.testing.platform.mock.BeanMock;
+import org.eclipse.scout.rt.testing.platform.mock.MockConfigPropertyRule;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +44,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(PlatformTestRunner.class)
 public class ServiceOperationInvokerTest {
+
+  @Rule
+  public MockConfigPropertyRule<String> m_idSignaturePasswordPropertyRule = new MockConfigPropertyRule<>(IdSignaturePasswordProperty.class, "myPassword");
 
   @BeanMock
   private IPingService m_pingSvc;


### PR DESCRIPTION
Uses IdCodec to generate a signature for the permission's ID and hashes that signature, providing stronger security than hashing the raw ID

469416