### PR TITLE
Client notification registry: Separate queue creation/lastAccess time

### DIFF
--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationNodeQueueTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationNodeQueueTest.java
@@ -11,19 +11,28 @@ package org.eclipse.scout.rt.server.clientnotification;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.scout.rt.dataobject.id.NodeId;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
 import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.platform.job.IFuture;
 import org.eclipse.scout.rt.platform.job.Jobs;
+import org.eclipse.scout.rt.platform.util.date.IDateProvider;
 import org.eclipse.scout.rt.server.clientnotification.ClientNotificationProperties.NodeQueueCapacity;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationAddress;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
 import org.eclipse.scout.rt.testing.platform.mock.MockConfigPropertyRule;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.eclipse.scout.rt.testing.platform.util.date.FixedDateProvider;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,12 +43,26 @@ import org.junit.runner.RunWith;
 @RunWith(PlatformTestRunner.class)
 public class ClientNotificationNodeQueueTest {
 
-  private ClientNotificationNodeQueue m_queue;
+  protected static final int MAX_TEST_CAPACITY = 10;
+  protected static final FixedDateProvider DATE_PROVIDER = new FixedDateProvider();
+  protected static List<IBean<Object>> s_beans = new ArrayList<>();
 
-  private static final int MAX_TEST_CAPACITY = 10;
+  protected ClientNotificationNodeQueue m_queue;
 
   @Rule
   public MockConfigPropertyRule<Integer> m_nodeQueueCapacityPropertyRule = new MockConfigPropertyRule<>(NodeQueueCapacity.class, MAX_TEST_CAPACITY);
+
+  @BeforeClass
+  public static void beforeClass() {
+    s_beans.add(BeanTestingHelper.get().registerBean(new BeanMetaData(IDateProvider.class)
+        .withApplicationScoped(true)
+        .withInitialInstance(DATE_PROVIDER)));
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    BeanTestingHelper.get().unregisterBeans(s_beans);
+  }
 
   @Before
   public void setup() {
@@ -79,6 +102,17 @@ public class ClientNotificationNodeQueueTest {
     List<ClientNotificationMessage> notifications = m_queue.getNotifications(100, MAX_TEST_CAPACITY, TimeUnit.MILLISECONDS);
     assertEquals(MAX_TEST_CAPACITY, notifications.size());
     assertEquals("test1", notifications.get(0).getNotification());
+  }
+
+  @Test
+  public void testLastConsumeAccess() {
+    assertEquals(0, m_queue.getLastConsumeAccess());
+    assertEquals("", m_queue.getLastConsumeAccessFormatted());
+
+    DATE_PROVIDER.setDate(new Date(1));
+    m_queue.consume(1, 1, TimeUnit.MILLISECONDS);
+    assertEquals(1, m_queue.getLastConsumeAccess());
+    assertEquals("1970-01-01 01:00:00.001", m_queue.getLastConsumeAccessFormatted());
   }
 
   private void putTestNotifications(int count) {

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistryTest.java
@@ -179,10 +179,27 @@ public class ClientNotificationRegistryTest {
   }
 
   /**
-   * If no message is consumed, queue is removed
+   * If no message is consumed, queue is removed after timeout.
    */
   @Test
   public void testQueueRemovedAfterTimeout() throws InterruptedException {
+    ClientNotificationRegistry reg = new ClientNotificationRegistry(10);
+    reg.registerNode(TEST_NODE, true);
+    reg.putForAllNodes("notification");
+    List<ClientNotificationMessage> consumed = consumeNoWait(reg, TEST_NODE);
+    assertEquals(1, consumed.size());
+    Thread.sleep(100);
+    reg.cleanupDeadNodes();
+    reg.putForAllNodes("notification2");
+    consumed = consumeNoWait(reg, TEST_NODE);
+    assertTrue(consumed.isEmpty());
+  }
+
+  /**
+   * If never a message was consumed, queue is removed after timeout.
+   */
+  @Test
+  public void testQueueRemovedAfterTimeoutNeverConsumer() throws InterruptedException {
     ClientNotificationRegistry reg = new ClientNotificationRegistry(10);
     reg.registerNode(TEST_NODE, true);
     Thread.sleep(100);

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/AbstractClientNotificationNodeQueue.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/AbstractClientNotificationNodeQueue.java
@@ -24,10 +24,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.scout.rt.dataobject.id.NodeId;
+import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.FinalValue;
 import org.eclipse.scout.rt.platform.util.date.DateUtility;
+import org.eclipse.scout.rt.platform.util.date.IDateProvider;
 import org.eclipse.scout.rt.server.clientnotification.ClientNotificationProperties.NodeQueueCapacity;
 import org.eclipse.scout.rt.shared.clientnotification.ClientNotificationMessage;
 import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationAddress;
@@ -43,10 +45,12 @@ public abstract class AbstractClientNotificationNodeQueue implements IClientNoti
 
   protected final FinalValue<NodeId> m_clientNodeId = new FinalValue<>();
 
+  protected final Long m_createTimestamp = System.currentTimeMillis();
+
   protected final AtomicLong m_lastConsumeAccess;
 
   public AbstractClientNotificationNodeQueue() {
-    m_lastConsumeAccess = new AtomicLong(System.currentTimeMillis());
+    m_lastConsumeAccess = new AtomicLong();
   }
 
   @Override
@@ -110,6 +114,11 @@ public abstract class AbstractClientNotificationNodeQueue implements IClientNoti
     }
   }
 
+  @Override
+  public long getCreateTimestamp() {
+    return m_createTimestamp;
+  }
+
   /**
    * @return time since messages have last been consumed
    */
@@ -120,12 +129,15 @@ public abstract class AbstractClientNotificationNodeQueue implements IClientNoti
 
   @Override
   public String getLastConsumeAccessFormatted() {
+    if (getLastConsumeAccess() == 0) {
+      return "";
+    }
     return DateUtility.format(new Date(getLastConsumeAccess()), "yyyy-MM-dd HH:mm:ss.SSS");
   }
 
   @Override
   public List<ClientNotificationMessage> consume(int maxAmount, long maxWaitTime, TimeUnit unit) {
-    m_lastConsumeAccess.set(System.currentTimeMillis());
+    m_lastConsumeAccess.set(BEANS.get(IDateProvider.class).currentUTCMillis());
 
     List<ClientNotificationMessage> result = getNotifications(maxAmount, maxWaitTime, unit);
     LOG.debug("Consumed {} notifications. [clientNodeId={}]", result.size(), getClientNodeId());

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistry.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/ClientNotificationRegistry.java
@@ -407,7 +407,10 @@ public class ClientNotificationRegistry {
       Iterator<IClientNotificationNodeQueue> iter = m_notificationQueues.values().iterator();
       while (iter.hasNext()) {
         IClientNotificationNodeQueue queue = iter.next();
-        if (isQueueExpired(queue.getLastConsumeAccess())) {
+        long queueLastConsumeAccess = queue.getLastConsumeAccess();
+        // use queue creation timestamp if messages were never consumed yet, avoid cleaning up new queues which were never consumed within cleanup interval
+        long lastAccess = queueLastConsumeAccess != 0 ? queueLastConsumeAccess : queue.getCreateTimestamp();
+        if (isQueueExpired(lastAccess)) {
           LOG.info("Removing expired queue [clientNodeId={}, lastConsumeAccess={}]", queue.getClientNodeId(), queue.getLastConsumeAccessFormatted());
           expiredQueues.add(queue);
           iter.remove();

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/IClientNotificationNodeQueue.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/clientnotification/IClientNotificationNodeQueue.java
@@ -49,6 +49,11 @@ public interface IClientNotificationNodeQueue {
   List<ClientNotificationMessage> consume(int maxAmount, long maxWaitTime, TimeUnit unit);
 
   /**
+   * @return timestamp of queue creation.
+   */
+  long getCreateTimestamp();
+
+  /**
    * @return timestamp of last message consume invocation.
    */
   long getLastConsumeAccess();


### PR DESCRIPTION
Offer separate methods to get queue creation timestamp and queue
last consume access. The former implementation implied that the
queue's creation timestamp was also the initial last consume access
timestamp, which was wrong as long as a queue was never consumed.

470449