### PR TITLE
Improve loading style of accordion, table and tile grid

### DIFF
--- a/eclipse-scout-core/src/accordion/Accordion.less
+++ b/eclipse-scout-core/src/accordion/Accordion.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,7 +31,8 @@
 
   &.loading {
     & > .group,
-    & > .scrollbar {
+    & > .scrollbar,
+    & + .scroll-shadow {
       opacity: 0;
     }
 

--- a/eclipse-scout-core/src/table/Table.less
+++ b/eclipse-scout-core/src/table/Table.less
@@ -227,7 +227,8 @@
     & > .table-aggregate-row,
     & > .table-data-fill,
     & > .cell-editor-popup,
-    & > .scrollbar {
+    & > .scrollbar,
+    & + .scroll-shadow {
       opacity: 0;
     }
 

--- a/eclipse-scout-core/src/tile/TileGrid.less
+++ b/eclipse-scout-core/src/tile/TileGrid.less
@@ -48,8 +48,10 @@
 
   &.loading {
     & > .tile,
-    & > .scrollbar {
-      opacity: 0;
+    & > .scrollbar,
+    & + .scroll-shadow {
+      // "!important" is necessary because the TileGridLayout sets the opacity using inline style.
+      opacity: 0 !important;
     }
 
     & > .loading-indicator {


### PR DESCRIPTION
Accordion, table and tile grid hide their scrollbars while they are loading as there is no scrollable content when the loading indicator is visible. Additionally, hide the scroll shadow in this case, as it indicates the content is scrollable which it is not while loading.

470588