### PR TITLE
Add UI node id header for requests from UI

### DIFF
--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/rest/NodeIdClientRequestFilter.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/rest/NodeIdClientRequestFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.rest;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+
+import org.eclipse.scout.rt.dataobject.id.IIds;
+import org.eclipse.scout.rt.dataobject.id.NodeId;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
+
+@ApplicationScoped
+public class NodeIdClientRequestFilter implements ClientRequestFilter {
+
+  @Override
+  public void filter(ClientRequestContext requestContext) throws IOException {
+    addNodeIdHeader(requestContext);
+  }
+
+  protected void addNodeIdHeader(ClientRequestContext requestContext) {
+    NodeId nodeId = NodeId.current();
+    if (nodeId != null) {
+      requestContext.getHeaders().add(NodeId.HTTP_HEADER_NAME, IIds.toString(nodeId));
+    }
+  }
+}

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/rest/ScoutBackendRestClientHelper.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/rest/ScoutBackendRestClientHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,7 @@ public class ScoutBackendRestClientHelper extends AbstractRestClientHelper {
     // no classic IdSignatureClientRequestFilter; process resource will determine on its own if header should be added
     filters.add(BEANS.get(ServiceTunnelIdSignatureClientRequestFilter.class));
     filters.add(BEANS.get(SessionIdClientRequestFilter.class));
+    filters.add(BEANS.get(NodeIdClientRequestFilter.class));
     return filters;
   }
 

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/servicetunnel/HttpServiceTunnel.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/servicetunnel/HttpServiceTunnel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,6 @@ import org.eclipse.scout.rt.client.clientnotification.ClientNotificationDispatch
 import org.eclipse.scout.rt.client.context.ClientRunContexts;
 import org.eclipse.scout.rt.client.services.common.perf.IPerformanceAnalyzerService;
 import org.eclipse.scout.rt.client.servicetunnel.ServiceTunnelClientConfigProperties.BackendUrlProperty;
-import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.config.CONFIG;
@@ -158,7 +157,6 @@ public class HttpServiceTunnel {
       userAgent = UserAgents.createDefault();
     }
     request.setUserAgent(userAgent.createIdentifier());
-    request.setClientNodeId(NodeId.current());
   }
 
   /**

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/id/NodeId.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/id/NodeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,11 @@ import org.eclipse.scout.rt.platform.util.StringUtility;
 public final class NodeId extends AbstractStringId {
   @Serial
   private static final long serialVersionUID = 1L;
+
+  /**
+   * Name of the HTTP header to transport the {@code node id} of the client.
+   */
+  public static final String HTTP_HEADER_NAME = "X-Scout-Client-Node-Id";
 
   private NodeId(String id) {
     super(id);

--- a/org.eclipse.scout.rt.server.session/src/main/java/org/eclipse/scout/rt/server/session/context/HttpServerSessionRunContextProducer.java
+++ b/org.eclipse.scout.rt.server.session/src/main/java/org/eclipse/scout/rt/server/session/context/HttpServerSessionRunContextProducer.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
+import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.util.StringUtility;
@@ -76,10 +77,12 @@ public class HttpServerSessionRunContextProducer {
     }
 
     String clientSessionId = req.getHeader(SessionId.HTTP_HEADER_NAME);
+    NodeId clientNodeId = NodeId.of(req.getHeader(NodeId.HTTP_HEADER_NAME));
 
     final ServerSessionRunContext serverRunContext = (ServerSessionRunContext) getInnerRunContextProducer().produce(req, resp, contextToFill);
     serverRunContext.withUserAgent(HttpClientInfo.get(req).toUserAgents().build());
     serverRunContext.withThreadLocal(SessionId.CURRENT, clientSessionId);
+    serverRunContext.withClientNodeId(clientNodeId);
     if (!hasSessionSupport()) {
       // don't touch the session
       return serverRunContext;

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/ServerHttpRunContextProducerTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/ServerHttpRunContextProducerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.BeanMetaData;
 import org.eclipse.scout.rt.platform.IBean;
@@ -40,6 +41,8 @@ import org.junit.runner.RunWith;
 public class ServerHttpRunContextProducerTest {
   protected static final String TEST_SESSION_ID = "test-session-42";
   protected static final String CHROME_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36";
+  protected static final String TEST_NODE_NAME = "testNode";
+  protected static final NodeId TEST_NODE_ID = NodeId.of(TEST_NODE_NAME);
 
   protected ServerHttpRunContextProducer m_producer;
 
@@ -50,7 +53,7 @@ public class ServerHttpRunContextProducerTest {
 
   @Test
   public void testProduceServerRunContext() {
-    HttpServletRequest req = createRequestMock(null, null);
+    HttpServletRequest req = createRequestMock(null, null, null);
     HttpServletResponse resp = mock(HttpServletResponse.class);
 
     RunContext context = m_producer.produce(req, resp);
@@ -72,7 +75,7 @@ public class ServerHttpRunContextProducerTest {
 
   @Test
   public void testProduceSessionId() {
-    HttpServletRequest req = createRequestMock(TEST_SESSION_ID, null);
+    HttpServletRequest req = createRequestMock(TEST_SESSION_ID, null, null);
     HttpServletResponse resp = mock(HttpServletResponse.class);
 
     RunContext context = m_producer.produce(req, resp);
@@ -81,7 +84,7 @@ public class ServerHttpRunContextProducerTest {
 
   @Test
   public void testProduceNoSessionId() {
-    HttpServletRequest req = createRequestMock(null, null);
+    HttpServletRequest req = createRequestMock(null, null, null);
     HttpServletResponse resp = mock(HttpServletResponse.class);
 
     RunContext context = m_producer.produce(req, resp);
@@ -90,7 +93,7 @@ public class ServerHttpRunContextProducerTest {
 
   @Test
   public void testProduceUserAgent() {
-    HttpServletRequest req = createRequestMock(null, CHROME_USER_AGENT);
+    HttpServletRequest req = createRequestMock(null, CHROME_USER_AGENT, null);
     HttpServletResponse resp = mock(HttpServletResponse.class);
 
     RunContext context = m_producer.produce(req, resp);
@@ -102,7 +105,7 @@ public class ServerHttpRunContextProducerTest {
 
   @Test
   public void testProduceNoUserAgent() {
-    HttpServletRequest req = createRequestMock(null, null);
+    HttpServletRequest req = createRequestMock(null, null, null);
     HttpServletResponse resp = mock(HttpServletResponse.class);
 
     RunContext context = m_producer.produce(req, resp);
@@ -112,9 +115,28 @@ public class ServerHttpRunContextProducerTest {
     assertEquals(UiEngineType.UNKNOWN, serverRunContext.getUserAgent().getUiEngineType());
   }
 
-  protected HttpServletRequest createRequestMock(String sessionId, String userAgent) {
+  @Test
+  public void testProduceClientNodeId() {
+    HttpServletRequest req = createRequestMock(TEST_SESSION_ID, null, TEST_NODE_NAME);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+
+    ServerRunContext context = (ServerRunContext) m_producer.produce(req, resp);
+    assertEquals(TEST_NODE_ID, context.getClientNodeId());
+  }
+
+  @Test
+  public void testProduceNoClientNodeId() {
+    HttpServletRequest req = createRequestMock(null, null, null);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+
+    ServerRunContext context = (ServerRunContext) m_producer.produce(req, resp);
+    assertNull(context.getClientNodeId());
+  }
+
+  protected HttpServletRequest createRequestMock(String sessionId, String userAgent, String clientNodeName) {
     HttpServletRequest req = mock(HttpServletRequest.class);
     when(req.getHeader(eq(SessionId.HTTP_HEADER_NAME))).thenReturn(sessionId);
+    when(req.getHeader(eq(NodeId.HTTP_HEADER_NAME))).thenReturn(clientNodeName);
     when(req.getHeader(eq("User-Agent"))).thenReturn(userAgent);
     return req;
   }

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/PiggyBackClientNotificationTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/PiggyBackClientNotificationTest.java
@@ -30,7 +30,6 @@ import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -56,7 +55,8 @@ public class PiggyBackClientNotificationTest {
 
   @Test
   public void testPiggyBack() {
-    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(NodeId.HTTP_HEADER_NAME)).thenReturn("testNodeId");
 
     RunContexts.copyCurrent()
         .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST, req)
@@ -66,7 +66,6 @@ public class PiggyBackClientNotificationTest {
           Class[] parameterTypes = new Class[]{String.class};
           Object[] args = new Object[]{"test"};
           ServiceTunnelRequest serviceTunnelRequest = new ServiceTunnelRequest(IPingService.class.getName(), "ping", parameterTypes, args);
-          serviceTunnelRequest.setClientNodeId(NodeId.of("testNodeId"));
           ServiceTunnelResponse res = s.evaluate(serviceTunnelRequest);
           assertEquals("pong", res.getData());
           assertNull(res.getException());

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelServiceTest.java
@@ -23,6 +23,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
+import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.platform.context.RunContexts;
@@ -57,7 +58,8 @@ public class ServiceTunnelServiceTest {
   public void before() {
     m_requestMock = mock(HttpServletRequest.class);
     m_responseMock = mock(HttpServletResponse.class);
-    when(m_requestMock.getHeader(SessionId.HTTP_HEADER_NAME)).thenReturn("testId");
+    when(m_requestMock.getHeader(SessionId.HTTP_HEADER_NAME)).thenReturn("testSessionId");
+    when(m_requestMock.getHeader(NodeId.HTTP_HEADER_NAME)).thenReturn("testNodeId");
   }
 
   @Test
@@ -90,7 +92,8 @@ public class ServiceTunnelServiceTest {
       ServiceTunnelService s = BEANS.get(ServiceTunnelService.class);
       ServiceTunnelRequest serviceRequest = prepareTestRequest();
       ServerRunContext context = s.createServiceTunnelRunContext(serviceRequest);
-      assertEquals("testId", context.call(SessionId.CURRENT::get));
+      assertEquals("testSessionId", context.call(SessionId.CURRENT::get));
+      assertEquals(NodeId.of("testNodeId"), context.getClientNodeId());
     });
   }
 

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/ServerHttpRunContextProducer.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/ServerHttpRunContextProducer.java
@@ -12,6 +12,7 @@ package org.eclipse.scout.rt.server.context;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.context.RunContext;
 import org.eclipse.scout.rt.server.commons.context.HttpRunContextProducer;
 import org.eclipse.scout.rt.server.commons.servlet.HttpClientInfo;
@@ -27,7 +28,8 @@ public class ServerHttpRunContextProducer extends HttpRunContextProducer {
     ServerRunContext serverRunContext = (ServerRunContext) super.produce(req, resp);
     return serverRunContext
         .withUserAgent(HttpClientInfo.get(req).toUserAgents().build())
-        .withThreadLocal(SessionId.CURRENT, req.getHeader(SessionId.HTTP_HEADER_NAME));
+        .withThreadLocal(SessionId.CURRENT, req.getHeader(SessionId.HTTP_HEADER_NAME))
+        .withClientNodeId(NodeId.of(req.getHeader(NodeId.HTTP_HEADER_NAME)));
   }
 
   @Override

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelService.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
+import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.context.RunContext;
@@ -127,11 +128,14 @@ public class ServiceTunnelService {
   }
 
   protected ServerRunContext createServiceTunnelRunContext(ServiceTunnelRequest serviceRequest) {
+    final HttpServletRequest req = IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST.get();
+    NodeId clientNodeId = NodeId.of(req.getHeader(NodeId.HTTP_HEADER_NAME));
+
     // overwrite default settings from HTTP request with values from ServiceTunnelRequest
     return ServerRunContexts.copyCurrent()
         .withLocale(serviceRequest.getLocale())
         .withUserAgent(UserAgents.createByIdentifier(serviceRequest.getUserAgent()))
-        .withClientNodeId(serviceRequest.getClientNodeId());
+        .withClientNodeId(clientNodeId);
   }
 
   // === MESSAGE UNMARSHALLING / MARSHALLING ===

--- a/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelRequest.java
+++ b/org.eclipse.scout.rt.shared/src/main/java/org/eclipse/scout/rt/shared/servicetunnel/ServiceTunnelRequest.java
@@ -14,7 +14,6 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.nls.NlsLocale;
 import org.eclipse.scout.rt.platform.util.VerboseUtility;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
@@ -35,7 +34,6 @@ public class ServiceTunnelRequest implements Serializable {
   private final Object[] m_args;
   private final Locale m_locale;
   private String m_userAgent;
-  private NodeId m_clientNodeId;
 
   public ServiceTunnelRequest(String serviceInterfaceName, String op, Class[] parameterTypes, Object[] args) {
     m_serviceInterfaceClassName = serviceInterfaceName;
@@ -92,20 +90,6 @@ public class ServiceTunnelRequest implements Serializable {
    */
   public void setUserAgent(String userAgent) {
     m_userAgent = userAgent;
-  }
-
-  /**
-   * Returns the unique ID of the client node which triggered this service request.
-   */
-  public NodeId getClientNodeId() {
-    return m_clientNodeId;
-  }
-
-  /**
-   * Sets the unique ID of the client node which triggered this service request.
-   */
-  public void setClientNodeId(NodeId notificationNodeId) {
-    m_clientNodeId = notificationNodeId;
   }
 
   @Override

--- a/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/ClientNodeIdHttpProxyRequestOptionsModifierTest.java
+++ b/org.eclipse.scout.rt.ui.html.test/src/test/java/org/eclipse/scout/rt/ui/html/ClientNodeIdHttpProxyRequestOptionsModifierTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import static org.junit.Assert.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+import org.eclipse.scout.rt.client.testenvironment.TestEnvironmentClientSession;
+import org.eclipse.scout.rt.dataobject.id.IIds;
+import org.eclipse.scout.rt.dataobject.id.NodeId;
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestContext;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestOptions;
+import org.eclipse.scout.rt.testing.client.runner.ClientTestRunner;
+import org.eclipse.scout.rt.testing.client.runner.RunWithClientSession;
+import org.eclipse.scout.rt.testing.platform.runner.RunWithSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+@RunWith(ClientTestRunner.class)
+@RunWithSubject("default")
+@RunWithClientSession(TestEnvironmentClientSession.class)
+public class ClientNodeIdHttpProxyRequestOptionsModifierTest {
+
+  /**
+   * Client node ID header should be present on proxied request
+   */
+  @Test
+  public void testClientNodeId() {
+    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    HttpSession session = Mockito.mock(HttpSession.class);
+    Mockito.when(request.getSession(false)).thenReturn(session);
+
+    ClientNodeIdHttpProxyRequestOptionsModifier modifier = new ClientNodeIdHttpProxyRequestOptionsModifier();
+    HttpProxyRequestOptions options = new HttpProxyRequestOptions();
+    modifier.modify(options, createRequestContext(request));
+
+    assertTrue(options.getCustomRequestHeaders().containsKey(NodeId.HTTP_HEADER_NAME));
+    assertEquals(IIds.toString(NodeId.current()), options.getCustomRequestHeaders().get(NodeId.HTTP_HEADER_NAME));
+  }
+
+  protected HttpProxyRequestContext createRequestContext(HttpServletRequest request) {
+    return BEANS.get(HttpProxyRequestContext.class)
+        .withRequest(request);
+  }
+}

--- a/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/ClientNodeIdHttpProxyRequestOptionsModifier.java
+++ b/org.eclipse.scout.rt.ui.html/src/main/java/org/eclipse/scout/rt/ui/html/ClientNodeIdHttpProxyRequestOptionsModifier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.ui.html;
+
+import org.eclipse.scout.rt.dataobject.id.IIds;
+import org.eclipse.scout.rt.dataobject.id.NodeId;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestContext;
+import org.eclipse.scout.rt.server.commons.servlet.HttpProxyRequestOptions;
+import org.eclipse.scout.rt.server.commons.servlet.IHttpProxyRequestOptionsModifier;
+
+/**
+ * Adds the {@value NodeId#HTTP_HEADER_NAME} header to the proxied request.
+ */
+public class ClientNodeIdHttpProxyRequestOptionsModifier implements IHttpProxyRequestOptionsModifier {
+
+  @Override
+  public void modify(HttpProxyRequestOptions options, HttpProxyRequestContext context) {
+    options.withCustomRequestHeader(NodeId.HTTP_HEADER_NAME, IIds.toString(NodeId.current()));
+  }
+}


### PR DESCRIPTION
Additionally, for requests proxied to the backend, the corresponding client node ID gets sent to the backend via HTTP header

379091