### PR TITLE
AbstractTable: add default implementation for execRowDrop()

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -6842,15 +6842,15 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     }
 
     // Compute new position
-    if (position === TableRowDropPosition.LAST_CHILD) {
-      // Insert at end of subtree
+    if (position === TableRowDropPosition.AFTER || position === TableRowDropPosition.LAST_CHILD) {
+      // Insert after last child of target row
       let lastRow = targetRow;
       while (arrays.hasElements(lastRow.childRows)) {
         lastRow = arrays.last(lastRow.childRows);
       }
       targetIndex = this.rows.indexOf(lastRow) + 1;
-    }
-    if (position === TableRowDropPosition.AFTER || position === TableRowDropPosition.FIRST_CHILD) {
+    } else if (position === TableRowDropPosition.FIRST_CHILD) {
+      // Insert directly after target row
       targetIndex++;
     }
     if (sourceIndex < targetIndex) {

--- a/eclipse-scout-core/src/table/TableMoveSupport.ts
+++ b/eclipse-scout-core/src/table/TableMoveSupport.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {arrays, BaseDoEntity, DraggableElement, Event, graphics, MoveData, MoveSupport, Point, Rectangle, scout, strings, Table, TableField, TableRow, typeName} from '../index';
+import {arrays, BaseDoEntity, BooleanColumn, DraggableElement, Event, graphics, MoveData, MoveSupport, Point, Rectangle, scout, strings, Table, TableField, TableRow, typeName} from '../index';
 import $ from 'jquery';
 
 export class TableMoveSupport extends MoveSupport<DraggableTableRowElement> {
@@ -435,6 +435,9 @@ export class TableMoveSupport extends MoveSupport<DraggableTableRowElement> {
     for (let column of this.table.visibleColumns()) {
       if (!column.nodeColumnCandidate) {
         continue; // ignore special gui-only columns
+      }
+      if (column instanceof BooleanColumn) {
+        continue; // ignore boolean columns, they don't have a meaningful text
       }
       // Explicitly cast text to String, because callText() might return other types (see Column#_formatValue)-
       // Some "empty" values would not be falsy otherwise, e.g. an empty array.

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/AbstractTable.java
@@ -1092,12 +1092,12 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
 
     // add convenience observer for drag & drop callbacks, event history and ui sort possible check
     addTableListener(e -> {
-          //event history
-          IEventHistory<TableEvent> h = getEventHistory();
-          if (h != null) {
-            h.notifyEvent(e);
-          }
-          //dnd
+      //event history
+      IEventHistory<TableEvent> h = getEventHistory();
+      if (h != null) {
+        h.notifyEvent(e);
+      }
+      //dnd
       switch (e.getType()) {
         case TableEvent.TYPE_ROWS_DRAG_REQUEST -> {
           if (e.getDragObject() == null) {
@@ -1149,8 +1149,7 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
         }
         case TableEvent.TYPE_COLUMN_HEADERS_UPDATED, TableEvent.TYPE_COLUMN_STRUCTURE_CHANGED -> checkIfColumnPreventsUiSortForTable();
       }
-        }
-    );
+    });
   }
 
   protected void initMenus() {
@@ -4456,7 +4455,72 @@ public abstract class AbstractTable extends AbstractWidget implements ITable, IC
     }
   }
 
+  /**
+   * Called when rows are {@linkplain #isRowsDraggable() draggable} and the user moved a row.
+   * <p>
+   * Subclasses can override this method. The default calls {@link #dropRow(ITableRow, ITableRow, TableRowDropPosition)}.
+   */
   protected void execRowDrop(ITableRow sourceRow, ITableRow targetRow, TableRowDropPosition position) {
+    dropRow(sourceRow, targetRow, position);
+  }
+
+  @Override
+  public void dropRow(ITableRow sourceRow, ITableRow targetRow, TableRowDropPosition position) {
+    setTableChanging(true);
+    try {
+      int sourceIndex = sourceRow.getRowIndex();
+      int targetIndex = targetRow.getRowIndex();
+
+      // Check if source row gets a new parent row
+      ITableRow parentRow = targetRow.getParentRow();
+      if (position == TableRowDropPosition.FIRST_CHILD || position == TableRowDropPosition.LAST_CHILD) {
+        parentRow = targetRow;
+      }
+      boolean parentRowChanged = false;
+      if (sourceRow.getParentRow() != parentRow) {
+        int[] keyColumnIndexes = getColumnSet().getKeyColumnIndexes();
+        int[] parentKeyColumnIndexes = getColumnSet().getParentKeyColumnIndexes();
+        Assertions.assertEqual(keyColumnIndexes.length, parentKeyColumnIndexes.length,
+            "Mismatch between key columns and parent key columns. keyColumnIndexes={}, parentKeyColumnIndexes={}",
+            keyColumnIndexes, parentKeyColumnIndexes);
+        for (int i = 0; i < parentKeyColumnIndexes.length; i++) {
+          sourceRow.setCellValue(parentKeyColumnIndexes[i], parentRow == null ? null : parentRow.getCellValue(keyColumnIndexes[i]));
+        }
+        rebuildTreeStructure();
+
+        parentRowChanged = true;
+      }
+
+      // Compute new position
+      if (position == TableRowDropPosition.AFTER || position == TableRowDropPosition.LAST_CHILD) {
+        // Insert after last child of target row
+        ITableRow lastRow = targetRow;
+        while (CollectionUtility.hasElements(lastRow.getChildRows())) {
+          lastRow = CollectionUtility.lastElement(lastRow.getChildRows());
+        }
+        targetIndex = lastRow.getRowIndex() + 1;
+      }
+      else if (position == TableRowDropPosition.FIRST_CHILD) {
+        // Insert directly after target row
+        targetIndex++;
+      }
+      if (sourceIndex < targetIndex) {
+        // Going downward -> because the source row will be removed from its old place, all subsequent
+        // rows will be moved up by 1 -> decrease target index by the same amount.
+        targetIndex--;
+      }
+
+      // Update row
+      if (sourceIndex != targetIndex) {
+        moveRow(sourceIndex, targetIndex);
+      }
+      else if (parentRowChanged) {
+        updateRow(sourceRow);
+      }
+    }
+    finally {
+      setTableChanging(false);
+    }
   }
 
   private void fireRowOrderChanged() {

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/ITable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/basic/table/ITable.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.scout.rt.api.data.table.TableRowDropPosition;
 import org.eclipse.scout.rt.client.ui.AbstractEventBuffer;
 import org.eclipse.scout.rt.client.ui.ClientUIPreferences;
 import org.eclipse.scout.rt.client.ui.IAppLinkCapable;
@@ -1360,4 +1361,10 @@ public interface ITable extends IWidget, IDNDSupport, IStyleable, IAppLinkCapabl
    * <b>Caution</b>: use this with care because it should only be necessary in very rare cases.
    */
   void firePendingEvents();
+
+  /**
+   * Moves a row within the table. The new location is computed using the given target row and position.
+   * If the table is hierarchical, the parent row is updated accordingly.
+   */
+  void dropRow(ITableRow sourceRow, ITableRow targetRow, TableRowDropPosition position);
 }


### PR DESCRIPTION
Add default row move implementation for Java table, analog to JS table.

Small additional change:
- TableMoveSupport: improve row text

469978