### PR TITLE
Table: update tree structure when adding/updating/removing rows

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -3379,7 +3379,13 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     this._triggerRowsDeleted(rows);
 
     if (invalidate) {
-      this._renderViewport();
+      if (removedRows.some(removedRow => removedRow.parentRow ? arrays.empty(removedRow.parentRow.childRows) : arrays.hasElements(removedRow.childRows))) {
+        // If one of the removed rows was the last child row of a parent row or a root row with children,
+        // re-render the entire viewport to correctly update the indentation of the tableNodeColumn.
+        this._rerenderViewport();
+      } else {
+        this._renderViewport();
+      }
       // Update markers and filler because row may be removed by removeRows. RenderViewport doesn't do it if view range is already correctly rendered.
       this._renderRangeMarkers();
       this._renderFiller();
@@ -4287,11 +4293,13 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
 
   protected _rebuildTreeStructure() {
     let hierarchical = false;
+    let wasHierarchical = false;
     this.rows.forEach(row => {
       row.childRows = [];
       hierarchical = hierarchical || !objects.isNullOrUndefined(row.parentRow);
+      wasHierarchical = wasHierarchical || !objects.isNullOrUndefined(row['_parentRowId']);
     });
-    if (!hierarchical) {
+    if (!hierarchical && !wasHierarchical) {
       this.rootRows = this.rows;
       this._setHierarchical(hierarchical);
       return;

--- a/eclipse-scout-core/test/table/HierarchicalTableSpec.ts
+++ b/eclipse-scout-core/test/table/HierarchicalTableSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -334,15 +334,21 @@ describe('HierarchicalTableSpec', () => {
       table.render();
     });
 
-    it('is updated when insert a new child row', () => {
-      let row = helper.createModelRow('33', ['newRow']);
+    it('is updated when inserting a new child row', () => {
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 1, 2, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, '0', '1', null]);
       spyOn(table, '_renderViewport').and.callThrough();
 
+      let row = helper.createModelRow('33', ['newRow']);
       row.parentRow = rows[0].id;
       table.insertRow(row);
       row = table.rowById('33');
       expect(table._renderViewport.calls.count()).toBe(2);
 
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 1, 2, 1, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, '0', '1', '0', null]);
       expectRowIds(table.visibleRows, [0, 1, 2, 33, 3]);
       expectRowIds(getExpandedRows(table), [0, 1]);
       expect(rows[0].childRows.length).toBe(2);
@@ -350,28 +356,154 @@ describe('HierarchicalTableSpec', () => {
       expect(row.parentRow).toBe(rows[0]);
     });
 
+    it('is updated when inserting a new child row into a non-hierarchical table', () => {
+      rows[1].parentRow = null;
+      rows[2].parentRow = null;
+      table.updateRows([rows[1], rows[2]]);
+
+      expect(table.hierarchical).toBe(false);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 0, 0, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, null, null, null]);
+      spyOn(table, '_renderViewport').and.callThrough();
+      spyOn(table, '_rerenderViewport').and.callThrough();
+
+      let row = helper.createModelRow('33', ['newRow']);
+      row.parentRow = rows[0].id;
+      table.insertRow(row);
+      row = table.rowById('33');
+      expect(table._renderViewport.calls.count()).toBe(2);
+      expect(table._rerenderViewport.calls.count()).toBe(1);
+
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 1, 0, 0, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, '0', null, null, null]);
+      expectRowIds(table.visibleRows, [0, 33, 1, 2, 3]);
+      expectRowIds(getExpandedRows(table), [0]);
+      expect(rows[0].childRows.length).toBe(1);
+      expect(rows[0].childRows[0]).toBe(row);
+      expect(row.parentRow).toBe(rows[0]);
+    });
+
     it('is updated when deleting a child row', () => {
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 1, 2, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, '0', '1', null]);
+      expectRowIds(table.rows, [0, 1, 2, 3]);
+      expectRowIds(getTreeRows(table), [0, 1, 2, 3]);
+      spyOn(table, '_renderViewport').and.callThrough();
+      spyOn(table, '_rerenderViewport').and.callThrough();
+
       let expectedRowIds = [0, 1, 3];
       table.deleteRow(rows[2]);
+
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 1, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, '0', null]);
       expectRowIds(table.rows, expectedRowIds);
       expectRowIds(getTreeRows(table), expectedRowIds);
       expectRowIds(table._filteredRows, expectedRowIds);
       expectRowIds(table.visibleRows, expectedRowIds);
       expectRowIds(getUiRows(table), expectedRowIds);
+      expect(table._renderViewport.calls.count()).toBe(1);
+      expect(table._rerenderViewport.calls.count()).toBe(1);
+
+      expectedRowIds = [0, 3];
+      table.deleteRow(rows[1]);
+
+      expect(table.hierarchical).toBe(false);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, null]);
+      expectRowIds(table.rows, expectedRowIds);
+      expectRowIds(getTreeRows(table), expectedRowIds);
+      expectRowIds(table._filteredRows, expectedRowIds);
+      expectRowIds(table.visibleRows, expectedRowIds);
+      expectRowIds(getUiRows(table), expectedRowIds);
+      expect(table._renderViewport.calls.count()).toBe(2);
+      expect(table._rerenderViewport.calls.count()).toBe(2);
     });
 
     it('is updated when deleting a row and its children', () => {
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 1, 2, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, '0', '1', null]);
+      expectRowIds(table.rows, [0, 1, 2, 3]);
+      expectRowIds(getTreeRows(table), [0, 1, 2, 3]);
+      spyOn(table, '_renderViewport').and.callThrough();
+      spyOn(table, '_rerenderViewport').and.callThrough();
+
       // cascade deleted row
       let expectedRowIds = [0, 3];
       table.deleteRow(rows[1]);
 
+      expect(table.hierarchical).toBe(false);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, null]);
       expectRowIds(table.rows, expectedRowIds);
       expectRowIds(getTreeRows(table), expectedRowIds);
       expectRowIds(table._filteredRows, expectedRowIds);
       expectRowIds(table.visibleRows, expectedRowIds);
       expectRowIds(getUiRows(table), expectedRowIds);
+      expect(table._renderViewport.calls.count()).toBe(1);
+      expect(table._rerenderViewport.calls.count()).toBe(1);
     });
 
+    it('is updated when altering row hierarchy', () => {
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 1, 2, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, '0', '1', null]);
+      expectRowIds(table.rows, [0, 1, 2, 3]);
+      expectRowIds(getTreeRows(table), [0, 1, 2, 3]);
+      spyOn(table, '_renderViewport').and.callThrough();
+      spyOn(table, '_rerenderViewport').and.callThrough();
+
+      rows[2].parentRow = rows[0];
+      table.updateRow(rows[2]);
+      // +-- 0
+      // |   +-- 1
+      // |   +-- 2
+      // +-- 3
+
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 1, 1, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, '0', '0', null]);
+      expectRowIds(table.rows, [0, 1, 2, 3]);
+      expectRowIds(getTreeRows(table), [0, 1, 2, 3]);
+      expect(table._renderViewport.calls.count()).toBe(1);
+      expect(table._rerenderViewport.calls.count()).toBe(1);
+
+      // Switch from 'hierarchical' to 'non-hierarchical'
+      rows[1].parentRow = null;
+      rows[2].parentRow = null;
+      table.updateRows([rows[1], rows[2]]);
+      // 0
+      // 1
+      // 2
+      // 3
+
+      expect(table.hierarchical).toBe(false);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 0, 0, 0]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, null, null, null]);
+      expectRowIds(table.rows, [0, 1, 2, 3]);
+      expectRowIds(getTreeRows(table), [0, 1, 2, 3]);
+      expect(table._renderViewport.calls.count()).toBe(2);
+      expect(table._rerenderViewport.calls.count()).toBe(2);
+
+      // Switch from 'non-hierarchical' to 'hierarchical'
+      rows[1].parentRow = rows[3];
+      table.updateRow(rows[1]);
+      // +-- 0
+      // +-- 2
+      // +-- 3
+      //     +-- 1
+
+      expect(table.hierarchical).toBe(true);
+      expect(table.rows.map(row => row.hierarchyLevel)).toEqual([0, 0, 0, 1]);
+      expect(table.rows.map(row => row['_parentRowId'])).toEqual([null, null, null, '3']);
+      expectRowIds(table.rows, [0, 2, 3, 1]);
+      expectRowIds(getTreeRows(table), [0, 2, 3, 1]);
+      expect(table._renderViewport.calls.count()).toBe(3);
+      expect(table._rerenderViewport.calls.count()).toBe(3);
+    });
   });
 
   describe('expanded rows', () => {


### PR DESCRIPTION
When adding, updating or removing rows in a table, its "hierarchical" property might change. Unless the table was non-hierarchical before the change and is non-hierarchical after the change, the internal data structures managing the row hierarchy have to be fully re-created.

Additionally, if the table switches from hierarchical to non-hierarchical mode or vice versa, all rows in the viewport have to be re-rendered to adjust for the changed indentation of the tableNodeColumn. For example, if there are two rows A and B where B is a child row of A and row B is deleted, row A still has to be re-rendered, despite not being directly altered.

471043