### PR TITLE
Fix UiNotifications in cluster

### DIFF
--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/code/CodeTypeInvalidationNotificationListener.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/code/CodeTypeInvalidationNotificationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -66,6 +66,10 @@ public class CodeTypeInvalidationNotificationListener implements ICacheInvalidat
     }
     ITransaction transaction = ITransaction.CURRENT.get();
     if (transaction == null) {
+      return;
+    }
+    if (!propagate) {
+      // Do not create ui notifications if propagate flag is false as ui notifications are already propagated to other cluster nodes by the UiNotificationRegistry.
       return;
     }
     CodeTypeUiNotificationTransactionMember member = transaction.registerMemberIfAbsentAndNotCancelled(CodeTypeUiNotificationTransactionMember.TRANSACTION_MEMBER_ID, this::createTransactionMember);
@@ -148,7 +152,7 @@ public class CodeTypeInvalidationNotificationListener implements ICacheInvalidat
       // send message to current user directly including the new code types
       // this is required so that the caches are update to date very soon after the user applied the change
       CodeTypeUpdateMessageDo messageWithNewCodeTypes = BEANS.get(CodeTypeUpdateMessageDo.class).withCodeTypes(codeTypes);
-      uiNotificationRegistry.put(TOPIC, currentUserId, messageWithNewCodeTypes, noTransaction().withPublishOverCluster(false));
+      uiNotificationRegistry.put(TOPIC, currentUserId, messageWithNewCodeTypes, noTransaction());
 
       // send updated codeType ids to other users so that they can reload them
       Set<String> idsToUpdate = codeTypes.stream().map(CodeTypeDo::getId).collect(toSet());
@@ -156,7 +160,7 @@ public class CodeTypeInvalidationNotificationListener implements ICacheInvalidat
       CodeTypeUpdateMessageDo messageWithCodeTypeIdsToUpdate = BEANS.get(CodeTypeUpdateMessageDo.class)
           .withCodeTypeIds(idsToUpdate)
           .withReloadDelayWindow(reloadDelayWindow);
-      uiNotificationRegistry.putExcept(TOPIC, singleton(currentUserId), messageWithCodeTypeIdsToUpdate, noTransaction().withPublishOverCluster(false));
+      uiNotificationRegistry.putExcept(TOPIC, singleton(currentUserId), messageWithCodeTypeIdsToUpdate, noTransaction());
     }
 
     protected String getUserId() {

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/security/PermissionsInvalidationNotificationListener.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/security/PermissionsInvalidationNotificationListener.java
@@ -59,6 +59,10 @@ public class PermissionsInvalidationNotificationListener implements ICacheInvali
     if (transaction == null) {
       return;
     }
+    if (!propagate) {
+      // Do not create ui notifications if propagate flag is false as ui notifications are already propagated to other cluster nodes by the UiNotificationRegistry.
+      return;
+    }
     transaction.registerMemberIfAbsentAndNotCancelled(PermissionsUiNotificationTransactionMember.TRANSACTION_MEMBER_ID, id -> createTransactionMember(filter));
   }
 
@@ -107,11 +111,11 @@ public class PermissionsInvalidationNotificationListener implements ICacheInvali
         cacheKeys.stream()
             .map(User::getUserId)
             .filter(Objects::nonNull)
-            .forEach(userId -> uiNotificationRegistry.put(TOPIC, userId, updateDo, noTransaction().withPublishOverCluster(false)));
+            .forEach(userId -> uiNotificationRegistry.put(TOPIC, userId, updateDo, noTransaction()));
       }
       else {
         // update for all clients
-        uiNotificationRegistry.put(TOPIC, updateDo, noTransaction().withPublishOverCluster(false));
+        uiNotificationRegistry.put(TOPIC, updateDo, noTransaction());
       }
     }
   }

--- a/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationPutOptions.java
+++ b/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationPutOptions.java
@@ -50,15 +50,20 @@ public class UiNotificationPutOptions {
   }
 
   /**
+   * For internal use only.
+   *
    * @param publishOverCluster
    *     Whether the notification is published to all other cluster nodes or not. Default is {@code true}.
    */
-  public UiNotificationPutOptions withPublishOverCluster(Boolean publishOverCluster) {
+  protected UiNotificationPutOptions withPublishOverCluster(Boolean publishOverCluster) {
     m_publishOverCluster = publishOverCluster;
     return this;
   }
 
-  public Boolean getPublishOverCluster() {
+  /**
+   * For internal use only.
+   */
+  protected Boolean getPublishOverCluster() {
     return m_publishOverCluster;
   }
 
@@ -71,12 +76,5 @@ public class UiNotificationPutOptions {
    */
   public static UiNotificationPutOptions noTransaction() {
     return new UiNotificationPutOptions().withTransactional(false);
-  }
-
-  /**
-   * Creates an {@link UiNotificationPutOptions} instance with {@code publishOverCluster = false}.
-   */
-  public static UiNotificationPutOptions noClusterSync() {
-    return new UiNotificationPutOptions().withPublishOverCluster(false);
   }
 }

--- a/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationRegistry.java
+++ b/org.eclipse.scout.rt.uinotification/src/main/java/org/eclipse/scout/rt/api/uinotification/UiNotificationRegistry.java
@@ -386,7 +386,7 @@ public class UiNotificationRegistry {
   public void handleClusterNotification(UiNotificationMessageDo message) {
     UiNotificationDo notification = message.getNotification();
     LOG.info("Received ui notification with id {} from cluster node {} for topic {} and user {}.", notification.getId(), notification.getNodeId(), notification.getTopic(), message.getUser());
-    putInternal(message, UiNotificationPutOptions.noClusterSync());
+    putInternal(message, new UiNotificationPutOptions().withPublishOverCluster(false));
   }
 
   protected void putInternal(UiNotificationMessageDo message, UiNotificationPutOptions options) {

--- a/org.eclipse.scout.rt.uinotification/src/test/java/org/eclipse/scout/rt/api/uinotification/UiNotificationRegistryTest.java
+++ b/org.eclipse.scout.rt.uinotification/src/test/java/org/eclipse/scout/rt/api/uinotification/UiNotificationRegistryTest.java
@@ -608,7 +608,7 @@ public class UiNotificationRegistryTest {
       registry.put("topic", createMessage(), UiNotificationPutOptions.noTransaction().withPublishOverCluster(false));
       verify(clusterService, times(2)).publish(any());
 
-      registry.put("topic", createMessage(), UiNotificationPutOptions.noClusterSync().withTransactional(false));
+      registry.put("topic", createMessage(), new UiNotificationPutOptions().withPublishOverCluster(false).withTransactional(false));
       verify(clusterService, times(2)).publish(any());
     }
     finally {


### PR DESCRIPTION
The UiNotification holds all notifications known on a cluster node and each notification has information from which node it originated. When a listener subscribed on a topic the registry sends the last known notification for each cluster node. These last known notifications are part of the polling mechanism and will be used to filter the response so that only unknown notifications are sent to the UI and will be updated each time the poller processes a notification.
If a notification is added to the registry as a result of an event that is synced over the cluster the notification needs to be added to the registry using the clusterSync-flag set to true, and it must only be added on the cluster node that initially created the event. If the notification is added on each node using clusterSync=false, there are different notifications on each node and all of these notifications are only known to one node. In this case the response for the subscription or the poller will only contain one of these notifications. So if the poller reaches any other node in the future it will consider these notifications as unknown and therefore, processes them resulting in the listener being executed multiple times for each original event. In addition, the time when the listener is executed is no longer deterministic for the subsequent executions as this depends on the poller being routed to different cluster nodes which may happen at any time.
In order to fix this issue, all ui notifications added to the registry as a result of a cluster sync event are add using clusterSync=true but only on the node the event initially occurs.

470605