### PR TITLE
Remove redundant client node id assignment in service tunnel

### DIFF
--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/PiggyBackClientNotificationTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/PiggyBackClientNotificationTest.java
@@ -18,9 +18,8 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.BEANS;
-import org.eclipse.scout.rt.platform.context.RunContexts;
 import org.eclipse.scout.rt.server.clientnotification.ClientNotificationRegistry;
-import org.eclipse.scout.rt.server.commons.servlet.IHttpServletRoundtrip;
+import org.eclipse.scout.rt.server.context.ServerHttpRunContextProducer;
 import org.eclipse.scout.rt.shared.clientnotification.IClientNotificationService;
 import org.eclipse.scout.rt.shared.services.common.ping.IPingService;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
@@ -58,9 +57,7 @@ public class PiggyBackClientNotificationTest {
     HttpServletRequest req = mock(HttpServletRequest.class);
     when(req.getHeader(NodeId.HTTP_HEADER_NAME)).thenReturn("testNodeId");
 
-    RunContexts.copyCurrent()
-        .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST, req)
-        .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_RESPONSE, mock(HttpServletResponse.class))
+    BEANS.get(ServerHttpRunContextProducer.class).produce(req, mock(HttpServletResponse.class))
         .run(() -> {
           ServiceTunnelService s = new ServiceTunnelService();
           Class[] parameterTypes = new Class[]{String.class};

--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelServiceTest.java
@@ -16,8 +16,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
-import javax.security.auth.Subject;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Response;
@@ -26,12 +24,10 @@ import jakarta.ws.rs.core.StreamingOutput;
 import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.context.RunContext;
-import org.eclipse.scout.rt.platform.context.RunContexts;
-import org.eclipse.scout.rt.platform.security.User;
 import org.eclipse.scout.rt.platform.serialization.IObjectSerializer;
 import org.eclipse.scout.rt.platform.serialization.SerializationUtility;
 import org.eclipse.scout.rt.server.commons.servlet.IHttpServletRoundtrip;
-import org.eclipse.scout.rt.server.commons.servlet.logging.ServletDiagnosticsProviderFactory;
+import org.eclipse.scout.rt.server.context.ServerHttpRunContextProducer;
 import org.eclipse.scout.rt.server.context.ServerRunContext;
 import org.eclipse.scout.rt.shared.services.common.ping.IPingService;
 import org.eclipse.scout.rt.shared.servicetunnel.ServiceTunnelRequest;
@@ -112,12 +108,6 @@ public class ServiceTunnelServiceTest {
   }
 
   private static RunContext createServletRunContext(final HttpServletRequest req, final HttpServletResponse resp) {
-    return RunContexts.copyCurrent(true)
-        .withSubject(Subject.current())
-        .withUser(User.current())
-        .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST, req)
-        .withThreadLocal(IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_RESPONSE, resp)
-        .withThreadLocal(SessionId.CURRENT, req.getHeader(SessionId.HTTP_HEADER_NAME))
-        .withDiagnostics(BEANS.get(ServletDiagnosticsProviderFactory.class).getProviders(req, resp));
+    return BEANS.get(ServerHttpRunContextProducer.class).produce(req, resp);
   }
 }

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelService.java
@@ -24,7 +24,6 @@ import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
-import org.eclipse.scout.rt.dataobject.id.NodeId;
 import org.eclipse.scout.rt.platform.ApplicationScoped;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.context.RunContext;
@@ -128,14 +127,10 @@ public class ServiceTunnelService {
   }
 
   protected ServerRunContext createServiceTunnelRunContext(ServiceTunnelRequest serviceRequest) {
-    final HttpServletRequest req = IHttpServletRoundtrip.CURRENT_HTTP_SERVLET_REQUEST.get();
-    NodeId clientNodeId = NodeId.of(req.getHeader(NodeId.HTTP_HEADER_NAME));
-
     // overwrite default settings from HTTP request with values from ServiceTunnelRequest
     return ServerRunContexts.copyCurrent()
         .withLocale(serviceRequest.getLocale())
-        .withUserAgent(UserAgents.createByIdentifier(serviceRequest.getUserAgent()))
-        .withClientNodeId(clientNodeId);
+        .withUserAgent(UserAgents.createByIdentifier(serviceRequest.getUserAgent()));
   }
 
   // === MESSAGE UNMARSHALLING / MARSHALLING ===


### PR DESCRIPTION
The client node ID is already propagated from the HTTP header by ServerHttpRunContextProducer and added to the ServerRunContext.

Therefore, setting the client node ID again in ServiceTunnelService is redundant and can be removed.

379091