### PR TITLE
Restrict client notification collector to service tunnel

### DIFF
--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/ServerRunContextTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/context/ServerRunContextTest.java
@@ -26,6 +26,7 @@ import org.eclipse.scout.rt.platform.job.Jobs;
 import org.eclipse.scout.rt.platform.security.User;
 import org.eclipse.scout.rt.platform.transaction.TransactionScope;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
+import org.eclipse.scout.rt.server.clientnotification.ClientNotificationCollector;
 import org.eclipse.scout.rt.shared.ui.UserAgent;
 import org.eclipse.scout.rt.shared.ui.UserAgents;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
@@ -42,6 +43,7 @@ public class ServerRunContextTest {
     assertNull(runContext.getSubject());
     assertNull(runContext.getUserAgent());
     assertNull(runContext.getLocale());
+    assertNull(runContext.getClientNotificationCollector());
     assertEquals(TransactionScope.REQUIRES_NEW, runContext.getTransactionScope());
   }
 
@@ -54,6 +56,7 @@ public class ServerRunContextTest {
     runContext.withUserAgent(UserAgents.create().build());
     runContext.withLocale(Locale.CANADA_FRENCH);
     runContext.withTransactionScope(TransactionScope.MANDATORY);
+    runContext.withClientNotificationCollector(new ClientNotificationCollector());
 
     ServerRunContext copy = runContext.copy();
 
@@ -63,6 +66,7 @@ public class ServerRunContextTest {
     assertSame(runContext.getUserAgent(), copy.getUserAgent());
     assertSame(runContext.getLocale(), copy.getLocale());
     assertEquals(TransactionScope.MANDATORY, runContext.getTransactionScope());
+    assertSame(runContext.getClientNotificationCollector(), copy.getClientNotificationCollector());
   }
 
   @Test
@@ -73,6 +77,7 @@ public class ServerRunContextTest {
     assertNull(serverCtx.getSubject());
     assertNull(serverCtx.getUserAgent());
     assertNull(serverCtx.getLocale());
+    assertNull(serverCtx.getClientNotificationCollector());
     assertEquals(TransactionScope.REQUIRES_NEW, serverCtx.getTransactionScope());
   }
 
@@ -82,6 +87,7 @@ public class ServerRunContextTest {
     final Locale locale = Locale.CANADA_FRENCH;
     final Subject subject = new Subject();
     final User user = BEANS.get(User.class).withUserId("alice").setReadOnly();
+    final ClientNotificationCollector clientNotificationCollector = new ClientNotificationCollector();
 
     ServerRunContexts
         .empty()
@@ -89,6 +95,7 @@ public class ServerRunContextTest {
         .withLocale(locale)
         .withSubject(subject)
         .withUser(user)
+        .withClientNotificationCollector(clientNotificationCollector)
         .run(() -> {
           RunContext runContext = RunContexts.copyCurrent();
           assertThat(runContext, CoreMatchers.instanceOf(ServerRunContext.class));
@@ -98,6 +105,7 @@ public class ServerRunContextTest {
           assertSame(locale, serverCtx.getLocale());
           assertSame(subject, serverCtx.getSubject());
           assertSame(user, serverCtx.getUser());
+          assertSame(clientNotificationCollector, serverCtx.getClientNotificationCollector());
         });
   }
 

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/ServerRunContext.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/context/ServerRunContext.java
@@ -56,7 +56,7 @@ public class ServerRunContext extends RunContext {
 
   protected UserAgent m_userAgent;
   protected NodeId m_clientNodeId;
-  protected ClientNotificationCollector m_clientNotificationCollector = new ClientNotificationCollector();
+  protected ClientNotificationCollector m_clientNotificationCollector;
 
   @Override
   protected <RESULT> void interceptCallableChain(final CallableChain<RESULT> callableChain) {

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/servicetunnel/ServiceTunnelService.java
@@ -31,6 +31,7 @@ import org.eclipse.scout.rt.platform.util.LazyValue;
 import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruption;
 import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruption.IRestorer;
 import org.eclipse.scout.rt.rest.id.IdSignatureClientRequestFilter;
+import org.eclipse.scout.rt.server.clientnotification.ClientNotificationCollector;
 import org.eclipse.scout.rt.server.commons.servlet.IHttpServletRoundtrip;
 import org.eclipse.scout.rt.server.commons.servlet.cache.HttpCacheControl;
 import org.eclipse.scout.rt.server.context.ServerRunContext;
@@ -130,7 +131,8 @@ public class ServiceTunnelService {
     // overwrite default settings from HTTP request with values from ServiceTunnelRequest
     return ServerRunContexts.copyCurrent()
         .withLocale(serviceRequest.getLocale())
-        .withUserAgent(UserAgents.createByIdentifier(serviceRequest.getUserAgent()));
+        .withUserAgent(UserAgents.createByIdentifier(serviceRequest.getUserAgent()))
+        .withClientNotificationCollector(new ClientNotificationCollector());
   }
 
   // === MESSAGE UNMARSHALLING / MARSHALLING ===


### PR DESCRIPTION
REST invocations to a Scout backend are also executed within a
ServerRunContext but do not have the possibility to include client
notification as piggyback in the invocation response. Before this
change client notifications added piggyback during a REST invocation
where later discarded and not dispatched to the calling UI node.

471219