### PR TITLE
Use angle down icon if element can be expanded

### DIFF
--- a/eclipse-scout-core/src/form/fields/groupbox/GroupBox.less
+++ b/eclipse-scout-core/src/form/fields/groupbox/GroupBox.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -108,10 +108,10 @@
     &::before {
       #scout.font-icon();
       font-size: @group-box-control-font-size;
-      content: @icon-angle-down-bold;
+      content: @icon-angle-up-bold;
 
       .group-box.collapsed > & {
-        content: @icon-angle-up-bold;
+        content: @icon-angle-down-bold;
       }
     }
   }

--- a/eclipse-scout-core/src/group/Group.less
+++ b/eclipse-scout-core/src/group/Group.less
@@ -91,7 +91,7 @@
     margin-top: 0;
 
     &::before {
-      content: @icon-angle-down;
+      content: @icon-angle-up;
     }
 
     &.collapsed {


### PR DESCRIPTION
Currently, the icon for a Group/Groupbox reflects the current state: The group is open, so the icon points down. This is the same as for a tree node.

The semantic for a drop-down is different, it reflects what's going to happen:
The menu can be opened, so the icon points down.

The second behavior is more common and also used by other ui frameworks. -> Change the icons for GroupBox and Group (Accordion).

463141