### PR TITLE
PageWithTable: align loading indicators in a Scout Classic application

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/OutlineAdapter.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  App, ChildModelOf, dataObjects, ErrorHandler, EventHandler, Form, icons, objects, Outline, OutlineReloadKeyStroke, Page, PageModel, PageParamDo, PageResolver, RemoteEvent, scout, Table, TableAdapter, TableFilterRemovedEvent, TableRow,
-  TableRowInitEvent, TableRowsInsertedEvent, TreeAdapter, TreeNodeModel
+  App, ChildModelOf, dataObjects, ErrorHandler, EventHandler, Form, icons, objects, Outline, OutlineReloadKeyStroke, Page, PageModel, PageParamDo, PageResolver, PageWithTable, RemoteEvent, scout, Table, TableAdapter,
+  TableFilterRemovedEvent, TableRow, TableRowInitEvent, TableRowsInsertedEvent, TreeAdapter, TreeNodeModel
 } from '../../index';
 
 export class OutlineAdapter extends TreeAdapter {
@@ -179,6 +179,7 @@ export class OutlineAdapter extends TreeAdapter {
     objects.replacePrototypeFunction(Page, '_updateDetailTableMenus', OutlineAdapter._updateDetailTableMenus, true);
     objects.replacePrototypeFunction(Page, 'linkWithRow', OutlineAdapter.linkWithRow, true);
     objects.replacePrototypeFunction(Page, 'unlinkWithRow', OutlineAdapter.unlinkWithRow, true);
+    objects.replacePrototypeFunction(PageWithTable, '_initDetailTable', OutlineAdapter._initDetailTable, true);
   }
 
   /**
@@ -370,6 +371,14 @@ export class OutlineAdapter extends TreeAdapter {
     this.unlinkWithRowOrig(row);
     // @ts-expect-error
     this._updateDetailMenus();
+  }
+
+  protected static _initDetailTable(this: Page & { _initDetailTableOrig }, table: Table) {
+    this._initDetailTableOrig(table);
+
+    if (this.outline.modelAdapter instanceof OutlineAdapter) {
+      table.setAsyncLoading(false);
+    }
   }
 }
 

--- a/eclipse-scout-core/src/desktop/outline/SearchOutlineAdapter.ts
+++ b/eclipse-scout-core/src/desktop/outline/SearchOutlineAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {App, Event, objects, OutlineAdapter, Page, RemoteEvent, SearchOutline, SearchOutlineModel, SearchPage, SearchState} from '../../index';
+import {App, Event, objects, OutlineAdapter, Page, PageWithTable, RemoteEvent, SearchOutline, SearchOutlineModel, SearchPage, SearchState, Table} from '../../index';
 
 export class SearchOutlineAdapter extends OutlineAdapter {
   declare widget: SearchOutline;
@@ -125,6 +125,11 @@ export class SearchOutlineAdapter extends OutlineAdapter {
     // When this function is called on a SearchOutline it will call 'this._initTreeNodeInternalOrig' which is the function itself and therefore, a stack overflow error is thrown.
     // And as there is nothing to remember (i.e. the SearchOutline has no own implementation of _initTreeNodeInternal) this flag can simply be set to false.
     objects.replacePrototypeFunction(SearchOutline, '_initTreeNodeInternal', SearchOutlineAdapter._initTreeNodeInternalRemote, false);
+    // Currently the _initDetailTable function of the PageWithTable is OutlineAdapter._initDetailTable and _initDetailTableOrig is PageWithTable._initDetailTable (both are inherited from the prototype of the PageWithTable).
+    // Remembering the orig function will result in OutlineAdapter._initDetailTable being _initDetailTableOrig on the prototype of PageWithTable.
+    // When this function is called on a PageWithTable it will call 'this._initDetailTableOrig' which is the function itself and therefore, a stack overflow error is thrown.
+    // And as there is nothing more to remember this flag can simply be set to false.
+    objects.replacePrototypeFunction(PageWithTable, '_initDetailTable', SearchOutlineAdapter._initDetailTable, false);
   }
 
   protected static override _initTreeNodeInternalRemote(this: SearchOutline & { modelAdapter: SearchOutlineAdapter; _initTreeNodeInternalOrig }, page: SearchPage, parentNode: Page) {
@@ -139,6 +144,16 @@ export class SearchOutlineAdapter extends OutlineAdapter {
     const searchState = this.modelAdapter._searchStates.get(page.id);
     if (searchState) {
       page.searchState = searchState;
+    }
+  }
+
+  protected static override _initDetailTable(this: Page & { _initDetailTableOrig }, table: Table) {
+    // _initDetailTable was replaced without remembering the orig function which was OutlineAdapter._initDetailTable.
+    // Therefore, call this function directly and not via _initDetailTableOrig.
+    OutlineAdapter._initDetailTable.call(this, table);
+
+    if (this.outline.modelAdapter instanceof SearchOutlineAdapter) {
+      table.setAsyncLoading(true);
     }
   }
 }

--- a/eclipse-scout-core/src/index.ts
+++ b/eclipse-scout-core/src/index.ts
@@ -551,6 +551,7 @@ export * from './table/TableHeaderMenuGroupEventMap';
 export * from './table/TableHeaderMenuButton';
 export * from './table/TableHeaderMenuButtonModel';
 export * from './table/TableLayout';
+export * from './table/TableLoadingSupport';
 export * from './table/TableSelectionHandler';
 export * from './table/TableTileGridMediator';
 export * from './table/TableTileGridMediatorModel';

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -13,10 +13,10 @@ import {
   FilterResult, FilterSupport, FullModelOf, graphics, GridAriaRules, HtmlComponent, IconColumn, InitModelOf, Insets, IUserFilterStateDo, keys, KeyStrokeContext, LimitedResultTableStatus, LoadingSupport, Menu, MenuBar, MenuDestinations,
   MenuItemsOrder, menus as menuUtil, menus, NumberColumn, NumberColumnAggregationFunction, NumberColumnBackgroundEffect, ObjectOrChildModel, ObjectOrModel, objects, Predicate, PropertyChangeEvent, Range, scout, scrollbars,
   ScrollToAlignment, ScrollToOptions, Status, StatusOrModel, strings, styles, TabbableCoordinator, TableClientUiPreferenceProfileDo, TableCompactHandler, TableControl, TableCopyKeyStroke, TableCustomizer, TableDefaultRowActionKeyStroke,
-  TableEventMap, TableFooter, TableGroupEvent, TableHeader, TableLayout, TableModel, TableMoveSupport, TableNavigationCollapseKeyStroke, TableNavigationDownKeyStroke, TableNavigationEndKeyStroke, TableNavigationExpandKeyStroke,
-  TableNavigationHomeKeyStroke, TableNavigationPageDownKeyStroke, TableNavigationPageUpKeyStroke, TableNavigationUpKeyStroke, TableOrganizer, TableRefreshKeyStroke, TableRow, TableRowDropPosition, TableRowModel, TableSelectAllKeyStroke,
-  TableSelectionHandler, TableSelectKeyStroke, TableStartCellEditKeyStroke, TableTextUserFilter, TableTileGridMediator, TableToggleRowKeyStroke, TableTooltip, TableUiPreferences, tableUiPreferences, TableUpdateBuffer, TableUserFilter,
-  TableUserFilterModel, Tile, TileTableHeaderBox, tooltips, TooltipSupport, TreeGridAriaRules, UiPreferences, UpdateFilteredElementsOptions, UserFilterStateMappers, ValueField, Widget
+  TableEventMap, TableFooter, TableGroupEvent, TableHeader, TableLayout, TableLoadingSupport, TableModel, TableMoveSupport, TableNavigationCollapseKeyStroke, TableNavigationDownKeyStroke, TableNavigationEndKeyStroke,
+  TableNavigationExpandKeyStroke, TableNavigationHomeKeyStroke, TableNavigationPageDownKeyStroke, TableNavigationPageUpKeyStroke, TableNavigationUpKeyStroke, TableOrganizer, TableRefreshKeyStroke, TableRow, TableRowDropPosition,
+  TableRowModel, TableSelectAllKeyStroke, TableSelectionHandler, TableSelectKeyStroke, TableStartCellEditKeyStroke, TableTextUserFilter, TableTileGridMediator, TableToggleRowKeyStroke, TableTooltip, TableUiPreferences, tableUiPreferences,
+  TableUpdateBuffer, TableUserFilter, TableUserFilterModel, Tile, TileTableHeaderBox, tooltips, TooltipSupport, TreeGridAriaRules, UiPreferences, UpdateFilteredElementsOptions, UserFilterStateMappers, ValueField, Widget
 } from '../index';
 import $ from 'jquery';
 
@@ -137,6 +137,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   userPreferenceContext: string;
   uiPreferencesEnabled: boolean;
   rowsDraggable = false;
+  asyncLoading = true;
 
   $data: JQuery;
   $emptyData: JQuery;
@@ -521,7 +522,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   }
 
   protected override _createLoadingSupport(): LoadingSupport {
-    return new LoadingSupport({
+    return new TableLoadingSupport({
       widget: this,
       withGlassPane: true,
       $container: () => {
@@ -6865,6 +6866,10 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     } else if (parentRowChanged) {
       this.updateRow(sourceRow);
     }
+  }
+
+  setAsyncLoading(asyncLoading: boolean) {
+    this.setProperty('asyncLoading', asyncLoading);
   }
 
   /* --- STATIC HELPERS ------------------------------------------------------------- */

--- a/eclipse-scout-core/src/table/TableEventMap.ts
+++ b/eclipse-scout-core/src/table/TableEventMap.ts
@@ -242,4 +242,5 @@ export interface TableEventMap extends WidgetEventMap {
   'propertyChange:virtual': PropertyChangeEvent<boolean>;
   'propertyChange:maxRowCount': PropertyChangeEvent<number>;
   'propertyChange:estimatedRowCount': PropertyChangeEvent<number>;
+  'propertyChange:asyncLoading': PropertyChangeEvent<boolean>;
 }

--- a/eclipse-scout-core/src/table/TableLoadingSupport.ts
+++ b/eclipse-scout-core/src/table/TableLoadingSupport.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {LoadingSupport, LoadingSupportOptions, PropertyChangeEvent, Table} from '../index';
+
+export class TableLoadingSupport extends LoadingSupport {
+
+  declare widget: Table;
+
+  protected _busy = false;
+  protected _tableAsyncLoadingChangeHandler = this._onTableAsyncLoadingChange.bind(this);
+  protected _tableRemoveHandler = this._onTableRemove.bind(this);
+
+  constructor(options: LoadingSupportOptions) {
+    super(options);
+
+    this.widget.on('propertyChange:asyncLoading', this._tableAsyncLoadingChangeHandler);
+    this.widget.on('remove', this._tableRemoveHandler);
+    this.widget.one('destroy', e => {
+      this.widget.off('propertyChange:asyncLoading', this._tableAsyncLoadingChangeHandler);
+      this.widget.off('remove', this._tableRemoveHandler);
+    });
+  }
+
+  protected override _renderLoadingIndicator() {
+    // only render the loading indicator if table supports async loading
+    if (this.widget.asyncLoading) {
+      super._renderLoadingIndicator();
+    }
+
+    // update busy indicator
+    this._updateDesktopBusy();
+  }
+
+  protected override _removeLoadingIndicator() {
+    // remove loading indicator and update busy indicator
+    super._removeLoadingIndicator();
+    this._updateDesktopBusy();
+  }
+
+  protected _onTableAsyncLoadingChange(event: PropertyChangeEvent<boolean>) {
+    // remove loading indicator if there is one and render a new one
+    this._removeLoadingIndicator();
+    this.renderLoading(true);
+  }
+
+  protected _onTableRemove() {
+    // remove busy indicator, this can not be done in remove() as it is also asynchronously triggered by _removeLoadingIndicator()
+    this._setDesktopBusy(false);
+  }
+
+  protected _updateDesktopBusy() {
+    // mark desktop busy if table does not support asyncLoading and is loading
+    this._setDesktopBusy(!this.widget.asyncLoading && this.widget.isLoading());
+  }
+
+  protected _setDesktopBusy(busy: boolean) {
+    // check and update _busy to ensure Desktop.setBusy is not called multiple times with the same value
+    if (this._busy === busy) {
+      return;
+    }
+    this._busy = busy;
+
+    // set desktop busy, use same delay as Session and abort-properties from loading support
+    this.widget.session.desktop.setBusy({
+      busy,
+      renderDelay: 500, // longer delay as otherwise the cursor flickers on every backend call
+      busyIndicatorModel: {
+        cancellable: this.abortable
+      },
+      onCancel: this.abortHandler
+    });
+  }
+}

--- a/eclipse-scout-core/src/table/TableModel.ts
+++ b/eclipse-scout-core/src/table/TableModel.ts
@@ -318,4 +318,13 @@ export interface TableModel extends WidgetModel {
    * @see TableRow.dropTypes
    */
   rowsDraggable?: boolean;
+  /**
+   * Specifies whether the table loads its data asynchronously.
+   *
+   * If set to true the table shows a loading indicator when it is loading.
+   * Otherwise, the desktop is busy while the table is loading.
+   *
+   * Default is true.
+   */
+  asyncLoading?: boolean;
 }

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {
-  Action, arrays, BeanColumn, BooleanColumn, Cell, Column, ColumnModel, Device, graphics, IconColumn, icons, keys, Menu, MenuDestinations, NumberColumn, ObjectFactory, Point, Range, RemoteEvent, scout, scrollbars, SmartColumn,
-  StaticLookupCall, Status, strings, Table, TableAdapter, TableField, TableRow, TableRowModel, TableUserFilter, Tooltip
+  Action, arrays, BeanColumn, BooleanColumn, Cell, Column, ColumnModel, Device, graphics, IconColumn, icons, keys, LoadingSupport, Menu, MenuDestinations, NumberColumn, ObjectFactory, Point, Range, RemoteEvent, scout, scrollbars,
+  SmartColumn, StaticLookupCall, Status, strings, Table, TableAdapter, TableField, TableRow, TableRowModel, TableUserFilter, Tooltip
 } from '../../src/index';
 import {JQueryTesting, LocaleSpecHelper, SpecTable, SpecTableModel, TableSpecHelper} from '../../src/testing/index';
 import $ from 'jquery';
@@ -5421,6 +5421,83 @@ describe('Table', () => {
 
       table.addFilter(row => row !== table.rows[0]);
       expect(table.focusedRow).toBe(null);
+    });
+  });
+
+  describe('asyncLoading', () => {
+
+    beforeEach(() => {
+      jasmine.clock().uninstall();
+      $(`<style>
+      @keyframes nop { 0% { opacity: 1; } 100% { opacity: 1; } }
+      .loading-indicator.animate-remove { animation: nop; animation-duration: 100ms;}
+      </style>`).appendTo($('#sandbox'));
+    });
+
+    it('renders loading indicator while loading when asyncLoading=true', async () => {
+      const model = helper.createModelFixture(3, 2);
+      const table = helper.createTable(model);
+      table.loadingSupport.setLoadingIndicatorDelay(0);
+      table.render();
+
+      table.setAsyncLoading(true);
+      expect(session.desktop.busy).toBeFalse();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(0);
+
+      table.setLoading(true);
+      expect(session.desktop.busy).toBeFalse();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(1);
+
+      table.setLoading(false);
+      await JQueryTesting.whenAnimationEnd((table.loadingSupport as LoadingSupport & { _$loadingIndicator: JQuery })._$loadingIndicator);
+      expect(session.desktop.busy).toBeFalse();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(0);
+    });
+
+    it('sets desktop busy while loading when asyncLoading=false', () => {
+      const model = helper.createModelFixture(3, 2);
+      const table = helper.createTable(model);
+      table.loadingSupport.setLoadingIndicatorDelay(0);
+      table.render();
+
+      table.setAsyncLoading(false);
+      expect(session.desktop.busy).toBeFalse();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(0);
+
+      table.setLoading(true);
+      expect(session.desktop.busy).toBeTrue();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(0);
+
+      table.setLoading(false);
+      expect(session.desktop.busy).toBeFalse();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(0);
+    });
+
+    it('may be changed while loading', async () => {
+      const model = helper.createModelFixture(3, 2);
+      const table = helper.createTable(model);
+      table.loadingSupport.setLoadingIndicatorDelay(0);
+      table.render();
+
+      table.setLoading(true);
+
+      table.setAsyncLoading(true);
+      expect(session.desktop.busy).toBeFalse();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(1);
+
+      table.setAsyncLoading(false);
+      await JQueryTesting.whenAnimationEnd((table.loadingSupport as LoadingSupport & { _$loadingIndicator: JQuery })._$loadingIndicator);
+      expect(session.desktop.busy).toBeTrue();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(0);
+
+      table.setAsyncLoading(true);
+      expect(session.desktop.busy).toBeFalse();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(1);
+
+      table.setLoading(false);
+      await JQueryTesting.whenAnimationEnd((table.loadingSupport as LoadingSupport & { _$loadingIndicator: JQuery })._$loadingIndicator);
+      expect(session.desktop.busy).toBeFalse();
+      expect(table.$data.children('.glasspane.loading-glasspane').length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
A PageWithTable sets its table loading while the data is loaded. This leads to a loading indicator being displayed in the table while the rest of the application, e.g. the search form, is still enabled. The behavior differs from a Scout Classic IPageWithTable, where the table is not loading but the desktop is busy and shows a modal busy indicator. To not confuse users in Scout Classic applications having Scout JS PageWithTable, this behavior is aligned.
A new property asyncLoading was introduced on the Scout JS table which determines whether the table shows a loading indicator or sets the desktop busy while loading its data. By default, this property is set to true, which means a loading indicator is shown.
The OutlineAdapter disables asyncLoading on all tables that belong to a PageWithTable, which means the loading indicator is not rendered while the data is loaded. Instead, the desktop is set busy during this time.

471868