### PR TITLE
Inject relevant style sheets into PopupWindow

### DIFF
--- a/eclipse-scout-core/src/desktop/DesktopFormController.ts
+++ b/eclipse-scout-core/src/desktop/DesktopFormController.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -125,6 +125,7 @@ export class DesktopFormController extends FormController implements DesktopForm
       // error assertion
       throw new Error('Neither property \'formId\' nor \'popupWindow\' exists on data parameter');
     }
+    // noinspection JSIgnoredPromiseFromCall
     popupWindow._onReady();
   }
 

--- a/eclipse-scout-core/src/desktop/PopupWindow.ts
+++ b/eclipse-scout-core/src/desktop/PopupWindow.ts
@@ -25,6 +25,8 @@ export class PopupWindow extends EventEmitter {
   htmlComp: HtmlComponent;
   $container: JQuery;
 
+  protected _headInjectStyleSheetHandler = this._onHeadInjectStyleSheet.bind(this);
+
   constructor(myWindow: Window, form: Form) { // use 'myWindow' in place of 'window' to prevent confusion with global window variable
     super();
 
@@ -47,6 +49,7 @@ export class PopupWindow extends EventEmitter {
   }
 
   protected _onPageHide() {
+    $(window.document.head).off('injectStyleSheet', this._headInjectStyleSheetHandler);
     if (this.form.destroyed) {
       $.log.isDebugEnabled() && $.log.debug('form ID ' + this.form.id + ' is already destroyed - don\'t trigger unload event');
     } else {
@@ -55,7 +58,7 @@ export class PopupWindow extends EventEmitter {
   }
 
   /** @internal */
-  _onReady() {
+  async _onReady(): Promise<void> {
     // set container (used as document-root from callers)
     let myDocument = this.myWindow.document,
       $myWindow = $(this.myWindow),
@@ -74,6 +77,8 @@ export class PopupWindow extends EventEmitter {
     this.htmlComp = HtmlComponent.install(this.$container, this.session);
     this.htmlComp.setLayout(new SingleLayout());
     this.$container.height($myWindow.height());
+    // wait for relevant stylesheets to be injected before rendering
+    await this._injectStyleSheets();
     this.form.render(this.$container);
 
     // resize browser-window before layout?
@@ -115,6 +120,36 @@ export class PopupWindow extends EventEmitter {
     // Finally set initialized flag to true, at this point the PopupWindow is fully initialized
     this.initialized = true;
     this.trigger('init');
+  }
+
+  /**
+   * Injects all style sheets from {@link window} marked with `relevantForPopupWindow` into {@link myWindow}.
+   */
+  protected async _injectStyleSheets(): Promise<void> {
+    $(window.document.head).on('injectStyleSheet', this._headInjectStyleSheetHandler);
+    await Promise.all(
+      [...window.document.styleSheets]
+        .map(styleSheet => $(styleSheet.ownerNode) as JQuery<HTMLLinkElement>)
+        .map($linkTag => this._injectStyleSheet($linkTag))
+    );
+  }
+
+  /**
+   * Injects a style sheet if it is marked with `relevantForPopupWindow` into {@link myWindow}.
+   */
+  protected async _injectStyleSheet($linkTag: JQuery<HTMLLinkElement>): Promise<JQuery> {
+    if (!$linkTag.length || !$linkTag.data('relevantForPopupWindow')) {
+      return;
+    }
+    const url = $linkTag[0].href;
+    if (!url) {
+      return;
+    }
+    return $.injectStyleSheet(url, {document: this.myWindow.document});
+  }
+
+  protected async _onHeadInjectStyleSheet(event: JQuery.InjectStyleSheetEvent): Promise<void> {
+    await this._injectStyleSheet(event.$linkTag);
   }
 
   // Note: currently _onResize is only called when the window is resized, but not when the position of the window changes.

--- a/eclipse-scout-core/src/jquery/jquery-scout-types.ts
+++ b/eclipse-scout-core/src/jquery/jquery-scout-types.ts
@@ -25,6 +25,13 @@ export interface InjectScriptOptions extends InjectOptions {
   removeTag?: boolean;
 }
 
+export interface InjectStyleSheetOptions extends InjectOptions {
+  /**
+   * {@link Record} of key value pairs to be set as data on the injected style sheet.
+   */
+  data?: Record<string, string | number | boolean | symbol | object>;
+}
+
 export interface AppLink {
   ref: string;
   name?: string;
@@ -127,7 +134,7 @@ declare global {
      *   $.injectStyleSheet('http://server/path/style.css')
      *     .done(function($linkTag) { ... });
      */
-    injectStyleSheet(url: string, options?: InjectOptions): JQuery.Promise<JQuery>;
+    injectStyleSheet(url: string, options?: InjectStyleSheetOptions): JQuery.Promise<JQuery>;
 
     /**
      * Dynamically adds styles to the document.
@@ -1219,5 +1226,26 @@ declare global {
     onPassive<TType extends string>(eventType: TType, handler: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TType>): this;
 
     offPassive<TType extends string>(eventType: TType, handler: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TType>): this;
+  }
+
+  module JQuery {
+    interface InjectStyleSheetEvent<
+      TDelegateTarget = any,
+      TData = any,
+      TCurrentTarget = any,
+      TTarget = any,
+    > extends TriggeredEvent<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+      type: 'injectStyleSheet';
+      $linkTag: JQuery<HTMLLinkElement>;
+    }
+
+    interface TypeToTriggeredEventMap<
+      TDelegateTarget,
+      TData,
+      TCurrentTarget,
+      TTarget,
+    > {
+      injectStyleSheet: InjectStyleSheetEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+    }
   }
 }

--- a/eclipse-scout-core/src/jquery/jquery-scout.js
+++ b/eclipse-scout-core/src/jquery/jquery-scout.js
@@ -252,7 +252,8 @@ $.injectStyleSheet = (url, options) => {
 
   let myDocument = options.document || window.document;
   let linkTag = myDocument.createElement('link');
-  $(linkTag)
+  const $linkTag = $(linkTag);
+  $linkTag
     .attr('rel', 'stylesheet')
     .attr('type', 'text/css')
     .attr('href', url)
@@ -263,10 +264,20 @@ $.injectStyleSheet = (url, options) => {
         deferred.resolve($(linkTag));
       }
     });
+  if (objects.isObject(options.data)) {
+    for (const [key, value] of Object.entries(options.data)) {
+      $linkTag.data(key, value);
+    }
+  }
+
   // Use raw JS function to append the <script> tag, because jQuery handles
   // script tags specially (see "domManip" function) and uses eval() which
   // is not CSP-safe.
   myDocument.head.appendChild(linkTag);
+  $(myDocument.head).trigger({
+    type: 'injectStyleSheet',
+    $linkTag
+  });
 
   return deferred.promise();
 };

--- a/eclipse-scout-core/test/_res/blue.css
+++ b/eclipse-scout-core/test/_res/blue.css
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+.scout {
+  background-color: #00f;
+}

--- a/eclipse-scout-core/test/_res/green.css
+++ b/eclipse-scout-core/test/_res/green.css
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+.scout {
+  background-color: #0f0;
+}

--- a/eclipse-scout-core/test/_res/popup-window.html
+++ b/eclipse-scout-core/test/_res/popup-window.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Testing Popup</title>
+  </head>
+  <body>
+    <div class="scout"></div>
+  </body>
+</html>

--- a/eclipse-scout-core/test/_res/red.css
+++ b/eclipse-scout-core/test/_res/red.css
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+.scout {
+  background-color: #f00;
+}

--- a/eclipse-scout-core/test/_res/yellow.css
+++ b/eclipse-scout-core/test/_res/yellow.css
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+.scout {
+  background-color: #ff0;
+}

--- a/eclipse-scout-core/test/desktop/PopupWindowSpec.ts
+++ b/eclipse-scout-core/test/desktop/PopupWindowSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import {Form, GroupBox, PopupWindow, scout} from '../../src/index';
+import $ from 'jquery';
 
 describe('PopupWindow', () => {
   let session: SandboxSession, $sandbox: JQuery, myForm: Form, myWindow: Window,
@@ -16,12 +17,21 @@ describe('PopupWindow', () => {
     };
 
   class SpecPopupWindow extends PopupWindow {
-    override _onResize() {
-      super._onResize();
+
+    injectStyleSheetPromises: Promise<JQuery>[] = [];
+
+    protected override _onResize() {
+      // Don't execute during spec
+    }
+
+    protected override async _injectStyleSheet($linkTag: JQuery<HTMLLinkElement>): Promise<JQuery> {
+      const promise = super._injectStyleSheet($linkTag);
+      this.injectStyleSheetPromises.push(promise);
+      return promise;
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     setFixtures(sandbox());
     session = sandboxSession();
     $sandbox = $('#sandbox');
@@ -35,11 +45,18 @@ describe('PopupWindow', () => {
     });
 
     // window mock
-    myWindow = $sandbox.window(true);
+    myWindow = window.open('_res/popup-window.html', '_blank');
     myWindow.opener = {
       location: {href: null},
       onerror: myErrorHandler
     };
+    const deferred = $.Deferred();
+    $(myWindow).one('pageshow', () => deferred.resolve());
+    await deferred.promise();
+  });
+
+  afterEach(() => {
+    myWindow.close();
   });
 
   it('Constructor sets cross references and window-name', () => {
@@ -50,21 +67,67 @@ describe('PopupWindow', () => {
     expect(myForm.popupWindow).toBe(popupWindow);
   });
 
-  it('Initialization in _onReady', () => {
-    let popupWindow = new SpecPopupWindow(myWindow, myForm),
-      called = false;
+  describe('_onReady', () => {
 
-    popupWindow.one('init', () => {
-      called = true;
+    it('initializes PopupWindow', async () => {
+      let popupWindow = new SpecPopupWindow(myWindow, myForm),
+        called = false;
+
+      popupWindow.one('init', () => {
+        called = true;
+      });
+      expect(popupWindow.initialized).toBe(false);
+      await popupWindow._onReady();
+      expect(called).toBe(true);
+      expect(popupWindow.initialized).toBe(true);
+      expect(myWindow.onerror).toBe(myErrorHandler);
     });
-    expect(popupWindow.initialized).toBe(false);
-    popupWindow._onReady();
-    popupWindow._onResize = () => {
-      // Don't execute during spec
-    };
-    expect(called).toBe(true);
-    expect(popupWindow.initialized).toBe(true);
-    expect(myWindow.onerror).toBe(myErrorHandler);
-  });
 
+    it('injects relevant styleSheets', async () => {
+      const popupWindow = new SpecPopupWindow(myWindow, myForm);
+
+      const $red = await $.injectStyleSheet('_res/red.css', {document});
+      const $green = await $.injectStyleSheet('_res/green.css', {document, data: {relevantForPopupWindow: true}});
+
+      let windowStyleSheetHrefs = [...document.styleSheets].map(styleSheet => styleSheet.href);
+      let popupWindowStyleSheetHrefs = [...myWindow.document.styleSheets].map(styleSheet => styleSheet.href);
+
+      expect(windowStyleSheetHrefs).toContain(`${document.location.origin}/_res/red.css`);
+      expect(windowStyleSheetHrefs).toContain(`${document.location.origin}/_res/green.css`);
+      expect(popupWindowStyleSheetHrefs).not.toContain(`${document.location.origin}/_res/red.css`);
+      expect(popupWindowStyleSheetHrefs).not.toContain(`${document.location.origin}/_res/green.css`);
+
+      await popupWindow._onReady();
+
+      windowStyleSheetHrefs = [...document.styleSheets].map(styleSheet => styleSheet.href);
+      popupWindowStyleSheetHrefs = [...myWindow.document.styleSheets].map(styleSheet => styleSheet.href);
+
+      expect(windowStyleSheetHrefs).toContain(`${document.location.origin}/_res/red.css`);
+      expect(windowStyleSheetHrefs).toContain(`${document.location.origin}/_res/green.css`);
+      expect(popupWindowStyleSheetHrefs).not.toContain(`${document.location.origin}/_res/red.css`);
+      expect(popupWindowStyleSheetHrefs).toContain(`${document.location.origin}/_res/green.css`);
+
+      const $blue = await $.injectStyleSheet('_res/blue.css', {document});
+      const $yellow = await $.injectStyleSheet('_res/yellow.css', {document, data: {relevantForPopupWindow: true}});
+
+      await Promise.all(popupWindow.injectStyleSheetPromises);
+
+      windowStyleSheetHrefs = [...document.styleSheets].map(styleSheet => styleSheet.href);
+      popupWindowStyleSheetHrefs = [...myWindow.document.styleSheets].map(styleSheet => styleSheet.href);
+
+      expect(windowStyleSheetHrefs).toContain(`${document.location.origin}/_res/red.css`);
+      expect(windowStyleSheetHrefs).toContain(`${document.location.origin}/_res/green.css`);
+      expect(windowStyleSheetHrefs).toContain(`${document.location.origin}/_res/blue.css`);
+      expect(windowStyleSheetHrefs).toContain(`${document.location.origin}/_res/yellow.css`);
+      expect(popupWindowStyleSheetHrefs).not.toContain(`${document.location.origin}/_res/red.css`);
+      expect(popupWindowStyleSheetHrefs).toContain(`${document.location.origin}/_res/green.css`);
+      expect(popupWindowStyleSheetHrefs).not.toContain(`${document.location.origin}/_res/blue.css`);
+      expect(popupWindowStyleSheetHrefs).toContain(`${document.location.origin}/_res/yellow.css`);
+
+      $yellow.remove();
+      $blue.remove();
+      $green.remove();
+      $red.remove();
+    });
+  });
 });


### PR DESCRIPTION
The PopupWindow may display content that depends on dynamically injected style sheets (e.g. by jquery-scout). These style sheets are not reused from the main window or injected dynamically by the browser. The PopupWindow now ensures that all relevant style sheets (marked with 'relevantForPopupWindow') are injected into the popup before any data is rendered. Additionally, all relevant style sheets that are injected into the main window while the popup is opened are injected into the popup window as well.

463702