### PR TITLE
Improve lookup text search handling for dash characters

### DIFF
--- a/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/lookup/LookupHelperTest.java
+++ b/org.eclipse.scout.rt.dataobject.test/src/test/java/org/eclipse/scout/rt/dataobject/lookup/LookupHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -253,5 +253,30 @@ public class LookupHelperTest {
     assertEquals(LookupHelper.DEFAULT_MAX_ROWS, m_helper.maxRowCount(BEANS.get(FixtureEnumLookupRestrictionDo.class)));
     assertEquals(LookupHelper.DEFAULT_MAX_ROWS, m_helper.maxRowCount(BEANS.get(FixtureEnumLookupRestrictionDo.class).withMaxRowCount(null)));
     assertEquals(42, m_helper.maxRowCount(BEANS.get(FixtureEnumLookupRestrictionDo.class).withMaxRowCount(42)));
+  }
+
+  @Test
+  public void testSoftHyphenIgnored() {
+    m_testData.put(10L, new FixtureData(10L, "Test\u00ADtestbaz", "additional data", true));
+
+    var restriction = BEANS.get(LongLookupRestrictionDo.class).withText("Testtest");
+    var lookupResponse = m_helper.filterData(restriction, m_testData.values().stream(), FixtureData::getId, FixtureData::getText, FixtureData::getActive, LongLookupRowDo.class);
+    assertLookupResponse(lookupResponse, 10L);
+    assertActiveLookupRows(lookupResponse, 10L);
+  }
+
+  @Test
+  public void testEnDashEmDash() {
+    // Dash
+    m_testData.put(10L, new FixtureData(10L, "Test-testbaz", "additional data", true));
+    // En dash
+    m_testData.put(11L, new FixtureData(11L, "Test–testbaz", "additional data", true));
+    // Em dash
+    m_testData.put(12L, new FixtureData(12L, "Test—testbaz", "additional data", true));
+
+    var restriction = BEANS.get(LongLookupRestrictionDo.class).withText("Test-test");
+    var lookupResponse = m_helper.filterData(restriction, m_testData.values().stream(), FixtureData::getId, FixtureData::getText, FixtureData::getActive, LongLookupRowDo.class);
+    assertLookupResponse(lookupResponse, 10L, 11L, 12L);
+    assertActiveLookupRows(lookupResponse, 10L, 11L, 12L);
   }
 }

--- a/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/lookup/LookupHelper.java
+++ b/org.eclipse.scout.rt.dataobject/src/main/java/org/eclipse/scout/rt/dataobject/lookup/LookupHelper.java
@@ -44,6 +44,7 @@ public class LookupHelper {
   protected static final String WILDCARD = "*";
   protected static final String WILDCARD_REPLACE = "@wildcard@";
   protected static final String MATCH_ALL_REGEX = ".*";
+  protected static final String DASH_REGEX = "[-‐‑‒–—﹘－]*";
 
   /**
    * Filter stream of {@code data} according to specified {@code restriction} and converts the stream to a
@@ -336,7 +337,12 @@ public class LookupHelper {
         return false;
       }
       String text = textAccessor.apply(data);
-      return text != null && pattern.matcher(text).matches();
+      if (text == null) {
+        return false;
+      }
+      // Replace format characters (e.g. soft hyphen)
+      text = text.replaceAll("\\p{Cf}", "");
+      return pattern.matcher(text).matches();
     };
   }
 
@@ -371,6 +377,8 @@ public class LookupHelper {
     }
     text = text.replace(wildcard, WILDCARD_REPLACE);
     text = StringUtility.escapeRegexMetachars(text);
+    // Dash matches all dashes (en dash, em dash, etc.)
+    text = text.replace("-", DASH_REGEX);
 
     // replace repeating wildcards to prevent regex DoS
     String duplicateWildcards = WILDCARD_REPLACE.concat(WILDCARD_REPLACE);


### PR DESCRIPTION
Match all dash variants as a regular hyphen and ignore soft hyphens when performing text searches.