### PR TITLE
EventSupport: trigger listeners in the order they were registered

### DIFF
--- a/eclipse-scout-core/src/events/EventSupport.ts
+++ b/eclipse-scout-core/src/events/EventSupport.ts
@@ -11,9 +11,10 @@ import {Event, EventHandler, EventListener, scout, strings} from '../index';
 import $ from 'jquery';
 
 export class EventSupport {
-  protected _eventListenersByType = new Map<string, Set<EventListener>>();
-  protected _eventListenersByHandler = new Map<EventHandler, Set<EventListener>>();
+  protected _eventListenersByType = new Map<string, Set<EventListenerWithSortIndex>>();
+  protected _eventListenersByHandler = new Map<EventHandler, Set<EventListenerWithSortIndex>>();
   protected _subTypeProviders = new Map<string, EventSubTypeProvider>();
+  protected _sortIndex = 0;
 
   protected _assertFunc(func: EventHandler) {
     if (!func) {
@@ -153,6 +154,8 @@ export class EventSupport {
     if (!listener) {
       return;
     }
+
+    (listener as EventListenerWithSortIndex)._sortIndex = this._sortIndex++;
 
     // add listener for handlers
     this._addListenerByHandler(listener.func, listener);
@@ -298,41 +301,42 @@ export class EventSupport {
       .map(t => this._getListenersByType(t))
       .reduce((a, b) => new Set([...a, ...b]), new Set());
 
-    // trigger all listeners
-    for (const listener of listeners) {
+    // trigger all listeners in order they were registered
+    const listenersSorted = [...listeners].sort((l1, l2) => l1._sortIndex - l2._sortIndex);
+    for (const listener of listenersSorted) {
       listener.func(event);
     }
   }
 
   /**
-   * Gets a {@link Set} of {@link EventListener}s for the requested type.
+   * Gets a {@link Set} of {@link EventListenerWithSortIndex}s for the requested type.
    * The result of this method is never `null`.
    * If the create-flag is set, the {@link Set} is added to {@link _eventListenersByType}.
    */
-  protected _getListenersByType(type: string, create = false): Set<EventListener> {
+  protected _getListenersByType(type: string, create = false): Set<EventListenerWithSortIndex> {
     return this._getListenersByIdentifier(this._eventListenersByType, type || null, create);
   }
 
   /**
-   * Adds an {@link EventListener} to {@link _eventListenersByType} for the given identifier.
+   * Adds an {@link EventListenerWithSortIndex} to {@link _eventListenersByType} for the given identifier.
    */
-  protected _addListenerByType(type: string, listener: EventListener) {
+  protected _addListenerByType(type: string, listener: EventListenerWithSortIndex) {
     this._addListenerByIdentifier(this._eventListenersByType, type || null, listener);
   }
 
   /**
-   * Removes an {@link EventListener} from {@link _eventListenersByType} for the given identifier.
+   * Removes an {@link EventListenerWithSortIndex} from {@link _eventListenersByType} for the given identifier.
    */
-  protected _removeListenerByType(type: string, listener: EventListener) {
+  protected _removeListenerByType(type: string, listener: EventListenerWithSortIndex) {
     this._removeListenerByIdentifier(this._eventListenersByType, type || null, listener);
   }
 
   /**
-   * Gets a {@link Set} of {@link EventListener}s for the requested {@link EventHandler}.
+   * Gets a {@link Set} of {@link EventListenerWithSortIndex}s for the requested {@link EventHandler}.
    * The result of this method is never `null`.
    * If the create-flag is set, the {@link Set} is added to {@link _eventListenersByHandler}.
    */
-  protected _getListenersByHandler(handler: EventHandler, create = false): Set<EventListener> {
+  protected _getListenersByHandler(handler: EventHandler, create = false): Set<EventListenerWithSortIndex> {
     if (!handler) {
       return new Set();
     }
@@ -341,9 +345,9 @@ export class EventSupport {
   }
 
   /**
-   * Adds an {@link EventListener} to {@link _eventListenersByHandler} for the given identifier.
+   * Adds an {@link EventListenerWithSortIndex} to {@link _eventListenersByHandler} for the given identifier.
    */
-  protected _addListenerByHandler(handler: EventHandler, listener: EventListener) {
+  protected _addListenerByHandler(handler: EventHandler, listener: EventListenerWithSortIndex) {
     if (!handler) {
       return;
     }
@@ -352,9 +356,9 @@ export class EventSupport {
   }
 
   /**
-   * Removes an {@link EventListener} from {@link _eventListenersByHandler} for the given identifier.
+   * Removes an {@link EventListenerWithSortIndex} from {@link _eventListenersByHandler} for the given identifier.
    */
-  protected _removeListenerByHandler(handler: EventHandler, listener: EventListener) {
+  protected _removeListenerByHandler(handler: EventHandler, listener: EventListenerWithSortIndex) {
     if (!handler) {
       return;
     }
@@ -363,11 +367,11 @@ export class EventSupport {
   }
 
   /**
-   * Gets a {@link Set} of {@link EventListener}s for the requested identifier from the given {@link Map}.
+   * Gets a {@link Set} of {@link EventListenerWithSortIndex}s for the requested identifier from the given {@link Map}.
    * The result of this method is never `null`.
    * If the create-flag is set, the {@link Set} is added to the {@link Map}.
    */
-  protected _getListenersByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListener>>, identifier: TIdentifier, create = false): Set<EventListener> {
+  protected _getListenersByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListenerWithSortIndex>>, identifier: TIdentifier, create = false): Set<EventListenerWithSortIndex> {
     if (!listenerMap) {
       return new Set();
     }
@@ -387,9 +391,9 @@ export class EventSupport {
   }
 
   /**
-   * Adds an {@link EventListener} to the given {@link Map} for the given identifier.
+   * Adds an {@link EventListenerWithSortIndex} to the given {@link Map} for the given identifier.
    */
-  protected _addListenerByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListener>>, identifier: TIdentifier, listener: EventListener) {
+  protected _addListenerByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListenerWithSortIndex>>, identifier: TIdentifier, listener: EventListenerWithSortIndex) {
     if (!listenerMap || !listener) {
       return;
     }
@@ -398,9 +402,9 @@ export class EventSupport {
   }
 
   /**
-   * Removes an {@link EventListener} from the given {@link Map} for the given identifier.
+   * Removes an {@link EventListenerWithSortIndex} from the given {@link Map} for the given identifier.
    */
-  protected _removeListenerByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListener>>, identifier: TIdentifier, listener: EventListener) {
+  protected _removeListenerByIdentifier<TIdentifier extends string | EventHandler>(listenerMap: Map<TIdentifier, Set<EventListenerWithSortIndex>>, identifier: TIdentifier, listener: EventListenerWithSortIndex) {
     if (!listenerMap || !listener) {
       return;
     }
@@ -434,6 +438,7 @@ export class EventSupport {
   }
 }
 
+export type EventListenerWithSortIndex = EventListener & { _sortIndex?: number };
 /**
  * Builds a complete type for an {@link Event}.
  * Consider a `FancyEvent` that is always triggered with the type 'fancy' but has a property `subType` which can hold the values 'foo' or 'bar'.

--- a/eclipse-scout-core/test/events/EventSupportSpec.ts
+++ b/eclipse-scout-core/test/events/EventSupportSpec.ts
@@ -652,6 +652,87 @@ describe('EventSupport', () => {
       expect(count1).toBe(5);
       expect(count2).toBe(4);
     });
+
+    it('triggers listeners in order they aer registered', () => {
+      const eventSupport = new EventSupport();
+      eventSupport.registerSubTypeProvider('fancy', (event: FancyEvent) => event.subType);
+      let listenersTriggered = [];
+
+      const handlerA = () => listenersTriggered.push('a');
+      const handlerB = () => listenersTriggered.push('b');
+      const handlerC = () => listenersTriggered.push('c');
+      const handlerD = () => listenersTriggered.push('d');
+
+      // simple case
+      eventSupport.on('lorem', handlerA);
+      eventSupport.on('lorem', handlerB);
+      eventSupport.on('lorem', handlerC);
+
+      eventSupport.trigger('lorem');
+      expect(listenersTriggered).toEqual(['a', 'b', 'c']);
+
+      eventSupport.off('lorem');
+      listenersTriggered = [];
+
+      // listeners added multiple times
+      eventSupport.on('lorem', handlerC);
+      eventSupport.on('lorem', handlerB);
+      eventSupport.on('lorem', handlerC);
+      eventSupport.on('lorem', handlerA);
+      eventSupport.on('lorem', handlerB);
+
+      eventSupport.trigger('lorem');
+      expect(listenersTriggered).toEqual(['c', 'b', 'c', 'a', 'b']);
+
+      eventSupport.off('lorem');
+      listenersTriggered = [];
+
+      // listeners are de- and re-registered
+      eventSupport.on('lorem', handlerC);
+      eventSupport.on('lorem', handlerB);
+      eventSupport.off('lorem', handlerC);
+      eventSupport.on('lorem', handlerC);
+      eventSupport.on('lorem', handlerA);
+      eventSupport.off('lorem', handlerB);
+      eventSupport.on('lorem', handlerB);
+
+      eventSupport.trigger('lorem');
+      expect(listenersTriggered).toEqual(['c', 'a', 'b']);
+
+      eventSupport.off('lorem');
+      listenersTriggered = [];
+
+      // listeners registered for event with subtype
+      eventSupport.on('fancy:lorem', handlerA);
+      eventSupport.on('fancy:lorem', handlerB);
+      eventSupport.on('fancy:lorem', handlerC);
+
+      eventSupport.trigger('fancy', new FancyEvent('lorem'));
+      expect(listenersTriggered).toEqual(['a', 'b', 'c']);
+
+      eventSupport.off('fancy:lorem');
+      listenersTriggered = [];
+
+      // listeners registered for event without subtype
+      eventSupport.on('fancy', handlerC);
+      eventSupport.on('fancy', handlerB);
+      eventSupport.on('fancy', handlerA);
+
+      eventSupport.trigger('fancy', new FancyEvent('lorem'));
+      expect(listenersTriggered).toEqual(['c', 'b', 'a']);
+
+      eventSupport.off('fancy');
+      listenersTriggered = [];
+
+      // listeners registered for event with and without subtype
+      eventSupport.on('fancy', handlerA);
+      eventSupport.on('fancy:lorem', handlerB);
+      eventSupport.on('fancy:lorem', handlerC);
+      eventSupport.on('fancy', handlerD);
+
+      eventSupport.trigger('fancy', new FancyEvent('lorem'));
+      expect(listenersTriggered).toEqual(['a', 'b', 'c', 'd']);
+    });
   });
 
   describe('registerSubTypeProvider', () => {


### PR DESCRIPTION
Prior to the performance optimizations of the EventSupport the listeners were stored in on array. When an event was triggered all listeners were executed in the order they were added to this array. Now the listeners are stored in sets (grouped by type and handler). When an event is triggered and all listeners in one of these sets are executed they are as well execution in the order they were registered, because the iteration happens in insertion order. But if there are multiple sets relevant for an event, e.g. because the event contains a subtype, the execution in registration order was no longer guaranteed. To fix this all listeners added are enhanced with a sort index when they are registered and when an event is triggered all relevant listeners are sorted using this index.

471899