### PR TITLE
Table: fix updateColumnHeaders when column is grouped

### DIFF
--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -6479,9 +6479,10 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   }
 
   /**
+   * Updates column properties and redraws the header. Always add all affected columns, e.g. when a column is grouped and other sorted columns need to adjust their sortIndex.
    * @param columns array of columns which were updated.
    */
-  updateColumnHeaders(columns: Column[]) {
+  updateColumnHeaders(columns: ObjectOrModel<Column>[]) {
     let oldColumnState: ColumnModel;
 
     // Update model columns
@@ -6507,6 +6508,9 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
         // Adjust indices of other sort columns (if a sort column in the middle got removed, there won't necessarily be an event for the other columns)
         this._removeSortColumn(column);
       } else if (column.grouped && column.sortActive && column.sortIndex === -1) {
+        // the column was not grouped earlier, but is now -> use _addGroupColumn to update e.g. sortIndex of all other columns
+        // reset the grouped-flag as _addGroupColumn does nothing if the column is grouped already
+        column.grouped = false;
         this._addGroupColumn(column);
       } else if (column.sortActive && column.sortIndex === -1) {
         // Necessary if there is a tail sort column (there won't be an event for the tail sort column if another sort column was added before)

--- a/eclipse-scout-core/test/table/TableSpec.ts
+++ b/eclipse-scout-core/test/table/TableSpec.ts
@@ -3158,6 +3158,188 @@ describe('Table', () => {
       expect($colHeaders.eq(2).text()).toBe('<b>test</b>');
       expect($colHeaders.eq(3).text()).toBe('test');
     });
+
+    it('updates the grouped state of model columns', () => {
+      table = helper.createTable(model);
+      [column0, column1, column2] = table.columns;
+
+      const getSortAndGroupInfo = (c: Column) => {
+        const {sortActive, sortAscending, sortIndex, grouped} = c;
+        return {sortActive, sortAscending, sortIndex, grouped};
+      };
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false}
+      ]);
+
+      // sort descending by column2
+      table.updateColumnHeaders([
+        {
+          ...column2,
+          sortActive: true,
+          sortAscending: false
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: true, sortAscending: false, sortIndex: 0, grouped: false}
+      ]);
+
+      // group and sort by column1
+      table.updateColumnHeaders([
+        {
+          ...column1,
+          sortActive: true,
+          sortIndex: 0,
+          grouped: true
+        },
+        {
+          ...column2,
+          sortIndex: 1
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: true, sortAscending: true, sortIndex: 0, grouped: true},
+        {sortActive: true, sortAscending: false, sortIndex: 1, grouped: false}
+      ]);
+
+      // group additionally and sort descending by column0
+      table.updateColumnHeaders([
+        {
+          ...column0,
+          sortActive: true,
+          sortAscending: false,
+          sortIndex: 1,
+          grouped: true
+        },
+        {
+          ...column2,
+          sortIndex: 2
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: true, sortAscending: false, sortIndex: 1, grouped: true},
+        {sortActive: true, sortAscending: true, sortIndex: 0, grouped: true},
+        {sortActive: true, sortAscending: false, sortIndex: 2, grouped: false}
+      ]);
+
+      // remove grouped columns
+      table.updateColumnHeaders([
+        {
+          ...column0,
+          sortActive: false,
+          sortAscending: true,
+          sortIndex: -1,
+          grouped: false
+        },
+        {
+          ...column1,
+          sortActive: false,
+          sortIndex: -1,
+          grouped: false
+        },
+        {
+          ...column2,
+          sortIndex: 0
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: true, sortAscending: false, sortIndex: 0, grouped: false}
+      ]);
+
+      // sort by column1
+      table.updateColumnHeaders([
+        {
+          ...column1,
+          sortActive: true,
+          sortIndex: 1
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: true, sortAscending: true, sortIndex: 1, grouped: false},
+        {sortActive: true, sortAscending: false, sortIndex: 0, grouped: false}
+      ]);
+
+      // add grouped to first sort column (column2)
+      table.updateColumnHeaders([
+        {
+          ...column2,
+          grouped: true
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: true, sortAscending: true, sortIndex: 1, grouped: false},
+        {sortActive: true, sortAscending: false, sortIndex: 0, grouped: true}
+      ]);
+
+      // remove grouped columns
+      table.updateColumnHeaders([
+        {
+          ...column1,
+          sortIndex: 0
+        },
+        {
+          ...column2,
+          sortActive: false,
+          sortIndex: -1,
+          grouped: false
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: true, sortAscending: true, sortIndex: 0, grouped: false},
+        {sortActive: false, sortAscending: false, sortIndex: -1, grouped: false}
+      ]);
+
+      // sort by column2
+      table.updateColumnHeaders([
+        {
+          ...column2,
+          sortActive: true,
+          sortIndex: 1
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: true, sortAscending: true, sortIndex: 0, grouped: false},
+        {sortActive: true, sortAscending: false, sortIndex: 1, grouped: false}
+      ]);
+
+      // add grouped to second sort column (column2)
+      table.updateColumnHeaders([
+        {
+          ...column1,
+          sortIndex: 1
+        },
+        {
+          ...column2,
+          sortIndex: 0,
+          grouped: true
+        }
+      ]);
+
+      expect(table.columns.map(c => getSortAndGroupInfo(c))).toEqual([
+        {sortActive: false, sortAscending: true, sortIndex: -1, grouped: false},
+        {sortActive: true, sortAscending: true, sortIndex: 1, grouped: false},
+        {sortActive: true, sortAscending: false, sortIndex: 0, grouped: true}
+      ]);
+    });
   });
 
   describe('headerVisible', () => {


### PR DESCRIPTION
When a column is grouped or sorted on the UI server, all changed column properties are sent to the browser and set on the columns using Table.updateColumnHeaders. If a column is grouped but was not grouped earlier _addGroupColumn ensures that the sortIndex of this column and all other columns are updated correctly (e.g. because other sort columns need to be moved as grouped columns always sort first). But as _addGroupColumn does nothing if the grouped flag is already set, the grouped flag needs to be reset before calling _addGroupColumn or otherwise the sort indices may be corrupt.

473226