### PR TITLE
TableTileGridMediator: update group order on row order change

### DIFF
--- a/eclipse-scout-core/src/table/TableTileGridMediator.ts
+++ b/eclipse-scout-core/src/table/TableTileGridMediator.ts
@@ -526,6 +526,14 @@ export class TableTileGridMediator extends Widget implements TableTileGridMediat
     }
     this.tiles = this.table.rows.map(row => this.tilesMap[row.id]);
     this.tileAccordion.setTiles(this.tiles);
+
+    // row order changes may affect group order
+    // collect all groups in the order they are present on the tiles in a Set (maintains insertion order and removes duplicates)
+    const groups = new Set(this.tiles.map(tile => this.tileAccordion.getGroupByTile(tile)));
+    // add all unused groups
+    this.tileAccordion.groups.forEach(group => groups.add(group));
+    // update groups
+    this.tileAccordion.setGroups([...groups]);
   }
 
   /** @internal */

--- a/eclipse-scout-core/test/table/TableTileModeSpec.ts
+++ b/eclipse-scout-core/test/table/TableTileModeSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -64,10 +64,14 @@ describe('TableTileModeSpec', () => {
     });
 
     it('groups data', () => {
-      table.columns[0].grouped = true;
-      table.sort(table.columns[0], 'desc');
       table.setTileMode(true);
-      expect(table.tableTileGridMediator.tileAccordion.groups.length).toBe(5);
+      expect(table.tableTileGridMediator.tileAccordion.groups.map(g => g.id)).toEqual(['default']);
+
+      table.group(table.columns[0], 'desc');
+      expect(table.tableTileGridMediator.tileAccordion.groups.map(g => g.id)).toEqual(['4_0', '3_0', '2_0', '1_0', '0_0']);
+
+      table.sort(table.columns[0], 'asc');
+      expect(table.tableTileGridMediator.tileAccordion.groups.map(g => g.id)).toEqual(['0_0', '1_0', '2_0', '3_0', '4_0']);
     });
 
     it('filters data (key filter)', () => {


### PR DESCRIPTION
When the row order of the table changes the order of the groups may be affected and needs to be updated (e.g. if a grouped column changes its sort direction).
Therefore, sort the groups in the order they appear on the already sorted tiles when processing a 'rowOrderChanged' event.

473309