### PR TITLE
PageWithTable maxRowCount must not be overwritten with server value

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/PageWithTable.ts
@@ -589,14 +589,16 @@ export class PageWithTable extends Page implements PageWithTableModel {
     }
   }
 
+  // see org.eclipse.scout.rt.client.ui.desktop.outline.pages.AbstractPageWithTable.setResultInfo
   protected _readLimitedResultInfo(numRows: number, limitedResultInfoDo?: LimitedResultInfoContributionDo) {
     if (!limitedResultInfoDo) {
       return;
     }
     // update table properties. The footer is automatically updated after the new rows have been created
-    if (scout.create(TableMaxResultsHelper).isLoadMoreDataPossible(numRows, limitedResultInfoDo.estimatedRowCount, limitedResultInfoDo.maxRowCount)) {
-      // only update if the next load would be a ReloadReason.OVERRIDE_ROW_LIMIT so that the new limit is used
-      this.detailTable.setMaxRowCount(limitedResultInfoDo.maxRowCount);
+    this.detailTable.setMaxRowCountServer(limitedResultInfoDo.maxRowCount);
+    if (limitedResultInfoDo.limitedResult && limitedResultInfoDo.estimatedRowCount > 0) {
+      // if there is an estimation, but it is lower than the actual rows: correct it
+      limitedResultInfoDo.estimatedRowCount = Math.max(numRows + 1, limitedResultInfoDo.estimatedRowCount);
     }
     this.detailTable.setEstimatedRowCount(limitedResultInfoDo.estimatedRowCount);
   }

--- a/eclipse-scout-core/src/table/Table.ts
+++ b/eclipse-scout-core/src/table/Table.ts
@@ -94,6 +94,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   visibleRows: TableRow[];
   estimatedRowCount: number;
   maxRowCount: number;
+  maxRowCountServer: number;
   aggregateRowHeight: number;
   truncatedCellTooltipEnabled: boolean;
   checkableColumn: BooleanColumn;
@@ -226,6 +227,7 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
     this.visibleRows = [];
     this.estimatedRowCount = 0;
     this.maxRowCount = 0;
+    this.maxRowCountServer = 0;
     this.truncatedCellTooltipEnabled = null;
     this.visibleRowsMap = {};
     this.rowLevelPadding = 0;
@@ -5855,6 +5857,13 @@ export class Table extends Widget implements TableModel, Filterable<TableRow> {
   /** @see TableModel.maxRowCount */
   setMaxRowCount(maxRowCount: number) {
     this.setProperty('maxRowCount', maxRowCount);
+  }
+
+  /**
+   * Sets the new value of the maxRowCount received from the server.
+   */
+  setMaxRowCountServer(maxRowCountServer: number) {
+    this.setProperty('maxRowCountServer', maxRowCountServer);
   }
 
   /** @see TableModel.estimatedRowCount */

--- a/eclipse-scout-core/src/table/TableAdapter.ts
+++ b/eclipse-scout-core/src/table/TableAdapter.ts
@@ -39,6 +39,8 @@ export class TableAdapter extends ModelAdapter {
     if (this.widget.hasUserFilter()) {
       this._onWidgetFilter();
     }
+
+    this.widget.maxRowCountServer = this.widget.maxRowCount; // in scout classic maxRowCount always comes from the server.
   }
 
   protected _sendRowsSelected(rowIds: string[], debounceSend?: boolean) {
@@ -685,6 +687,11 @@ export class TableAdapter extends ModelAdapter {
     model.objectType = scout.nvl(model.objectType, 'TableRow');
     defaultValues.applyTo(model);
     return model;
+  }
+
+  protected _syncMaxRowCount(maxRowCount: number) {
+    this.widget.setMaxRowCount(maxRowCount);
+    this.widget.setMaxRowCountServer(maxRowCount);
   }
 
   protected static _createRowRemote(this: Table & { modelAdapter: TableAdapter; _createRowOrig }, rowModel: TableRowModel): TableRow {

--- a/eclipse-scout-core/src/table/TableEventMap.ts
+++ b/eclipse-scout-core/src/table/TableEventMap.ts
@@ -241,6 +241,7 @@ export interface TableEventMap extends WidgetEventMap {
   'propertyChange:viewRangeSize': PropertyChangeEvent<number>;
   'propertyChange:virtual': PropertyChangeEvent<boolean>;
   'propertyChange:maxRowCount': PropertyChangeEvent<number>;
+  'propertyChange:maxRowCountServer': PropertyChangeEvent<number>;
   'propertyChange:estimatedRowCount': PropertyChangeEvent<number>;
   'propertyChange:asyncLoading': PropertyChangeEvent<boolean>;
 }

--- a/eclipse-scout-core/src/table/TableFooter.ts
+++ b/eclipse-scout-core/src/table/TableFooter.ts
@@ -306,10 +306,10 @@ export class TableFooter extends Widget implements TableFooterModel {
   }
 
   protected _renderInfoLoad() {
-    let $info = this._infoLoadAction.$container,
-      numRows = this.table.rows.length,
-      estRows = this.table.estimatedRowCount,
-      maxRows = this.table.maxRowCount;
+    const $info = this._infoLoadAction.$container;
+    const numRows = this.table.rows.length;
+    const estRows = this.table.estimatedRowCount;
+    const maxRowsServer = this.table.maxRowCountServer;
 
     $info.empty();
     let $infoButton;
@@ -322,11 +322,11 @@ export class TableFooter extends Widget implements TableFooterModel {
         $info.appendSpan().text(this.session.text('ui.NumRowsLoaded', this.computeCountInfo(numRows)));
       }
       if (this.table.hasReloadHandler) {
-        if (scout.create(TableMaxResultsHelper).isLoadMoreDataPossible(numRows, estRows, maxRows)) {
-          if (estRows < maxRows) {
+        if (scout.create(TableMaxResultsHelper).isLoadMoreDataPossible(numRows, estRows)) {
+          if (estRows < maxRowsServer) {
             $infoButton = $info.appendSpan('table-info-button').text(this.session.text('ui.LoadAllData')).appendTo($info);
           } else {
-            $infoButton = $info.appendSpan('table-info-button').text(this.session.text('ui.LoadNData', this.computeCountInfo(maxRows))).appendTo($info);
+            $infoButton = $info.appendSpan('table-info-button').text(this.session.text('ui.LoadNData', this.computeCountInfo(maxRowsServer))).appendTo($info);
           }
         } else {
           $infoButton = $info.appendSpan('table-info-button').text(this.session.text('ui.ReloadData')).appendTo($info);
@@ -814,8 +814,7 @@ export class TableFooter extends Widget implements TableFooterModel {
     } else {
       let numRows = this.table.rows.length;
       let estRows = this.table.estimatedRowCount;
-      let maxRows = this.table.maxRowCount;
-      if (scout.create(TableMaxResultsHelper).isLoadMoreDataPossible(numRows, estRows, maxRows)) {
+      if (scout.create(TableMaxResultsHelper).isLoadMoreDataPossible(numRows, estRows)) {
         this.table.reload(Table.ReloadReason.OVERRIDE_ROW_LIMIT);
       } else {
         this.table.reload();

--- a/eclipse-scout-core/src/table/TableMaxResultsHelper.ts
+++ b/eclipse-scout-core/src/table/TableMaxResultsHelper.ts
@@ -15,11 +15,10 @@ export class TableMaxResultsHelper {
    * Checks if more data could be loaded into the table.
    * @param numRows The number of currently loaded rows of the table.
    * @param estRows The number of estimated rows that would be available.
-   * @param maxRows The number of maximum rows that are allowed to be loaded.
-   * @returns true if a estRows and maxRows are available and the currently loaded number of rows (numRows) is smaller than the two. This means more data could be loaded.
+   * @returns true if a estRows is available and the currently loaded number of rows (numRows) is smaller. This means more data could be loaded.
    */
-  isLoadMoreDataPossible(numRows: number, estRows: number, maxRows: number): boolean {
-    return estRows > 0 && maxRows > 0 && numRows < estRows && numRows < maxRows;
+  isLoadMoreDataPossible(numRows: number, estRows: number): boolean {
+    return estRows > 0 && numRows < estRows;
   }
 
   /**
@@ -60,6 +59,9 @@ export class TableMaxResultsHelper {
    * @returns the maximum number of rows for the given table and reload reason.
    */
   getMaxTableRowCount(table: Table, reloadReason: TableReloadReason): number {
+    if (Table.ReloadReason.OVERRIDE_ROW_LIMIT === reloadReason) {
+      return 0; // no limit
+    }
     return table?.maxRowCount;
   }
 }

--- a/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
+++ b/eclipse-scout-core/test/desktop/outline/pages/PageWithTableSpec.ts
@@ -163,9 +163,68 @@ describe('PageWithTable', () => {
     page._transformTableDataToTableRows = data => undefined;
     page.detailTable.reload();
     await page.detailTable.when('propertyChange:loading');
-    expect(page.detailTable.maxRowCount).toBe(456);
+    expect(page.detailTable.maxRowCountServer).toBe(456);
+    expect(page.detailTable.maxRowCount).toBe(0);
     expect(page.detailTable.estimatedRowCount).toBe(1111);
     expect(page.detailTable.tableStatus.message).toBe('[undefined text: MaxOutlineRowWarningWithEstimatedRowCount]');
+  });
+
+  it('server row limits do not overwrite client model', async () => {
+    const serverLimit = 5;
+    const clientLimit = 3;
+    const allData = [{cells: [1]}, {cells: [2]}, {cells: [3]}, {cells: [4]}, {cells: [5]}, {cells: [6]}];
+
+    page.detailTable.setMaxRowCount(clientLimit);
+    page._loadTableData = searchFilter => {
+      searchFilter = page._withMaxRowCountContribution(searchFilter);
+      const maxRowsContribution = searchFilter?._contributions?.[0] as MaxRowCountContributionDo;
+      const limit = Math.min(maxRowsContribution?.hint || Number.MAX_SAFE_INTEGER, serverLimit);
+      const data = allData.slice(0, limit);
+      return $.resolvedPromise({
+        rows: data,
+        _contributions: [{
+          _type: 'scout.LimitedResultInfoContribution',
+          limitedResult: data.length < allData.length,
+          maxRowCount: serverLimit,
+          estimatedRowCount: allData.length
+        }]
+      });
+    };
+    page._transformTableDataToTableRows = res => res.rows;
+    expect(page.detailTable.maxRowCount).toBe(clientLimit);
+
+    page.detailTable.reload();
+    await page.detailTable.when('propertyChange:loading');
+    expect(page.detailTable.maxRowCountServer).toBe(serverLimit);
+    expect(page.detailTable.maxRowCount).toBe(clientLimit);
+    expect(page.detailTable.estimatedRowCount).toBe(allData.length);
+    expect(page.detailTable.tableStatus.message).toBe('[undefined text: MaxOutlineRowWarningWithEstimatedRowCount]');
+    expect(page.detailTable.rows.length).toBe(clientLimit);
+    page.detailTable.reload(Table.ReloadReason.OVERRIDE_ROW_LIMIT);
+    await page.detailTable.when('propertyChange:loading');
+    expect(page.detailTable.maxRowCountServer).toBe(serverLimit);
+    expect(page.detailTable.maxRowCount).toBe(clientLimit);
+    expect(page.detailTable.estimatedRowCount).toBe(allData.length);
+    expect(page.detailTable.rows.length).toBe(serverLimit);
+    expect(page.detailTable.tableStatus.message).toBe('[undefined text: MaxOutlineRowWarningWithEstimatedRowCount]');
+  });
+
+  it('corrects wrong row estimation', async () => {
+    page._loadTableData = searchFilter => {
+      return $.resolvedPromise({
+        _contributions: [{
+          _type: 'scout.LimitedResultInfoContribution',
+          limitedResult: true,
+          estimatedRowCount: 2 // estimation is lower than actual rows
+        }]
+      });
+    };
+    page._transformTableDataToTableRows = data => [{cells: [1]}, {cells: [2]}, {cells: [3]}, {cells: [4]}];
+    page.detailTable.reload();
+    await page.detailTable.when('propertyChange:loading');
+
+    expect(page.detailTable.estimatedRowCount).toBe(5); // expect to be one more than actual rows (corrected estimation)
+    expect(page.detailTable.rows.length).toBe(4);
   });
 
   it('stores reload reason', async () => {

--- a/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/table/MaxResultsHelper.java
+++ b/org.eclipse.scout.rt.api.data/src/main/java/org/eclipse/scout/rt/api/data/table/MaxResultsHelper.java
@@ -141,6 +141,7 @@ public class MaxResultsHelper {
     private int m_requestedMaxResults; // <= 0 if not specified
     private boolean m_estimateRowCountEnabled;
     private int m_estimatedRowCount; // <= 0 if not specified
+    private LimitedResultInfoContributionDo m_limitedResultInfoContributionDo;
 
     /**
      * @param maxResultsLimit
@@ -224,7 +225,7 @@ public class MaxResultsHelper {
      * <li>The maximum number of entries that are allowed
      * ({@link LimitedResultInfoContributionDo#getMaxRowCount()})</li>
      * <li>({@link LimitedResultInfoContributionDo#getEstimatedRowCount()}) An estimation how may rows would be
-     * available Must be set using {@link #setEstimatedRowCount(int)}.</li>
+     * available. Must be set using {@link #setEstimatedRowCount(int)}.</li>
      * </ol>
      * <p>
      * <b>Note</b>: The given data {@link List} is directly modified! No new list is created! The returned list is the
@@ -250,6 +251,7 @@ public class MaxResultsHelper {
         // only set estimation if limited
         contribution.withEstimatedRowCount(getEstimatedRowCount());
       }
+      m_limitedResultInfoContributionDo = contribution;
       return result;
     }
 
@@ -340,6 +342,40 @@ public class MaxResultsHelper {
      */
     public void setEstimatedRowCount(int estimatedRowCount) {
       m_estimatedRowCount = estimatedRowCount;
+    }
+
+    /**
+     * @return The {@link LimitedResultInfoContributionDo} or {@code null}. A value can be set by calling {@link #limit(List, IDoEntity)} or {@link #setLimitedResultInfoContributionDo(LimitedResultInfoContributionDo)}.
+     */
+    public LimitedResultInfoContributionDo getLimitedResultInfoContributionDo() {
+      return m_limitedResultInfoContributionDo;
+    }
+
+    /**
+     * Sets the created {@link LimitedResultInfoContributionDo}.
+     *
+     * @param limitedResultInfoContributionDo
+     *     the new {@link LimitedResultInfoContributionDo} or {@code null}.
+     */
+    public void setLimitedResultInfoContributionDo(LimitedResultInfoContributionDo limitedResultInfoContributionDo) {
+      m_limitedResultInfoContributionDo = limitedResultInfoContributionDo;
+    }
+
+    /**
+     * Writes the current {@link #getLimitedResultInfoContributionDo()} to the given {@link IDoEntity}.
+     *
+     * @param response
+     *     The {@link IDoEntity} that should receive the {@link LimitedResultInfoContributionDo}. May be {@code null}, then this method does nothing.
+     * @return The input {@link IDoEntity}.
+     */
+    public <T extends IDoEntity> T applyResultInfoTo(T response) {
+      if (response != null) {
+        LimitedResultInfoContributionDo resultInfo = getLimitedResultInfoContributionDo();
+        if (resultInfo != null) {
+          response.putContribution(resultInfo);
+        }
+      }
+      return response;
     }
   }
 }

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/AbstractPageWithTable.java
@@ -694,6 +694,23 @@ public abstract class AbstractPageWithTable<T extends ITable> extends AbstractPa
   }
 
   @Override
+  public void setResultInfo(boolean limitedResult, int maxRowCount, long estimatedRowCount) {
+    T table = getTable(false);
+    if (table == null) {
+      return;
+    }
+
+    // see also PageWithTable.ts#_readLimitedResultInfo
+    setLimitedResult(limitedResult);
+    if (limitedResult && estimatedRowCount > 0) {
+      // if there is an estimation, but it is lower than the actual rows: correct it
+      estimatedRowCount = Math.max(table.getRowCount() + 1L, estimatedRowCount);
+    }
+    table.setEstimatedRowCount(estimatedRowCount);
+    table.setMaxRowCount(maxRowCount);
+  }
+
+  @Override
   public boolean isAlwaysCreateChildPage() {
     return FLAGS_BIT_HELPER.isBitSet(ALWAYS_CREATE_CHILD_PAGE, m_flags);
   }
@@ -734,9 +751,7 @@ public abstract class AbstractPageWithTable<T extends ITable> extends AbstractPa
     }
 
     table.importFromTableBeanData(tablePageData);
-    setLimitedResult(tablePageData.isLimitedResult());
-    table.setEstimatedRowCount(tablePageData.getEstimatedRowCount());
-    table.setMaxRowCount(tablePageData.getMaxRowCount());
+    setResultInfo(tablePageData.isLimitedResult(), tablePageData.getMaxRowCount(), tablePageData.getEstimatedRowCount());
   }
 
   /**

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/IPageWithTable.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/IPageWithTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,18 @@ public interface IPageWithTable<T extends ITable> extends IPage<T> {
   boolean isSearchActive();
 
   void setSearchActive(boolean b);
+
+  /**
+   * Apply result meta info to this page.
+   *
+   * @param limitedResult
+   *     If the result was limited (not complete)
+   * @param maxRowCount
+   *     Maximum row count the user is allowed to load into this table.
+   * @param estimatedRowCount
+   *     In case the result was limited, how many rows that are estimated to be available in total.
+   */
+  void setResultInfo(boolean limitedResult, int maxRowCount, long estimatedRowCount);
 
   /**
    * @since 6.0


### PR DESCRIPTION
If a page declares a client side maxRowCount property, it must be kept after loading data from the server to ensure a subsequent reload does not load more data than requested in the property.

Only if the reloadReason is OVERRIDE_ROW_LIMIT, the client side property can be ignored to fetch as many data as the server allows.

For this the limits from the server must be stored in an extra property.

473678