### PR TITLE
Bind REST resources as singletons and mark IRestResource as ApplicationScoped

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.server/src/main/java/org/eclipse/scout/rt/rest/jersey/server/ResourceBinderContributor.java
+++ b/org.eclipse.scout.rt.rest.jersey.server/src/main/java/org/eclipse/scout/rt/rest/jersey/server/ResourceBinderContributor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.server;
+
+import static java.util.Collections.singleton;
+import static org.eclipse.scout.rt.rest.RestApplicationContributors.lookupBeanClasses;
+
+import java.util.Set;
+
+import jakarta.inject.Singleton;
+
+import org.eclipse.scout.rt.rest.IRestResource;
+import org.eclipse.scout.rt.rest.RestApplication.IRestApplicationSingletonsContributor;
+import org.glassfish.jersey.inject.hk2.AbstractBinder;
+
+/**
+ * Registers all {@link IRestResource} implementations in {@link Singleton} scope,
+ * allowing Jersey/HK2 to reuse a single instance per resource.
+ */
+public class ResourceBinderContributor implements IRestApplicationSingletonsContributor {
+  @Override
+  public Set<Object> contribute() {
+    return singleton(new AbstractBinder() {
+      @Override
+      protected void configure() {
+        lookupBeanClasses(IRestResource.class)
+            .forEach(resourceClass -> bindAsContract(resourceClass)
+                .in(Singleton.class));
+      }
+    });
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/CountResource.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/CountResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.fixture;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.scout.rt.rest.IRestResource;
+
+@Path("count")
+public class CountResource implements IRestResource {
+
+  protected final AtomicInteger m_counter = new AtomicInteger();
+
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  public int getCount() {
+    return m_counter.getAndIncrement();
+  }
+}

--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/server/CountResourceTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/server/CountResourceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.server;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.ws.rs.client.WebTarget;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.rest.jersey.JerseyTestApplication;
+import org.eclipse.scout.rt.rest.jersey.JerseyTestRestClientHelper;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PlatformTestRunner.class)
+public class CountResourceTest {
+
+  @BeforeClass
+  public static void beforeClass() {
+    BEANS.get(JerseyTestApplication.class).ensureStarted();
+  }
+
+  @Test
+  public void testCount() {
+    JerseyTestRestClientHelper helper = BEANS.get(JerseyTestRestClientHelper.class);
+    WebTarget target = helper.target("api/count");
+    // assert incrementing counter (resource is application scoped and is able to retain internal state)
+    for (int i = 0; i < 3; i++) {
+      Integer count = target.request().get(Integer.class);
+      assertEquals(Integer.valueOf(i), count);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/IRestResource.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/IRestResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,11 +9,11 @@
  */
 package org.eclipse.scout.rt.rest;
 
-import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.ApplicationScoped;
 
 /**
  * Marks a class as REST resource so that it can be found by {@link RestApplication} using jandex.
  */
-@Bean
+@ApplicationScoped
 public interface IRestResource {
 }


### PR DESCRIPTION
Register all IRestResource implementations in HK2 Singleton scope so
that Jersey reuses resource instances instead of creating a new
instance for each request.

473791