### PR TITLE
Table: fix filter if table text filter is removed and added again

### DIFF
--- a/eclipse-scout-core/src/table/TableFooter.ts
+++ b/eclipse-scout-core/src/table/TableFooter.ts
@@ -126,6 +126,7 @@ export class TableFooter extends Widget implements TableFooterModel {
     let filter = this.table.getFilter(TableTextUserFilter.TYPE) as TableTextUserFilter;
     if (filter) {
       this._$textFilter.val(filter.text);
+      this.filterText = filter.text;
     }
     this.$clearIcon = $filter.appendSpan('clear-icon unfocusable action text-field-icon')
       .on('mousedown', this._onDeleteFilterMouseDown.bind(this));
@@ -792,17 +793,15 @@ export class TableFooter extends Widget implements TableFooterModel {
   }
 
   protected _applyFilter() {
-    let filterText = this._$textFilter.val() as string;
+    let filterText = this._$textFilter.val();
     if (this.filterText !== filterText) {
       this.filterText = filterText;
       if (filterText) {
-        let filter = scout.create(TableTextUserFilter, {
+        this.table.addFilter(scout.create(TableTextUserFilter, {
           session: this.session,
-          table: this.table
-        });
-
-        filter.text = filterText;
-        this.table.addFilter(filter);
+          table: this.table,
+          text: filterText
+        }));
       } else {
         this.table.removeFilterByKey(TableTextUserFilter.TYPE);
       }
@@ -860,6 +859,7 @@ export class TableFooter extends Widget implements TableFooterModel {
       let currentText = this._$textFilter.val();
       if (currentText !== textFilter.text) {
         this._$textFilter.val(textFilter.text);
+        this.filterText = textFilter.text;
         this._updateHasFilterText();
       }
     }

--- a/eclipse-scout-core/src/table/TableFooterModel.ts
+++ b/eclipse-scout-core/src/table/TableFooterModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,5 +11,4 @@ import {Table, WidgetModel} from '../index';
 
 export interface TableFooterModel extends WidgetModel {
   table?: Table;
-  filterText?: string;
 }

--- a/eclipse-scout-core/test/table/TableFooterSpec.ts
+++ b/eclipse-scout-core/test/table/TableFooterSpec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {scout, Status, TableControl, TableTextUserFilter} from '../../src/index';
+import {scout, Status, Table, TableControl, TableTextUserFilter} from '../../src/index';
 import {JQueryTesting, TableSpecHelper} from '../../src/testing/index';
 import $ from 'jquery';
 
@@ -52,6 +52,21 @@ describe('TableFooterSpec', () => {
       expect(table.events.count()).toBe(listenerCount);
     });
 
+    it('initializes the filter text from an existing table text filter', () => {
+      let model = helper.createModelFixture(2);
+      model.tableStatusVisible = true;
+      let table = helper.createTable(model);
+      table.addFilter(scout.create(TableTextUserFilter, {
+        session: session,
+        table: table,
+        text: 'text'
+      }));
+
+      expect(table.footer.filterText).toBe(undefined);
+      table.render();
+      expect(table.footer.filterText).toBe('text');
+      expect(table.footer.$container.find('.table-text-filter').val()).toBe('text');
+    });
   });
 
   describe('remove', () => {
@@ -291,9 +306,9 @@ describe('TableFooterSpec', () => {
   });
 
   describe('text filter', () => {
-    let table;
-    let $filterInput;
-    let $filterInfo;
+    let table: Table;
+    let $filterInput: JQuery;
+    let $filterInfo: JQuery;
 
     beforeEach(() => {
       table = helper.createTable(helper.createModelFixture(2, 2));
@@ -359,6 +374,30 @@ describe('TableFooterSpec', () => {
 
       // Ensure filter can be added again
       addTextFilterAndAssert();
+    });
+
+    it('updates filter info if table text filter is added or removed programmatically', () => {
+      let textFilter = scout.create(TableTextUserFilter, {
+        session: session,
+        table: table,
+        text: 'text'
+      });
+
+      table.addFilter(textFilter);
+      expect(table.footer.filterText).toBe('text');
+      expect($filterInput.val()).toBe('text');
+      expect($filterInfo).not.toBeHidden();
+
+      table.removeFilter(textFilter);
+      expect(table.footer.filterText).toBe('');
+      expect($filterInput.val()).toBe('');
+      expect($filterInfo).toHaveClass('hiding');
+
+      // Ensure filter can be added again
+      table.addFilter(textFilter);
+      expect(table.footer.filterText).toBe('text');
+      expect($filterInput.val()).toBe('text');
+      expect($filterInfo).not.toBeHidden();
     });
   });
 


### PR DESCRIPTION
The previous change 095758a89c06924de8332c38e4da87ec5ec633f2 correctly updated the 'filterText' property when the table text filter was removed programmatically. However, when a table text filter was added, the property was not updated, only the input field.

472907