### PR TITLE
Add RemoveChildPagesHybridAction

### DIFF
--- a/eclipse-scout-core/src/desktop/outline/pages/js/JsPageHelper.ts
+++ b/eclipse-scout-core/src/desktop/outline/pages/js/JsPageHelper.ts
@@ -219,7 +219,7 @@ export class JsPageHelper implements JsPageHelperModel, ObjectWithType {
   }
 
   /**
-   * Calls loadChildPages on the UI server for the given ids or {@link PageParamDo}s. The pages are created by the Java equivalent of the JsPage (see AbstractJsPage.createChildPage).
+   * Calls `loadChildPages` on the UI server for the given ids or {@link PageParamDo}s. The pages are created by the Java equivalent of the JsPage (see AbstractJsPage.createChildPage).
    * The returned {@link Promise} is resolved when all child pages are created on the UI server.
    *
    * @param idsOrPageParams ids or {@link PageParamDo}s that are used to create child pages on the UI server.
@@ -267,6 +267,22 @@ export class JsPageHelper implements JsPageHelperModel, ObjectWithType {
     // As the session processes all events in the response synchronously the nodesInserted-event is processed before the Promise that is waiting for the hybrid action to complete is resolved.
     // Therefore, all child pages created on the UI server are already inserted into the tree, and they can be collected into the child pages map.
     this._addChildPagesToIdMap();
+  }
+
+  /**
+   * Calls `removeChildPages` on the UI server.
+   * The returned {@link Promise} is resolved when all child pages are removed on the UI server.
+   */
+  async callRemoveChildPages(): Promise<void> {
+    if (!this.page.childNodes.length) {
+      return;
+    }
+    const hybridManager = await HybridManager.get(this.page.session, true);
+    await hybridManager.callActionAndWaitWithContext('scout.RemoveChildPages',
+      null,
+      scout.create(HybridActionContextElements)
+        .withElement('page', HybridActionContextElement.of(this.outline, this.page))
+    );
   }
 
   /**

--- a/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/RemoveChildPagesHybridAction.java
+++ b/org.eclipse.scout.rt.client/src/main/java/org/eclipse/scout/rt/client/ui/desktop/outline/pages/js/RemoveChildPagesHybridAction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.client.ui.desktop.outline.pages.js;
+
+import org.eclipse.scout.rt.client.ui.desktop.hybrid.AbstractHybridAction;
+import org.eclipse.scout.rt.client.ui.desktop.hybrid.HybridActionType;
+import org.eclipse.scout.rt.dataobject.IDoEntity;
+
+@HybridActionType(RemoveChildPagesHybridAction.TYPE)
+public class RemoveChildPagesHybridAction extends AbstractHybridAction<IDoEntity> {
+
+  protected static final String TYPE = "scout.RemoveChildPages";
+
+  @Override
+  public void execute(IDoEntity data) {
+    try {
+      var jsPage = getContextElement("page").getElement(IJsPage.class);
+      jsPage.getTree().removeAllChildNodes(jsPage);
+    }
+    finally { // always signal the end of the action to the UI, even in the case of an error on the server
+      fireHybridActionEndEvent();
+    }
+  }
+}


### PR DESCRIPTION
The action is necessary if a js page uses searchRequired. In that case PageWithTable._resetTableData has to remove the remote child pages first before any table row can be deleted. Why? Because deleting the rows will also delete the child pages, but the ui is not allowed to delete pages managed by the server. There may still be a response pending containing events for these remote pages which would result in an error if they cannot be found.

474004