### PR TITLE
Use IDateProvider instead of DateProvider

### DIFF
--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/date/FixedDateProvider.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/date/FixedDateProvider.java
@@ -9,22 +9,25 @@
  */
 package org.eclipse.scout.rt.testing.platform.util.date;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Calendar;
 import java.util.Date;
 
 import org.eclipse.scout.rt.platform.IBeanManager;
 import org.eclipse.scout.rt.platform.IgnoreBean;
-import org.eclipse.scout.rt.platform.util.Assertions;
 import org.eclipse.scout.rt.platform.util.date.DateProvider;
+import org.eclipse.scout.rt.platform.util.date.IDateProvider;
 
 /**
- * A date / time provider for testing whose methods return the same date and time when called repeatedly. This provider
- * needs to be registered <strong>manually</strong> with the {@link IBeanManager}.
- *
- * @since 5.2
+ * A {@link IDateProvider} for testing whose methods return the same date and time when called repeatedly.
+ * <p>
+ * NOTE: This provider needs to be registered <strong>manually</strong> with the {@link IBeanManager}.
  */
 @IgnoreBean
+@SuppressWarnings("deprecation")
 public class FixedDateProvider extends DateProvider {
+
   private volatile Date m_date;
 
   /**
@@ -53,7 +56,7 @@ public class FixedDateProvider extends DateProvider {
    */
   public void setTimeMillis(long newTimeMillis) {
     setDate(new Date(newTimeMillis));
-    Assertions.assertEquals(newTimeMillis, currentUTCMillis());
+    assertEquals(newTimeMillis, currentUTCMillis());
   }
 
   /**
@@ -84,7 +87,7 @@ public class FixedDateProvider extends DateProvider {
   @Override
   public Calendar currentCalendar() {
     Calendar currentCalendar = super.currentCalendar();
-    currentCalendar.setTime(m_date);
+    currentCalendar.setTime(getDate());
     return currentCalendar;
   }
 }

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/date/FixedDateRule.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/date/FixedDateRule.java
@@ -46,7 +46,7 @@ public class FixedDateRule extends AbstractScoutTestRule {
 
       @Override
       public void evaluate() throws Throwable {
-        // NOTE: register IDateProvider and NOT DateProvider -> there should be no BEANS.get(DateProvider.class) calls
+        // NOTE: register IDateProvider and NOT DateProvider -> there should be no BEANS.get(IDateProvider.class) calls
         IBean<Object> bean = BeanTestingHelper.get().registerBean(new BeanMetaData(IDateProvider.class, getDateProvider()));
         try {
           base.evaluate();

--- a/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/date/LogicalTimeDateProvider.java
+++ b/org.eclipse.scout.rt.platform.test/src/main/java/org/eclipse/scout/rt/testing/platform/util/date/LogicalTimeDateProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.testing.platform.util.date;
+
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.scout.rt.platform.IBeanManager;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.util.date.DateUtility;
+import org.eclipse.scout.rt.platform.util.date.IDateProvider;
+
+/**
+ * A {@link IDateProvider} for testing that is initialized with the current {@link Date} and ticks one minute on every
+ * invocation.<p>
+ * NOTE: This provider needs to be registered <strong>manually</strong> with the {@link IBeanManager}.
+ */
+@IgnoreBean
+public class LogicalTimeDateProvider extends FixedDateProvider {
+
+  private final AtomicInteger m_counter = new AtomicInteger();
+
+  public LogicalTimeDateProvider() {
+    super();
+  }
+
+  public LogicalTimeDateProvider(Date date) {
+    super(date);
+  }
+
+  @Override
+  public Date getDate() {
+    return DateUtility.addMinutes(super.getDate(), m_counter.getAndIncrement());
+  }
+}

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/date/DateProviderTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/date/DateProviderTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 /**
  * Tests for {@link DateProvider}
  */
+@SuppressWarnings("deprecation")
 public class DateProviderTest {
 
   @Test
@@ -52,7 +53,7 @@ public class DateProviderTest {
 
     GregorianCalendar returnedCalendar = new GregorianCalendar();
     returnedCalendar.setTime(returned);
-    assertEquals("Milliseconds value of truncated date must be 0", returnedCalendar.get(GregorianCalendar.MILLISECOND), 0);
+    assertEquals("Milliseconds value of truncated date must be 0", 0, returnedCalendar.get(GregorianCalendar.MILLISECOND));
   }
 
   @Test

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/date/FixedDateProviderTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/date/FixedDateProviderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.util.date;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import org.eclipse.scout.rt.testing.platform.util.date.FixedDateProvider;
+import org.junit.Test;
+
+/**
+ * Testcases for {@link FixedDateProvider}
+ */
+public class FixedDateProviderTest {
+
+  private static final Date NOW = new Date();
+
+  @Test
+  public void testGetDate() {
+    FixedDateProvider fixedDateProvider = new FixedDateProvider();
+    assertEquals(fixedDateProvider.getDate(), fixedDateProvider.currentMillis());
+
+    fixedDateProvider = new FixedDateProvider(NOW);
+    assertEquals(NOW, fixedDateProvider.getDate());
+  }
+
+  @Test
+  public void testSetDate() {
+    FixedDateProvider fixedDateProvider = new FixedDateProvider(NOW);
+    assertEquals(NOW, fixedDateProvider.getDate());
+    Date date = DateUtility.addDays(NOW, 1);
+    fixedDateProvider.setDate(date);
+    assertEquals(date, fixedDateProvider.getDate());
+  }
+
+  @Test
+  public void testSetTimeMillis() {
+    FixedDateProvider fixedDateProvider = new FixedDateProvider(NOW);
+    fixedDateProvider.setTimeMillis(1000);
+    assertEquals(1000, fixedDateProvider.currentUTCMillis());
+  }
+
+  @Test
+  public void testCurrentCalendar() {
+    FixedDateProvider fixedDateProvider = new FixedDateProvider(NOW);
+    Calendar calendar = fixedDateProvider.currentCalendar();
+    assertEquals(NOW, calendar.getTime());
+  }
+}

--- a/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/date/LogicalTimeDateProviderTest.java
+++ b/org.eclipse.scout.rt.platform.test/src/test/java/org/eclipse/scout/rt/platform/util/date/LogicalTimeDateProviderTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.platform.util.date;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Date;
+
+import org.eclipse.scout.rt.testing.platform.util.date.LogicalTimeDateProvider;
+import org.junit.Test;
+
+/**
+ * Testcases for {@link LogicalTimeDateProvider}
+ */
+public class LogicalTimeDateProviderTest {
+
+  private static final Date NOW = new Date();
+
+  @Test
+  public void testGetDate() {
+    LogicalTimeDateProvider dateProvider = new LogicalTimeDateProvider(NOW);
+    assertEquals(NOW, dateProvider.getDate());
+    for (int i = 1; i <= 5; i++) {
+      assertEquals(DateUtility.addMinutes(NOW, i), dateProvider.getDate());
+    }
+  }
+}

--- a/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/date/DateProvider.java
+++ b/org.eclipse.scout.rt.platform/src/main/java/org/eclipse/scout/rt/platform/util/date/DateProvider.java
@@ -17,7 +17,10 @@ import java.util.TimeZone;
  * Simple Date provider implementation.
  *
  * @since 5.2
+ * @deprecated Do not call this class directly but interact with {@link IDateProvider} instead.
  */
+@Deprecated
+@SuppressWarnings("DeprecatedIsStillUsed")
 public class DateProvider implements IDateProvider {
 
   protected Date getDate() {


### PR DESCRIPTION
- Cleanup DateProvider usages in code and change to use IDateProvider instead (allow to exchange for tests).
- Use FixedDateProvider and LogicalTimeDateProvider for all unit tests

474038