### PR TITLE
Application: Add HTTP connection idle timeout, improve stream/async TO

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
@@ -57,6 +57,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationAutoCreateSelfSignedCertificateProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationCertificateAliasProperty;
+import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationConnectionIdleTimeoutProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationConsoleInputHandlerEnabledProperty;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationContextHandlerExtendedResourceLookup;
 import org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationContextPathProperty;
@@ -227,6 +228,7 @@ public class Application {
   protected ServerConnector createHttpServerConnector(Server server) {
     HttpConfiguration httpConfig = createHttpConfiguration();
     ServerConnector http = new ServerConnector(server, new HttpConnectionFactory(httpConfig), new HTTP2CServerConnectionFactory(httpConfig));
+    http.setIdleTimeout(CONFIG.getPropertyValue(ScoutApplicationConnectionIdleTimeoutProperty.class));
     return http;
   }
 
@@ -244,7 +246,7 @@ public class Application {
 
     SslConnectionFactory tls = new SslConnectionFactory(sslContextFactory, alpn.getProtocol());
     ServerConnector https = new ServerConnector(server, tls, alpn, http2, http11);
-
+    https.setIdleTimeout(CONFIG.getPropertyValue(ScoutApplicationConnectionIdleTimeoutProperty.class));
     return https;
   }
 

--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/ApplicationProperties.java
@@ -18,6 +18,8 @@ import org.eclipse.jetty.compression.gzip.GzipEncoderConfig;
 import org.eclipse.jetty.compression.server.CompressionConfig;
 import org.eclipse.jetty.compression.server.CompressionHandler;
 import org.eclipse.jetty.http.HttpCookie.SameSite;
+import org.eclipse.jetty.http2.server.AbstractHTTP2ServerConnectionFactory;
+import org.eclipse.jetty.server.AbstractConnector;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Platform;
 import org.eclipse.scout.rt.platform.config.AbstractBooleanConfigProperty;
@@ -671,6 +673,39 @@ public final class ApplicationProperties {
     }
   }
 
+  /**
+   * Sets the maximum idle time for a Jetty server connection (e.g. TCP connection socket timeout).
+   * <p>
+   * <b>Note:</b> If {@link ScoutApplicationHttpSessionEnabledProperty} is enabled, keep this value larger or equals to {@link ScoutApplicationSessionTimeoutProperty} to ensure the connection is not closed as long as a session is active.
+   *
+   * @see AbstractConnector#setIdleTimeout(long)
+   */
+  public static class ScoutApplicationConnectionIdleTimeoutProperty extends AbstractPositiveLongConfigProperty {
+
+    @Override
+    public String getKey() {
+      return "scout.app.jetty.connection.idleTimeout";
+    }
+
+    @Override
+    public Long getDefaultValue() {
+      // Do not use a short timeout in DEV mode to allow longer debugging sessions
+      return TimeUnit.MINUTES.toMillis(Platform.get().inDevelopmentMode() ? 60 : 6);
+    }
+
+    @Override
+    public String description() {
+      return "The jetty server idle timeout for HTTP and HTTPS connector in milliseconds. Default: " + getDefaultValue() + ".";
+    }
+  }
+
+  /**
+   * Sets the timeout for HTTP/2 stream connections.
+   * <p>
+   * <b>Note:</b> Keep this value smaller or equals to {@link ScoutApplicationConnectionIdleTimeoutProperty} to ensure the stream can be closed before the underlying connection is terminated.
+   *
+   * @see AbstractHTTP2ServerConnectionFactory#setStreamIdleTimeout(long)
+   */
   public static class ScoutApplicationStreamIdleTimeoutProperty extends AbstractPositiveLongConfigProperty {
 
     @Override
@@ -680,7 +715,8 @@ public final class ApplicationProperties {
 
     @Override
     public Long getDefaultValue() {
-      return TimeUnit.HOURS.toMillis(1);
+      // Do not use a short timeout in DEV mode to allow longer debugging sessions
+      return TimeUnit.MINUTES.toMillis(Platform.get().inDevelopmentMode() ? 60 : 6);
     }
 
     @Override

--- a/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxyConfigProperties.java
+++ b/org.eclipse.scout.rt.server.commons/src/main/java/org/eclipse/scout/rt/server/commons/servlet/HttpProxyConfigProperties.java
@@ -11,6 +11,9 @@ package org.eclipse.scout.rt.server.commons.servlet;
 
 import java.util.concurrent.TimeUnit;
 
+import jakarta.servlet.AsyncContext;
+
+import org.eclipse.scout.rt.platform.Platform;
 import org.eclipse.scout.rt.platform.config.AbstractClassConfigProperty;
 import org.eclipse.scout.rt.platform.config.AbstractLongConfigProperty;
 import org.eclipse.scout.rt.shared.http.async.AbstractAsyncHttpClientManager;
@@ -39,6 +42,14 @@ public final class HttpProxyConfigProperties {
     }
   }
 
+  /**
+   * Sets the timeout (in milliseconds) for the {@link AsyncContext} used by the {@link HttpProxy} when forwarding requests.
+   * <p>
+   * <b>Note:</b> Keep this value smaller or equals to {@link org.eclipse.scout.rt.app.ApplicationProperties.ScoutApplicationStreamIdleTimeoutProperty}
+   * to ensure the async context can be closed before the underlying connection is terminated.
+   *
+   * @see AsyncContext#setTimeout(long)
+   */
   public static class HttpProxyAsyncTimeoutConfigProperty extends AbstractLongConfigProperty {
 
     @Override
@@ -48,12 +59,13 @@ public final class HttpProxyConfigProperties {
 
     @Override
     public String description() {
-      return "Timeout for async servlet contexts.";
+      return "Timeout in milliseconds for async servlet contexts. Default: " + getDefaultValue() + ".";
     }
 
     @Override
     public Long getDefaultValue() {
-      return TimeUnit.HOURS.toMillis(1);
+      // Do not use a short timeout in DEV mode to allow longer debugging sessions
+      return TimeUnit.MINUTES.toMillis(Platform.get().inDevelopmentMode() ? 60 : 6);
     }
   }
 }


### PR DESCRIPTION
- Added new low-level HTTP connection timeout for HTTP/HTTPS default 6m
- Improved default value for HTTP2 stream timeout, new value 6 min
- Improved default value for HTTP async context timeout, new value 6 min

475330