### PR TITLE
REST: Add logLevel to ErrorDo

### DIFF
--- a/eclipse-scout-core/src/ErrorHandler.ts
+++ b/eclipse-scout-core/src/ErrorHandler.ts
@@ -97,6 +97,7 @@ export interface ErrorDo extends DoEntity {
   message?: string;
   correlationId?: string;
   severity?: string;
+  logLevel?: LogLevel;
 }
 
 export class ErrorHandler implements ErrorHandlerModel, ObjectWithType {
@@ -320,7 +321,7 @@ export class ErrorHandler implements ErrorHandlerModel, ObjectWithType {
 
     if (errorDo) {
       errorInfo.message = errorDo.message;
-      errorInfo.level = this._severityToLogLevel(errorDo.severity);
+      errorInfo.level = scout.nvl(errorDo.logLevel, this._severityToLogLevel(errorDo.severity));
     }
 
     // logging info

--- a/eclipse-scout-core/test/ErrorHandlerSpec.ts
+++ b/eclipse-scout-core/test/ErrorHandlerSpec.ts
@@ -208,6 +208,32 @@ describe('ErrorHandler', () => {
         expect(errorInfo.level).toBe(LogLevel.WARN);
       }).always(done);
     });
+
+    it('can handle ErrorDo logLevel', done => {
+      let errorDo: ErrorDo = {
+        _type: 'scout.Error',
+        httpStatus: 404,
+        errorCode: 'T1234',
+        message: 'test message',
+        correlationId: 'Corr1234',
+        title: 'test title',
+        severity: 'warning',
+        logLevel: LogLevel.INFO
+      };
+      let fakeXHR = {
+        readyState: 4,
+        status: 404,
+        statusText: 'Not found',
+        responseJSON: {
+          error: errorDo
+        }
+      };
+      errorHandler.analyzeError(fakeXHR).then(errorInfo => {
+        expect(errorInfo.errorDo).toBe(errorDo);
+        expect(errorInfo.message).toBe(errorDo.message);
+        expect(errorInfo.level).toBe(LogLevel.INFO);
+      }).always(done);
+    });
   });
 
   describe('MessageBoxModel for error', () => {

--- a/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/exception/DefaultExceptionMapperTest.java
+++ b/org.eclipse.scout.rt.rest.test/src/test/java/org/eclipse/scout/rt/rest/exception/DefaultExceptionMapperTest.java
@@ -30,6 +30,7 @@ import org.eclipse.scout.rt.platform.status.IStatus;
 import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.rest.error.ErrorDo;
 import org.eclipse.scout.rt.rest.error.ErrorResponse;
+import org.eclipse.scout.rt.rest.logger.LogLevel;
 import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -129,6 +130,7 @@ public class DefaultExceptionMapperTest {
       assertEquals(exception.getStatus().getCode(), error.getErrorCodeAsInt());
       assertEquals("warning", error.getSeverity());
       assertEquals(exception.getStatus().getSeverity(), error.getSeverityAsInt());
+      assertEquals(LogLevel.INFO, error.getLogLevel());
     }
   }
 

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/error/ErrorDo.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/error/ErrorDo.java
@@ -16,6 +16,7 @@ import org.eclipse.scout.rt.dataobject.DoValue;
 import org.eclipse.scout.rt.dataobject.TypeName;
 import org.eclipse.scout.rt.platform.status.IStatus;
 import org.eclipse.scout.rt.platform.util.TypeCastUtility;
+import org.eclipse.scout.rt.rest.logger.LogLevel;
 
 @TypeName("scout.Error")
 public class ErrorDo extends DoEntity {
@@ -58,6 +59,16 @@ public class ErrorDo extends DoEntity {
    */
   public DoValue<String> severity() {
     return doValue("severity");
+  }
+
+  /**
+   * Optional log level overriding the default level derived from {@link #severity()}.
+   * <p>
+   * If {@code null}, the log level is determined from the severity.
+   * </p>
+   */
+  public DoValue<LogLevel> logLevel() {
+    return doValue("logLevel");
   }
 
   /**
@@ -181,5 +192,22 @@ public class ErrorDo extends DoEntity {
   @Generated("DoConvenienceMethodsGenerator")
   public String getSeverity() {
     return severity().get();
+  }
+
+  /**
+   * See {@link #logLevel()}.
+   */
+  @Generated("DoConvenienceMethodsGenerator")
+  public ErrorDo withLogLevel(LogLevel logLevel) {
+    logLevel().set(logLevel);
+    return this;
+  }
+
+  /**
+   * See {@link #logLevel()}.
+   */
+  @Generated("DoConvenienceMethodsGenerator")
+  public LogLevel getLogLevel() {
+    return logLevel().get();
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/error/ErrorResponseBuilder.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/error/ErrorResponseBuilder.java
@@ -24,6 +24,7 @@ import org.eclipse.scout.rt.platform.Bean;
 import org.eclipse.scout.rt.platform.context.CorrelationId;
 import org.eclipse.scout.rt.platform.status.IStatus;
 import org.eclipse.scout.rt.platform.util.ObjectUtility;
+import org.eclipse.scout.rt.rest.logger.LogLevel;
 
 /**
  * Builder for {@link ErrorDo} and {@link ErrorResponse} objects.
@@ -37,6 +38,7 @@ public class ErrorResponseBuilder {
   private String m_message;
   private String m_severity;
   private boolean m_correlationId = true;
+  private LogLevel m_logLevel;
   private Map<String, String> m_headers = new LinkedHashMap<>();
 
   public ErrorResponseBuilder withHttpStatus(int httpStatus) {
@@ -88,6 +90,11 @@ public class ErrorResponseBuilder {
     return this;
   }
 
+  public ErrorResponseBuilder withLogLevel(LogLevel logLevel) {
+    m_logLevel = logLevel;
+    return this;
+  }
+
   public ErrorResponseBuilder addHeader(String key, String value) {
     m_headers.put(key, value);
     return this;
@@ -126,6 +133,9 @@ public class ErrorResponseBuilder {
     }
     if (m_correlationId) {
       error.withCorrelationId(CorrelationId.CURRENT.get());
+    }
+    if (m_logLevel != null) {
+      error.withLogLevel(m_logLevel);
     }
     return error;
   }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/AbstractVetoExceptionMapper.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/exception/AbstractVetoExceptionMapper.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.exception.VetoException;
 import org.eclipse.scout.rt.rest.error.ErrorResponseBuilder;
+import org.eclipse.scout.rt.rest.logger.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,7 @@ public abstract class AbstractVetoExceptionMapper<E extends VetoException> exten
         .withMessage(exception.getStatus().getBody())
         .withErrorCode(exception.getStatus().getCode())
         .withSeverity(exception.getStatus().getSeverity())
-        .withCorrelationId(false);
+        .withCorrelationId(false)
+        .withLogLevel(LogLevel.INFO);
   }
 }

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/logger/LogLevel.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/logger/LogLevel.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.logger;
+
+import org.eclipse.scout.rt.dataobject.enumeration.EnumName;
+import org.eclipse.scout.rt.dataobject.enumeration.IEnum;
+
+@EnumName("scout.LogLevel")
+public enum LogLevel implements IEnum {
+
+  TRACE("trace"),
+  DEBUG("debug"),
+  INFO("info"),
+  WARN("warn"),
+  ERROR("error");
+
+  private final String m_key;
+
+  LogLevel(String key) {
+    m_key = key;
+  }
+
+  @Override
+  public String stringValue() {
+    return m_key;
+  }
+}


### PR DESCRIPTION
Add an optional logLevel property to REST error responses.

This allows server-side code to explicitly control how errors are logged on the client instead of relying solely on the severity-to-log-level mapping.

Veto exceptions are now reported with log level INFO.

474040