### PR TITLE
Add per-cache statistics for InvalidateCacheNotification

### DIFF
--- a/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/clustersync/ClusterSynchronizationServiceTest.java
+++ b/org.eclipse.scout.rt.server.test/src/test/java/org/eclipse/scout/rt/server/services/common/clustersync/ClusterSynchronizationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ import org.eclipse.scout.rt.platform.IBeanInstanceProducer;
 import org.eclipse.scout.rt.platform.IgnoreBean;
 import org.eclipse.scout.rt.platform.Replace;
 import org.eclipse.scout.rt.platform.cache.AllCacheEntryFilter;
+import org.eclipse.scout.rt.platform.cache.ICacheEntryFilter;
 import org.eclipse.scout.rt.platform.cache.InvalidateCacheNotification;
 import org.eclipse.scout.rt.platform.transaction.ITransaction;
 import org.eclipse.scout.rt.server.mom.IClusterMomDestinations;
@@ -54,8 +55,10 @@ import org.mockito.ArgumentCaptor;
 public class ClusterSynchronizationServiceTest {
   private static final NodeId TEST_NODE = NodeId.of("node");
   private static final String TEST_USER = "user";
+  private static final String TEST_CACHE_ID = "cacheId";
 
   private ClusterNotificationMessage m_message;
+  private ClusterNotificationMessage m_cacheInvalidationMessage;
   private ClusterSynchronizationService m_svc = null;
 
   private IMomImplementor m_nullMomImplementorSpy;
@@ -71,6 +74,7 @@ public class ClusterSynchronizationServiceTest {
 
     ClusterNotificationProperties testProps = new ClusterNotificationProperties(TEST_NODE, TEST_USER);
     m_message = new ClusterNotificationMessage("notification", testProps);
+    m_cacheInvalidationMessage = new ClusterNotificationMessage(new InvalidateCacheNotification(TEST_CACHE_ID, mock(ICacheEntryFilter.class)), testProps);
 
     m_svc = new ClusterSynchronizationService();
     m_svc.enable();
@@ -86,15 +90,60 @@ public class ClusterSynchronizationServiceTest {
    */
   @SuppressWarnings("unchecked")
   @Test
-  public void testReveiveInfoUpdated() {
+  public void testReceiveInfoUpdated() {
     IMessage<IClusterNotificationMessage> momMsg = mock(IMessage.class);
     when(momMsg.getTransferObject()).thenReturn(m_message);
     m_svc.onMessage(momMsg);
 
-    IClusterNodeStatusInfo nodeInfo = m_svc.getStatusInfo();
-    assertEquals(1, nodeInfo.getReceivedMessageCount());
-    assertEquals(0, nodeInfo.getSentMessageCount());
-    assertEquals(TEST_NODE, nodeInfo.getLastChangedOriginNodeId());
+    IClusterNodeStatusInfo statusInfo = m_svc.getStatusInfo();
+    assertEquals(1, statusInfo.getReceivedMessageCount());
+    assertEquals(0, statusInfo.getSentMessageCount());
+    assertEquals(TEST_NODE, statusInfo.getLastChangedOriginNodeId());
+    assertEquals(TEST_USER, statusInfo.getLastChangedUserId());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testStatusForMessageType() {
+    IMessage<IClusterNotificationMessage> momMsg = mock(IMessage.class);
+    when(momMsg.getTransferObject()).thenReturn(m_message);
+    m_svc.onMessage(momMsg);
+
+    IClusterNodeStatusInfo status = m_svc.getStatusInfo(String.class);
+    assertEquals(1, status.getReceivedMessageCount());
+    assertEquals(0, status.getSentMessageCount());
+    assertEquals(TEST_NODE, status.getLastChangedOriginNodeId());
+    assertEquals(TEST_USER, status.getLastChangedUserId());
+
+    assertEmptyStatusInfo(m_svc.getStatusInfo(Long.class));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testCacheInvalidationStatusWithoutCacheId() {
+    IMessage<IClusterNotificationMessage> momMsg = mock(IMessage.class);
+    when(momMsg.getTransferObject()).thenReturn(m_cacheInvalidationMessage);
+    m_svc.onMessage(momMsg);
+
+    // status for invalidation notification requires a cache id - getCacheInvalidationStatusInfo should be used
+    IClusterNodeStatusInfo status = m_svc.getStatusInfo(InvalidateCacheNotification.class);
+    assertEmptyStatusInfo(status);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testCacheInvalidationStatus() {
+    IMessage<IClusterNotificationMessage> momMsg = mock(IMessage.class);
+    when(momMsg.getTransferObject()).thenReturn(m_cacheInvalidationMessage);
+    m_svc.onMessage(momMsg);
+
+    IClusterNodeStatusInfo status = m_svc.getCacheInvalidationStatusInfo(TEST_CACHE_ID);
+    assertEquals(1, status.getReceivedMessageCount());
+    assertEquals(0, status.getSentMessageCount());
+    assertEquals(TEST_NODE, status.getLastChangedOriginNodeId());
+    assertEquals(TEST_USER, status.getLastChangedUserId());
+
+    assertEmptyStatusInfo(m_svc.getCacheInvalidationStatusInfo("notExistingCacheId"));
   }
 
   /**
@@ -192,7 +241,7 @@ public class ClusterSynchronizationServiceTest {
 
   private void assertNoMessageSent() {
     verify(m_nullMomImplementorSpy, never()).publish(eq(IClusterMomDestinations.CLUSTER_NOTIFICATION_TOPIC), any(IClusterNotificationMessage.class), any(PublishInput.class));
-    assertEmptyNodeInfo(m_svc.getStatusInfo());
+    assertEmptyStatusInfo(m_svc.getStatusInfo());
   }
 
   private void assertSingleMessageSent() {
@@ -204,7 +253,7 @@ public class ClusterSynchronizationServiceTest {
     assertEquals("default", statusInfo.getLastChangedUserId());
   }
 
-  private void assertEmptyNodeInfo(IClusterNodeStatusInfo status) {
+  private void assertEmptyStatusInfo(IClusterNodeStatusInfo status) {
     assertEquals(0, status.getReceivedMessageCount());
     assertEquals(0, status.getSentMessageCount());
     assertNull(status.getLastChangedOriginNodeId());

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/clustersync/ClusterSynchronizationService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/clustersync/ClusterSynchronizationService.java
@@ -30,6 +30,7 @@ import org.eclipse.scout.rt.platform.IPlatform.State;
 import org.eclipse.scout.rt.platform.IPlatformListener;
 import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.PlatformEvent;
+import org.eclipse.scout.rt.platform.cache.InvalidateCacheNotification;
 import org.eclipse.scout.rt.platform.config.CONFIG;
 import org.eclipse.scout.rt.platform.security.User;
 import org.eclipse.scout.rt.platform.transaction.AbstractTransactionMember;
@@ -55,7 +56,7 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
   private static final String TRANSACTION_MEMBER_ID = ClusterSynchronizationService.class.getName();
 
   private final ClusterNodeStatusInfo m_statusInfo = new ClusterNodeStatusInfo();
-  private final ConcurrentMap<Class<? extends Serializable>, ClusterNodeStatusInfo> m_messageStatusMap = new ConcurrentHashMap<>();
+  private final ConcurrentMap<MessageStatusMapKey, ClusterNodeStatusInfo> m_messageStatusMap = new ConcurrentHashMap<>();
 
   private final Subject m_subject;
   private final LazyValue<User> m_user = new LazyValue<>(this::createUser);
@@ -90,9 +91,8 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
     return m_statusInfo;
   }
 
-  protected ClusterNodeStatusInfo getStatusInfoInternal(Class<? extends Serializable> messageType) {
-    m_messageStatusMap.putIfAbsent(messageType, new ClusterNodeStatusInfo());
-    return m_messageStatusMap.get(messageType);
+  protected ClusterNodeStatusInfo getStatusInfoInternal(MessageStatusMapKey key) {
+    return m_messageStatusMap.computeIfAbsent(key, k -> new ClusterNodeStatusInfo());
   }
 
   public NodeId getNodeId() {
@@ -185,11 +185,27 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
     for (IClusterNotificationMessage message : messages) {
       LOG.trace("Publishing {}", message);
       MOM.publish(ClusterMom.class, IClusterMomDestinations.CLUSTER_NOTIFICATION_TOPIC, message);
+      updateSentStatusInfo(message);
     }
-    for (IClusterNotificationMessage im : messages) {
-      getStatusInfoInternal().updateSentStatus(im);
-      getStatusInfoInternal(im.getNotification().getClass()).updateReceiveStatus(im);
+  }
+
+  protected void updateSentStatusInfo(IClusterNotificationMessage message) {
+    getStatusInfoInternal().updateSentStatus(message);
+    getStatusInfoInternal(createStatusInfoMapKey(message)).updateSentStatus(message);
+  }
+
+  protected void updateReceiveStatusInfo(IClusterNotificationMessage message) {
+    getStatusInfoInternal().updateReceiveStatus(message);
+    getStatusInfoInternal(createStatusInfoMapKey(message)).updateReceiveStatus(message);
+  }
+
+  protected MessageStatusMapKey createStatusInfoMapKey(IClusterNotificationMessage message) {
+    Serializable notification = message.getNotification();
+    String identifier = null;
+    if (notification instanceof InvalidateCacheNotification invalidateCacheNotification) {
+      identifier = invalidateCacheNotification.getCacheId();
     }
+    return new MessageStatusMapKey(notification.getClass(), identifier);
   }
 
   @Override
@@ -211,15 +227,17 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
       }
 
       LOG.trace("Handling {}", notificationMessage);
-
-      getStatusInfoInternal().updateReceiveStatus(notificationMessage);
-      getStatusInfoInternal(notificationMessage.getNotification().getClass()).updateReceiveStatus(notificationMessage);
-
-      createRunContext().run(() -> {
-        NotificationHandlerRegistry reg = BEANS.get(NotificationHandlerRegistry.class);
-        reg.notifyNotificationHandlers(notificationMessage.getNotification());
-      });
+      handleMessage(notificationMessage);
     }
+  }
+
+  protected void handleMessage(IClusterNotificationMessage notificationMessage) {
+    updateReceiveStatusInfo(notificationMessage);
+
+    createRunContext().run(() -> {
+      NotificationHandlerRegistry reg = BEANS.get(NotificationHandlerRegistry.class);
+      reg.notifyNotificationHandlers(notificationMessage.getNotification());
+    });
   }
 
   protected ServerRunContext createRunContext() {
@@ -276,7 +294,26 @@ public class ClusterSynchronizationService implements IClusterSynchronizationSer
 
   @Override
   public IClusterNodeStatusInfo getStatusInfo(Class<? extends Serializable> messageType) {
-    return getStatusInfoInternal(messageType).getStatus();
+    return getStatusInfoInternal(new MessageStatusMapKey(messageType)).getStatus();
+  }
+
+  @Override
+  public IClusterNodeStatusInfo getCacheInvalidationStatusInfo(String cacheId) {
+    return getStatusInfoInternal(new MessageStatusMapKey(InvalidateCacheNotification.class, cacheId)).getStatus();
+  }
+
+  protected record MessageStatusMapKey(Class<? extends Serializable> messageType, String identifier) {
+
+    public MessageStatusMapKey {
+      if (identifier == null && InvalidateCacheNotification.class.isAssignableFrom(messageType)) {
+        //noinspection LoggingPlaceholderCountMatchesArgumentCount
+        LOG.warn("For {} the cacheId is required as identifier", InvalidateCacheNotification.class.getSimpleName(), LOG.isDebugEnabled() ? new Exception("stacktrace") : null);
+      }
+    }
+
+    public MessageStatusMapKey(Class<? extends Serializable> messageType) {
+      this(messageType, null);
+    }
   }
 
   /**

--- a/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/clustersync/IClusterSynchronizationService.java
+++ b/org.eclipse.scout.rt.server/src/main/java/org/eclipse/scout/rt/server/services/common/clustersync/IClusterSynchronizationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@ import java.io.Serializable;
 
 import org.eclipse.scout.rt.platform.IPlatform.State;
 import org.eclipse.scout.rt.platform.IPlatformListener;
+import org.eclipse.scout.rt.platform.cache.InvalidateCacheNotification;
 import org.eclipse.scout.rt.platform.service.IService;
 
 /**
@@ -21,9 +22,9 @@ import org.eclipse.scout.rt.platform.service.IService;
 public interface IClusterSynchronizationService extends IService {
 
   /**
-   * Indicates the order of the cluster synchronization's {@link IPlatformListener} to shutdown itself upon entering
+   * Indicates the order of the cluster synchronization's {@link IPlatformListener} to shut down itself upon entering
    * platform state {@link State#PlatformStopping}. Any listener depending on cluster synchronization facility must be
-   * configured with an order less than {@link #DESTROY_ORDER}.
+   * configured with an order less than this value.
    */
   long DESTROY_ORDER = 5_700;
 
@@ -43,9 +44,14 @@ public interface IClusterSynchronizationService extends IService {
   IClusterNodeStatusInfo getStatusInfo();
 
   /**
-   * @return info about sent and received messages of a given message type
+   * @return info about sent and received messages of a given message type. For {@link InvalidateCacheNotification} use {@link #getCacheInvalidationStatusInfo(String)}.
    */
   IClusterNodeStatusInfo getStatusInfo(Class<? extends Serializable> messageType);
+
+  /**
+   * @return info about sent and received messages of {@link InvalidateCacheNotification} for the provided {@code cacheId}.
+   */
+  IClusterNodeStatusInfo getCacheInvalidationStatusInfo(String cacheId);
 
   IClusterNotificationProperties getNotificationProperties();
 


### PR DESCRIPTION
Store cluster synchronization status information using a message type and optional identifier key. For cache invalidation messages, the cache ID is used as identifier, allowing status information to be queried per cache via getInvalidationStatusInfo(String).

214038