### PR TITLE
Restore GzipHandler-like defaults for CompressionHandler

### DIFF
--- a/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
+++ b/org.eclipse.scout.rt.app/src/main/java/org/eclipse/scout/rt/app/Application.java
@@ -470,6 +470,7 @@ public class Application {
     GzipEncoderConfig encoderConfig = new GzipEncoderConfig();
 
     Builder configBuilder = CompressionConfig.builder();
+    configBuilder.defaults();
 
     setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedInflatePaths.class, configBuilder::decompressExcludePath);
     setStringPropertyValueIfFilled(ScoutApplicationGzipExcludedMethods.class, configBuilder::compressExcludeMethod);


### PR DESCRIPTION
With the migration to Jetty 12.1.x, GzipHandler was replaced by CompressionHandler. The new handler does not use the same defaults as the legacy implementation, which can lead to different compression behavior after the upgrade.

This change applies an explicit default configuration to CompressionHandler to better match the behavior of the former GzipHandler and maintain compatibility with existing deployments.

476535