### PR TITLE
ChunkedDataWriter: fetch and iterate within the same transaction

### DIFF
--- a/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/ChunkedDataResource.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/main/java/org/eclipse/scout/rt/rest/jersey/fixture/ChunkedDataResource.java
@@ -159,7 +159,7 @@ public class ChunkedDataResource implements IRestResource {
   public Response getDataObjectsScoutIterator() {
     @SuppressWarnings("resource")
     IChunkedDataWriter<FixtureDo> writer = IChunkedDataWriter.create(FixtureDo.class, "\n\n", 100);
-    return writer.toResponse(Stream.of(1, 2, 3).map(this::createFixtureDo).iterator());
+    return writer.toResponse(() -> Stream.of(1, 2, 3).map(this::createFixtureDo).iterator());
   }
 
   /**

--- a/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/server/chunked/ChunkedDataWriterTest.java
+++ b/org.eclipse.scout.rt.rest.jersey.test/src/test/java/org/eclipse/scout/rt/rest/jersey/server/chunked/ChunkedDataWriterTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.rt.rest.jersey.server.chunked;
+
+import static org.junit.Assert.*;
+
+import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.scout.rt.platform.BEANS;
+import org.eclipse.scout.rt.platform.BeanMetaData;
+import org.eclipse.scout.rt.platform.IBean;
+import org.eclipse.scout.rt.platform.IgnoreBean;
+import org.eclipse.scout.rt.platform.Replace;
+import org.eclipse.scout.rt.platform.context.RunContext;
+import org.eclipse.scout.rt.platform.context.RunContexts.RunContextFactory;
+import org.eclipse.scout.rt.platform.transaction.ITransaction;
+import org.eclipse.scout.rt.platform.transaction.TransactionCancelledError;
+import org.eclipse.scout.rt.platform.transaction.TransactionScope;
+import org.eclipse.scout.rt.platform.util.CollectionUtility;
+import org.eclipse.scout.rt.platform.util.SleepUtil;
+import org.eclipse.scout.rt.platform.util.concurrent.ThreadInterruptedError;
+import org.eclipse.scout.rt.rest.chunked.IChunkedDataWriter;
+import org.eclipse.scout.rt.testing.platform.BeanTestingHelper;
+import org.eclipse.scout.rt.testing.platform.runner.JUnitExceptionHandler;
+import org.eclipse.scout.rt.testing.platform.runner.PlatformTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PlatformTestRunner.class)
+public class ChunkedDataWriterTest {
+
+  private FixtureIterator m_iterator;
+
+  @Test
+  public void testToResponse() {
+    @SuppressWarnings("resource")
+    IChunkedDataWriter<String> writer = IChunkedDataWriter.create(String.class, "\r\n", 100);
+    Response res = writer.toResponse(() -> fetchData());
+    assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
+    assertTrue(m_iterator.waitForCompletionAndVerifyTxn());
+  }
+
+  @Test
+  public void testToResponse_supplierThrowsUncheckedException() throws Exception {
+    @SuppressWarnings("resource")
+    IChunkedDataWriter<String> writer = IChunkedDataWriter.create(String.class, "\r\n", 100);
+
+    JUnitExceptionHandler exceptionHandler = BEANS.get(JUnitExceptionHandler.class);
+    exceptionHandler.ignoreExceptionOnce(RuntimeException.class, () -> {
+      assertThrows(RuntimeException.class,
+          () -> writer.toResponse(() -> {
+            throw new RuntimeException("by intention");
+          }));
+      // The exception above is thrown in a job and finally handled by the JUnitExceptionHandler.
+      // But because it involves another job, we must give it some time to be processed.
+      SleepUtil.sleepSafe(100, TimeUnit.MILLISECONDS);
+    });
+
+    exceptionHandler.ignoreExceptionOnce(TransactionCancelledError.class, () -> {
+      assertThrows(TransactionCancelledError.class,
+          () -> writer.toResponse(() -> {
+            throw new TransactionCancelledError("by intention");
+          }));
+      // same applies here (see comment above)
+      SleepUtil.sleepSafe(100, TimeUnit.MILLISECONDS);
+    });
+  }
+
+  @Test
+  public void testToResponse_differentTransactions() {
+    IBean<Object> fixtureRunCtxFactoryBean = BeanTestingHelper.get().registerBean(new BeanMetaData(RequiresNewFixtureRunContextFactory.class));
+    try {
+      @SuppressWarnings("resource")
+      IChunkedDataWriter<String> writer = IChunkedDataWriter.create(String.class, "\r\n", 100);
+      FixtureIterator iterator = fetchData();
+      Response res = writer.toResponse(() -> iterator);
+      assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
+      assertFalse(iterator.waitForCompletionAndVerifyTxn());
+    }
+    finally {
+      BeanTestingHelper.get().unregisterBean(fixtureRunCtxFactoryBean);
+    }
+  }
+
+  protected FixtureIterator fetchData() {
+    m_iterator = new FixtureIterator();
+    return m_iterator;
+  }
+
+  protected static class FixtureIterator implements Iterator<String> {
+    final ITransaction m_creatingTxn;
+    final Iterator<String> m_delegate;
+    final CountDownLatch m_completedLatch;
+    private volatile boolean m_iteratesInCreatingTxn = true;
+
+    public FixtureIterator() {
+      m_delegate = CollectionUtility.arrayList("a", "b", "c").iterator();
+      m_creatingTxn = ITransaction.CURRENT.get();
+      m_completedLatch = new CountDownLatch(1);
+    }
+
+    @Override
+    public boolean hasNext() {
+      checkTxn();
+      boolean hasNext = m_delegate.hasNext();
+      if (!hasNext) {
+        m_completedLatch.countDown();
+      }
+      return hasNext;
+    }
+
+    @Override
+    public String next() {
+      checkTxn();
+      return m_delegate.next();
+    }
+
+    private void checkTxn() {
+      if (m_creatingTxn != ITransaction.CURRENT.get()) {
+        m_iteratesInCreatingTxn = false;
+      }
+    }
+
+    public boolean waitForCompletionAndVerifyTxn() {
+      try {
+        return m_completedLatch.await(5, TimeUnit.SECONDS) && m_iteratesInCreatingTxn;
+      }
+      catch (InterruptedException e) {
+        throw new ThreadInterruptedError("Interrupted", e);
+      }
+    }
+  }
+
+  @Replace
+  @IgnoreBean
+  private static class RequiresNewFixtureRunContextFactory extends RunContextFactory {
+
+    @Override
+    public RunContext empty() {
+      return super.empty()
+          .withTransactionScope(TransactionScope.REQUIRES_NEW);
+    }
+
+    @Override
+    public RunContext copyCurrent() {
+      return super.copyCurrent()
+          .withTransactionScope(TransactionScope.REQUIRES_NEW);
+    }
+  }
+}

--- a/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/chunked/IChunkedDataWriter.java
+++ b/org.eclipse.scout.rt.rest/src/main/java/org/eclipse/scout/rt/rest/chunked/IChunkedDataWriter.java
@@ -12,12 +12,16 @@ package org.eclipse.scout.rt.rest.chunked;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.platform.Bean;
+import org.eclipse.scout.rt.platform.exception.DefaultRuntimeExceptionTranslator;
 import org.eclipse.scout.rt.platform.util.Assertions.AssertionException;
 import org.eclipse.scout.rt.platform.util.concurrent.IRunnable;
 import org.eclipse.scout.rt.rest.IRestResource;
@@ -33,8 +37,7 @@ import org.eclipse.scout.rt.rest.IRestResource;
  * &#064;Produces(MediaType.APPLICATION_JSON)
  * public Response load() {
  *   IChunkedDataWriter&#060;ExampleDo&#062; writer = IChunkedDataWriter.create(ExampleDo.class, "\r\n", 100);
- *   Iterator&#060;ExampleDo&#062; iterator = fetchData();  // load data from source, e.g. database
- *   return writer.toResponse(iterator);
+ *   return writer.toResponse(() -> fetchData()));   // load data from source, e.g. database
  * }
  * </pre>
  */
@@ -95,13 +98,66 @@ public interface IChunkedDataWriter<T> extends Closeable {
 
   /**
    * Schedules job which consumes given iterator and returns response created by {@link #toEntity()}.
+   *
+   * @deprecated Instead, use {@link #toResponse(Supplier)}
    */
+  @Deprecated(forRemoval = true, since = "26.2")
   default Response toResponse(Iterator<T> iterator) {
     writeAsync(() -> {
       while (iterator.hasNext()) {
         write(iterator.next());
       }
     });
+    return Response.ok(toEntity()).build();
+  }
+
+  /**
+   * Schedules a new job that executes the given iterator supplier and writes its values to the chunked response created with {@link #toEntity()}.
+   * The iterator supplier as well as the iteration loop are performed within the same job in order to use
+   * the same transaction. This method blocks until the supplier completes and re-throws any unchecked exception.
+   */
+  default Response toResponse(Supplier<Iterator<T>> iteratorSupplier) {
+    final CountDownLatch supplierDone = new CountDownLatch(1);
+    final AtomicReference<Throwable> uncheckedException = new AtomicReference<>();
+
+    writeAsync(() -> {
+      // invoke supplier within the same transaction that also runs over the iterator,
+      // so that txn-related resources are still available (e.g. db connection)
+      Iterator<T> iterator;
+      try {
+        iterator = iteratorSupplier.get();
+      }
+      catch (@SuppressWarnings("squid:S1181") RuntimeException | Error e) {
+        uncheckedException.set(e);
+        throw e;
+      }
+      finally {
+        supplierDone.countDown();
+      }
+
+      // write chunked data
+      while (iterator.hasNext()) {
+        write(iterator.next());
+      }
+    });
+
+    // wait for the supplier to complete
+    try {
+      supplierDone.await();
+    }
+    catch (@SuppressWarnings("squid:S2142") InterruptedException e) {
+      throw BEANS.get(DefaultRuntimeExceptionTranslator.class).translate(e);
+    }
+
+    // rethrow any unchecked exception occurred by the supplier
+    Throwable throwable = uncheckedException.get();
+    if (throwable instanceof RuntimeException runtimeException) {
+      throw runtimeException;
+    }
+    if (throwable instanceof Error error) {
+      throw error;
+    }
+
     return Response.ok(toEntity()).build();
   }
 }


### PR DESCRIPTION
Chunked data transfer is used for large amounts of data, such as those loaded from a database. In this case, it is absolutely necessary that the execution of the SQL statement and the iteration over the ResultSet take place within the same transaction.

This change modifies the signature of toResponse from an Iterator<T> to a Supplier<Iterator<T>>, allowing to create and iterate in the same RunContext.

474697

(cherry picked from commit 93fd4878c2f9e2beec2a39d53261279d1ea21d3d) (cherry picked from commit d4e9dfedce55c1a98d5e081b478b6c561e1eac64)